### PR TITLE
Use daemon threads for connection backoff resetter

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -19,6 +19,7 @@
 
 package io.temporal.serviceclient;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
@@ -168,7 +169,9 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
   }
 
   private ScheduledExecutorService startConnectionBackoffResetter(Duration backoffResetFrequency) {
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService executor =
+        Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setDaemon(true).build());
 
     executor.scheduleWithFixedDelay(
         () -> {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -171,7 +171,10 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
   private ScheduledExecutorService startConnectionBackoffResetter(Duration backoffResetFrequency) {
     ScheduledExecutorService executor =
         Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder().setDaemon(true).build());
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("ConnectionBackoffResetter-thread-%d")
+                .build());
 
     executor.scheduleWithFixedDelay(
         () -> {


### PR DESCRIPTION
Recently we've added a connection backoff resetter as a way to mitigate long gRPC backoff intervals (look [here](https://github.com/grpc/grpc-java/issues/7456) for details).

The way resetter works is that we have a thread pool that periodically resets connection backoff allowing threads to detect backends faster.
Initially those threads in the thread pool used default thread factory resulting in creation of user threads (as opposed to daemon threads) and were blocking JVM shutdown in case of failure in main program.

This caused unwanted behavior and displayed on our java canary as a "stuck jvm" with crashed main in case if the process was unable to startup properly (e.g. register the namespace).

With this change threads are made daemon threads and will no longer block jvm exit.

Example canary startup log when backend is unavailable after the change (expected behavior, JVM exits if it's unable to create a namespace):
```
Exception in thread "main" io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:262)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:243)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:156)
	at io.temporal.api.workflowservice.v1.WorkflowServiceGrpc$WorkflowServiceBlockingStub.registerNamespace(WorkflowServiceGrpc.java:2574)
	at io.temporal.canary.Initializer.registerNamespace(Initializer.java:150)
	at io.temporal.canary.Initializer.<init>(Initializer.java:74)
	at io.temporal.canary.Canary.start(Canary.java:22)
	at io.temporal.canary.Main.main(Main.java:42)
Caused by: io.grpc.netty.shaded.io.netty.channel.AbstractChannel$AnnotatedConnectException: finishConnect(..) failed: Connection refused: /127.0.0.1:7233
Caused by: io.grpc.netty.shaded.io.netty.channel.AbstractChannel$AnnotatedConnectException: finishConnect(..) failed: Connection refused: /127.0.0.1:7233

Caused by: java.net.ConnectException: finishConnect(..) failed: Connection refused
Caused by: java.net.ConnectException: finishConnect(..) failed: Connection refused

	at io.grpc.netty.shaded.io.netty.channel.unix.Errors.throwConnectException(Errors.java:124)
	at io.grpc.netty.shaded.io.netty.channel.unix.Socket.finishConnect(Socket.java:243)
	at io.grpc.netty.shaded.io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.doFinishConnect(AbstractEpollChannel.java:672)
	at io.grpc.netty.shaded.io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.finishConnect(AbstractEpollChannel.java:649)
	at io.grpc.netty.shaded.io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.epollOutReady(AbstractEpollChannel.java:529)
	at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:465)
	at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:832)

Execution failed for task ':Main.main()'.
> Process 'command '/home/fury/.jdks/openjdk-14.0.1/bin/java'' finished with non-zero exit value 1
```