### PR TITLE
Return supported query types for unsupported queries

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/QueryDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/QueryDispatcher.java
@@ -75,7 +75,8 @@ class QueryDispatcher {
     Object[] args;
     if (handler == null) {
       if (dynamicQueryHandler == null) {
-        throw new IllegalStateException("Unknown query type: " + queryName);
+        throw new IllegalArgumentException(
+            "Unknown query type: " + queryName + ", knownTypes=" + queryCallbacks.keySet());
       }
       args = new Object[] {new EncodedValues(input, converter)};
     } else {


### PR DESCRIPTION
Unsupported queries should return supported query types, for example:
```
Error: Query workflow failed.
Error Details: rpc error: code = InvalidArgument desc = java.lang.IllegalArgumentException: Unknown query type: queryGreeting123, knownTypes=[queryGreeting]
```
After recent refactoring we've lost that part of the message.