### PR TITLE
Make keep alive configurable and opt-in

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -111,10 +111,13 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       NettyChannelBuilder builder =
           NettyChannelBuilder.forTarget(options.getTarget())
               .defaultLoadBalancingPolicy("round_robin")
-              .keepAliveTime(30, TimeUnit.SECONDS)
-              .keepAliveTimeout(15, TimeUnit.SECONDS)
-              .keepAliveWithoutCalls(true)
               .maxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE);
+      if (options.getEnableKeepAlive()) {
+        builder
+            .keepAliveTime(options.getKeepAliveTime().toMillis(), TimeUnit.MILLISECONDS)
+            .keepAliveTimeout(options.getKeepAliveTimeout().toMillis(), TimeUnit.MILLISECONDS)
+            .keepAliveWithoutCalls(options.getKeepAlivePermitWithoutStream());
+      }
 
       if (options.getSslContext() == null && !options.getEnableHttps()) {
         builder.usePlaintext();


### PR DESCRIPTION
This approach should make it safer for our users and allow us time to test the feature before we enable it by default.