### PR TITLE
Updating dependencies

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testImplementation group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 configurations.all {

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -2,12 +2,12 @@
 
 buildscript {
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.14'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.15'
     }
 }
 
 plugins {
-    id 'com.google.protobuf' version '0.8.14'
+    id 'com.google.protobuf' version '0.8.15'
     id 'java-library'
     id 'net.ltgt.errorprone' version '1.3.0'
     id 'net.minecrell.licenser' version '0.4.1'
@@ -90,7 +90,7 @@ dependencies {
 
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testImplementation group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 configurations.all {

--- a/temporal-testing-junit4/build.gradle
+++ b/temporal-testing-junit4/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     api project(':temporal-testing')
 
-    api group: 'junit', name: 'junit', version: '4.13.1'
+    api group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 license {


### PR DESCRIPTION
Addressing
```
❯ ./gradlew checkUpdates
Starting a Gradle Daemon (subsequent builds will be faster)

> Configure project :temporal-sdk
project ':temporal-sdk': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-sdk': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-sdk': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Configure project :temporal-serviceclient
project ':temporal-serviceclient': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-serviceclient': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-serviceclient': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Configure project :temporal-testing
project ':temporal-testing': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Configure project :temporal-testing-junit4
project ':temporal-testing-junit4': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing-junit4': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing-junit4': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Configure project :temporal-testing-junit5
project ':temporal-testing-junit5': Plugin name.remal.check-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing-junit5': Plugin name.remal.check-dependency-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...
project ':temporal-testing-junit5': Plugin name.remal.check-gradle-updates is deprecated: Use automatic dependency updates software like Renovate, Dependabot, etc...

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: junit:junit: 4.13.1 -> 4.13.2

> Task :temporal-sdk:checkGradleUpdates
New Gradle version is available: 6.8.2 (downloadUrl: https://services.gradle.org/distributions/gradle-6.8.2-bin.zip)

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.google.protobuf:com.google.protobuf.gradle.plugin: 0.8.14 -> 0.8.15
New dependency version: com.google.protobuf:protobuf-gradle-plugin: 0.8.14 -> 0.8.15
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.10.0
New dependency version: junit:junit: 4.13.1 -> 4.13.2

> Task :temporal-serviceclient:checkGradleUpdates
New Gradle version is available: 6.8.2 (downloadUrl: https://services.gradle.org/distributions/gradle-6.8.2-bin.zip)

> Task :temporal-testing:checkGradleUpdates
New Gradle version is available: 6.8.2 (downloadUrl: https://services.gradle.org/distributions/gradle-6.8.2-bin.zip)

> Task :temporal-testing-junit4:checkDependencyUpdates
New dependency version: junit:junit: 4.13.1 -> 4.13.2

> Task :temporal-testing-junit4:checkGradleUpdates
New Gradle version is available: 6.8.2 (downloadUrl: https://services.gradle.org/distributions/gradle-6.8.2-bin.zip)

> Task :temporal-testing-junit5:checkGradleUpdates
New Gradle version is available: 6.8.2 (downloadUrl: https://services.gradle.org/distributions/gradle-6.8.2-bin.zip)

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 24s
```