### PR TITLE
Add namespace to requests where it was missing

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientFactoryImpl.java
@@ -69,7 +69,8 @@ public class ManualActivityCompletionClientFactoryImpl
     if (taskToken == null || taskToken.length == 0) {
       throw new IllegalArgumentException("null or empty task token");
     }
-    return new ManualActivityCompletionClientImpl(service, taskToken, dataConverter, metricsScope);
+    return new ManualActivityCompletionClientImpl(
+        service, namespace, taskToken, dataConverter, metricsScope);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientImpl.java
@@ -59,13 +59,14 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
 
   ManualActivityCompletionClientImpl(
       WorkflowServiceStubs service,
+      String namespace,
       byte[] taskToken,
       DataConverter dataConverter,
       Scope metricsScope) {
     this.service = service;
     this.taskToken = taskToken;
     this.dataConverter = dataConverter;
-    this.namespace = null;
+    this.namespace = namespace;
     this.execution = null;
     this.activityId = null;
     this.metricsScope = metricsScope;
@@ -93,6 +94,7 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
     if (taskToken != null) {
       RespondActivityTaskCompletedRequest.Builder request =
           RespondActivityTaskCompletedRequest.newBuilder()
+              .setNamespace(namespace)
               .setTaskToken(ByteString.copyFrom(taskToken));
       if (convertedResult.isPresent()) {
         request.setResult(convertedResult.get());
@@ -152,6 +154,7 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       RespondActivityTaskFailedRequest request =
           RespondActivityTaskFailedRequest.newBuilder()
               .setFailure(FailureConverter.exceptionToFailure(exception))
+              .setNamespace(namespace)
               .setTaskToken(ByteString.copyFrom(taskToken))
               .build();
       try {
@@ -207,10 +210,8 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
     if (taskToken != null) {
       RecordActivityTaskHeartbeatRequest.Builder request =
           RecordActivityTaskHeartbeatRequest.newBuilder()
+              .setNamespace(namespace)
               .setTaskToken(ByteString.copyFrom(taskToken));
-      if (namespace != null) {
-        request.setNamespace(namespace);
-      }
       if (convertedDetails.isPresent()) {
         request.setDetails(convertedDetails.get());
       }
@@ -269,6 +270,7 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
     if (taskToken != null) {
       RespondActivityTaskCanceledRequest.Builder request =
           RespondActivityTaskCanceledRequest.newBuilder()
+              .setNamespace(namespace)
               .setTaskToken(ByteString.copyFrom(taskToken));
       if (convertedDetails.isPresent()) {
         request.setDetails(convertedDetails.get());

--- a/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientImpl.java
@@ -27,16 +27,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatByIdRequest;
-import io.temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatByIdResponse;
-import io.temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest;
-import io.temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatResponse;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskCanceledByIdRequest;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskCompletedByIdRequest;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskFailedByIdRequest;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest;
+import io.temporal.api.workflowservice.v1.*;
 import io.temporal.client.ActivityCanceledException;
 import io.temporal.client.ActivityCompletionFailureException;
 import io.temporal.client.ActivityNotExistsException;
@@ -217,6 +208,9 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       RecordActivityTaskHeartbeatRequest.Builder request =
           RecordActivityTaskHeartbeatRequest.newBuilder()
               .setTaskToken(ByteString.copyFrom(taskToken));
+      if (namespace != null) {
+        request.setNamespace(namespace);
+      }
       if (convertedDetails.isPresent()) {
         request.setDetails(convertedDetails.get());
       }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -127,6 +127,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
           RespondWorkflowTaskCompletedRequest.newBuilder()
               .setTaskToken(workflowTask.getTaskToken())
               .setIdentity(options.getIdentity())
+              .setNamespace(namespace)
               .setBinaryChecksum(options.getBinaryChecksum())
               .addCommands(
                   Command.newBuilder()
@@ -243,7 +244,9 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
   private Result handleQueryOnlyWorkflowTask(
       PollWorkflowTaskQueueResponse.Builder workflowTask, Scope metricsScope) {
     RespondQueryTaskCompletedRequest.Builder queryCompletedRequest =
-        RespondQueryTaskCompletedRequest.newBuilder().setTaskToken(workflowTask.getTaskToken());
+        RespondQueryTaskCompletedRequest.newBuilder()
+            .setTaskToken(workflowTask.getTaskToken())
+            .setNamespace(namespace);
     WorkflowExecution execution = workflowTask.getWorkflowExecution();
     String runId = execution.getRunId();
     WorkflowRunTaskHandler workflowRunTaskHandler = null;

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -206,7 +206,9 @@ public final class ActivityWorker implements SuspendableWorker {
         if (failure.hasCanceledFailureInfo()) {
           CanceledFailureInfo info = failure.getCanceledFailureInfo();
           RespondActivityTaskCanceledRequest.Builder canceledRequest =
-              RespondActivityTaskCanceledRequest.newBuilder().setIdentity(options.getIdentity());
+              RespondActivityTaskCanceledRequest.newBuilder()
+                  .setIdentity(options.getIdentity())
+                  .setNamespace(namespace);
           if (info.hasDetails()) {
             canceledRequest.setDetails(info.getDetails());
           }
@@ -268,6 +270,7 @@ public final class ActivityWorker implements SuspendableWorker {
                 .toBuilder()
                 .setTaskToken(task.getTaskToken())
                 .setIdentity(options.getIdentity())
+                .setNamespace(namespace)
                 .build();
         GrpcRetryer.retry(
             ro,
@@ -286,6 +289,7 @@ public final class ActivityWorker implements SuspendableWorker {
                   .toBuilder()
                   .setTaskToken(task.getTaskToken())
                   .setIdentity(options.getIdentity())
+                  .setNamespace(namespace)
                   .build();
           ro = RpcRetryOptions.newBuilder().setRetryOptions(ro).validateBuildWithDefaults();
 
@@ -304,6 +308,7 @@ public final class ActivityWorker implements SuspendableWorker {
                     .toBuilder()
                     .setTaskToken(task.getTaskToken())
                     .setIdentity(options.getIdentity())
+                    .setNamespace(namespace)
                     .build();
             ro = RpcRetryOptions.newBuilder().setRetryOptions(ro).validateBuildWithDefaults();
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -357,6 +357,7 @@ public final class WorkflowWorker
             taskCompleted
                 .toBuilder()
                 .setIdentity(options.getIdentity())
+                .setNamespace(namespace)
                 .setBinaryChecksum(options.getBinaryChecksum())
                 .setTaskToken(taskToken)
                 .build();
@@ -388,6 +389,7 @@ public final class WorkflowWorker
               taskFailed
                   .toBuilder()
                   .setIdentity(options.getIdentity())
+                  .setNamespace(namespace)
                   .setTaskToken(taskToken)
                   .build();
           GrpcRetryer.retry(
@@ -400,7 +402,8 @@ public final class WorkflowWorker
         } else {
           RespondQueryTaskCompletedRequest queryCompleted = response.getQueryCompleted();
           if (queryCompleted != null) {
-            queryCompleted = queryCompleted.toBuilder().setTaskToken(taskToken).build();
+            queryCompleted =
+                queryCompleted.toBuilder().setTaskToken(taskToken).setNamespace(namespace).build();
             // Do not retry query response.
             service
                 .blockingStub()

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -116,7 +116,10 @@ public final class WorkerFactory {
                 .put(MetricsTag.TASK_QUEUE, "sticky")
                 .build());
     dispatcher =
-        new PollWorkflowTaskDispatcher(workflowClient.getWorkflowServiceStubs(), metricsScope);
+        new PollWorkflowTaskDispatcher(
+            workflowClient.getWorkflowServiceStubs(),
+            workflowClient.getOptions().getNamespace(),
+            metricsScope);
     stickyPoller =
         new Poller<>(
             id.toString(),

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/PollWorkflowTaskDispatcherTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/PollWorkflowTaskDispatcherTests.java
@@ -76,7 +76,8 @@ public class PollWorkflowTaskDispatcherTests {
     AtomicBoolean handled = new AtomicBoolean(false);
     Functions.Proc1<PollWorkflowTaskQueueResponse> handler = r -> handled.set(true);
 
-    PollWorkflowTaskDispatcher dispatcher = new PollWorkflowTaskDispatcher(service, metricsScope);
+    PollWorkflowTaskDispatcher dispatcher =
+        new PollWorkflowTaskDispatcher(service, "default", metricsScope);
     dispatcher.subscribe("taskqueue1", handler);
 
     // Act
@@ -97,7 +98,8 @@ public class PollWorkflowTaskDispatcherTests {
     Functions.Proc1<PollWorkflowTaskQueueResponse> handler = r -> handled.set(true);
     Functions.Proc1<PollWorkflowTaskQueueResponse> handler2 = r -> handled2.set(true);
 
-    PollWorkflowTaskDispatcher dispatcher = new PollWorkflowTaskDispatcher(service, metricsScope);
+    PollWorkflowTaskDispatcher dispatcher =
+        new PollWorkflowTaskDispatcher(service, "default", metricsScope);
     dispatcher.subscribe("taskqueue1", handler);
     dispatcher.subscribe("taskqueue2", handler2);
 
@@ -120,7 +122,8 @@ public class PollWorkflowTaskDispatcherTests {
     Functions.Proc1<PollWorkflowTaskQueueResponse> handler = r -> handled.set(true);
     Functions.Proc1<PollWorkflowTaskQueueResponse> handler2 = r -> handled2.set(true);
 
-    PollWorkflowTaskDispatcher dispatcher = new PollWorkflowTaskDispatcher(service, metricsScope);
+    PollWorkflowTaskDispatcher dispatcher =
+        new PollWorkflowTaskDispatcher(service, "default", metricsScope);
     dispatcher.subscribe("taskqueue1", handler);
     dispatcher.subscribe("taskqueue1", handler2);
 
@@ -153,7 +156,7 @@ public class PollWorkflowTaskDispatcherTests {
     when(mockService.blockingStub()).thenReturn(stub);
 
     PollWorkflowTaskDispatcher dispatcher =
-        new PollWorkflowTaskDispatcher(mockService, metricsScope);
+        new PollWorkflowTaskDispatcher(mockService, "default", metricsScope);
     dispatcher.subscribe("taskqueue1", handler);
 
     // Act


### PR DESCRIPTION
Similarly to [this PR](https://github.com/temporalio/sdk-go/pull/304) in go SDK, we are populating namespace field where it was missing.

Related proto changes in the API repo are [#101](https://github.com/temporalio/api/pull/101) and [#102](https://github.com/temporalio/api/pull/102).