### PR TITLE
Updating java sdk dependencies

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'de.marcphilipp.nexus-publish' version '0.4.0'
-    id 'name.remal.check-updates' version '1.1.6'
+    id 'name.remal.check-updates' version '1.2.2'
 }
 
 apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
@@ -37,16 +37,16 @@ java {
 
 dependencies {
     errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-    errorprone('com.google.errorprone:error_prone_core:2.4.0')
+    errorprone('com.google.errorprone:error_prone_core:2.5.1')
 
     api project(':temporal-serviceclient')
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
-    api group: 'io.micrometer', name: 'micrometer-core', version: '1.6.2'
+    api group: 'io.micrometer', name: 'micrometer-core', version: '1.6.3'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.3'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.0'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.1'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.1'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'de.marcphilipp.nexus-publish' version '0.4.0'
-    id 'name.remal.check-updates' version '1.1.6'
+    id 'name.remal.check-updates' version '1.2.2'
 }
 
 apply plugin: 'com.google.protobuf'
@@ -75,16 +75,16 @@ java {
 
 dependencies {
     errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-    errorprone('com.google.errorprone:error_prone_core:2.4.0')
+    errorprone('com.google.errorprone:error_prone_core:2.5.1')
 
-    api 'io.grpc:grpc-protobuf:1.34.1'
-    api 'io.grpc:grpc-stub:1.34.1'
-    api 'io.grpc:grpc-core:1.34.1'
+    api 'io.grpc:grpc-protobuf:1.35.0'
+    api 'io.grpc:grpc-stub:1.35.0'
+    api 'io.grpc:grpc-core:1.35.0'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.14.0'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
 
-    implementation 'io.grpc:grpc-netty-shaded:1.34.1'
+    implementation 'io.grpc:grpc-netty-shaded:1.35.0'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
@@ -128,7 +128,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.35.0'
         }
     }
     generateProtoTasks {

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'de.marcphilipp.nexus-publish' version '0.4.0'
-    id 'name.remal.check-updates' version '1.1.6'
+    id 'name.remal.check-updates' version '1.2.2'
 }
 
 apply plugin: 'maven-publish'
@@ -36,7 +36,7 @@ java {
 
 dependencies {
     errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-    errorprone('com.google.errorprone:error_prone_core:2.4.0')
+    errorprone('com.google.errorprone:error_prone_core:2.5.1')
 
     api project(':temporal-sdk')
 


### PR DESCRIPTION
```
❯ ./gradlew checkUpdates

> Configure project :temporal-sdk
project ':temporal-sdk': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-sdk': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-sdk': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Configure project :temporal-serviceclient
project ':temporal-serviceclient': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-serviceclient': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-serviceclient': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Configure project :temporal-testing
project ':temporal-testing': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.9.1

```