### PR TITLE
Add a gradle task that cleans all sub-projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,3 +74,14 @@ subprojects {
     }
 }
 //logging.captureStandardOutput LogLevel.INFO
+
+task clean {
+    subprojects.each {
+        it.afterEvaluate {
+            def cleanTask = it.tasks.findByName('clean')
+            if (cleanTask) {
+                dependsOn(cleanTask)
+            }
+        }
+    }
+}


### PR DESCRIPTION
We've ran into a confusing situation when generated files were left over after upgrading to a new version of protobuf files. Running clean from the root project didn't help either as generated code is located under `temporal-serviceclient/build`.
This change makes top level clean to also clean sub-projects.