### PR TITLE
Default schedule to start timeout

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -187,8 +187,7 @@ public class WorkerFactoryOptions {
             !workflowHostLocalTaskQueueScheduleToStartTimeout.isNegative(),
             "negative workflowHostLocalTaskQueueScheduleToStartTimeoutSeconds");
       }
-      if (workflowHostLocalTaskQueueScheduleToStartTimeout == null
-          || workflowHostLocalTaskQueueScheduleToStartTimeout.isZero()) {
+      if (workflowHostLocalTaskQueueScheduleToStartTimeout == null) {
         workflowHostLocalTaskQueueScheduleToStartTimeout = DEFAULT_STICKY_SCHEDULE_TO_START_TIMEOUT;
       }
       if (workflowInterceptors == null) {

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -41,6 +41,7 @@ public class WorkerFactoryOptions {
   private static final int DEFAULT_HOST_LOCAL_WORKFLOW_POLL_THREAD_COUNT = 5;
   private static final int DEFAULT_WORKFLOW_CACHE_SIZE = 600;
   private static final int DEFAULT_MAX_WORKFLOW_THREAD_COUNT = 600;
+  private static final Duration DEFAULT_STICKY_SCHEDULE_TO_START_TIMEOUT = Duration.ofSeconds(5);
 
   private static final WorkerFactoryOptions DEFAULT_INSTANCE;
 
@@ -49,6 +50,7 @@ public class WorkerFactoryOptions {
   }
 
   public static class Builder {
+
     private Duration workflowHostLocalTaskQueueScheduleToStartTimeout;
     private int workflowCacheSize;
     private int maxWorkflowThreadCount;
@@ -184,6 +186,10 @@ public class WorkerFactoryOptions {
         Preconditions.checkState(
             !workflowHostLocalTaskQueueScheduleToStartTimeout.isNegative(),
             "negative workflowHostLocalTaskQueueScheduleToStartTimeoutSeconds");
+      }
+      if (workflowHostLocalTaskQueueScheduleToStartTimeout == null
+          || workflowHostLocalTaskQueueScheduleToStartTimeout.isZero()) {
+        workflowHostLocalTaskQueueScheduleToStartTimeout = DEFAULT_STICKY_SCHEDULE_TO_START_TIMEOUT;
       }
       if (workflowInterceptors == null) {
         workflowInterceptors = new WorkflowInterceptor[0];

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -325,6 +325,7 @@ public class WorkflowTest {
         WorkerFactoryOptions.newBuilder()
             .setWorkflowInterceptors(tracer)
             .setActivityInterceptors(activityInterceptor)
+            .setWorkflowHostLocalTaskQueueScheduleToStartTimeout(Duration.ZERO)
             .setWorkflowHostLocalTaskQueueScheduleToStartTimeout(
                 versionTest ? Duration.ZERO : Duration.ofSeconds(10))
             .build();


### PR DESCRIPTION
This change sets default value for schedule to start timeout option property to 5 seconds. This behavior is similar to what we have in go sdk:
https://github.com/temporalio/sdk-go/blob/d2bd562a1e775d645ab3205248c45d96bda3fc0c/internal/internal_task_pollers.go#L60