### PR TITLE
Move gRPC connections to idle periodically in order to trigger LB

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -134,11 +134,11 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
             options.getConnectionBackoffResetFrequency().getSeconds(),
             TimeUnit.SECONDS);
       }
-      if (options.getEnterIdleChannelStateFrequency() != null) {
+      if (options.getGrpcReconnectFrequency() != null) {
         grpcConnectionManager.scheduleWithFixedDelay(
             enterGrpcIdleChannelStateTask(),
-            options.getEnterIdleChannelStateFrequency().getSeconds(),
-            options.getEnterIdleChannelStateFrequency().getSeconds(),
+            options.getGrpcReconnectFrequency().getSeconds(),
+            options.getGrpcReconnectFrequency().getSeconds(),
             TimeUnit.SECONDS);
       }
       channelNeedsShutdown = true;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -44,6 +44,10 @@ public class WorkflowServiceStubsOptions {
   private static final Duration DEFAULT_QUERY_RPC_TIMEOUT = Duration.ofSeconds(10);
   /** Default timeout that will be used to reset connection backoff. */
   private static final Duration DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY = Duration.ofSeconds(10);
+  /**
+   * Default timeout that will be used to enter idle channel state and reconnect to temporal server.
+   */
+  private static final Duration DEFAULT_ENTER_IDLE_CHANNEL_STATE_FREQUENCY = Duration.ofMinutes(5);
 
   private static final WorkflowServiceStubsOptions DEFAULT_INSTANCE;
 
@@ -85,6 +89,12 @@ public class WorkflowServiceStubsOptions {
   /** Frequency at which connection backoff is going to be reset */
   private final Duration connectionBackoffResetFrequency;
 
+  /**
+   * Frequency at which grpc connection channel will be moved into an idle state, triggering a new
+   * connection to the temporal frontend host.
+   */
+  private final Duration enterIdleChannelStateFrequency;
+
   /** Optional gRPC headers */
   private final Metadata headers;
 
@@ -109,6 +119,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
+    this.enterIdleChannelStateFrequency = builder.enterIdleChannelStateFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
     this.headers = builder.headers;
@@ -140,6 +151,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
+    this.enterIdleChannelStateFrequency = builder.enterIdleChannelStateFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
     if (builder.headers != null) {
@@ -191,6 +203,11 @@ public class WorkflowServiceStubsOptions {
     return connectionBackoffResetFrequency;
   }
 
+  /** @return frequency at which grpc channel should be moved into an idle state. */
+  public Duration getEnterIdleChannelStateFrequency() {
+    return enterIdleChannelStateFrequency;
+  }
+
   public Metadata getHeaders() {
     return headers;
   }
@@ -230,6 +247,7 @@ public class WorkflowServiceStubsOptions {
     private Duration rpcLongPollTimeout = DEFAULT_POLL_RPC_TIMEOUT;
     private Duration rpcQueryTimeout = DEFAULT_QUERY_RPC_TIMEOUT;
     private Duration connectionBackoffResetFrequency = DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY;
+    private Duration enterIdleChannelStateFrequency = DEFAULT_ENTER_IDLE_CHANNEL_STATE_FREQUENCY;
     private Metadata headers;
     private Function<
             WorkflowServiceGrpc.WorkflowServiceBlockingStub,
@@ -252,6 +270,7 @@ public class WorkflowServiceStubsOptions {
       this.rpcQueryTimeout = options.rpcQueryTimeout;
       this.rpcTimeout = options.rpcTimeout;
       this.connectionBackoffResetFrequency = options.connectionBackoffResetFrequency;
+      this.enterIdleChannelStateFrequency = options.enterIdleChannelStateFrequency;
       this.blockingStubInterceptor = options.blockingStubInterceptor;
       this.futureStubInterceptor = options.futureStubInterceptor;
       this.headers = options.headers;
@@ -318,11 +337,26 @@ public class WorkflowServiceStubsOptions {
      * performed and we'll rely on default gRPC backoff behavior defined in
      * ExponentialBackoffPolicy.
      *
-     * @param connectionBackoffResetFrequency frequency.
+     * @param connectionBackoffResetFrequency frequency, defaults to once every 10 seconds. Set to
+     *     null in order to disable this feature.
      */
     public Builder setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {
       this.connectionBackoffResetFrequency = connectionBackoffResetFrequency;
       return this;
+    }
+
+    /**
+     * Sets frequency at which gRPC channel will be moved into an idle state and triggers tear-down
+     * of the channel's name resolver and load balancer, while still allowing on-going RPCs on the
+     * channel to continue. New RPCs on the channel will trigger creation of a new connection. This
+     * allows worker to connect to a new temporal backend host periodically avoiding hot spots and
+     * resulting in a more even connection distribution.
+     *
+     * @param enterIdleChannelStateFrequency frequency, defaults to once every 5 minutes. Set to
+     *     null in order to disable this feature.
+     */
+    public void setEnterIdleChannelStateFrequency(Duration enterIdleChannelStateFrequency) {
+      this.enterIdleChannelStateFrequency = enterIdleChannelStateFrequency;
     }
 
     /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -47,7 +47,7 @@ public class WorkflowServiceStubsOptions {
   /**
    * Default timeout that will be used to enter idle channel state and reconnect to temporal server.
    */
-  private static final Duration DEFAULT_ENTER_IDLE_CHANNEL_STATE_FREQUENCY = Duration.ofMinutes(5);
+  private static final Duration DEFAULT_GRPC_RECONNECT_FREQUENCY = Duration.ofMinutes(1);
 
   private static final WorkflowServiceStubsOptions DEFAULT_INSTANCE;
 
@@ -93,7 +93,7 @@ public class WorkflowServiceStubsOptions {
    * Frequency at which grpc connection channel will be moved into an idle state, triggering a new
    * connection to the temporal frontend host.
    */
-  private final Duration enterIdleChannelStateFrequency;
+  private final Duration grpcReconnectFrequency;
 
   /** Optional gRPC headers */
   private final Metadata headers;
@@ -119,7 +119,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
-    this.enterIdleChannelStateFrequency = builder.enterIdleChannelStateFrequency;
+    this.grpcReconnectFrequency = builder.grpcReconnectFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
     this.headers = builder.headers;
@@ -151,7 +151,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
-    this.enterIdleChannelStateFrequency = builder.enterIdleChannelStateFrequency;
+    this.grpcReconnectFrequency = builder.grpcReconnectFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
     if (builder.headers != null) {
@@ -204,8 +204,8 @@ public class WorkflowServiceStubsOptions {
   }
 
   /** @return frequency at which grpc channel should be moved into an idle state. */
-  public Duration getEnterIdleChannelStateFrequency() {
-    return enterIdleChannelStateFrequency;
+  public Duration getGrpcReconnectFrequency() {
+    return grpcReconnectFrequency;
   }
 
   public Metadata getHeaders() {
@@ -247,7 +247,7 @@ public class WorkflowServiceStubsOptions {
     private Duration rpcLongPollTimeout = DEFAULT_POLL_RPC_TIMEOUT;
     private Duration rpcQueryTimeout = DEFAULT_QUERY_RPC_TIMEOUT;
     private Duration connectionBackoffResetFrequency = DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY;
-    private Duration enterIdleChannelStateFrequency = DEFAULT_ENTER_IDLE_CHANNEL_STATE_FREQUENCY;
+    private Duration grpcReconnectFrequency = DEFAULT_GRPC_RECONNECT_FREQUENCY;
     private Metadata headers;
     private Function<
             WorkflowServiceGrpc.WorkflowServiceBlockingStub,
@@ -270,7 +270,7 @@ public class WorkflowServiceStubsOptions {
       this.rpcQueryTimeout = options.rpcQueryTimeout;
       this.rpcTimeout = options.rpcTimeout;
       this.connectionBackoffResetFrequency = options.connectionBackoffResetFrequency;
-      this.enterIdleChannelStateFrequency = options.enterIdleChannelStateFrequency;
+      this.grpcReconnectFrequency = options.grpcReconnectFrequency;
       this.blockingStubInterceptor = options.blockingStubInterceptor;
       this.futureStubInterceptor = options.futureStubInterceptor;
       this.headers = options.headers;
@@ -352,11 +352,11 @@ public class WorkflowServiceStubsOptions {
      * allows worker to connect to a new temporal backend host periodically avoiding hot spots and
      * resulting in a more even connection distribution.
      *
-     * @param enterIdleChannelStateFrequency frequency, defaults to once every 5 minutes. Set to
-     *     null in order to disable this feature.
+     * @param grpcReconnectFrequency frequency, defaults to once every 1 minute. Set to null in
+     *     order to disable this feature.
      */
-    public void setEnterIdleChannelStateFrequency(Duration enterIdleChannelStateFrequency) {
-      this.enterIdleChannelStateFrequency = enterIdleChannelStateFrequency;
+    public void setGrpcReconnectFrequency(Duration grpcReconnectFrequency) {
+      this.grpcReconnectFrequency = grpcReconnectFrequency;
     }
 
     /**


### PR DESCRIPTION
gRPC abstracts away connection management from the user allowing interactions only on the level of the channel.
One of our issues was that all connections that gRPC is using are long living and would last as long as the server responds on keep alive requests (which practically can mean forever). This results in us being unable to properly load balance connections to the temporal front ends over time.

Consider a simple example:
```
Let's say we have 2 frontend hosts running and 20 workers 
connect to them. At the beginning, since we are using round-robing 
load balancer connections will be distributed evenly (or close to that), 
so we'll have 10 and 10 connections to each front end host on average. 
Now let's assume these front end hosts reboot one after another. 
What would happen is that front end host that comes up first would 
get all 20 worker connections and front end host that comes up later 
would have zero. This situation won't change unless workers restart.
```

To prevent this situation from happening we choose to move gRPC channels on the worker side into the idle state, which triggers a reconnection to the front end and new invocation of the load balancer. This allows us to distribute connections more evenly over time.

Currently we are doing this simply every 5 minutes, but in the future we could add a special header in the response from the server, which would allow front-end host to ask client to reconnect allowing more targeted actions. This is slightly more complex change, which would require propagating additional info through the ring and adding a new header, so we opt for simplicity here.

I've tested this change with aggressive settings for entering idle state (every 1, 10 and 30 seconds) using bench test. Results don't show any impact on request latency and no visible impact on the number of gRPC request errors.
