### PR TITLE
Apply time unit in cancellable scope

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/CompletablePromiseImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/CompletablePromiseImpl.java
@@ -26,6 +26,7 @@ import io.temporal.workflow.Functions;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -111,7 +112,7 @@ class CompletablePromiseImpl<V> implements CompletablePromise<V> {
       throws TimeoutException {
     if (!completed) {
       WorkflowInternal.await(
-          Duration.ofMillis(timeout),
+          Duration.ofMillis(unit.toMillis(timeout)),
           "Feature.get",
           () -> {
             if (cancellable) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/CompletablePromiseImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/CompletablePromiseImpl.java
@@ -26,7 +26,6 @@ import io.temporal.workflow.Functions;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -178,8 +178,8 @@ public final class WorkerOptions {
     }
 
     /**
-     * If set to true worker would only handle workflow tasks and local activities.
-     * Non-local activities will not be executed by this worker.
+     * If set to true worker would only handle workflow tasks and local activities. Non-local
+     * activities will not be executed by this worker.
      *
      * <p>Default is false.
      */


### PR DESCRIPTION
See [this thread](https://community.temporal.io/t/completablepromiseimpl-cancellablegetimpl-ignores-timeunit-parameter/1210) for more context.