### PR TITLE
Fix NPE in sticky poller

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
@@ -136,7 +136,7 @@ public class SyncWorkflowWorker
 
   @Override
   public boolean isStarted() {
-    return workflowWorker.isStarted() && laWorker.isStarted();
+    return workflowWorker.isStarted() && (laWorker.isStarted() || !laWorker.hasSupportedTypes());
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
@@ -136,7 +136,7 @@ public class SyncWorkflowWorker
 
   @Override
   public boolean isStarted() {
-    return workflowWorker.isStarted() && (laWorker.isStarted() || !laWorker.hasSupportedTypes());
+    return workflowWorker.isStarted() && (laWorker.isStarted() || !laWorker.isAnyTypeSupported());
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -93,7 +93,7 @@ public final class LocalActivityWorker implements SuspendableWorker {
     }
   }
 
-  public boolean hasSupportedTypes() {
+  public boolean isAnyTypeSupported() {
     return handler.isAnyTypeSupported();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -93,6 +93,10 @@ public final class LocalActivityWorker implements SuspendableWorker {
     }
   }
 
+  public boolean hasSupportedTypes() {
+    return handler.isAnyTypeSupported();
+  }
+
   @Override
   public boolean isStarted() {
     if (poller == null) {

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -176,7 +176,6 @@ public final class WorkerFactory {
             workflowThreadPool,
             workflowClient.getOptions().getContextPropagators());
     workers.add(worker);
-    dispatcher.subscribe(taskQueue, worker.workflowWorker);
     return worker;
   }
 
@@ -196,6 +195,9 @@ public final class WorkerFactory {
 
     for (Worker worker : workers) {
       worker.start();
+      if (worker.workflowWorker.isStarted()) {
+        dispatcher.subscribe(worker.getTaskQueue(), worker.workflowWorker);
+      }
     }
 
     if (stickyPoller != null) {


### PR DESCRIPTION
Previously we've used to always initialize a sticky task queue dispatcher and start a sticky poller.
This caused problems like:
```
java.lang.NullPointerException: null
    	at io.temporal.internal.worker.WorkflowWorker.apply(WorkflowWorker.java:272) ~[service-1.0.jar:?]
    	at io.temporal.internal.sync.SyncWorkflowWorker.apply(SyncWorkflowWorker.java:215) ~[service-1.0.jar:?]
    	at io.temporal.internal.sync.SyncWorkflowWorker.apply(SyncWorkflowWorker.java:51) ~[service-1.0.jar:?]
    	at io.temporal.internal.worker.PollWorkflowTaskDispatcher.process(PollWorkflowTaskDispatcher.java:75) ~[service-1.0.jar:?]
    	at io.temporal.internal.worker.PollWorkflowTaskDispatcher.process(PollWorkflowTaskDispatcher.java:40) ~[service-1.0.jar:?]
    	at io.temporal.internal.worker.Poller$PollExecutionTask.run(Poller.java:277) ~[service-1.0.jar:?]
    	at io.temporal.internal.worker.Poller$PollLoopTask.run(Poller.java:242) [service-1.0.jar:?]
    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
    	at java.lang.Thread.run(Thread.java:834) [?:?]
```
In case if user would register a worker that doesn't have any activities alongside worker that doesn't have any workflows registered and would run them on the same task queue. This happened because if both workers are created using same factory object in the same java process they would be polling on the same sticky task queue and one of them wouldn't have workflow implementations registered. Furthermore since the same sticky task queue is used, latest registered worker would be the one registered with the dispatcher.

This fix addresses the problem by only subscribing workers to the sticky task queue dispatcher if they have workflows registered.

For more context read here:
https://community.temporal.io/t/timeouts-on-local-host-specific-task-queue/844/14