### PR TITLE
Release lock before running close and use tryLock in the WorkflowWorker

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -311,11 +311,11 @@ class DeterministicRunnerImpl implements DeterministicRunner {
       throw e;
     } finally {
       inRunUntilAllBlocked = false;
+      lock.unlock();
       // Close was requested while running
       if (closeRequested) {
         close();
       }
-      lock.unlock();
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/UnableToAcquireLockException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/UnableToAcquireLockException.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+/** Internal. Do not throw or catch in application level code. */
+public final class UnableToAcquireLockException extends RuntimeException {
+
+  public UnableToAcquireLockException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
User [reported an issue](https://community.temporal.io/t/timeout-issues-after-upgrading-to-1-6-3-temporal-and-1-0-5-java-client/1446) on our community forum where workers were leaking threads. 

It turns out that root cause was a deadlock condition in our code:
Workflow task event loop was trying to close (after signal failure) without releasing a lock, close function was waiting for a workflow method to finish, while workflow method was trying to yield, but needed a lock to get current workflow status.
As a result workflow task was stuck, occupying a thread and a lock for the run id. This resulted in all subsequent attempts for the same workflow task to also be stuck, occupying threads, ultimately using up all available threads in the thread pool (since we retry workflow tasks indefinitely) and suffocating the worker.

This change is 2-fold:
1. We've addressed immediate root cause of the deadlock by unlocking the lock before running the close method.
2. Workflow worker will no longer wait for the lock indefinitely, we've added a 1 second delay that should prevent us from spawning multiple threads for the same workflow task if a similar issue happens again.