### PR TITLE
Add keep alive to gRPC connection

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -111,6 +111,9 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       NettyChannelBuilder builder =
           NettyChannelBuilder.forTarget(options.getTarget())
               .defaultLoadBalancingPolicy("round_robin")
+              .keepAliveTime(30, TimeUnit.SECONDS)
+              .keepAliveTimeout(15, TimeUnit.SECONDS)
+              .keepAliveWithoutCalls(true)
               .maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
 
       if (options.getSslContext() == null && !options.getEnableHttps()) {


### PR DESCRIPTION
Similarly to [this PR](https://github.com/temporalio/sdk-go/pull/370) in go SDK adds [keep alive](https://github.com/grpc/grpc/blob/master/doc/keepalive.md) to java sdk. For more details please read summary of the above mentioned PR.