### PR TITLE
Rename metric tags

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -27,15 +27,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class MetricsTag {
-  public static final String ACTIVITY_TYPE = "ActivityType";
-  public static final String NAMESPACE = "Namespace";
-  public static final String TASK_QUEUE = "TaskQueue";
-  public static final String WORKFLOW_TYPE = "WorkflowType";
-  public static final String SIGNAL_NAME = "SignalName";
-  public static final String QUERY_TYPE = "QueryType";
-  public static final String STATUS_CODE = "StatusCode";
-  public static final String EXCEPTION = "Exception";
-  public static final String OPERATION_NAME = "Operation";
+  public static final String ACTIVITY_TYPE = "activity_type";
+  public static final String NAMESPACE = "namespace";
+  public static final String TASK_QUEUE = "task_queue";
+  public static final String WORKFLOW_TYPE = "workflow_type";
+  public static final String SIGNAL_NAME = "signal_name";
+  public static final String QUERY_TYPE = "query_type";
+  public static final String STATUS_CODE = "status_code";
+  public static final String EXCEPTION = "exception";
+  public static final String OPERATION_NAME = "operation";
 
   /** Used to pass metrics scope to the interceptor */
   public static final CallOptions.Key<Scope> METRICS_TAGS_CALL_OPTIONS_KEY =


### PR DESCRIPTION
Bring tag names inline with prometheus naming conventions and go sdk/dashboards.