### PR TITLE
Workflowtest Refactoring: Child tests and a few others

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/AsyncRetryOptionsChangeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/AsyncRetryOptionsChangeTest.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowException;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.internal.sync.DeterministicRunnerTest;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AsyncRetryOptionsChangeTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(IllegalThreadStateException.class)
+                  .build(),
+              TestAsyncRetryOptionsChangeWorkflow.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  /** @see DeterministicRunnerTest#testRetry() */
+  @Test
+  public void testAsyncRetryOptionsChange() {
+    TestWorkflows.TestWorkflow2 client =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow2.class);
+    String result = null;
+    try {
+      result = client.execute(SDKTestWorkflowRule.useExternalService);
+      Assert.fail("unreachable");
+    } catch (WorkflowException e) {
+      Assert.assertTrue(e.getCause() instanceof ApplicationFailure);
+      Assert.assertEquals(
+          IllegalThreadStateException.class.getName(),
+          ((ApplicationFailure) e.getCause()).getType());
+      Assert.assertEquals(
+          "message='simulated', type='java.lang.IllegalThreadStateException', nonRetryable=false",
+          e.getCause().getMessage());
+    }
+    Assert.assertNull(result);
+    List<String> trace = client.getTrace();
+    Assert.assertEquals(trace.toString(), 3, trace.size());
+    Assert.assertEquals("started", trace.get(0));
+    Assert.assertTrue(trace.get(1).startsWith("retry at "));
+    Assert.assertTrue(trace.get(2).startsWith("retry at "));
+  }
+
+  public static class TestAsyncRetryOptionsChangeWorkflow implements TestWorkflows.TestWorkflow2 {
+
+    private final List<String> trace = new ArrayList<>();
+
+    @Override
+    public String execute(boolean useExternalService) {
+      RetryOptions retryOptions;
+      if (Workflow.isReplaying()) {
+        retryOptions =
+            RetryOptions.newBuilder()
+                .setMaximumInterval(Duration.ofSeconds(1))
+                .setInitialInterval(Duration.ofSeconds(1))
+                .setMaximumAttempts(3)
+                .build();
+      } else {
+        retryOptions =
+            RetryOptions.newBuilder()
+                .setMaximumInterval(Duration.ofSeconds(1))
+                .setInitialInterval(Duration.ofSeconds(1))
+                .setMaximumAttempts(2)
+                .build();
+      }
+
+      trace.clear(); // clear because of replay
+      trace.add("started");
+      Async.retry(
+              retryOptions,
+              Optional.of(Duration.ofSeconds(2)),
+              () -> {
+                trace.add("retry at " + Workflow.currentTimeMillis());
+                return Workflow.newFailedPromise(new IllegalThreadStateException("simulated"));
+              })
+          .get();
+      trace.add("beforeSleep");
+      Workflow.sleep(60000);
+      trace.add("done");
+      return "";
+    }
+
+    @Override
+    public List<String> getTrace() {
+      return trace;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/AsyncRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/AsyncRetryTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowException;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.internal.sync.DeterministicRunnerTest;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AsyncRetryTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestAsyncRetryWorkflowImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  /** @see DeterministicRunnerTest#testRetry() */
+  @Test
+  public void testAsyncRetry() {
+    TestWorkflows.TestWorkflow2 client =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow2.class);
+    String result = null;
+    try {
+      result = client.execute(SDKTestWorkflowRule.useExternalService);
+      Assert.fail("unreachable");
+    } catch (WorkflowException e) {
+      Assert.assertTrue(e.getCause() instanceof ApplicationFailure);
+      Assert.assertEquals("test", ((ApplicationFailure) e.getCause()).getType());
+      Assert.assertEquals(
+          "message='simulated', type='test', nonRetryable=false", e.getCause().getMessage());
+    }
+    Assert.assertNull(result);
+    List<String> trace = client.getTrace();
+    Assert.assertEquals(trace.toString(), 3, trace.size());
+    Assert.assertEquals("started", trace.get(0));
+    Assert.assertTrue(trace.get(1).startsWith("retry at "));
+    Assert.assertTrue(trace.get(2).startsWith("retry at "));
+  }
+
+  public static class TestAsyncRetryWorkflowImpl implements TestWorkflows.TestWorkflow2 {
+
+    private static final RetryOptions retryOptions =
+        RetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofSeconds(1))
+            .setMaximumInterval(Duration.ofSeconds(1))
+            .setBackoffCoefficient(1)
+            .build();
+
+    private final List<String> trace = new ArrayList<>();
+
+    @Override
+    public String execute(boolean useExternalService) {
+      trace.clear(); // clear because of replay
+      trace.add("started");
+      Async.retry(
+              retryOptions,
+              Optional.of(Duration.ofSeconds(2)),
+              () -> {
+                trace.add("retry at " + Workflow.currentTimeMillis());
+                return Workflow.newFailedPromise(
+                    ApplicationFailure.newFailure("simulated", "test"));
+              })
+          .get();
+      trace.add("beforeSleep");
+      Workflow.sleep(60000);
+      trace.add("done");
+      return "";
+    }
+
+    @Override
+    public List<String> getTrace() {
+      return trace;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/AwaitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/AwaitTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AwaitTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestAwait.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testAwait() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(" awoken i=1 loop i=1 awoken i=2 loop i=2 awoken i=3", result);
+  }
+
+  public static class TestAwait implements TestWorkflows.TestWorkflow1 {
+
+    private int i;
+    private int j;
+
+    @Override
+    public String execute(String taskQueue) {
+      StringBuilder result = new StringBuilder();
+      Async.procedure(
+          () -> {
+            while (true) {
+              Workflow.await(() -> i > j);
+              result.append(" awoken i=" + i);
+              j++;
+            }
+          });
+
+      for (i = 1; i < 3; i++) {
+        Workflow.await(() -> j >= i);
+        result.append(" loop i=" + i);
+      }
+      assertFalse(Workflow.await(Duration.ZERO, () -> false));
+      return result.toString();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildAsyncLambdaWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildAsyncLambdaWorkflowTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildAsyncLambdaWorkflowTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWaitOnSignalWorkflowImpl.class, TestChildAsyncLambdaWorkflow.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  /**
+   * The purpose of this test is to exercise the lambda execution logic inside Async.procedure(),
+   * which executes on a different thread than workflow-main. This is different than executing
+   * classes that implements the workflow method interface, which executes on the workflow main
+   * thread.
+   */
+  @Test
+  public void testChildAsyncLambdaWorkflow() {
+    WorkflowOptions.Builder options = WorkflowOptions.newBuilder();
+    options.setWorkflowRunTimeout(Duration.ofSeconds(200));
+    options.setWorkflowTaskTimeout(Duration.ofSeconds(60));
+    options.setTaskQueue(testWorkflowRule.getTaskQueue());
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options.build());
+    Assert.assertEquals(null, client.execute(testWorkflowRule.getTaskQueue()));
+  }
+
+  public static class TestWaitOnSignalWorkflowImpl implements WorkflowTest.WaitOnSignalWorkflow {
+
+    private final CompletablePromise<String> signal = Workflow.newPromise();
+
+    @Override
+    public void execute() {
+      signal.get();
+    }
+
+    @Override
+    public void signal(String value) {
+      Workflow.sleep(Duration.ofSeconds(1));
+      signal.complete(value);
+    }
+  }
+
+  public static class TestChildAsyncLambdaWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      ChildWorkflowOptions workflowOptions =
+          ChildWorkflowOptions.newBuilder()
+              .setWorkflowRunTimeout(Duration.ofSeconds(100))
+              .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+              .setTaskQueue(taskQueue)
+              .build();
+
+      WorkflowTest.WaitOnSignalWorkflow child =
+          Workflow.newChildWorkflowStub(WorkflowTest.WaitOnSignalWorkflow.class, workflowOptions);
+      Promise<Void> promise = Async.procedure(child::execute);
+      Promise<WorkflowExecution> executionPromise = Workflow.getWorkflowExecution(child);
+      assertNotNull(executionPromise);
+      WorkflowExecution execution = executionPromise.get();
+      assertNotEquals("", execution.getWorkflowId());
+      assertNotEquals("", execution.getRunId());
+      child.signal("test");
+
+      promise.get();
+      return null;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildAsyncWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildAsyncWorkflowTest.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestMultiargdsWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildAsyncWorkflowTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestChildAsyncWorkflow.class,
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testChildAsyncWorkflow() {
+    WorkflowOptions.Builder options = WorkflowOptions.newBuilder();
+    options.setWorkflowRunTimeout(Duration.ofSeconds(200));
+    options.setWorkflowTaskTimeout(Duration.ofSeconds(60));
+    options.setTaskQueue(testWorkflowRule.getTaskQueue());
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options.build());
+    Assert.assertEquals(null, client.execute(testWorkflowRule.getTaskQueue()));
+  }
+
+  public static class TestChildAsyncWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      ChildWorkflowOptions workflowOptions =
+          ChildWorkflowOptions.newBuilder().setTaskQueue(taskQueue).build();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc stubF =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc.class, workflowOptions);
+      assertEquals("func", Async.function(stubF::func).get());
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc1 stubF1 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc1.class, workflowOptions);
+      assertEquals(1, (int) Async.function(stubF1::func1, 1).get());
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc2 stubF2 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc2.class, workflowOptions);
+      assertEquals("12", Async.function(stubF2::func2, "1", 2).get());
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc3 stubF3 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc3.class, workflowOptions);
+      assertEquals("123", Async.function(stubF3::func3, "1", 2, 3).get());
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc4 stubF4 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc4.class, workflowOptions);
+      assertEquals("1234", Async.function(stubF4::func4, "1", 2, 3, 4).get());
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc5 stubF5 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc5.class, workflowOptions);
+      assertEquals("12345", Async.function(stubF5::func5, "1", 2, 3, 4, 5).get());
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc6 stubF6 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsFunc6.class, workflowOptions);
+      assertEquals("123456", Async.function(stubF6::func6, "1", 2, 3, 4, 5, 6).get());
+
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc stubP =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc.class, workflowOptions);
+      Async.procedure(stubP::proc).get();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc1 stubP1 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc1.class, workflowOptions);
+      Async.procedure(stubP1::proc1, "1").get();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc2 stubP2 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc2.class, workflowOptions);
+      Async.procedure(stubP2::proc2, "1", 2).get();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc3 stubP3 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc3.class, workflowOptions);
+      Async.procedure(stubP3::proc3, "1", 2, 3).get();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc4 stubP4 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc4.class, workflowOptions);
+      Async.procedure(stubP4::proc4, "1", 2, 3, 4).get();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc5 stubP5 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc5.class, workflowOptions);
+      Async.procedure(stubP5::proc5, "1", 2, 3, 4, 5).get();
+      TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc6 stubP6 =
+          Workflow.newChildWorkflowStub(
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsProc6.class, workflowOptions);
+      Async.procedure(stubP6::proc6, "1", 2, 3, 4, 5, 6).get();
+      return null;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowAsyncRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowAsyncRetryTest.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.*;
+
+import io.temporal.client.WorkflowException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.ChildWorkflowFailure;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.testing.WorkflowReplayer;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowAsyncRetryTest {
+
+  private final WorkflowTest.AngryChildActivityImpl angryChildActivity =
+      new WorkflowTest.AngryChildActivityImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestChildWorkflowAsyncRetryWorkflow.class, WorkflowTest.AngryChild.class)
+          .setActivityImplementations(angryChildActivity)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testChildWorkflowAsyncRetry() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(20))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    try {
+      client.execute(testWorkflowRule.getTaskQueue());
+      fail("unreachable");
+    } catch (WorkflowException e) {
+      assertTrue(String.valueOf(e.getCause()), e.getCause() instanceof ChildWorkflowFailure);
+      assertTrue(e.getCause().getCause() instanceof ApplicationFailure);
+      assertEquals("test", ((ApplicationFailure) e.getCause().getCause()).getType());
+      assertEquals(
+          "message='simulated failure', type='test', nonRetryable=false",
+          e.getCause().getCause().getMessage());
+    }
+    assertEquals(3, angryChildActivity.getInvocationCount());
+  }
+
+  /** Tests that WorkflowReplayer fails if replay does not match workflow run. */
+  @Test(expected = RuntimeException.class)
+  public void testAlteredWorkflowReplayFailure() throws Exception {
+    Assume.assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testChildWorkflowRetryHistory.json", AlteredTestChildWorkflowRetryWorkflow.class);
+  }
+
+  public static class TestChildWorkflowAsyncRetryWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    private WorkflowTest.ITestChild child;
+
+    public TestChildWorkflowAsyncRetryWorkflow() {}
+
+    @Override
+    public String execute(String taskQueue) {
+      ChildWorkflowOptions options =
+          ChildWorkflowOptions.newBuilder()
+              .setWorkflowRunTimeout(Duration.ofSeconds(5))
+              .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+              .setTaskQueue(taskQueue)
+              .setRetryOptions(
+                  RetryOptions.newBuilder()
+                      .setMaximumInterval(Duration.ofSeconds(1))
+                      .setInitialInterval(Duration.ofSeconds(1))
+                      .setMaximumAttempts(3)
+                      .build())
+              .build();
+      child = Workflow.newChildWorkflowStub(WorkflowTest.ITestChild.class, options);
+      return Async.function(child::execute, taskQueue, 0).get();
+    }
+  }
+
+  public static class AlteredTestChildWorkflowRetryWorkflow
+      extends TestChildWorkflowAsyncRetryWorkflow {
+
+    public AlteredTestChildWorkflowRetryWorkflow() {}
+
+    @Override
+    public String execute(String taskQueue) {
+      Workflow.sleep(Duration.ofMinutes(1));
+      return super.execute(taskQueue);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowCancellationTest.java
@@ -1,0 +1,221 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowCancellationTest {
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+          SDKTestWorkflowRule.newBuilder()
+              .setWorkflowTypes(TestParentWorkflowImpl.class, TestChildWorkflowImpl.class)
+              .setActivityImplementations(activitiesImpl)
+              .setWorkerInterceptors(
+                  new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+              .build();
+
+  @Test
+  public void testChildWorkflowWaitCancellationRequested() {
+    WorkflowStub client = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow");
+    WorkflowExecution execution =
+        client.start(ChildWorkflowCancellationType.WAIT_CANCELLATION_REQUESTED);
+    testWorkflowRule.waitForOKQuery(client);
+    client.cancel();
+    try {
+      client.getResult(String.class);
+      Assert.fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+    GetWorkflowExecutionHistoryRequest request =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+            .setExecution(execution)
+            .build();
+    GetWorkflowExecutionHistoryResponse response =
+        testWorkflowRule
+            .getTestEnvironment()
+            .getWorkflowService()
+            .blockingStub()
+            .getWorkflowExecutionHistory(request);
+
+    boolean hasChildCanceled = false;
+    boolean hasChildCancelRequested = false;
+    for (HistoryEvent event : response.getHistory().getEventsList()) {
+      if (event.getEventType() == EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED) {
+        hasChildCanceled = true;
+      }
+      if (event.getEventType()
+          == EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED) {
+        hasChildCancelRequested = true;
+      }
+    }
+    Assert.assertTrue(hasChildCancelRequested);
+    Assert.assertFalse(hasChildCanceled);
+  }
+
+  @Test
+  public void testChildWorkflowWaitCancellationCompleted() {
+    WorkflowStub client = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow");
+    WorkflowExecution execution =
+        client.start(ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED);
+    testWorkflowRule.waitForOKQuery(client);
+    client.cancel();
+    try {
+      client.getResult(String.class);
+      Assert.fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+    GetWorkflowExecutionHistoryRequest request =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+            .setExecution(execution)
+            .build();
+    GetWorkflowExecutionHistoryResponse response =
+        testWorkflowRule
+            .getTestEnvironment()
+            .getWorkflowService()
+            .blockingStub()
+            .getWorkflowExecutionHistory(request);
+
+    boolean hasChildCanceled = false;
+    for (HistoryEvent event : response.getHistory().getEventsList()) {
+      if (event.getEventType() == EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED) {
+        hasChildCanceled = true;
+      }
+    }
+    Assert.assertTrue(hasChildCanceled);
+  }
+
+  @Test
+  public void testChildWorkflowCancellationAbandon() {
+    WorkflowStub client = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow");
+    WorkflowExecution execution = client.start(ChildWorkflowCancellationType.ABANDON);
+    testWorkflowRule.waitForOKQuery(client);
+    client.cancel();
+    try {
+      client.getResult(String.class);
+      Assert.fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+    GetWorkflowExecutionHistoryRequest request =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+            .setExecution(execution)
+            .build();
+    GetWorkflowExecutionHistoryResponse response =
+        testWorkflowRule
+            .getTestEnvironment()
+            .getWorkflowService()
+            .blockingStub()
+            .getWorkflowExecutionHistory(request);
+
+    boolean hasChildCancelInitiated = false;
+    for (HistoryEvent event : response.getHistory().getEventsList()) {
+      if (event.getEventType()
+          == EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED) {
+        hasChildCancelInitiated = true;
+      }
+    }
+    Assert.assertFalse(hasChildCancelInitiated);
+  }
+
+  @Test
+  public void testChildWorkflowCancellationTryCancel() {
+    WorkflowStub client = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow");
+    WorkflowExecution execution = client.start(ChildWorkflowCancellationType.TRY_CANCEL);
+    testWorkflowRule.waitForOKQuery(client);
+    client.cancel();
+    try {
+      client.getResult(String.class);
+      Assert.fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+    GetWorkflowExecutionHistoryRequest request =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+            .setExecution(execution)
+            .build();
+    GetWorkflowExecutionHistoryResponse response =
+        testWorkflowRule
+            .getTestEnvironment()
+            .getWorkflowService()
+            .blockingStub()
+            .getWorkflowExecutionHistory(request);
+
+    boolean hasChildCancelInitiated = false;
+    boolean hasChildCancelRequested = false;
+    for (HistoryEvent event : response.getHistory().getEventsList()) {
+      if (event.getEventType()
+          == EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED) {
+        hasChildCancelInitiated = true;
+      }
+      if (event.getEventType()
+          == EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED) {
+        hasChildCancelRequested = true;
+      }
+    }
+    Assert.assertTrue(hasChildCancelInitiated);
+    Assert.assertFalse(hasChildCancelRequested);
+  }
+
+  public static class TestParentWorkflowImpl implements WorkflowTest.TestWorkflow {
+
+    @Override
+    public void execute(ChildWorkflowCancellationType cancellationType) {
+      WorkflowTest.TestChildWorkflow child =
+          Workflow.newChildWorkflowStub(
+              WorkflowTest.TestChildWorkflow.class,
+              ChildWorkflowOptions.newBuilder().setCancellationType(cancellationType).build());
+      child.execute();
+    }
+  }
+
+  public static class TestChildWorkflowImpl implements WorkflowTest.TestChildWorkflow {
+    @Override
+    public void execute() {
+      try {
+        Workflow.sleep(Duration.ofHours(1));
+      } catch (CanceledFailure e) {
+        Workflow.newDetachedCancellationScope(() -> Workflow.sleep(Duration.ofSeconds(1))).run();
+      }
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowExecutionPromiseHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowExecutionPromiseHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowExecutionPromiseHandlerTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestNamedChild.class, TestChildWorkflowExecutionPromiseHandler.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  /** Tests that handler of the WorkflowExecution promise is executed in a workflow thread. */
+  @Test
+  public void testChildWorkflowExecutionPromiseHandler() {
+    WorkflowClient workflowStub = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(20))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        workflowStub.newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    String result = client.execute(testWorkflowRule.getTaskQueue());
+    assertEquals("FOO", result);
+  }
+
+  public static class TestNamedChild implements WorkflowTest.ITestNamedChild {
+
+    @Override
+    public String execute(String arg) {
+      return arg.toUpperCase();
+    }
+  }
+
+  public static class TestChildWorkflowExecutionPromiseHandler
+      implements TestWorkflows.TestWorkflow1 {
+
+    private WorkflowTest.ITestNamedChild child;
+
+    @Override
+    public String execute(String taskQueue) {
+      child = Workflow.newChildWorkflowStub(WorkflowTest.ITestNamedChild.class);
+      Promise<String> childResult = Async.function(child::execute, "foo");
+      Promise<WorkflowExecution> executionPromise = Workflow.getWorkflowExecution(child);
+      CompletablePromise<String> result = Workflow.newPromise();
+      // Ensure that the callback can execute Workflow.* functions.
+      executionPromise.thenApply(
+          (we) -> {
+            Workflow.sleep(Duration.ofSeconds(1));
+            result.complete(childResult.get());
+            return null;
+          });
+      return result.get();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowRetryTest.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static io.temporal.workflow.shared.SDKTestWorkflowRule.NAMESPACE;
+import static io.temporal.workflow.shared.SDKTestWorkflowRule.regenerateHistoryForReplay;
+import static org.junit.Assert.*;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.RetryOptions;
+import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.ChildWorkflowFailure;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.testing.WorkflowReplayer;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowRetryTest {
+
+  private final AtomicReference<String> lastStartedWorkflowType = new AtomicReference<>();
+  private final WorkflowTest.AngryChildActivityImpl angryChildActivity =
+      new WorkflowTest.AngryChildActivityImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+          SDKTestWorkflowRule.newBuilder()
+              .setWorkflowTypes(
+                  WorkflowImplementationOptions.newBuilder()
+                      .setFailWorkflowExceptionTypes(UnsupportedOperationException.class)
+                      .build(),
+                  TestChildWorkflowRetryWorkflow.class,
+                  WorkflowTest.AngryChild.class)
+              .setActivityImplementations(angryChildActivity)
+              .setWorkerInterceptors(
+                  new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+              .setWorkflowClientOptions(
+                  WorkflowClientOptions.newBuilder()
+                      .setBinaryChecksum(SDKTestWorkflowRule.BINARY_CHECKSUM)
+                      .setInterceptors(
+                          new WorkflowClientInterceptorBase() {
+                            @Override
+                            public WorkflowStub newUntypedWorkflowStub(
+                                String workflowType, WorkflowOptions options, WorkflowStub next) {
+                              lastStartedWorkflowType.set(workflowType);
+                              return next;
+                            }
+                          })
+                      .setNamespace(NAMESPACE)
+                      .build())
+              .build();
+
+  @Test
+  public void testChildWorkflowRetry() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(20))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    try {
+      client.execute(testWorkflowRule.getTaskQueue());
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.toString(), e.getCause() instanceof ChildWorkflowFailure);
+      assertTrue(e.toString(), e.getCause().getCause() instanceof ApplicationFailure);
+      assertEquals("test", ((ApplicationFailure) e.getCause().getCause()).getType());
+      assertEquals(
+          "message='simulated failure', type='test', nonRetryable=false",
+          e.getCause().getCause().getMessage());
+    }
+    assertEquals("TestWorkflow1", lastStartedWorkflowType.get());
+    assertEquals(3, angryChildActivity.getInvocationCount());
+    WorkflowExecution execution = WorkflowStub.fromTyped(client).getExecution();
+    regenerateHistoryForReplay(
+        testWorkflowRule.getTestEnvironment().getWorkflowService(),
+        execution,
+        "testChildWorkflowRetryHistory");
+  }
+
+  /**
+   * Tests that history that was created before server side retry was supported is backwards
+   * compatible with the client that supports the server side retry.
+   */
+  @Test
+  public void testChildWorkflowRetryReplay() throws Exception {
+    Assume.assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "testChildWorkflowRetryHistory.json", TestChildWorkflowRetryWorkflow.class);
+  }
+
+  public static class TestChildWorkflowRetryWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    private WorkflowTest.ITestChild child;
+
+    public TestChildWorkflowRetryWorkflow() {}
+
+    @Override
+    public String execute(String taskQueue) {
+      ChildWorkflowOptions options =
+          ChildWorkflowOptions.newBuilder()
+              .setWorkflowRunTimeout(Duration.ofSeconds(500))
+              .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+              .setTaskQueue(taskQueue)
+              .setRetryOptions(
+                  RetryOptions.newBuilder()
+                      .setMaximumInterval(Duration.ofSeconds(1))
+                      .setInitialInterval(Duration.ofSeconds(1))
+                      .setMaximumAttempts(3)
+                      .build())
+              .build();
+      child = Workflow.newChildWorkflowStub(WorkflowTest.ITestChild.class, options);
+
+      return child.execute(taskQueue, 0);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowTest {
+
+  private static String child2Id;
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestParentWorkflow.class, TestNamedChild.class, WorkflowTest.TestChild.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testChildWorkflow() {
+    child2Id = UUID.randomUUID().toString();
+
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    assertEquals("HELLO WORLD!", client.execute(testWorkflowRule.getTaskQueue()));
+  }
+
+  public static class TestNamedChild implements WorkflowTest.ITestNamedChild {
+    @Override
+    public String execute(String arg) {
+      return arg.toUpperCase();
+    }
+  }
+
+  public static class TestParentWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    private final WorkflowTest.ITestChild child1 =
+        Workflow.newChildWorkflowStub(WorkflowTest.ITestChild.class);
+    private final WorkflowTest.ITestNamedChild child2;
+
+    public TestParentWorkflow() {
+      ChildWorkflowOptions options =
+          ChildWorkflowOptions.newBuilder().setWorkflowId(child2Id).build();
+      child2 = Workflow.newChildWorkflowStub(WorkflowTest.ITestNamedChild.class, options);
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      Promise<String> r1 = Async.function(child1::execute, "Hello ", 0);
+      String r2 = child2.execute("World!");
+      assertEquals(child2Id, Workflow.getWorkflowExecution(child2).get().getWorkflowId());
+      return r1.get() + r2;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowTimeoutTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Throwables;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowTimeoutTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestParentWorkflowWithChildTimeout.class, WorkflowTest.TestChild.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testChildWorkflowTimeout() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    String result = client.execute(testWorkflowRule.getTaskQueue());
+    assertTrue(result, result.contains("ChildWorkflowFailure"));
+    assertTrue(result, result.contains("TimeoutFailure"));
+  }
+
+  public static class TestParentWorkflowWithChildTimeout implements TestWorkflows.TestWorkflow1 {
+
+    private final WorkflowTest.ITestChild child;
+
+    public TestParentWorkflowWithChildTimeout() {
+      ChildWorkflowOptions options =
+          ChildWorkflowOptions.newBuilder().setWorkflowRunTimeout(Duration.ofSeconds(1)).build();
+      child = Workflow.newChildWorkflowStub(WorkflowTest.ITestChild.class, options);
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      try {
+        child.execute("Hello ", (int) Duration.ofDays(1).toMillis());
+      } catch (Exception e) {
+        return Throwables.getStackTraceAsString(e);
+      }
+      throw new RuntimeException("not reachable");
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowWithCronScheduleTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static io.temporal.workflow.WorkflowTest.lastCompletionResult;
+import static io.temporal.workflow.shared.TestOptions.newWorkflowOptionsWithTimeouts;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class ChildWorkflowWithCronScheduleTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+          SDKTestWorkflowRule.newBuilder()
+              .setWorkflowTypes(
+                  TestCronParentWorkflow.class, WorkflowTest.TestWorkflowWithCronScheduleImpl.class)
+              .setActivityImplementations(activitiesImpl)
+              .setWorkerInterceptors(
+                  new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+              .build();
+
+  @Test
+  public void testChildWorkflowWithCronSchedule() {
+    // Min interval in cron is 1min. So we will not test it against real service in Jenkins.
+    // Feel free to uncomment the line below and test in local.
+    Assume.assumeFalse("skipping as test will timeout", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowStub client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(
+                "TestWorkflow1",
+                newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+                    .toBuilder()
+                    .setWorkflowRunTimeout(Duration.ofHours(10))
+                    .build());
+    client.start(testName.getMethodName());
+    testWorkflowRule.getTestEnvironment().sleep(Duration.ofHours(3));
+    client.cancel();
+
+    try {
+      client.getResult(String.class);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+
+    // Run 3 failed. So on run 4 we get the last completion result from run 2.
+    assertEquals("run 2", lastCompletionResult);
+  }
+
+  public static class TestCronParentWorkflow implements TestWorkflows.TestWorkflow1 {
+    private final WorkflowTest.TestWorkflowWithCronSchedule cronChild =
+        Workflow.newChildWorkflowStub(WorkflowTest.TestWorkflowWithCronSchedule.class);
+
+    @Override
+    public String execute(String taskQueue) {
+      return cronChild.execute(taskQueue);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/NamedChildTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/NamedChildTest.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.*;
+
+import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.ChildWorkflowFailure;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.TestActivities;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NamedChildTest {
+
+  private static final String childReexecuteId = UUID.randomUUID().toString();
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestNamedChild.class, TestChildReexecuteWorkflow.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testChildAlreadyRunning() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    WorkflowIdReusePolicyParent client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(WorkflowIdReusePolicyParent.class, options);
+    try {
+      client.execute(false, WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof ChildWorkflowFailure);
+    }
+  }
+
+  @Test
+  public void testChildStartTwice() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    WorkflowIdReusePolicyParent client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(WorkflowIdReusePolicyParent.class, options);
+    try {
+      client.execute(true, WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof ChildWorkflowFailure);
+    }
+  }
+
+  @Test
+  public void testChildReexecute() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    WorkflowIdReusePolicyParent client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(WorkflowIdReusePolicyParent.class, options);
+    assertEquals(
+        "HELLO WORLD!",
+        client.execute(false, WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE));
+  }
+
+  @WorkflowInterface
+  public interface WorkflowIdReusePolicyParent {
+
+    @WorkflowMethod
+    String execute(boolean parallel, WorkflowIdReusePolicy policy);
+  }
+
+  public static class TestNamedChild implements WorkflowTest.ITestNamedChild {
+
+    @Override
+    public String execute(String arg) {
+      return arg.toUpperCase();
+    }
+  }
+
+  public static class TestChildReexecuteWorkflow implements WorkflowIdReusePolicyParent {
+
+    public TestChildReexecuteWorkflow() {}
+
+    @Override
+    public String execute(boolean parallel, WorkflowIdReusePolicy policy) {
+      ChildWorkflowOptions options =
+          ChildWorkflowOptions.newBuilder()
+              .setWorkflowId(childReexecuteId)
+              .setWorkflowIdReusePolicy(policy)
+              .build();
+
+      WorkflowTest.ITestNamedChild child1 =
+          Workflow.newChildWorkflowStub(WorkflowTest.ITestNamedChild.class, options);
+      Promise<String> r1P = Async.function(child1::execute, "Hello ");
+      String r1 = null;
+      if (!parallel) {
+        r1 = r1P.get();
+      }
+      WorkflowTest.ITestNamedChild child2 =
+          Workflow.newChildWorkflowStub(WorkflowTest.ITestNamedChild.class, options);
+      ChildWorkflowStub child2Stub = ChildWorkflowStub.fromTyped(child2);
+      // Same as String r2 = child2.execute("World!");
+      String r2 = child2Stub.execute(String.class, "World!");
+      if (parallel) {
+        r1 = r1P.get();
+      }
+      assertEquals(childReexecuteId, Workflow.getWorkflowExecution(child1).get().getWorkflowId());
+      assertEquals(childReexecuteId, Workflow.getWorkflowExecution(child2).get().getWorkflowId());
+      return r1 + r2;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/NonSerializableExceptionInChildWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/NonSerializableExceptionInChildWorkflowTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.failure.ChildWorkflowFailure;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NonSerializableExceptionInChildWorkflowTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(WorkflowTest.NonSerializableException.class)
+                  .build(),
+              TestNonSerializableExceptionInChildWorkflow.class,
+              NonSerializableExceptionChildWorkflowImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testNonSerializableExceptionInChildWorkflow() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertTrue(result.contains("NonSerializableException"));
+  }
+
+  public static class NonSerializableExceptionChildWorkflowImpl
+      implements WorkflowTest.NonSerializableExceptionChildWorkflow {
+
+    @Override
+    public String execute(String taskQueue) {
+      throw new WorkflowTest.NonSerializableException();
+    }
+  }
+
+  public static class TestNonSerializableExceptionInChildWorkflow
+      implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      WorkflowTest.NonSerializableExceptionChildWorkflow child =
+          Workflow.newChildWorkflowStub(WorkflowTest.NonSerializableExceptionChildWorkflow.class);
+      try {
+        child.execute(taskQueue);
+      } catch (ChildWorkflowFailure e) {
+        return e.getMessage();
+      }
+      return "done";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/StartChildWorkflowWithCancellationScopeAndCancelParentTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/StartChildWorkflowWithCancellationScopeAndCancelParentTest.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class StartChildWorkflowWithCancellationScopeAndCancelParentTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ParentThatStartsChildInCancellationScope.class, SleepyChild.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testStartChildWorkflowWithCancellationScopeAndCancelParent() {
+    WorkflowStub workflow = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow");
+    workflow.start(ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED);
+    workflow.cancel();
+    try {
+      workflow.getResult(Void.class);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+  }
+
+  public static class ParentThatStartsChildInCancellationScope
+      implements WorkflowTest.TestWorkflow {
+    @Override
+    public void execute(ChildWorkflowCancellationType cancellationType) {
+      WorkflowTest.TestChildWorkflow child =
+          Workflow.newChildWorkflowStub(
+              WorkflowTest.TestChildWorkflow.class,
+              ChildWorkflowOptions.newBuilder().setCancellationType(cancellationType).build());
+      List<Promise<Void>> children = new ArrayList<>();
+      // This is a non blocking call that returns immediately.
+      // Use child.composeGreeting("Hello", name) to call synchronously.
+      CancellationScope scope =
+          Workflow.newCancellationScope(
+              () -> {
+                Promise<Void> promise = Async.procedure(child::execute);
+                children.add(promise);
+              });
+      scope.run();
+      Promise.allOf(children).get();
+    }
+  }
+
+  public static class SleepyChild implements WorkflowTest.TestChildWorkflow {
+    @Override
+    public void execute() {
+      Workflow.await(() -> false);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/UntypedChildStubWorkflowAsyncInvokeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/UntypedChildStubWorkflowAsyncInvokeTest.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestMultiargdsWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UntypedChildStubWorkflowAsyncInvokeTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestUntypedChildStubWorkflowAsyncInvoke.class,
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testUntypedChildStubWorkflowAsyncInvoke() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    Assert.assertEquals(null, client.execute(testWorkflowRule.getTaskQueue()));
+  }
+
+  public static class TestUntypedChildStubWorkflowAsyncInvoke
+      implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      ChildWorkflowOptions workflowOptions =
+          ChildWorkflowOptions.newBuilder().setTaskQueue(taskQueue).build();
+      ChildWorkflowStub stubF =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc", workflowOptions);
+      Assert.assertEquals("func", Async.function(stubF::<String>execute, String.class).get());
+      // Workflow type overridden through the @WorkflowMethod.name
+      ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
+      Assert.assertEquals("1", Async.function(stubF1::<String>execute, String.class, "1").get());
+      ChildWorkflowStub stubF2 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc2", workflowOptions);
+      Assert.assertEquals(
+          "12", Async.function(stubF2::<String>execute, String.class, "1", 2).get());
+      ChildWorkflowStub stubF3 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc3", workflowOptions);
+      Assert.assertEquals(
+          "123", Async.function(stubF3::<String>execute, String.class, "1", 2, 3).get());
+      ChildWorkflowStub stubF4 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc4", workflowOptions);
+      Assert.assertEquals(
+          "1234", Async.function(stubF4::<String>execute, String.class, "1", 2, 3, 4).get());
+      ChildWorkflowStub stubF5 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc5", workflowOptions);
+      Assert.assertEquals(
+          "12345", Async.function(stubF5::<String>execute, String.class, "1", 2, 3, 4, 5).get());
+
+      ChildWorkflowStub stubP =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc", workflowOptions);
+      Async.procedure(stubP::<Void>execute, Void.class).get();
+      ChildWorkflowStub stubP1 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc1", workflowOptions);
+      Async.procedure(stubP1::<Void>execute, Void.class, "1").get();
+      ChildWorkflowStub stubP2 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc2", workflowOptions);
+      Async.procedure(stubP2::<Void>execute, Void.class, "1", 2).get();
+      ChildWorkflowStub stubP3 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc3", workflowOptions);
+      Async.procedure(stubP3::<Void>execute, Void.class, "1", 2, 3).get();
+      ChildWorkflowStub stubP4 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc4", workflowOptions);
+      Async.procedure(stubP4::<Void>execute, Void.class, "1", 2, 3, 4).get();
+      ChildWorkflowStub stubP5 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc5", workflowOptions);
+      Async.procedure(stubP5::<Void>execute, Void.class, "1", 2, 3, 4, 5).get();
+      return null;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/UntypedChildStubWorkflowAsyncTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/UntypedChildStubWorkflowAsyncTest.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestMultiargdsWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UntypedChildStubWorkflowAsyncTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestUntypedChildStubWorkflowAsync.class,
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testUntypedChildStubWorkflowAsync() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    Assert.assertEquals(null, client.execute(testWorkflowRule.getTaskQueue()));
+  }
+
+  public static class TestUntypedChildStubWorkflowAsync implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String taskQueue) {
+      ChildWorkflowOptions workflowOptions =
+          ChildWorkflowOptions.newBuilder().setTaskQueue(taskQueue).build();
+      ChildWorkflowStub stubF =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc", workflowOptions);
+      Assert.assertEquals("func", stubF.executeAsync(String.class).get());
+      // Workflow type overridden through the @WorkflowMethod.name
+      ChildWorkflowStub stubF1 = Workflow.newUntypedChildWorkflowStub("func1", workflowOptions);
+      Assert.assertEquals("1", stubF1.executeAsync(String.class, "1").get());
+      ChildWorkflowStub stubF2 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc2", workflowOptions);
+      Assert.assertEquals("12", stubF2.executeAsync(String.class, "1", 2).get());
+      ChildWorkflowStub stubF3 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc3", workflowOptions);
+      Assert.assertEquals("123", stubF3.executeAsync(String.class, "1", 2, 3).get());
+      ChildWorkflowStub stubF4 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc4", workflowOptions);
+      Assert.assertEquals("1234", stubF4.executeAsync(String.class, "1", 2, 3, 4).get());
+      ChildWorkflowStub stubF5 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc5", workflowOptions);
+      Assert.assertEquals("12345", stubF5.executeAsync(String.class, "1", 2, 3, 4, 5).get());
+      ChildWorkflowStub stubF6 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsFunc6", workflowOptions);
+      Assert.assertEquals("123456", stubF6.executeAsync(String.class, "1", 2, 3, 4, 5, 6).get());
+
+      ChildWorkflowStub stubP =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc", workflowOptions);
+      stubP.executeAsync(Void.class).get();
+      ChildWorkflowStub stubP1 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc1", workflowOptions);
+      stubP1.executeAsync(Void.class, "1").get();
+      ChildWorkflowStub stubP2 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc2", workflowOptions);
+      stubP2.executeAsync(Void.class, "1", 2).get();
+      ChildWorkflowStub stubP3 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc3", workflowOptions);
+      stubP3.executeAsync(Void.class, "1", 2, 3).get();
+      ChildWorkflowStub stubP4 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc4", workflowOptions);
+      stubP4.executeAsync(Void.class, "1", 2, 3, 4).get();
+      ChildWorkflowStub stubP5 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc5", workflowOptions);
+      stubP5.executeAsync(Void.class, "1", 2, 3, 4, 5).get();
+      ChildWorkflowStub stubP6 =
+          Workflow.newUntypedChildWorkflowStub("TestMultiargsWorkflowsProc6", workflowOptions);
+      stubP6.executeAsync(Void.class, "1", 2, 3, 4, 5, 6).get();
+      return null;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/UntypedChildStubWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/UntypedChildStubWorkflowTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestMultiargdsWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UntypedChildStubWorkflowTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowTest.TestUntypedChildStubWorkflow.class,
+              TestMultiargdsWorkflowFunctions.TestMultiargsWorkflowsImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testUntypedChildStubWorkflow() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(200))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(60))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    Assert.assertEquals(null, client.execute(testWorkflowRule.getTaskQueue()));
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static io.temporal.workflow.WorkflowTest.*;
+import static io.temporal.workflow.shared.TestOptions.newWorkflowOptionsWithTimeouts;
+import static org.junit.Assert.*;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import java.time.Duration;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class WorkflowWithCronScheduleTest {
+
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl(null);
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(WorkflowTest.TestWorkflowWithCronScheduleImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkerInterceptors(
+              new TracingWorkerInterceptor(new TracingWorkerInterceptor.FilteredTrace()))
+          .build();
+
+  @Test
+  public void testWorkflowWithCronSchedule() {
+    // Min interval in cron is 1min. So we will not test it against real service in Jenkins.
+    // Feel free to uncomment the line below and test in local.
+    Assume.assumeFalse("skipping as test will timeout", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowStub client =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(
+                "TestWorkflowWithCronSchedule",
+                newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+                    .toBuilder()
+                    .setWorkflowRunTimeout(Duration.ofHours(1))
+                    .setCronSchedule("0 * * * *")
+                    .build());
+    testWorkflowRule.registerDelayedCallback(Duration.ofHours(3), client::cancel);
+    client.start(testName.getMethodName());
+
+    try {
+      client.getResult(String.class);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+
+    // Run 3 failed. So on run 4 we get the last completion result from run 2.
+    assertEquals("run 2", lastCompletionResult);
+    // The last failure ought to be the one from run 3
+    assertTrue(lastFail.isPresent());
+    assertTrue(lastFail.get().getMessage().contains("simulated error"));
+  }
+}


### PR DESCRIPTION
Part of Workflowtest Refactor task: This test file was 7k lines long and contained dozens of tests. 

In addition to readability breaking it up will also enable Gradle to run all those tests in parallel.