### PR TITLE
Remove reset sticky call from cache invalidation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -56,6 +56,7 @@ import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
+import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.EncodedValues;
@@ -864,5 +865,11 @@ public class WorkflowExecutionUtils {
       String jsonHistory = CharStreams.toString(reader);
       return WorkflowExecutionHistory.fromJson(jsonHistory);
     }
+  }
+
+  public static boolean isFullHistory(PollWorkflowTaskQueueResponseOrBuilder workflowTask) {
+    return workflowTask.getHistory() != null
+        && workflowTask.getHistory().getEventsCount() > 0
+        && workflowTask.getHistory().getEvents(0).getEventId() == 1;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -38,6 +38,7 @@ import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
+import io.temporal.api.workflowservice.v1.ResetStickyTaskQueueRequest;
 import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
@@ -216,6 +217,14 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
 
       if (stickyTaskQueueName != null) {
         cache.invalidate(execution, metricsScope);
+        // Execute asynchronously
+        service
+            .futureStub()
+            .resetStickyTaskQueue(
+                ResetStickyTaskQueueRequest.newBuilder()
+                    .setNamespace(namespace)
+                    .setExecution(execution)
+                    .build());
       }
       throw e;
     } finally {

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -218,13 +218,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       if (stickyTaskQueueName != null) {
         cache.invalidate(execution, metricsScope);
         // Execute asynchronously
-        service
-            .futureStub()
-            .resetStickyTaskQueue(
-                ResetStickyTaskQueueRequest.newBuilder()
-                    .setNamespace(namespace)
-                    .setExecution(execution)
-                    .build());
+        resetStickyTaskList(execution);
       }
       throw e;
     } finally {
@@ -234,6 +228,16 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
         cache.markProcessingDone(runId);
       }
     }
+  }
+
+  private void resetStickyTaskList(WorkflowExecution execution) {
+    service
+        .futureStub()
+        .resetStickyTaskQueue(
+            ResetStickyTaskQueueRequest.newBuilder()
+                .setNamespace(namespace)
+                .setExecution(execution)
+                .build());
   }
 
   private Result handleQueryOnlyWorkflowTask(

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowExecutorCache.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowExecutorCache.java
@@ -19,6 +19,8 @@
 
 package io.temporal.internal.replay;
 
+import static io.temporal.internal.common.WorkflowExecutionUtils.isFullHistory;
+
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -145,12 +147,6 @@ public final class WorkflowExecutorCache {
 
   public long size() {
     return cache.size();
-  }
-
-  private boolean isFullHistory(PollWorkflowTaskQueueResponseOrBuilder workflowTask) {
-    return workflowTask.getHistory() != null
-        && workflowTask.getHistory().getEventsCount() > 0
-        && workflowTask.getHistory().getEvents(0).getEventId() == 1;
   }
 
   public void invalidateAll() {

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -109,11 +109,7 @@ public final class WorkerFactory {
             .tagged(MetricsTag.defaultTags(workflowClient.getOptions().getNamespace()));
 
     this.cache =
-        new WorkflowExecutorCache(
-            this.workflowClient.getWorkflowServiceStubs(),
-            workflowClient.getOptions().getNamespace(),
-            this.factoryOptions.getWorkflowCacheSize(),
-            metricsScope);
+        new WorkflowExecutorCache(this.factoryOptions.getWorkflowCacheSize(), metricsScope);
     Scope stickyScope =
         metricsScope.tagged(
             new ImmutableMap.Builder<String, String>(1)

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
@@ -68,7 +68,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
   public void whenHistoryIsFullNewWorkflowExecutorIsReturnedAndCached_InitiallyEmpty()
       throws Exception {
     // Arrange
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 10, new NoopScope());
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, new NoopScope());
     PollWorkflowTaskQueueResponse workflowTask =
         HistoryUtils.generateWorkflowTaskWithInitialHistory();
 
@@ -92,7 +92,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
     WorkflowServiceStubs service = testService.newClientStub();
 
     // Arrange
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 10, new NoopScope());
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, new NoopScope());
     PollWorkflowTaskQueueResponse workflowTask1 =
         HistoryUtils.generateWorkflowTaskWithInitialHistory(
             "namespace", "taskQueue", "workflowType", service);
@@ -137,7 +137,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
             .build();
     Scope scope = metricsScope.tagged(tags);
 
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 10, scope);
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, scope);
     TestWorkflowService testService = new TestWorkflowService(true);
     WorkflowServiceStubs service = testService.newClientStub();
     try {
@@ -178,7 +178,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
             .put(MetricsTag.TASK_QUEUE, "stickyTaskQueue")
             .build();
     Scope scope = metricsScope.tagged(tags);
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 10, scope);
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, scope);
 
     // Act
     PollWorkflowTaskQueueResponse workflowTask =
@@ -207,7 +207,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
     Scope scope = metricsScope.tagged(tags);
 
     // Arrange
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 50, scope);
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(50, scope);
     PollWorkflowTaskQueueResponse workflowTask1 =
         HistoryUtils.generateWorkflowTaskWithInitialHistory();
     PollWorkflowTaskQueueResponse workflowTask2 =
@@ -242,7 +242,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
   @Test
   public void evictAnyWillNotInvalidateItself() throws Exception {
     // Arrange
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 50, new NoopScope());
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(50, new NoopScope());
     PollWorkflowTaskQueueResponse workflowTask1 =
         HistoryUtils.generateWorkflowTaskWithInitialHistory();
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -68,8 +68,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
   @Test
   public void ifStickyExecutionAttributesAreNotSetThenWorkflowsAreNotCached() throws Throwable {
     // Arrange
-    WorkflowExecutorCache cache =
-        new WorkflowExecutorCache(service, "default", 10, new NoopScope());
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, new NoopScope());
     WorkflowTaskHandler taskHandler =
         new ReplayWorkflowTaskHandler(
             "namespace",
@@ -95,8 +94,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
   @Test
   public void ifStickyExecutionAttributesAreSetThenWorkflowsAreCached() throws Throwable {
     // Arrange
-    WorkflowExecutorCache cache =
-        new WorkflowExecutorCache(service, "default", 10, new NoopScope());
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, new NoopScope());
     WorkflowTaskHandler taskHandler =
         new ReplayWorkflowTaskHandler(
             "namespace",

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -637,7 +637,7 @@ public class DeterministicRunnerTest {
         new ThreadPoolExecutor(1, 3, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
     AtomicReference<String> status = new AtomicReference<>();
 
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 3, scope);
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(3, scope);
     ReplayWorkflowContext replayWorkflowContext = mock(ReplayWorkflowContext.class);
     when(replayWorkflowContext.getMetricsScope()).thenReturn(scope);
     when(replayWorkflowContext.getWorkflowExecution())
@@ -706,7 +706,7 @@ public class DeterministicRunnerTest {
         new ThreadPoolExecutor(1, 5, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
     AtomicReference<String> status = new AtomicReference<>();
 
-    WorkflowExecutorCache cache = new WorkflowExecutorCache(null, "default", 3, new NoopScope());
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(3, new NoopScope());
 
     DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(


### PR DESCRIPTION
This PR addresses an issue with overly aggressive calls to reset sticky during cache invalidation.
Instead we are only going to reset sticky tasklist when exceptions occur.