### PR TITLE
Expose WorkflowClientOptions via test extensions

### DIFF
--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -102,6 +102,7 @@ public class TestWorkflowRule implements TestRule {
     private static final long DEFAULT_TEST_TIMEOUT_SECONDS = 10;
 
     private WorkerOptions workerOptions;
+    private WorkflowClientOptions workflowClientOptions;
     private String namespace;
     private Class<?>[] workflowTypes;
     private Object[] activityImplementations;
@@ -114,6 +115,15 @@ public class TestWorkflowRule implements TestRule {
 
     public Builder setWorkerOptions(WorkerOptions options) {
       this.workerOptions = options;
+      return this;
+    }
+
+    /**
+     * Override {@link WorkflowClientOptions} for test environment. If set, takes precedence over
+     * {@link #setNamespace(String) namespace}.
+     */
+    public Builder setWorkflowClientOptions(WorkflowClientOptions workflowClientOptions) {
+      this.workflowClientOptions = workflowClientOptions;
       return this;
     }
 
@@ -172,13 +182,14 @@ public class TestWorkflowRule implements TestRule {
     }
 
     public TestWorkflowRule build() {
-      namespace = namespace == null ? "UnitTest" : namespace;
-      WorkflowClientOptions clientOptions =
-          WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
+      if (workflowClientOptions == null) {
+        namespace = namespace == null ? "UnitTest" : namespace;
+        workflowClientOptions = WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
+      }
       WorkerFactoryOptions factoryOptions = WorkerFactoryOptions.newBuilder().build();
       TestEnvironmentOptions testOptions =
           TestEnvironmentOptions.newBuilder()
-              .setWorkflowClientOptions(clientOptions)
+              .setWorkflowClientOptions(workflowClientOptions)
               .setWorkerFactoryOptions(factoryOptions)
               .setUseExternalService(useExternalService)
               .setTarget(target)

--- a/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -77,7 +77,7 @@ public class TestWorkflowExtension
   private static final String TASK_QUEUE_KEY = "taskQueue";
 
   private final WorkerOptions workerOptions;
-  private final String namespace;
+  private final WorkflowClientOptions workflowClientOptions;
   private final Class<?>[] workflowTypes;
   private final Object[] activityImplementations;
   private final boolean useExternalService;
@@ -88,7 +88,12 @@ public class TestWorkflowExtension
 
   private TestWorkflowExtension(Builder builder) {
     workerOptions = builder.workerOptions;
-    namespace = builder.namespace;
+    if (builder.workflowClientOptions != null) {
+      workflowClientOptions = builder.workflowClientOptions;
+    } else {
+      workflowClientOptions =
+          WorkflowClientOptions.newBuilder().setNamespace(builder.namespace).build();
+    }
     workflowTypes = builder.workflowTypes;
     activityImplementations = builder.activityImplementations;
     useExternalService = builder.useExternalService;
@@ -154,11 +159,9 @@ public class TestWorkflowExtension
 
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
-    WorkflowClientOptions clientOptions =
-        WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
     TestEnvironmentOptions testOptions =
         TestEnvironmentOptions.newBuilder()
-            .setWorkflowClientOptions(clientOptions)
+            .setWorkflowClientOptions(workflowClientOptions)
             .setUseExternalService(useExternalService)
             .setTarget(target)
             .build();
@@ -227,6 +230,7 @@ public class TestWorkflowExtension
     private static final Object[] NO_ACTIVITIES = new Object[0];
 
     private WorkerOptions workerOptions = WorkerOptions.getDefaultInstance();
+    private WorkflowClientOptions workflowClientOptions;
     private String namespace = "UnitTest";
     private Class<?>[] workflowTypes = NO_WORKFLOWS;
     private Object[] activityImplementations = NO_ACTIVITIES;
@@ -239,6 +243,15 @@ public class TestWorkflowExtension
     /** @see TestWorkflowEnvironment#newWorker(String, WorkerOptions) */
     public Builder setWorkerOptions(WorkerOptions options) {
       this.workerOptions = options;
+      return this;
+    }
+
+    /**
+     * Override {@link WorkflowClientOptions} for test environment. If set, takes precedence over
+     * {@link #setNamespace(String) namespace}.
+     */
+    public Builder setWorkflowClientOptions(WorkflowClientOptions workflowClientOptions) {
+      this.workflowClientOptions = workflowClientOptions;
       return this;
     }
 


### PR DESCRIPTION
## Overview

Extend `TestWorkflowRule` and `TestWorkflowExtension` to expose control over `WorkflowClientOptions`. If set, it takes precedence over configured test `namespace`.

## Background

I tried to use Kotlin data classes as workflow input and output types. That required overriding `ObjectMapper` used by `DataConverter` under the hood in order to add special [`KotlinModule`](https://github.com/FasterXML/jackson-module-kotlin). Unfortunately, that's not possible now with `TestWorkflowRule` or `TestWorkflowExtension` as they don't expose any property of `WorkflowClientOptions` other than `namespace`.
