### PR TITLE
Fix a typo in workflowClientCallsInterceptor() method name introduced in #382

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientInterceptor.java
@@ -35,7 +35,7 @@ public interface WorkflowClientInterceptor {
    * @return decorated stub
    * @deprecated consider implementing all intercepting functionality using {@link
    *     WorkflowClientCallsInterceptor} that is produced in {@link
-   *     #workflowClientClassInterceptor}. This method has to stay temporary because
+   *     #workflowClientCallsInterceptor}. This method has to stay temporary because
    *     TimeLockingInterceptor has to intercept top level {@link WorkflowStub} methods.
    */
   @Deprecated
@@ -49,7 +49,7 @@ public interface WorkflowClientInterceptor {
    * @return decorated stub
    * @deprecated consider implementing all intercepting functionality using {@link
    *     WorkflowClientCallsInterceptor} that is produced in {@link
-   *     #workflowClientClassInterceptor}. This method has to stay temporary because
+   *     #workflowClientCallsInterceptor}. This method has to stay temporary because
    *     TimeLockingInterceptor has to intercept top level {@link WorkflowStub} methods.
    */
   @Deprecated
@@ -59,11 +59,11 @@ public interface WorkflowClientInterceptor {
   ActivityCompletionClient newActivityCompletionClient(ActivityCompletionClient next);
 
   /**
-   * Called once during creation of WorkflowClient to create a chain of Client Interceptors
+   * Called once during creation of WorkflowClient to create a chain of Client Workflow Interceptors
    *
    * @param next next workflow client interceptor in the chain of interceptors
    * @return new interceptor that should decorate calls to {@code next}
    */
-  WorkflowClientCallsInterceptor workflowClientClassInterceptor(
+  WorkflowClientCallsInterceptor workflowClientCallsInterceptor(
       WorkflowClientCallsInterceptor next);
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientInterceptorBase.java
@@ -48,7 +48,7 @@ public class WorkflowClientInterceptorBase implements WorkflowClientInterceptor 
   }
 
   @Override
-  public WorkflowClientCallsInterceptor workflowClientClassInterceptor(
+  public WorkflowClientCallsInterceptor workflowClientCallsInterceptor(
       WorkflowClientCallsInterceptor next) {
     return next;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
@@ -101,7 +101,7 @@ public final class WorkflowClientInternal implements WorkflowClient {
         new RootWorkflowClientInvoker(genericClient, options, metricsScope);
     for (WorkflowClientInterceptor clientInterceptor : interceptors) {
       workflowClientInvoker =
-          clientInterceptor.workflowClientClassInterceptor(workflowClientInvoker);
+          clientInterceptor.workflowClientCallsInterceptor(workflowClientInvoker);
     }
     return workflowClientInvoker;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java
@@ -384,8 +384,8 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   /**
-   * RunId can change e.g. workflow does ContinueAsNew.
-   * Emptying runId in workflowExecution allows Temporal server figure out the current run id dynamically.
+   * RunId can change e.g. workflow does ContinueAsNew. Emptying runId in workflowExecution allows
+   * Temporal server figure out the current run id dynamically.
    */
   private WorkflowExecution currentExecutionWithoutRunId() {
     WorkflowExecution workflowExecution = execution.get();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ChildWorkflowRetryTest.java
@@ -67,7 +67,7 @@ public class ChildWorkflowRetryTest {
                   .setInterceptors(
                       new WorkflowClientInterceptorBase() {
                         @Override
-                        public WorkflowClientCallsInterceptor workflowClientClassInterceptor(
+                        public WorkflowClientCallsInterceptor workflowClientCallsInterceptor(
                             WorkflowClientCallsInterceptor next) {
                           return new WorkflowClientCallsInterceptorBase(next) {
                             @Override

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -142,7 +142,7 @@ public class WorkflowTest {
             .setInterceptors(
                 new WorkflowClientInterceptorBase() {
                   @Override
-                  public WorkflowClientCallsInterceptor workflowClientClassInterceptor(
+                  public WorkflowClientCallsInterceptor workflowClientCallsInterceptor(
                       WorkflowClientCallsInterceptor next) {
                     return new WorkflowClientCallsInterceptorBase(next) {
                       @Override


### PR DESCRIPTION
PR #382 had a typo with method ```#workflowClientCallsInterceptor``` named ```workflowClientClassInterceptor```. 
This PR fixes the mistake.