### PR TITLE
Return ref to this in SimpleSslContextBuilder

### DIFF
--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -83,8 +83,7 @@ dependencies {
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.14.0'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
-
-    implementation 'io.grpc:grpc-netty-shaded:1.35.0'
+    api 'io.grpc:grpc-netty-shaded:1.35.0'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
@@ -94,23 +94,31 @@ public class SimpleSslContextBuilder {
   /**
    * @param trustManager - custom trust manager that should be used with the SSLContext for
    *     verifying server CA authority.
+   * @return builder instance.
    */
-  public void setTrustManager(TrustManager trustManager) {
+  public SimpleSslContextBuilder setTrustManager(TrustManager trustManager) {
     this.trustManager = trustManager;
+    return this;
   }
 
   /**
    * @param useInsecureTrustManager - if set to true then insecure trust manager is going to be used
    *     instead of the system default one. Note that this makes client vulnerable to man in the
    *     middle attack. Use with caution.
+   * @return builder instance.
    */
-  public void setUseInsecureTrustManager(boolean useInsecureTrustManager) {
+  public SimpleSslContextBuilder setUseInsecureTrustManager(boolean useInsecureTrustManager) {
     this.useInsecureTrustManager = useInsecureTrustManager;
+    return this;
   }
 
-  /** @param keyPassword - the password of the key, or null if it's not password-protected. */
-  public void setKeyPassword(String keyPassword) {
+  /**
+   * @param keyPassword - the password of the key, or null if it's not password-protected.
+   * @return builder instance.
+   */
+  public SimpleSslContextBuilder setKeyPassword(String keyPassword) {
     this.keyPassword = keyPassword;
+    return this;
   }
 
   /**


### PR DESCRIPTION
Makes SimpleSslContextBuilder  an actual builder by returning reference to "this".
Also promoting netty dependency to the api from implementation so that clients can use SslContext without having to declare explicit dependency on `grpc-netty-shaded`