### PR TITLE
Adding debug mode

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -32,7 +32,13 @@ import java.util.function.Supplier;
  */
 interface DeterministicRunner {
 
+  boolean debugMode = Boolean.parseBoolean(System.getenv("TEMPORAL_DEBUG_MODE"));
+
   long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 1000;
+
+  static long getDeadlockDetectionTimeout() {
+    return debugMode ? Long.MAX_VALUE : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+  }
 
   static DeterministicRunner newRunner(Runnable root) {
     return new DeterministicRunnerImpl(root);

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowType;
@@ -141,7 +141,7 @@ class SyncWorkflow implements ReplayWorkflow {
     if (runner == null) {
       return false;
     }
-    runner.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    runner.runUntilAllBlocked(getDeadlockDetectionTimeout());
     return runner.isDone() || workflowProc.isDone(); // Do not wait for all other threads.
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 
 import com.google.common.base.Throwables;
 import io.temporal.workflow.Functions;
@@ -271,7 +271,7 @@ class WorkflowThreadContext {
         (r) -> {
           throw new DestroyWorkflowThreadError();
         });
-    runUntilBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    runUntilBlocked(getDeadlockDetectionTimeout());
   }
 
   /** To be called only from a workflow thread. */

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static junit.framework.TestCase.*;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
@@ -108,17 +108,17 @@ public class DeterministicRunnerTest {
               status = "done";
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("after1", status);
     // Just check that running again doesn't make any progress.
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("after1", status);
     unblock2 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("done", status);
     assertTrue(d.isDone());
   }
@@ -158,7 +158,7 @@ public class DeterministicRunnerTest {
             });
     try {
       for (int i = 0; i < Duration.ofSeconds(400).toMillis(); i += 10) {
-        d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+        d.runUntilAllBlocked(getDeadlockDetectionTimeout());
       }
       fail("failure expected");
     } catch (IllegalThreadStateException e) {
@@ -189,12 +189,12 @@ public class DeterministicRunnerTest {
               throw new RuntimeException("simulated");
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
     try {
-      d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+      d.runUntilAllBlocked(getDeadlockDetectionTimeout());
       fail("exception expected");
     } catch (Exception ignored) {
     }
@@ -218,11 +218,11 @@ public class DeterministicRunnerTest {
               status = "done";
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("after1", status);
     d.close();
     assertTrue(d.isDone());
@@ -255,10 +255,10 @@ public class DeterministicRunnerTest {
               thread2.get();
               trace.add("root done");
             });
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertFalse(d.isDone());
     unblock2 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(d.isDone());
     assertEquals("exitValue", d.getExitValue());
     String[] expected =
@@ -282,10 +282,10 @@ public class DeterministicRunnerTest {
                   "reason1", () -> CancellationScope.current().isCancelRequested());
               trace.add("root done");
             });
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertFalse(d.isDone());
     d.cancel("I just feel like it");
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(d.isDone());
     String[] expected =
         new String[] {
@@ -320,7 +320,7 @@ public class DeterministicRunnerTest {
               }
               trace.add("root done");
             });
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(trace.toString(), d.isDone());
     String[] expected =
         new String[] {
@@ -362,7 +362,7 @@ public class DeterministicRunnerTest {
               }
               trace.add("root done");
             });
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(trace.toString(), d.isDone());
     String[] expected =
         new String[] {
@@ -420,7 +420,7 @@ public class DeterministicRunnerTest {
               trace.add("root done");
             });
 
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(d.stackTrace(), d.isDone());
     String[] expected =
         new String[] {
@@ -476,7 +476,7 @@ public class DeterministicRunnerTest {
               trace.add("root done");
             });
 
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(d.stackTrace(), d.isDone());
     String[] expected =
         new String[] {
@@ -525,10 +525,10 @@ public class DeterministicRunnerTest {
               }
               trace.add("root done");
             });
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertFalse(trace.toString(), d.isDone());
     d.cancel("I just feel like it");
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertFalse(d.isDone());
     String[] expected =
         new String[] {
@@ -537,7 +537,7 @@ public class DeterministicRunnerTest {
     trace.setExpected(expected);
     trace.assertExpected();
     unblock1 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(d.stackTrace(), d.isDone());
     expected =
         new String[] {
@@ -563,17 +563,17 @@ public class DeterministicRunnerTest {
               async.get();
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("after1", status);
     // Just check that running again doesn't make any progress.
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("after1", status);
     unblock2 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals("done", status);
     assertTrue(d.isDone());
   }
@@ -605,9 +605,9 @@ public class DeterministicRunnerTest {
   @Test
   public void testChildTree() throws Throwable {
     DeterministicRunner d = new DeterministicRunnerImpl(new TestChildTreeRunnable(0)::apply);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     unblock1 = true;
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertTrue(d.isDone());
     List<String> expected = new ArrayList<>();
     for (int i = 0; i <= CHILDREN; i++) {
@@ -668,7 +668,7 @@ public class DeterministicRunnerTest {
 
     cache.getOrCreate(response, new com.uber.m3.tally.NoopScope(), () -> workflowRunTaskHandler);
     cache.addToCache(response.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals(2, threadPool.getActiveCount());
     assertEquals(1, cache.size());
 
@@ -689,7 +689,7 @@ public class DeterministicRunnerTest {
             },
             cache);
     // Act: This should kick out threads consumed by 'd'
-    d2.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d2.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     // Assert: Cache is evicted and only threads consumed by d2 remain.
     assertEquals(2, threadPool.getActiveCount());
@@ -730,7 +730,7 @@ public class DeterministicRunnerTest {
 
     cache.getOrCreate(response, new com.uber.m3.tally.NoopScope(), () -> workflowRunTaskHandler);
     cache.addToCache(response.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
-    d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     assertEquals(2, threadPool.getActiveCount());
     assertEquals(1, cache.size());
 
@@ -751,7 +751,7 @@ public class DeterministicRunnerTest {
             cache);
 
     // Act: This should not kick out threads consumed by 'd' since there's enough capacity
-    d2.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    d2.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     // Assert: Cache is not evicted and all threads remain.
     assertEquals(4, threadPool.getActiveCount());
@@ -801,7 +801,7 @@ public class DeterministicRunnerTest {
     assertEquals("initial", status);
 
     try {
-      d.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+      d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     } catch (Throwable t) {
       assertTrue(t instanceof WorkflowRejectedExecutionError);
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -73,7 +73,7 @@ public class PromiseTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin", "root done", "thread1 get failure",
@@ -92,7 +92,7 @@ public class PromiseTest {
               trace.add(f.get());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin", "thread1", "root done",
@@ -111,7 +111,7 @@ public class PromiseTest {
               trace.add(f.cancellableGet());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin", "thread1", "root done",
@@ -133,9 +133,9 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin", "root CanceledException", "root done",
@@ -228,7 +228,7 @@ public class PromiseTest {
               assertTrue(f3.get());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -272,7 +272,7 @@ public class PromiseTest {
               f1.complete("value1");
               trace.add("root done");
             });
-    runner.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    runner.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected = new String[] {"root begin", "value1.thenApply.f2Handle", "root done"};
 
     trace.setExpected(expected);
@@ -314,7 +314,7 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    runner.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    runner.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected = new String[] {"root begin", "exceptionally", "failure caught", "root done"};
 
     trace.setExpected(expected);
@@ -363,7 +363,7 @@ public class PromiseTest {
               assertTrue(f1.isCompleted() && f2.isCompleted() && f3.isCompleted());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -407,7 +407,7 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -464,7 +464,7 @@ public class PromiseTest {
               assertEquals("value1", any.get());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -524,7 +524,7 @@ public class PromiseTest {
               assertTrue(f1.isCompleted());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -585,7 +585,7 @@ public class PromiseTest {
               assertTrue(f3.isCompleted());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -628,7 +628,7 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowOptions;
@@ -67,7 +67,7 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     String[] expected =
         new String[] {
           "root begin",
@@ -102,9 +102,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     String[] expected =
         new String[] {
@@ -135,9 +135,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     String[] expected =
         new String[] {
@@ -291,9 +291,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     String[] expected =
         new String[] {
@@ -325,9 +325,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     String[] expected =
         new String[] {
@@ -361,9 +361,9 @@ public class WorkflowInternalQueueTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
-    r.runUntilAllBlocked(DEFAULT_DEADLOCK_DETECTION_TIMEOUT);
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
     String[] expected =
         new String[] {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 public class DeadlockDetectorTest {
 
   private static final String taskQueue = "deadlock-test";
+  boolean debugMode = Boolean.parseBoolean(System.getenv("TEMPORAL_DEBUG_MODE"));
 
   @WorkflowInterface
   public interface TestWorkflow {
@@ -75,8 +76,13 @@ public class DeadlockDetectorTest {
     TestWorkflow workflow = workflowClient.newWorkflowStub(TestWorkflow.class, options);
     try {
       workflow.execute();
-      fail("not reachable");
+      if (!debugMode) {
+        fail("not reachable in non-debug mode");
+      }
     } catch (WorkflowFailedException e) {
+      if (debugMode) {
+        fail("not reachable in debug mode");
+      }
       Throwable failure = e;
       while (failure.getCause() != null) {
         failure = failure.getCause();


### PR DESCRIPTION
We've recently added deadlock detector, which fails workflow tasks that run longer than 1 second.
This is great for production use, but it can be very annoying when debugging your application or tests.
Added environment variable `TEMPORAL_DEBUG_MODE` which can be set to true during debugging.
Current implementation simply disables deadlock detector, in future we might also adjust some timeouts automatically.