### PR TITLE
Don't swallow replay workflow exceptions

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -384,16 +384,12 @@ public final class Worker implements Suspendable {
    * @throws Exception if replay failed for any reason
    */
   public void replayWorkflowExecution(WorkflowExecutionHistory history) throws Exception {
-    try {
-      workflowWorker.queryWorkflowExecution(
-          history,
-          WorkflowClient.QUERY_TYPE_REPLAY_ONLY,
-          String.class,
-          String.class,
-          new Object[] {});
-    } catch (Exception e) {
-
-    }
+    workflowWorker.queryWorkflowExecution(
+        history,
+        WorkflowClient.QUERY_TYPE_REPLAY_ONLY,
+        String.class,
+        String.class,
+        new Object[] {});
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -3575,6 +3575,18 @@ public class WorkflowTest {
     }
   }
 
+  public static class AlteredTestChildWorkflowRetryWorkflow
+      extends TestChildWorkflowAsyncRetryWorkflow {
+
+    public AlteredTestChildWorkflowRetryWorkflow() {}
+
+    @Override
+    public String execute(String taskQueue) {
+      Workflow.sleep(Duration.ofMinutes(1));
+      return super.execute(taskQueue);
+    }
+  }
+
   @ActivityInterface
   public interface AngryChildActivity {
 
@@ -3657,6 +3669,15 @@ public class WorkflowTest {
 
     WorkflowReplayer.replayWorkflowExecutionFromResource(
         "testChildWorkflowRetryHistory.json", TestChildWorkflowRetryWorkflow.class);
+  }
+
+  /** Tests that WorkflowReplayer fails if replay does not match workflow run. */
+  @Test(expected = RuntimeException.class)
+  public void testAlteredWorkflowReplayFailure() throws Exception {
+    Assume.assumeFalse("skipping for docker tests", useExternalService);
+
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testChildWorkflowRetryHistory.json", AlteredTestChildWorkflowRetryWorkflow.class);
   }
 
   public static class TestChildWorkflowExecutionPromiseHandler implements TestWorkflow1 {

--- a/temporal-sdk/src/test/resources/testAsyncActivityRetryHistory.json
+++ b/temporal-sdk/src/test/resources/testAsyncActivityRetryHistory.json
@@ -16,7 +16,7 @@
       "input": {
         "payloads": [{
           "metadata": {
-            "encoding": "anNvbg=="
+            "encoding": "anNvbi9wbGFpbg=="
           },
           "data": "IldvcmtmbG93VGVzdC10ZXN0QXN5bmNBY3Rpdml0eVJldHJ5LTYxNzI0YTU2LTgyOTktNDJlYy1hOThkLWYxODAwMDBlODc4NCI="
         }]
@@ -25,9 +25,9 @@
       "workflowRunTimeout": "108000s",
       "workflowTaskTimeout": "5s",
       "initiator": "CONTINUE_AS_NEW_INITIATOR_WORKFLOW",
-      "originalExecutionRunId": "825ddcc7-0511-46a2-83ab-462c7731a927",
+      "originalExecutionRunId": "abdb8767-2b5c-4b1d-bda5-c40581f9eeb5",
       "identity": "unknown-mac",
-      "firstExecutionRunId": "825ddcc7-0511-46a2-83ab-462c7731a927"
+      "firstExecutionRunId": "abdb8767-2b5c-4b1d-bda5-c40581f9eeb5"
     }
   }, {
     "eventId": "2",
@@ -70,7 +70,7 @@
     "version": "-24",
     "taskId": "1051015",
     "activityTaskScheduledEventAttributes": {
-      "activityId": "0",
+      "activityId": "ec1557a9-20ec-3436-b765-f9f4e14fe8a8",
       "activityType": {
         "name": "HeartbeatAndThrowIO"
       },
@@ -187,7 +187,7 @@
           "activityType": {
             "name": "HeartbeatAndThrowIO"
           },
-          "activityId": "0",
+          "activityId": "ec1557a9-20ec-3436-b765-f9f4e14fe8a8",
           "retryState": "RETRY_STATE_TIMEOUT"
         }
       },

--- a/temporal-sdk/src/test/resources/testChildWorkflowRetryHistory.json
+++ b/temporal-sdk/src/test/resources/testChildWorkflowRetryHistory.json
@@ -16,7 +16,7 @@
       "input": {
         "payloads": [{
           "metadata": {
-            "encoding": "anNvbg=="
+            "encoding": "anNvbi9wbGFpbg=="
           },
           "data": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5LWM1YzU5OGNkLTA1ZDYtNDc5MC1iNDNlLWViZjE0OWFlZTY1YiI="
         }]
@@ -80,12 +80,12 @@
       "input": {
         "payloads": [{
           "metadata": {
-            "encoding": "anNvbg=="
+            "encoding": "anNvbi9wbGFpbg=="
           },
           "data": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5LWM1YzU5OGNkLTA1ZDYtNDc5MC1iNDNlLWViZjE0OWFlZTY1YiI="
         }, {
           "metadata": {
-            "encoding": "anNvbg=="
+            "encoding": "anNvbi9wbGFpbg=="
           },
           "data": "MA=="
         }]


### PR DESCRIPTION
## Overview

Allow `Worker.replayWorkflowExecution()` to throw an exception if the workflow history replay fails due to event mismatch.

Also includes a minimal set of changes to `testAsyncActivityRetryHistory.json` and `testChildWorkflowRetryHistory.json` so `WorkflowTest.testAsyncActivityRetryReplay` and `WorkflowTest.testChildWorkflowRetryReplay` to pass - seems like the replays used to fail before due to some expected history changes but tests still succeeded due to exception swallow block.

Fixes #301 