### PR TITLE
Add support for MaxConcurrentActivityExecutionSize for async activities

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
@@ -23,7 +23,6 @@ import com.uber.m3.tally.Scope;
 import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.worker.WorkerOptions;
-
 import java.lang.reflect.Type;
 import java.util.Optional;
 

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
@@ -20,7 +20,10 @@
 package io.temporal.activity;
 
 import com.uber.m3.tally.Scope;
+import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.ActivityCompletionException;
+import io.temporal.worker.WorkerOptions;
+
 import java.lang.reflect.Type;
 import java.util.Optional;
 
@@ -88,6 +91,19 @@ public interface ActivityExecutionContext {
   void doNotCompleteOnReturn();
 
   boolean isDoNotCompleteOnReturn();
+
+  /** Returns true if {@link #useLocalManualCompletion()} method has been called on this context. */
+  boolean isUseLocalManualCompletion();
+
+  /**
+   * Local manual completion, sets {@link #doNotCompleteOnReturn()} flag making activity completion
+   * asynchronous, also returns completion client. Returned completion client must be used to
+   * complete the activity on the same machine. Main difference from calling {@link
+   * #doNotCompleteOnReturn()} directly is that by using this method maximum number of concurrent
+   * activities defined by {@link WorkerOptions#getMaxConcurrentActivityExecutionSize()} will be
+   * respected.
+   */
+  ActivityCompletionClient useLocalManualCompletion();
 
   Scope getMetricsScope();
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityExecutionContextBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityExecutionContextBase.java
@@ -22,6 +22,7 @@ package io.temporal.common.interceptors;
 import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.activity.ActivityInfo;
+import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.ActivityCompletionException;
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -67,6 +68,16 @@ public class ActivityExecutionContextBase implements ActivityExecutionContext {
   @Override
   public boolean isDoNotCompleteOnReturn() {
     return next.isDoNotCompleteOnReturn();
+  }
+
+  @Override
+  public boolean isUseLocalManualCompletion() {
+    return next.isUseLocalManualCompletion();
+  }
+
+  @Override
+  public ActivityCompletionClient useLocalManualCompletion() {
+    return next.useLocalManualCompletion();
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/external/ManualActivityCompletionClientImpl.java
@@ -238,6 +238,7 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       RecordActivityTaskHeartbeatByIdRequest.Builder request =
           RecordActivityTaskHeartbeatByIdRequest.newBuilder()
               .setWorkflowId(execution.getWorkflowId())
+              .setNamespace(namespace)
               .setRunId(execution.getRunId())
               .setActivityId(activityId);
       if (convertedDetails.isPresent()) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityCompletionClientImpl.java
@@ -24,7 +24,6 @@ import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.internal.external.ManualActivityCompletionClientFactory;
 import io.temporal.workflow.Functions;
-
 import java.util.Optional;
 
 class ActivityCompletionClientImpl implements ActivityCompletionClient {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityCompletionClientImpl.java
@@ -24,6 +24,7 @@ import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.internal.external.ManualActivityCompletionClientFactory;
 import io.temporal.workflow.Functions;
+
 import java.util.Optional;
 
 class ActivityCompletionClientImpl implements ActivityCompletionClient {
@@ -96,21 +97,13 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   @Override
   public <V> void heartbeat(byte[] taskToken, V details) throws ActivityCompletionException {
-    try {
-      factory.getClient(taskToken).recordHeartbeat(details);
-    } finally {
-      completionHandle.apply();
-    }
+    factory.getClient(taskToken).recordHeartbeat(details);
   }
 
   @Override
   public <V> void heartbeat(String workflowId, Optional<String> runId, String activityId, V details)
       throws ActivityCompletionException {
-    try {
-      factory.getClient(toExecution(workflowId, runId), activityId).recordHeartbeat(details);
-    } finally {
-      completionHandle.apply();
-    }
+    factory.getClient(toExecution(workflowId, runId), activityId).recordHeartbeat(details);
   }
 
   Functions.Proc getCompletionHandle() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityExecutionContextImpl.java
@@ -37,6 +37,7 @@ import io.temporal.client.ActivityNotExistsException;
 import io.temporal.client.ActivityWorkerShutdownException;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.OptionsUtils;
+import io.temporal.internal.external.ManualActivityCompletionClientFactory;
 import io.temporal.internal.external.ManualActivityCompletionClientFactoryImpl;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.workflow.Functions;
@@ -75,7 +76,7 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
   private final Lock lock = new ReentrantLock();
   private ScheduledFuture future;
   private ActivityCompletionException lastException;
-  private final ManualActivityCompletionClientFactoryImpl manualCompletionClientFactory;
+  private final ManualActivityCompletionClientFactory manualCompletionClientFactory;
   private Functions.Proc completionHandle;
   private boolean useLocalManualCompletion;
 
@@ -241,11 +242,21 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
 
   @Override
   public boolean isDoNotCompleteOnReturn() {
-    return doNotCompleteOnReturn;
+    lock.lock();
+    try {
+      return doNotCompleteOnReturn;
+    } finally {
+      lock.unlock();
+    }
   }
 
   public boolean isUseLocalManualCompletion() {
-    return useLocalManualCompletion;
+    lock.lock();
+    try {
+      return useLocalManualCompletion;
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityExecutionContextImpl.java
@@ -231,7 +231,12 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
 
   @Override
   public void doNotCompleteOnReturn() {
-    doNotCompleteOnReturn = true;
+    lock.lock();
+    try {
+      doNotCompleteOnReturn = true;
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override
@@ -245,9 +250,14 @@ class ActivityExecutionContextImpl implements ActivityExecutionContext {
 
   @Override
   public ActivityCompletionClient useLocalManualCompletion() {
-    doNotCompleteOnReturn();
-    useLocalManualCompletion = true;
-    return new ActivityCompletionClientImpl(manualCompletionClientFactory, completionHandle);
+    lock.lock();
+    try {
+      doNotCompleteOnReturn();
+      useLocalManualCompletion = true;
+      return new ActivityCompletionClientImpl(manualCompletionClientFactory, completionHandle);
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInfoImpl.java
@@ -24,6 +24,7 @@ import io.temporal.activity.ActivityInfo;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,12 +33,17 @@ final class ActivityInfoImpl implements ActivityInfo {
   private final PollActivityTaskQueueResponse response;
   private final String activityNamespace;
   private final boolean local;
+  private final Functions.Proc completionHandle;
 
   ActivityInfoImpl(
-      PollActivityTaskQueueResponse response, String activityNamespace, boolean local) {
+      PollActivityTaskQueueResponse response,
+      String activityNamespace,
+      boolean local,
+      Functions.Proc completionHandle) {
     this.response = Objects.requireNonNull(response);
     this.activityNamespace = Objects.requireNonNull(activityNamespace);
     this.local = local;
+    this.completionHandle = completionHandle;
   }
 
   public byte[] getTaskToken() {
@@ -116,6 +122,10 @@ final class ActivityInfoImpl implements ActivityInfo {
   @Override
   public boolean isLocal() {
     return local;
+  }
+
+  public Functions.Proc getCompletionHandle() {
+    return completionHandle;
   }
 
   public Optional<Payloads> getInput() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/LocalActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/LocalActivityExecutionContextImpl.java
@@ -22,6 +22,7 @@ package io.temporal.internal.sync;
 import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.activity.ActivityInfo;
+import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.ActivityCompletionException;
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -70,6 +71,18 @@ class LocalActivityExecutionContextImpl implements ActivityExecutionContext {
   public boolean isDoNotCompleteOnReturn() {
     throw new UnsupportedOperationException(
         "isDoNotCompleteOnReturn is not supported for local activities");
+  }
+
+  @Override
+  public boolean isUseLocalManualCompletion() {
+    throw new UnsupportedOperationException(
+        "isUseLocalManualCompletion is not supported for local activities");
+  }
+
+  @Override
+  public ActivityCompletionClient useLocalManualCompletion() {
+    throw new UnsupportedOperationException(
+        "getManualCompletionClient is not supported for local activities");
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/TestActivityEnvironmentInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/TestActivityEnvironmentInternal.java
@@ -47,6 +47,7 @@ import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.FailureConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.internal.worker.ActivityTask;
 import io.temporal.internal.worker.ActivityTaskHandler;
 import io.temporal.internal.worker.ActivityTaskHandler.Result;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -259,7 +260,8 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
       }
       PollActivityTaskQueueResponse task = taskBuilder.build();
       Result taskResult =
-          activityTaskHandler.handle(task, testEnvironmentOptions.getMetricsScope(), false);
+          activityTaskHandler.handle(
+              new ActivityTask(task, () -> {}), testEnvironmentOptions.getMetricsScope(), false);
       return Workflow.newPromise(getReply(task, taskResult, resultClass, resultType));
     }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
@@ -195,7 +195,7 @@ public final class WorkflowClientInternal implements WorkflowClient {
   @Override
   public ActivityCompletionClient newActivityCompletionClient() {
     ActivityCompletionClient result =
-        new ActivityCompletionClientImpl(manualActivityCompletionClientFactory);
+        new ActivityCompletionClientImpl(manualActivityCompletionClientFactory, () -> {});
     for (WorkflowClientInterceptor i : interceptors) {
       result = i.newActivityCompletionClient(result);
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTask.java
@@ -22,7 +22,7 @@ package io.temporal.internal.worker;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.workflow.Functions;
 
-final class ActivityTask {
+public final class ActivityTask {
   private final PollActivityTaskQueueResponse response;
   private final Functions.Proc completionHandle;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTaskHandler.java
@@ -20,7 +20,6 @@
 package io.temporal.internal.worker;
 
 import com.uber.m3.tally.Scope;
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest;
@@ -41,6 +40,7 @@ public interface ActivityTaskHandler {
     private final TaskFailedResult taskFailed;
     private final RespondActivityTaskCanceledRequest taskCanceled;
     private final RpcRetryOptions requestRetryOptions;
+    private final boolean manualCompletion;
     private int attempt;
     private Duration backoff;
 
@@ -92,12 +92,14 @@ public interface ActivityTaskHandler {
         RespondActivityTaskCompletedRequest taskCompleted,
         TaskFailedResult taskFailed,
         RespondActivityTaskCanceledRequest taskCanceled,
-        RpcRetryOptions requestRetryOptions) {
+        RpcRetryOptions requestRetryOptions,
+        boolean manualCompletion) {
       this.activityId = activityId;
       this.taskCompleted = taskCompleted;
       this.taskFailed = taskFailed;
       this.taskCanceled = taskCanceled;
       this.requestRetryOptions = requestRetryOptions;
+      this.manualCompletion = manualCompletion;
     }
 
     public String getActivityId() {
@@ -135,6 +137,10 @@ public interface ActivityTaskHandler {
     public Duration getBackoff() {
       return backoff;
     }
+
+    public boolean isManualCompletion() {
+      return manualCompletion;
+    }
   }
 
   /**
@@ -145,8 +151,7 @@ public interface ActivityTaskHandler {
    * @param activityTask activity task which is response to PollActivityTaskQueue call.
    * @return One of the possible activity task replies.
    */
-  Result handle(
-      PollActivityTaskQueueResponse activityTask, Scope metricsScope, boolean isLocalActivity);
+  Result handle(ActivityTask activityTask, Scope metricsScope, boolean isLocalActivity);
 
   /** True if this handler handles at least one activity type. */
   boolean isAnyTypeSupported();

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -220,7 +220,8 @@ public final class LocalActivityWorker implements SuspendableWorker {
       metricsScope.counter(MetricsType.LOCAL_ACTIVITY_TOTAL_COUNTER).inc(1);
 
       Stopwatch sw = metricsScope.timer(MetricsType.LOCAL_ACTIVITY_EXECUTION_LATENCY).start();
-      ActivityTaskHandler.Result result = handler.handle(activityTask.build(), metricsScope, true);
+      ActivityTaskHandler.Result result =
+          handler.handle(new ActivityTask(activityTask.build(), () -> {}), metricsScope, true);
       sw.stop();
       int attempt = activityTask.getAttempt();
       result.setAttempt(attempt);

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -172,7 +172,8 @@ public class LocalActivityStateMachineTest {
               RespondActivityTaskCompletedRequest.newBuilder().setResult(result2).build(),
               null,
               null,
-              null);
+              null,
+              false);
       stateMachines.handleLocalActivityCompletion(completionActivity2);
       requests = stateMachines.takeLocalActivityRequests();
       assertEquals(1, requests.size());
@@ -185,7 +186,8 @@ public class LocalActivityStateMachineTest {
               RespondActivityTaskCompletedRequest.newBuilder().setResult(result3).build(),
               null,
               null,
-              null);
+              null,
+              false);
       stateMachines.handleLocalActivityCompletion(completionActivity3);
       requests = stateMachines.takeLocalActivityRequests();
       assertTrue(requests.isEmpty());
@@ -223,7 +225,8 @@ public class LocalActivityStateMachineTest {
               RespondActivityTaskCompletedRequest.newBuilder().setResult(result).build(),
               null,
               null,
-              null);
+              null,
+              false);
       stateMachines.handleLocalActivityCompletion(completionActivity1);
       requests = stateMachines.takeLocalActivityRequests();
       assertTrue(requests.isEmpty());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
@@ -28,14 +28,13 @@ import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.worker.WorkerOptions;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class LocalAsyncCompletionWorkflowTest {
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
@@ -28,13 +28,14 @@ import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.worker.WorkerOptions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
 
 public class LocalAsyncCompletionWorkflowTest {
 
@@ -85,7 +86,7 @@ public class LocalAsyncCompletionWorkflowTest {
         if (promise.getFailure() != null) {
           return "exception";
         }
-        if (promise.get() != 4) {
+        if (promise.get() != 4) { // All activities compute 2 * 2
           return "wrong result";
         }
       }
@@ -127,9 +128,9 @@ public class LocalAsyncCompletionWorkflowTest {
   }
 
   /**
-   * This test runs a workflow that executes multiple activities in the single handler thread. Test
-   * workflow is configured to fail with heartbeat timeout errors in case if activity pollers are
-   * too eager to poll tasks before previously fetched tasks are handled.
+   * This test runs 10 async activities in parallel. The expectation is that
+   * MAX_CONCURRENT_ACTIVITIES limit is being respected and only 1 activity should be running at the
+   * same time.
    */
   @Test
   public void verifyLocalActivityCompletionRespectsConcurrencySettings() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityExecutionContext;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.ActivityCompletionClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.worker.WorkerOptions;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LocalAsyncCompletionWorkflowTest {
+
+  public static final int MAX_CONCURRENT_ACTIVITIES = 1;
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkerOptions(
+              WorkerOptions.newBuilder()
+                  .setMaxConcurrentActivityExecutionSize(MAX_CONCURRENT_ACTIVITIES)
+                  .setActivityPollThreadCount(5)
+                  .build())
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(new AsyncActivityWithManualCompletion())
+          .setUseExternalService(Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE")))
+          .setTarget(System.getenv("TEMPORAL_SERVICE_ADDRESS"))
+          .build();
+
+  private static final AtomicInteger concurrentActivitiesCount = new AtomicInteger(0);
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+
+    @WorkflowMethod
+    String execute(String taskQueue);
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflow {
+
+    @Override
+    public String execute(String taskQueue) {
+      TestActivity activity =
+          Workflow.newActivityStub(
+              TestActivity.class,
+              ActivityOptions.newBuilder()
+                  .setScheduleToStartTimeout(Duration.ofSeconds(10))
+                  .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+                  .setHeartbeatTimeout(Duration.ofSeconds(1))
+                  .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
+                  .build());
+      List<Promise<Integer>> promises = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        promises.add(Async.function(() -> activity.execute(2)));
+      }
+      Promise.allOf(promises).get();
+      for (Promise<Integer> promise : promises) {
+        if (promise.getFailure() != null) {
+          return "exception";
+        }
+        if (promise.get() != 4) {
+          return "wrong result";
+        }
+      }
+      return "success";
+    }
+  }
+
+  @ActivityInterface
+  public interface TestActivity {
+
+    @ActivityMethod
+    int execute(int value);
+  }
+
+  public static class AsyncActivityWithManualCompletion implements TestActivity {
+
+    @Override
+    public int execute(int value) {
+      int concurrentActivities = concurrentActivitiesCount.incrementAndGet();
+      if (concurrentActivities > MAX_CONCURRENT_ACTIVITIES) {
+        throw new RuntimeException(
+            String.format(
+                "More than %d activities was running concurrently!", MAX_CONCURRENT_ACTIVITIES));
+      }
+      ActivityExecutionContext context = Activity.getExecutionContext();
+      context.heartbeat(value);
+      ActivityCompletionClient completionClient = context.useLocalManualCompletion();
+      try {
+        Thread.sleep(500);
+        completionClient.complete(context.getTaskToken(), value * 2);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        e.printStackTrace();
+        completionClient.completeExceptionally(context.getTaskToken(), e);
+      }
+      concurrentActivitiesCount.decrementAndGet();
+      return 0;
+    }
+  }
+
+  /**
+   * This test runs a workflow that executes multiple activities in the single handler thread. Test
+   * workflow is configured to fail with heartbeat timeout errors in case if activity pollers are
+   * too eager to poll tasks before previously fetched tasks are handled.
+   */
+  @Test
+  public void verifyLocalActivityCompletionRespectsConcurrencySettings() {
+    String taskQueue = testWorkflowRule.getTaskQueue();
+    TestWorkflow workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue(taskQueue).build());
+    String result = workflow.execute(taskQueue);
+    Assert.assertEquals("success", result);
+  }
+}


### PR DESCRIPTION
This PR introduces a new method `useLocalManualCompletion` in the activity context, which marks activity execution as async and returns `ActivityCompletionClient`. By doing so we expect user to manually complete activity execution on the same machine.
Also we do pass a completion handle down to the `ActivityCompletionClientImpl` and execute it only when user triggers the completion. This means that semaphore limit set by `setMaxConcurrentActivityExecutionSize` for activity polling will be respected for async activities.
Behavior is verified by `LocalAsyncCompletionWorkflowTest`.