### PR TITLE
Copy headers from factory options into grpc requests

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -32,8 +32,6 @@ import io.grpc.stub.MetadataUtils;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -140,7 +138,8 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
         new GrpcMetricsInterceptor(options.getMetricsScope());
     ClientInterceptor deadlineInterceptor = new GrpcDeadlineInterceptor(options);
     GrpcTracingInterceptor tracingInterceptor = new GrpcTracingInterceptor();
-    Metadata headers = options.getHeaders();
+    Metadata headers = new Metadata();
+    headers.merge(options.getHeaders());
     headers.put(LIBRARY_VERSION_HEADER_KEY, Version.LIBRARY_VERSION);
     headers.put(SUPPORTED_SERVER_VERSIONS_HEADER_KEY, Version.SUPPORTED_SERVER_VERSIONS);
     headers.put(CLIENT_NAME_HEADER_KEY, CLIENT_NAME_HEADER_VALUE);

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -140,7 +140,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
         new GrpcMetricsInterceptor(options.getMetricsScope());
     ClientInterceptor deadlineInterceptor = new GrpcDeadlineInterceptor(options);
     GrpcTracingInterceptor tracingInterceptor = new GrpcTracingInterceptor();
-    Metadata headers = headersFrom(options.getHeaders());
+    Metadata headers = options.getHeaders();
     headers.put(LIBRARY_VERSION_HEADER_KEY, Version.LIBRARY_VERSION);
     headers.put(SUPPORTED_SERVER_VERSIONS_HEADER_KEY, Version.SUPPORTED_SERVER_VERSIONS);
     headers.put(CLIENT_NAME_HEADER_KEY, CLIENT_NAME_HEADER_VALUE);

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -32,6 +32,8 @@ import io.grpc.stub.MetadataUtils;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -138,7 +140,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
         new GrpcMetricsInterceptor(options.getMetricsScope());
     ClientInterceptor deadlineInterceptor = new GrpcDeadlineInterceptor(options);
     GrpcTracingInterceptor tracingInterceptor = new GrpcTracingInterceptor();
-    Metadata headers = new Metadata();
+    Metadata headers = headersFrom(options.getHeaders());
     headers.put(LIBRARY_VERSION_HEADER_KEY, Version.LIBRARY_VERSION);
     headers.put(SUPPORTED_SERVER_VERSIONS_HEADER_KEY, Version.SUPPORTED_SERVER_VERSIONS);
     headers.put(CLIENT_NAME_HEADER_KEY, CLIENT_NAME_HEADER_VALUE);
@@ -164,6 +166,15 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
     }
     this.futureStub = fs;
     log.info(String.format("Created GRPC client for channel: %s", channel));
+  }
+
+  private Metadata headersFrom(Map<String, String> headers) {
+    Metadata metadata = new Metadata();
+    for (Entry<String, String> header : headers.entrySet()) {
+      metadata.put(
+          Metadata.Key.of(header.getKey(), Metadata.ASCII_STRING_MARSHALLER), header.getValue());
+    }
+    return metadata;
   }
 
   private ScheduledExecutorService startConnectionBackoffResetter(Duration backoffResetFrequency) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -168,15 +168,6 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
     log.info(String.format("Created GRPC client for channel: %s", channel));
   }
 
-  private Metadata headersFrom(Map<String, String> headers) {
-    Metadata metadata = new Metadata();
-    for (Entry<String, String> header : headers.entrySet()) {
-      metadata.put(
-          Metadata.Key.of(header.getKey(), Metadata.ASCII_STRING_MARSHALLER), header.getValue());
-    }
-    return metadata;
-  }
-
   private ScheduledExecutorService startConnectionBackoffResetter(Duration backoffResetFrequency) {
     ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -19,16 +19,15 @@
 
 package io.temporal.serviceclient;
 
-import com.google.common.collect.ImmutableMap;
 import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.Scope;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
 import io.grpc.NameResolver;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -87,7 +86,7 @@ public class WorkflowServiceStubsOptions {
   private final Duration connectionBackoffResetFrequency;
 
   /** Optional gRPC headers */
-  private final Map<String, String> headers;
+  private final Metadata headers;
 
   private final Scope metricsScope;
 
@@ -143,8 +142,10 @@ public class WorkflowServiceStubsOptions {
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
-    this.headers =
-        builder.headers == null ? ImmutableMap.of() : ImmutableMap.copyOf(builder.headers);
+    this.headers = new Metadata();
+    if (builder.headers != null) {
+      this.headers.merge(builder.headers);
+    }
     this.metricsScope = builder.metricsScope == null ? new NoopScope() : builder.metricsScope;
   }
 
@@ -189,7 +190,7 @@ public class WorkflowServiceStubsOptions {
     return connectionBackoffResetFrequency;
   }
 
-  public Map<String, String> getHeaders() {
+  public Metadata getHeaders() {
     return headers;
   }
 
@@ -219,6 +220,7 @@ public class WorkflowServiceStubsOptions {
    * @author venkat
    */
   public static class Builder {
+
     private ManagedChannel channel;
     private SslContext sslContext;
     private boolean enableHttps;
@@ -227,7 +229,7 @@ public class WorkflowServiceStubsOptions {
     private Duration rpcLongPollTimeout = DEFAULT_POLL_RPC_TIMEOUT;
     private Duration rpcQueryTimeout = DEFAULT_QUERY_RPC_TIMEOUT;
     private Duration connectionBackoffResetFrequency = DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY;
-    private Map<String, String> headers;
+    private Metadata headers;
     private Function<
             WorkflowServiceGrpc.WorkflowServiceBlockingStub,
             WorkflowServiceGrpc.WorkflowServiceBlockingStub>
@@ -330,7 +332,7 @@ public class WorkflowServiceStubsOptions {
       return this;
     }
 
-    public Builder setHeaders(Map<String, String> headers) {
+    public Builder setHeaders(Metadata headers) {
       this.headers = headers;
       return this;
     }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -142,9 +142,10 @@ public class WorkflowServiceStubsOptions {
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
-    this.headers = new Metadata();
     if (builder.headers != null) {
-      this.headers.merge(builder.headers);
+      this.headers = builder.headers;
+    } else {
+      this.headers = new Metadata();
     }
     this.metricsScope = builder.metricsScope == null ? new NoopScope() : builder.metricsScope;
   }


### PR DESCRIPTION
This PR contains changes required to populate headers on grpc requests to the server.
Previously headers set on factory options were simply ignored, here we fix it.