### PR TITLE
Upgrade dependencies and gradle version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'de.marcphilipp.nexus-publish' version '0.4.0'
-    id 'name.remal.check-updates' version '1.1.4'
+    id 'name.remal.check-updates' version '1.1.6'
 }
 
 apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
@@ -41,12 +41,12 @@ dependencies {
 
     api project(':temporal-serviceclient')
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
-    api group: 'io.micrometer', name: 'micrometer-core', version: '1.6.0'
+    api group: 'io.micrometer', name: 'micrometer-core', version: '1.6.2'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.0-jre'
-    implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.1'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.3'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.3'
+    implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.0'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.0'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -2,19 +2,19 @@
 
 buildscript {
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.13'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.14'
     }
 }
 
 plugins {
-    id 'com.google.protobuf' version '0.8.13'
+    id 'com.google.protobuf' version '0.8.14'
     id 'java-library'
     id 'net.ltgt.errorprone' version '1.3.0'
     id 'net.minecrell.licenser' version '0.4.1'
     id 'maven-publish'
     id 'signing'
     id 'de.marcphilipp.nexus-publish' version '0.4.0'
-    id 'name.remal.check-updates' version '1.1.4'
+    id 'name.remal.check-updates' version '1.1.6'
 }
 
 apply plugin: 'com.google.protobuf'
@@ -77,14 +77,14 @@ dependencies {
     errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
     errorprone('com.google.errorprone:error_prone_core:2.4.0')
 
-    api 'io.grpc:grpc-protobuf:1.33.1'
-    api 'io.grpc:grpc-stub:1.33.1'
-    api 'io.grpc:grpc-core:1.33.1'
-    api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.13.0'
+    api 'io.grpc:grpc-protobuf:1.34.0'
+    api 'io.grpc:grpc-stub:1.34.0'
+    api 'io.grpc:grpc-core:1.34.0'
+    api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.14.0'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
 
-    implementation 'io.grpc:grpc-netty-shaded:1.33.1'
+    implementation 'io.grpc:grpc-netty-shaded:1.34.0'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
@@ -124,11 +124,11 @@ jar {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.13.0'
+        artifact = 'com.google.protobuf:protoc:3.14.0'
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.33.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.34.0'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
Before:
```
❯ ./gradlew checkUpdates

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.cronutils:cron-utils: 9.1.1 -> 9.1.3
New dependency version: com.fasterxml.jackson.core:jackson-databind: 2.11.3 -> 2.12.0
New dependency version: com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.11.3 -> 2.12.0
New dependency version: io.micrometer:micrometer-core: 1.6.0 -> 1.6.2
New dependency version: name.remal.check-updates:name.remal.check-updates.gradle.plugin: 1.1.4 -> 1.1.6

> Task :temporal-sdk:checkGradleUpdates
New Gradle version is available: 6.7.1 (downloadUrl: https://services.gradle.org/distributions/gradle-6.7.1-bin.zip)

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.google.protobuf:com.google.protobuf.gradle.plugin: 0.8.13 -> 0.8.14
New dependency version: com.google.protobuf:protobuf-gradle-plugin: 0.8.13 -> 0.8.14
New dependency version: com.google.protobuf:protobuf-java-util: 3.13.0 -> 3.14.0
New dependency version: com.google.protobuf:protoc: 3.13.0 -> 3.14.0
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.9.1
New dependency version: io.grpc:grpc-core: 1.33.1 -> 1.34.0
New dependency version: io.grpc:grpc-netty-shaded: 1.33.1 -> 1.34.0
New dependency version: io.grpc:grpc-protobuf: 1.33.1 -> 1.34.0
New dependency version: io.grpc:grpc-stub: 1.33.1 -> 1.34.0
New dependency version: io.grpc:protoc-gen-grpc-java: 1.33.1 -> 1.34.0
New dependency version: name.remal.check-updates:name.remal.check-updates.gradle.plugin: 1.1.4 -> 1.1.6

> Task :temporal-serviceclient:checkGradleUpdates
New Gradle version is available: 6.7.1 (downloadUrl: https://services.gradle.org/distributions/gradle-6.7.1-bin.zip)


```


After:
```
❯ ./gradlew checkUpdates

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.9.1

```