### PR TITLE
Updating dependencies to the latest

### DIFF
--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     api group: 'io.micrometer', name: 'micrometer-core', version: '1.6.2'
 
-    implementation group: 'com.google.guava', name: 'guava', version: '30.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.3'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.0'

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -77,14 +77,14 @@ dependencies {
     errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
     errorprone('com.google.errorprone:error_prone_core:2.4.0')
 
-    api 'io.grpc:grpc-protobuf:1.34.0'
-    api 'io.grpc:grpc-stub:1.34.0'
-    api 'io.grpc:grpc-core:1.34.0'
+    api 'io.grpc:grpc-protobuf:1.34.1'
+    api 'io.grpc:grpc-stub:1.34.1'
+    api 'io.grpc:grpc-core:1.34.1'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.14.0'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
 
-    implementation 'io.grpc:grpc-netty-shaded:1.34.0'
+    implementation 'io.grpc:grpc-netty-shaded:1.34.1'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
@@ -128,7 +128,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.34.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
Before:
```
❯ ./gradlew checkUpdates

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.google.guava:guava: 30.0-jre -> 30.1-jre

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.9.1
New dependency version: io.grpc:grpc-core: 1.34.0 -> 1.34.1
New dependency version: io.grpc:grpc-netty-shaded: 1.34.0 -> 1.34.1
New dependency version: io.grpc:grpc-protobuf: 1.34.0 -> 1.34.1
New dependency version: io.grpc:grpc-stub: 1.34.0 -> 1.34.1
New dependency version: io.grpc:protoc-gen-grpc-java: 1.34.0 -> 1.34.1

```

After:
```
❯ ./gradlew checkUpdates

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.9.1


```