### PR TITLE
Stop using illegal reflective access for setting cause during exception

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
@@ -180,6 +180,9 @@ public class FailureConverter {
   }
 
   public static Failure exceptionToFailure(Throwable e) {
+    if (e instanceof CheckedExceptionWrapper) {
+      return exceptionToFailure(e.getCause());
+    }
     String message;
     if (e instanceof TemporalFailure) {
       TemporalFailure tf = (TemporalFailure) e;
@@ -189,9 +192,6 @@ public class FailureConverter {
       message = tf.getOriginalMessage();
     } else {
       message = e.getMessage() == null ? "" : e.getMessage();
-    }
-    if (e instanceof CheckedExceptionWrapper) {
-      return exceptionToFailure(e.getCause());
     }
     String stackTrace = serializeStackTrace(e);
     Failure.Builder failure =

--- a/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
@@ -180,11 +180,6 @@ public class FailureConverter {
   }
 
   public static Failure exceptionToFailure(Throwable e) {
-    e = CheckedExceptionWrapper.unwrap(e);
-    return exceptionToFailureNoUnwrapping(e);
-  }
-
-  public static Failure exceptionToFailureNoUnwrapping(Throwable e) {
     String message;
     if (e instanceof TemporalFailure) {
       TemporalFailure tf = (TemporalFailure) e;
@@ -195,11 +190,14 @@ public class FailureConverter {
     } else {
       message = e.getMessage() == null ? "" : e.getMessage();
     }
+    if (e instanceof CheckedExceptionWrapper) {
+      return exceptionToFailure(e.getCause());
+    }
     String stackTrace = serializeStackTrace(e);
     Failure.Builder failure =
         Failure.newBuilder().setMessage(message).setSource(JAVA_SDK).setStackTrace(stackTrace);
     if (e.getCause() != null) {
-      failure.setCause(exceptionToFailureNoUnwrapping(e.getCause()));
+      failure.setCause(exceptionToFailure(e.getCause()));
     }
     if (e instanceof ApplicationFailure) {
       ApplicationFailure ae = (ApplicationFailure) e;

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/CheckedExceptionWrapper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/CheckedExceptionWrapper.java
@@ -69,25 +69,11 @@ public final class CheckedExceptionWrapper extends RuntimeException {
   }
 
   /**
-   * Removes CheckedException wrapper from the whole chain of Exceptions. Assumes that wrapper
+   * Removes CheckedExceptionWrapper from the top of the chain of Exceptions. Assumes that wrapper
    * always has a cause which cannot be a wrapper.
    */
   public static Throwable unwrap(Throwable e) {
-    Throwable head = e;
-    if (head instanceof CheckedExceptionWrapper) {
-      head = head.getCause();
-    }
-    Throwable tail = head;
-    Throwable current = tail.getCause();
-    while (current != null) {
-      if (current instanceof CheckedExceptionWrapper) {
-        current = current.getCause();
-        setThrowableCause(tail, current);
-      }
-      tail = current;
-      current = tail.getCause();
-    }
-    return head;
+    return e instanceof CheckedExceptionWrapper ? e.getCause() : e;
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/CheckedExceptionWrapper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/CheckedExceptionWrapper.java
@@ -29,17 +29,6 @@ import java.lang.reflect.InvocationTargetException;
  */
 public final class CheckedExceptionWrapper extends RuntimeException {
 
-  private static final Field causeField;
-
-  static {
-    try {
-      causeField = Throwable.class.getDeclaredField("cause");
-      causeField.setAccessible(true);
-    } catch (NoSuchFieldException e) {
-      throw new RuntimeException("unexpected", e);
-    }
-  }
-
   /**
    * Returns CheckedExceptionWrapper if e is checked exception. If there is a need to return a
    * checked exception from an activity or workflow implementation throw a wrapped exception it
@@ -74,18 +63,6 @@ public final class CheckedExceptionWrapper extends RuntimeException {
    */
   public static Throwable unwrap(Throwable e) {
     return e instanceof CheckedExceptionWrapper ? e.getCause() : e;
-  }
-
-  /**
-   * Throwable.initCause throws IllegalStateException if cause is already set. This method uses
-   * reflection to set it directly.
-   */
-  private static void setThrowableCause(Throwable throwable, Throwable cause) {
-    try {
-      causeField.set(throwable, cause);
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException("unexpected", e);
-    }
   }
 
   private CheckedExceptionWrapper(Exception e) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -158,12 +158,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
               + ". If see continuously the workflow might be stuck.",
           e);
     }
-    Failure failure;
-    if (e instanceof Error) {
-      failure = FailureConverter.exceptionToFailureNoUnwrapping(e);
-    } else {
-      failure = FailureConverter.exceptionToFailure(e);
-    }
+    Failure failure = FailureConverter.exceptionToFailure(e);
     RespondWorkflowTaskFailedRequest failedRequest =
         RespondWorkflowTaskFailedRequest.newBuilder()
             .setTaskToken(workflowTask.getTaskToken())

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -27,7 +27,6 @@ import io.temporal.common.RetryOptions;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.ChildWorkflowFailure;
-import io.temporal.internal.common.CheckedExceptionWrapper;
 import io.temporal.internal.sync.WorkflowInternal;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Functions.Func;
@@ -812,9 +811,8 @@ public final class Workflow {
   /**
    * If there is a need to return a checked exception from a workflow implementation do not add the
    * exception to a method signature but wrap it using this method before rethrowing. The library
-   * code will unwrap it automatically using {@link #unwrap(Exception)} when propagating exception
-   * to a remote caller. {@link RuntimeException} are just returned from this method without
-   * modification.
+   * code will unwrap it automatically using when propagating exception to a remote caller. {@link
+   * RuntimeException} are just returned from this method without modification.
    *
    * <p>The reason for such design is that returning originally thrown exception from a remote call
    * (which child workflow and activity invocations are ) would not allow adding context information
@@ -841,21 +839,6 @@ public final class Workflow {
    */
   public static RuntimeException wrap(Exception e) {
     return WorkflowInternal.wrap(e);
-  }
-
-  /**
-   * Removes {@link io.temporal.internal.common.CheckedExceptionWrapper} from causal exception
-   * chain.
-   *
-   * @param e exception with causality chain that might contain wrapped exceptions.
-   * @return exception causality chain with CheckedExceptionWrapper removed.
-   */
-  public static Exception unwrap(Exception e) {
-    Throwable unwrapped = CheckedExceptionWrapper.unwrap(e);
-    if (unwrapped instanceof Error) {
-      throw (Error) unwrapped;
-    }
-    return (Exception) unwrapped;
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/RetryerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/RetryerTest.java
@@ -103,8 +103,9 @@ public class RetryerTest {
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
-      assertTrue(e.getCause() instanceof InterruptedException);
-      assertEquals("simulated", e.getCause().getMessage());
+      assertTrue(e.getCause() instanceof CheckedExceptionWrapper);
+      assertTrue(e.getCause().getCause() instanceof InterruptedException);
+      assertEquals("simulated", e.getCause().getCause().getMessage());
     }
     assertTrue(System.currentTimeMillis() - start < 100000);
   }

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/CheckedExceptionWrapperTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/CheckedExceptionWrapperTest.java
@@ -49,8 +49,9 @@ public class CheckedExceptionWrapperTest {
     } catch (Exception e) {
       Throwable result = CheckedExceptionWrapper.unwrap(e);
       Assert.assertEquals("2", result.getMessage());
-      Assert.assertEquals("1", result.getCause().getMessage());
-      Assert.assertNull(result.getCause().getCause());
+      Assert.assertEquals("java.lang.Exception: 1", result.getCause().getMessage());
+      Assert.assertEquals("1", result.getCause().getCause().getMessage());
+      Assert.assertNull(result.getCause().getCause().getCause());
     }
     Exception e = new Exception("5");
     Throwable eu = CheckedExceptionWrapper.unwrap(e);

--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -105,7 +105,7 @@ public class StickyWorkerTest {
     metricsScope =
         new RootScopeBuilder()
             .reporter(reporter)
-            .reportEvery(com.uber.m3.util.Duration.ofMillis(10));
+            .reportEvery(com.uber.m3.util.Duration.ofSeconds(10));
   }
 
   @After

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -2815,7 +2815,7 @@ public class WorkflowTest {
           // Errors cause workflow task to fail. But we want workflow to fail in this case.
           throw new RuntimeException(ae);
         }
-        Exception fnf = new FileNotFoundException();
+        Exception fnf = new FileNotFoundException("simulated exception");
         fnf.initCause(e);
         throw Workflow.wrap(fnf);
       }


### PR DESCRIPTION
This change removes illegal reflective access to the cause field in the `CheckedExceptionWrapper` replacing it with shallow unwrapping of the exception plus full unwrapping during serialization.

The reason we need to keep shallow unwrapping instead of getting rid of it entirely is because there are a few places in the pre-serialization code that either log or conduct actions based on the client exception. Look at [POJOWorkflowImplementationFactory](https://github.com/temporalio/sdk-java/blob/30420212a26283cf7cbe6339512058a3186074e8/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java#L297) and [POJOActivityTaskHandler](https://github.com/temporalio/sdk-java/blob/8fba0454392a79d7371f103bc8fb084c1be8ae68/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java#L330) as examples.

One tradeoff that we have to make here is whether or not we want to eliminate a possibility of client seeing CheckedExceptionWrapper as current approach doesn't guarantee that and if there are multiple layers of wrappers inner layers might be visible in the log, logged by POJOActivityTaskHandler. Preferred way to solve it could be by transforming that exception to Failure before logging, alternatively we could reimplement unwrap by serializing to failure and back, which would eliminate all exception wrappers in the process.