### PR TITLE
Report timers as histograms and use snake case naming convention

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/reporter/MicrometerClientStatsReporter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/reporter/MicrometerClientStatsReporter.java
@@ -26,6 +26,8 @@ import com.uber.m3.tally.StatsReporter;
 import com.uber.m3.util.Duration;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.config.NamingConvention;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +39,7 @@ public class MicrometerClientStatsReporter implements StatsReporter {
 
   public MicrometerClientStatsReporter(MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry);
+    registry.config().namingConvention(NamingConvention.snakeCase);
   }
 
   @Override
@@ -66,7 +69,11 @@ public class MicrometerClientStatsReporter implements StatsReporter {
 
   @Override
   public void reportTimer(String name, Map<String, String> tags, Duration interval) {
-    registry.timer(name, getTags(tags)).record(interval.getNanos(), TimeUnit.NANOSECONDS);
+    Timer.builder(name)
+        .tags(getTags(tags))
+        .publishPercentileHistogram(true)
+        .register(registry)
+        .record(interval.getNanos(), TimeUnit.NANOSECONDS);
   }
 
   @Override


### PR DESCRIPTION
This PR introduces two changes that make metrics reporting similar to Go.
Firstly we've reported timer metrics as plain numbers and not histograms, which meant that we didn't have all the bucket data and were unable to use percentiles, that we heavily rely up on in our SDK dashboard. Here we fix this issue by setting report histogram tag on metric reporter.
Secondly unlike in go we've used default prometheus naming convention which set time unit at the end of every latency metric resulting in diverging names. We fix it too here by applying snake_case metric convention.