### PR TITLE
Fix flaky test that was relying on sleep

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -154,7 +154,6 @@ public class StickyWorkerTest {
     WorkflowExecutorCache cache = factory.getCache();
     assertNotNull(cache);
     assertEquals(0, cache.size()); // removed from cache on completion
-    Thread.sleep(100);
 
     // Verify the workflow succeeded without having to recover from a failure
     Map<String, String> tags =
@@ -163,6 +162,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "GreetingSignalWorkflow")
             .build();
+    metricsScope.close();
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 1);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
 

--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -253,9 +253,6 @@ public class StickyWorkerTest {
     w.TaskQueueName = taskQueueName;
     workflow.execute(w);
 
-    // Wait for reporter
-    Thread.sleep(600);
-
     // Verify the workflow succeeded without having to recover from a failure
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(9)
@@ -263,6 +260,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "ActivitiesWorkflow")
             .build();
+    metricsScope.close();
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 4);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
     // Finish Workflow
@@ -294,9 +292,6 @@ public class StickyWorkerTest {
     // Act
     Assert.assertEquals("Hello World!", workflow.getGreeting("World"));
 
-    // Wait for reporter
-    Thread.sleep(600);
-
     // Verify the workflow succeeded without having to recover from a failure
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(9)
@@ -304,6 +299,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "GreetingParentWorkflow")
             .build();
+    metricsScope.close();
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 2);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
     // Finish Workflow
@@ -343,9 +339,6 @@ public class StickyWorkerTest {
     String result = workflow.execute(taskQueueName);
     assertEquals("1234, 1234, 1234, 3456", result);
 
-    // Wait for reporter
-    Thread.sleep(600);
-
     // Verify the workflow succeeded without having to recover from a failure
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(9)
@@ -353,6 +346,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "TestMutableSideEffectWorkflow")
             .build();
+    metricsScope.close();
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 1);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
     // Finish Workflow

--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -162,7 +162,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "GreetingSignalWorkflow")
             .build();
-    metricsScope.close();
+    metricsScope.close(); // Flush metrics
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 1);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
 
@@ -260,7 +260,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "ActivitiesWorkflow")
             .build();
-    metricsScope.close();
+    metricsScope.close(); // Flush metrics
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 4);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
     // Finish Workflow
@@ -299,7 +299,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "GreetingParentWorkflow")
             .build();
-    metricsScope.close();
+    metricsScope.close(); // Flush metrics
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 2);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
     // Finish Workflow
@@ -346,7 +346,7 @@ public class StickyWorkerTest {
             .put(MetricsTag.TASK_QUEUE, taskQueueName)
             .put(MetricsTag.WORKFLOW_TYPE, "TestMutableSideEffectWorkflow")
             .build();
-    metricsScope.close();
+    metricsScope.close(); // Flush metrics
     reporter.assertCounter(MetricsType.STICKY_CACHE_HIT, tags, 1);
     reporter.assertNoMetric(MetricsType.STICKY_CACHE_MISS, tags);
     // Finish Workflow


### PR DESCRIPTION
Common flaky test that we've seen so far was StickyWorkerTest:
```
io.temporal.worker.StickyWorkerTest > whenStickyIsEnabledThenTheWorkflowIsCachedChildWorkflows[Docker] FAILED
    java.lang.AssertionError: 1 expected:<2> but was:<1>
```

This test has been relying on sleep in order to wait for the metric reporter to send metrics.
Instead we should just close metric scope, which closes reporter, flushing all metrics.

Verified multiple times locally that tests pass.