### PR TITLE
Add helper methods for setting cloud sslContext

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
@@ -47,8 +47,8 @@ public class SimpleSslContextBuilder {
           // gRPC requires http2 protocol.
           ApplicationProtocolNames.HTTP_2);
 
-  private InputStream keyCertChain;
-  private InputStream key;
+  private final InputStream keyCertChain;
+  private final InputStream key;
   private TrustManager trustManager;
   private boolean useInsecureTrustManager;
   private String keyPassword;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021 Temporal Technologies, Inc. All Rights Reserved.
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
  *
  *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
@@ -33,7 +33,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
-public class TemporalSslContextBuilder {
+public class SimpleSslContextBuilder {
 
   // Default TLS protocol config that is used to communicate with TLS enabled temporal backend.
   private static final ApplicationProtocolConfig DEFAULT_APPLICATION_PROTOCOL_CONFIG =
@@ -47,21 +47,23 @@ public class TemporalSslContextBuilder {
           // gRPC requires http2 protocol.
           ApplicationProtocolNames.HTTP_2);
 
-  private final InputStream keyCertChainInputStream;
-  private final InputStream keyInputStream;
+  private InputStream keyCertChain;
+  private InputStream key;
   private TrustManager trustManager;
   private boolean useInsecureTrustManager;
   private String keyPassword;
 
   /**
-   * @param keyCertChainInputStream - an input stream for an X.509 client certificate chain in PEM
-   *     format.
-   * @param keyInputStream - an input stream for a PKCS#8 client private key in PEM format.
+   * @param keyCertChain - an input stream for an X.509 client certificate chain in PEM format.
+   * @param key - an input stream for a PKCS#8 client private key in PEM format.
    */
-  public TemporalSslContextBuilder(
-      InputStream keyCertChainInputStream, InputStream keyInputStream) {
-    this.keyCertChainInputStream = keyCertChainInputStream;
-    this.keyInputStream = keyInputStream;
+  public static SimpleSslContextBuilder newBuilder(InputStream keyCertChain, InputStream key) {
+    return new SimpleSslContextBuilder(keyCertChain, key);
+  }
+
+  private SimpleSslContextBuilder(InputStream keyCertChain, InputStream key) {
+    this.keyCertChain = keyCertChain;
+    this.key = key;
   }
 
   /**
@@ -84,7 +86,7 @@ public class TemporalSslContextBuilder {
                 : useInsecureTrustManager
                     ? InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0]
                     : getDefaultTrustManager())
-        .keyManager(keyCertChainInputStream, keyInputStream, keyPassword)
+        .keyManager(keyCertChain, key, keyPassword)
         .applicationProtocolConfig(DEFAULT_APPLICATION_PROTOCOL_CONFIG)
         .build();
   }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/TemporalSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/TemporalSslContextBuilder.java
@@ -74,6 +74,9 @@ public class TemporalSslContextBuilder {
    * @throws SSLException - when it was unable to build the context.
    */
   public SslContext build() throws SSLException {
+    if (trustManager != null && useInsecureTrustManager)
+      throw new IllegalArgumentException(
+          "Can not use insecure trust manager if custom trust manager is set.");
     return SslContextBuilder.forClient()
         .trustManager(
             trustManager != null
@@ -88,7 +91,7 @@ public class TemporalSslContextBuilder {
 
   /**
    * @param trustManager - custom trust manager that should be used with the SSLContext for
-   *     verifying server CA * authority.
+   *     verifying server CA authority.
    */
   public void setTrustManager(TrustManager trustManager) {
     this.trustManager = trustManager;
@@ -131,7 +134,7 @@ public class TemporalSslContextBuilder {
       }
     }
     throw new UnknownDefaultTrustManagerException(
-        "Unable to find X509TrustManager in the list of default trust managers");
+        "Unable to find X509TrustManager in the list of default trust managers.");
   }
 
   /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/TemporalSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/TemporalSslContextBuilder.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (C) 2021 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient;
+
+import io.grpc.netty.shaded.io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.grpc.netty.shaded.io.netty.handler.ssl.ApplicationProtocolNames;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+public class TemporalSslContextBuilder {
+
+  // Default TLS protocol config that is used to communicate with TLS enabled temporal backend.
+  private static final ApplicationProtocolConfig DEFAULT_APPLICATION_PROTOCOL_CONFIG =
+      new ApplicationProtocolConfig(
+          // HTTP/2 over TLS mandates the use of ALPN to negotiate the use of the protocol.
+          ApplicationProtocolConfig.Protocol.ALPN,
+          // NO_ADVERTISE is the only mode supported by both OpenSsl and JDK providers.
+          ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+          // ACCEPT is the only mode supported by both OpenSsl and JDK providers.
+          ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+          // gRPC requires http2 protocol.
+          ApplicationProtocolNames.HTTP_2);
+
+  private final InputStream keyCertChainInputStream;
+  private final InputStream keyInputStream;
+  private TrustManager trustManager;
+  private boolean useInsecureTrustManager;
+  private String keyPassword;
+
+  /**
+   * @param keyCertChainInputStream - an input stream for an X.509 client certificate chain in PEM
+   *     format.
+   * @param keyInputStream - an input stream for a PKCS#8 client private key in PEM format.
+   */
+  public TemporalSslContextBuilder(
+      InputStream keyCertChainInputStream, InputStream keyInputStream) {
+    this.keyCertChainInputStream = keyCertChainInputStream;
+    this.keyInputStream = keyInputStream;
+  }
+
+  /**
+   * Builds {@link SslContext} from specified parameters. If trust manager is set then it will be
+   * used to verify server authority, otherwise system default trust manager (or if {@link
+   * #useInsecureTrustManager} is set then insecure trust manager) is going to be used.
+   *
+   * @return - {@link SslContext} that can be used with the {@link
+   *     WorkflowServiceStubsOptions.Builder#setSslContext(SslContext)}
+   * @throws SSLException - when it was unable to build the context.
+   */
+  public SslContext build() throws SSLException {
+    return SslContextBuilder.forClient()
+        .trustManager(
+            trustManager != null
+                ? trustManager
+                : useInsecureTrustManager
+                    ? InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0]
+                    : getDefaultTrustManager())
+        .keyManager(keyCertChainInputStream, keyInputStream, keyPassword)
+        .applicationProtocolConfig(DEFAULT_APPLICATION_PROTOCOL_CONFIG)
+        .build();
+  }
+
+  /**
+   * @param trustManager - custom trust manager that should be used with the SSLContext for
+   *     verifying server CA * authority.
+   */
+  public void setTrustManager(TrustManager trustManager) {
+    this.trustManager = trustManager;
+  }
+
+  /**
+   * @param useInsecureTrustManager - if set to true then insecure trust manager is going to be used
+   *     instead of the system default one. Note that this makes client vulnerable to man in the
+   *     middle attack. Use with caution.
+   */
+  public void setUseInsecureTrustManager(boolean useInsecureTrustManager) {
+    this.useInsecureTrustManager = useInsecureTrustManager;
+  }
+
+  /** @param keyPassword - the password of the key, or null if it's not password-protected. */
+  public void setKeyPassword(String keyPassword) {
+    this.keyPassword = keyPassword;
+  }
+
+  /**
+   * @return system default trust manager.
+   * @throws UnknownDefaultTrustManagerException, which can be caused by {@link
+   *     NoSuchAlgorithmException} if {@link TrustManagerFactory#getInstance(String)} doesn't
+   *     support default algorithm, {@link KeyStoreException} in case if {@link KeyStore}
+   *     initialization failed or if no {@link X509TrustManager} has been found.
+   */
+  private X509TrustManager getDefaultTrustManager() {
+    TrustManagerFactory tmf;
+    try {
+      tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      // Using null here initialises the TMF with the default trust store.
+      tmf.init((KeyStore) null);
+    } catch (KeyStoreException | NoSuchAlgorithmException e) {
+      throw new UnknownDefaultTrustManagerException(e);
+    }
+
+    for (TrustManager tm : tmf.getTrustManagers()) {
+      if (tm instanceof X509TrustManager) {
+        return (X509TrustManager) tm;
+      }
+    }
+    throw new UnknownDefaultTrustManagerException(
+        "Unable to find X509TrustManager in the list of default trust managers");
+  }
+
+  /**
+   * Exception that is thrown in case if builder was unable to derive default system trust manager.
+   */
+  public static final class UnknownDefaultTrustManagerException extends RuntimeException {
+    public UnknownDefaultTrustManagerException(Throwable cause) {
+      super(cause);
+    }
+
+    public UnknownDefaultTrustManagerException(String message) {
+      super(message);
+    }
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -381,7 +381,7 @@ public class WorkflowServiceStubsOptions {
      * that require additional customization may use {@link #setSslContext(SslContext)} directly.
      *
      * @param keyCertChainFile - an X.509 client certificate chain file in PEM format.
-     * @param keyPassword - the password of the keyFile, or null if it's not password-protected.
+     * @param keyPassword - the password of the key, or null if it's not password-protected.
      * @param keyFile - a PKCS#8 client private key file in PEM format.
      * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form of the server's root
      *     certificate.
@@ -419,7 +419,7 @@ public class WorkflowServiceStubsOptions {
      * customization may use {@link #setSslContext(SslContext)} directly.
      *
      * @param keyCertChainFile - an X.509 client certificate chain file in PEM format.
-     * @param keyPassword - the password of the keyFile, or null if it's not password-protected.
+     * @param keyPassword - the password of the key, or null if it's not password-protected.
      * @param keyFile - a PKCS#8 client private key file in PEM format.
      */
     public Builder setInsecureSslContextWith(

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -296,11 +296,12 @@ public class WorkflowServiceStubsOptions {
      * Sets default SSL context parameters that can be used with the temporal cloud service. Users
      * that require additional customization may use {@link #setSslContext(SslContext)} directly.
      *
-     * @param keyCertChainInputStream - an input stream for an X.509 certificate chain in PEM
+     * @param keyCertChainInputStream - an input stream for an X.509 client certificate chain in PEM
      *     format.
      * @param keyPassword - the password of the keyFile, or null if it's not password-protected.
-     * @param keyInputStream - an input stream for a PKCS#8 private key in PEM format.
-     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form.
+     * @param keyInputStream - an input stream for a PKCS#8 client private key in PEM format.
+     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form of the server's root
+     *     certificate.
      * @throws SSLException - when it was unable to build the context.
      */
     public Builder setCloudSslContext(
@@ -323,10 +324,11 @@ public class WorkflowServiceStubsOptions {
      * Convenience method that overloads {@link #setCloudSslContext(InputStream, String,
      * InputStream, String...)} and uses no key password.
      *
-     * @param keyCertChainInputStream - an input stream for an X.509 certificate chain in PEM
+     * @param keyCertChainInputStream - an input stream for an X.509 client certificate chain in PEM
      *     format.
-     * @param keyInputStream - an input stream for a PKCS#8 private key in PEM format.
-     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form.
+     * @param keyInputStream - an input stream for a PKCS#8 client private key in PEM format.
+     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form of the server's root
+     *     certificate.
      */
     public Builder setCloudSslContext(
         InputStream keyCertChainInputStream, InputStream keyInputStream, String... fingerprints)
@@ -338,10 +340,11 @@ public class WorkflowServiceStubsOptions {
      * Sets default SSL context parameters that can be used with the temporal cloud service. Users
      * that require additional customization may use {@link #setSslContext(SslContext)} directly.
      *
-     * @param keyCertChainFile - an X.509 certificate chain file in PEM format.
+     * @param keyCertChainFile - an X.509 client certificate chain file in PEM format.
      * @param keyPassword - the password of the keyFile, or null if it's not password-protected.
-     * @param keyFile - a PKCS#8 private key file in PEM format.
-     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form.
+     * @param keyFile - a PKCS#8 client private key file in PEM format.
+     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form of the server's root
+     *     certificate.
      */
     public Builder setCloudSslContext(
         File keyCertChainFile, String keyPassword, File keyFile, String... fingerprints)
@@ -360,9 +363,10 @@ public class WorkflowServiceStubsOptions {
      * Convenience method that overloads {@link #setCloudSslContext(File, String, File, String...)}
      * and uses no key password.
      *
-     * @param keyCertChainFile - an X.509 certificate chain file in PEM format.
-     * @param keyFile - a PKCS#8 private key file in PEM format.
-     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form.
+     * @param keyCertChainFile - an X.509 client certificate chain file in PEM format.
+     * @param keyFile - a PKCS#8 client private key file in PEM format.
+     * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form of the server's root
+     *     certificate.
      */
     public Builder setCloudSslContext(File keyCertChainFile, File keyFile, String... fingerprints)
         throws IOException {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -311,7 +311,6 @@ public class WorkflowServiceStubsOptions {
         InputStream keyInputStream,
         String... fingerprints)
         throws SSLException {
-      // TODO consider using default fingerprints from the root CA if user didn't pass any.
       this.sslContext =
           SslContextBuilder.forClient()
               .trustManager(new FingerprintTrustManagerFactory(fingerprints))
@@ -390,7 +389,6 @@ public class WorkflowServiceStubsOptions {
     public Builder setSslContextWith(
         File keyCertChainFile, String keyPassword, File keyFile, String... fingerprints)
         throws IOException {
-      // TODO consider using default fingerprints from the root CA if user didn't pass any.
       this.sslContext =
           SslContextBuilder.forClient()
               .trustManager(new FingerprintTrustManagerFactory(fingerprints))

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -266,7 +266,7 @@ public class WorkflowServiceStubsOptions {
 
     /**
      * Sets gRPC SSL Context to use, used for more advanced scenarios such as mTLS. Supersedes
-     * enableHttps; Exclusive with channel. Consider using {@link TemporalSslContextBuilder} which
+     * enableHttps; Exclusive with channel. Consider using {@link SimpleSslContextBuilder} which
      * greatly simplifies creation of the TLS enabled SslContext with client and server key
      * validation.
      */

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -31,16 +31,14 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.util.FingerprintTrustManagerFactory;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
-
-import javax.net.ssl.SSLException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import javax.net.ssl.SSLException;
 
 public class WorkflowServiceStubsOptions {
 
@@ -232,9 +230,10 @@ public class WorkflowServiceStubsOptions {
    */
   public static class Builder {
 
+    // Default TLS protocol config that is used to communicate with temporal backend in the cloud.
     private static final ApplicationProtocolConfig DEFAULT_APPLICATION_PROTOCOL_CONFIG =
         new ApplicationProtocolConfig(
-            // HTTP/2 over TLS mandates the use of ALPN to negotiate the use of the http2.
+            // HTTP/2 over TLS mandates the use of ALPN to negotiate the use of the protocol.
             ApplicationProtocolConfig.Protocol.ALPN,
             // NO_ADVERTISE is the only mode supported by both OpenSsl and JDK providers.
             ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
@@ -299,15 +298,15 @@ public class WorkflowServiceStubsOptions {
      *
      * @param keyCertChainInputStream - an input stream for an X.509 certificate chain in PEM
      *     format.
-     * @param keyInputStream - an input stream for a PKCS#8 private key in PEM format.
      * @param keyPassword - the password of the keyFile, or null if it's not password-protected.
+     * @param keyInputStream - an input stream for a PKCS#8 private key in PEM format.
      * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form.
      * @throws SSLException - when it was unable to build the context.
      */
     public Builder setCloudSslContext(
         InputStream keyCertChainInputStream,
-        InputStream keyInputStream,
         String keyPassword,
+        InputStream keyInputStream,
         String... fingerprints)
         throws SSLException {
       // TODO consider using default fingerprints from the root CA if user didn't pass any.
@@ -321,8 +320,8 @@ public class WorkflowServiceStubsOptions {
     }
 
     /**
-     * Convenience method that overloads {@link #setCloudSslContext(InputStream, InputStream,
-     * String, String...)} and uses no key password.
+     * Convenience method that overloads {@link #setCloudSslContext(InputStream, String,
+     * InputStream, String...)} and uses no key password.
      *
      * @param keyCertChainInputStream - an input stream for an X.509 certificate chain in PEM
      *     format.
@@ -332,7 +331,7 @@ public class WorkflowServiceStubsOptions {
     public Builder setCloudSslContext(
         InputStream keyCertChainInputStream, InputStream keyInputStream, String... fingerprints)
         throws IOException {
-      return setCloudSslContext(keyCertChainInputStream, keyInputStream, null, fingerprints);
+      return setCloudSslContext(keyCertChainInputStream, null, keyInputStream, fingerprints);
     }
 
     /**
@@ -340,12 +339,12 @@ public class WorkflowServiceStubsOptions {
      * that require additional customization may use {@link #setSslContext(SslContext)} directly.
      *
      * @param keyCertChainFile - an X.509 certificate chain file in PEM format.
-     * @param keyFile - a PKCS#8 private key file in PEM format.
      * @param keyPassword - the password of the keyFile, or null if it's not password-protected.
+     * @param keyFile - a PKCS#8 private key file in PEM format.
      * @param fingerprints - a list of SHA1 fingerprints in hexadecimal form.
      */
     public Builder setCloudSslContext(
-        File keyCertChainFile, File keyFile, String keyPassword, String... fingerprints)
+        File keyCertChainFile, String keyPassword, File keyFile, String... fingerprints)
         throws IOException {
       // TODO consider using default fingerprints from the root CA if user didn't pass any.
       this.sslContext =
@@ -358,7 +357,7 @@ public class WorkflowServiceStubsOptions {
     }
 
     /**
-     * Convenience method that overloads {@link #setCloudSslContext(File, File, String, String...)}
+     * Convenience method that overloads {@link #setCloudSslContext(File, String, File, String...)}
      * and uses no key password.
      *
      * @param keyCertChainFile - an X.509 certificate chain file in PEM format.
@@ -367,7 +366,7 @@ public class WorkflowServiceStubsOptions {
      */
     public Builder setCloudSslContext(File keyCertChainFile, File keyFile, String... fingerprints)
         throws IOException {
-      return setCloudSslContext(keyCertChainFile, keyFile, null, fingerprints);
+      return setCloudSslContext(keyCertChainFile, null, keyFile, fingerprints);
     }
 
     /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -230,7 +230,7 @@ public class WorkflowServiceStubsOptions {
    */
   public static class Builder {
 
-    // Default TLS protocol config that is used to communicate with temporal backend in the cloud.
+    // Default TLS protocol config that is used to communicate with TLS enabled temporal backend.
     private static final ApplicationProtocolConfig DEFAULT_APPLICATION_PROTOCOL_CONFIG =
         new ApplicationProtocolConfig(
             // HTTP/2 over TLS mandates the use of ALPN to negotiate the use of the protocol.


### PR DESCRIPTION
Previously users were required to set verbose configuration for the SSL context in order to communicate with temporal backend in the cloud, e.g.
```
SslContext sslContext =
    SslContextBuilder.forClient()
        .keyManager(clientCert, clientCertKey))
        .trustManager(
            InsecureTrustManagerFactory.INSTANCE)
        .applicationProtocolConfig(
            new ApplicationProtocolConfig(
                ApplicationProtocolConfig.Protocol.ALPN,
                ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
                ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
                "h2"))
        .build();

WorkflowServiceStubs service =
    WorkflowServiceStubs.newInstance(
        WorkflowServiceStubsOptions.newBuilder()
            .setSslContext(sslContext)
            .setTarget(temporalServerAddr)
            .build());
```

This change greatly simplifies the experience allowing users to simply do:
```
WorkflowServiceStubs service =
        WorkflowServiceStubs.newInstance(
                WorkflowServiceStubsOptions.newBuilder()
                        .setSslContext(
                                new TemporalSslContextBuilder(
                                     clientCert, clientCertKey).build())
                        .setTarget(temporalServerAddr)
                        .build());

```

Also this addresses natural temptation of cutting corners and using InsecureTrustManagerFactory as a simpler option instead of checking certificate fingerprints or using system trust store as well as sets correct default parameters for the ApplicationProtocolConfig.
In addition this change removes the need for clients to directly depend on 
```
    compile group: 'io.grpc', name: 'grpc-netty-shaded', version: 'XXX'
```

As part of the implementation we've added a few methods:
* setSslContextWith - that takes keyCertChainInputStream, keyInputStream, keyPassword and trustManager.
* Its overloads that take fewer parameters and can derive defaults, most notable one is the one that creates default TrustManager.
* Insecure counterparts that utilize insecure trust manager, which can be useful during testing or prototyping.

Note that users that require more sophisticated setup may still use setSslContext method and manually populate all parameters.