### PR TITLE
Copy non retryable error types list in ensureDefaultFieldsForActivity

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1884,6 +1884,7 @@ class StateMachines {
 
     return RetryPolicy.newBuilder()
         .setInitialInterval(initialInterval)
+        .addAllNonRetryableErrorTypes(originalPolicy.getNonRetryableErrorTypesList())
         .setMaximumInterval(
             Durations.compare(originalPolicy.getMaximumInterval(), Durations.ZERO) == 0
                 ? Durations.fromMillis(


### PR DESCRIPTION
This should address #203 by copying non retryable errors in the test service.