### PR TITLE
Rename debug mode env var

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StateMachineDefinition.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StateMachineDefinition.java
@@ -24,7 +24,6 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.workflow.Functions;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
  */
 interface DeterministicRunner {
 
-  boolean debugMode = Boolean.parseBoolean(System.getenv("TEMPORAL_DEBUG_MODE"));
+  boolean debugMode = System.getenv("TEMPORAL_DEBUG") != null;
 
   long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 1000;
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class DeadlockDetectorTest {
 
   private static final String taskQueue = "deadlock-test";
-  boolean debugMode = Boolean.parseBoolean(System.getenv("TEMPORAL_DEBUG_MODE"));
+  boolean debugMode = System.getenv("TEMPORAL_DEBUG") != null;
 
   @WorkflowInterface
   public interface TestWorkflow {


### PR DESCRIPTION
Making behavior same as in go, renaming env var to `TEMPORAL_DEBUG` and making it take effect when set to non-empty as opposed to requiring `true` value being passed.