### PR TITLE
Make child workflowId available for Interceptors

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityInboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityInboundCallsInterceptorBase.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.common.interceptors;
+
+import io.temporal.activity.ActivityExecutionContext;
+
+public class ActivityInboundCallsInterceptorBase implements ActivityInboundCallsInterceptor {
+  private final ActivityInboundCallsInterceptor next;
+
+  public ActivityInboundCallsInterceptorBase(ActivityInboundCallsInterceptor next) {
+    this.next = next;
+  }
+
+  @Override
+  public void init(ActivityExecutionContext context) {
+    next.init(context);
+  }
+
+  @Override
+  public ActivityOutput execute(ActivityInput input) {
+    return next.execute(input);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -171,6 +171,7 @@ public interface WorkflowOutboundCallsInterceptor {
   }
 
   final class ChildWorkflowInput<R> {
+    private final String workflowId;
     private final String workflowType;
     private final Class<R> resultClass;
     private final Type resultType;
@@ -179,18 +180,24 @@ public interface WorkflowOutboundCallsInterceptor {
     private final Header header;
 
     public ChildWorkflowInput(
+        String workflowId,
         String workflowType,
         Class<R> resultClass,
         Type resultType,
         Object[] args,
         ChildWorkflowOptions options,
         Header header) {
+      this.workflowId = workflowId;
       this.workflowType = workflowType;
       this.resultClass = resultClass;
       this.resultType = resultType;
       this.args = args;
       this.options = options;
       this.header = header;
+    }
+
+    public String getWorkflowId() {
+      return workflowId;
     }
 
     public String getWorkflowType() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowStubImpl.java
@@ -98,7 +98,13 @@ class ChildWorkflowStubImpl implements ChildWorkflowStub {
     ChildWorkflowOutput<R> result =
         outboundCallsInterceptor.executeChildWorkflow(
             new WorkflowOutboundCallsInterceptor.ChildWorkflowInput<>(
-                workflowType, resultClass, resultType, args, options, Header.empty()));
+                getWorkflowIdForStart(options),
+                workflowType,
+                resultClass,
+                resultType,
+                args,
+                options,
+                Header.empty()));
     execution.completeFrom(result.getWorkflowExecution());
     return result.getResult();
   }
@@ -123,5 +129,13 @@ class ChildWorkflowStubImpl implements ChildWorkflowStub {
       e.setStackTrace(Thread.currentThread().getStackTrace());
       throw e;
     }
+  }
+
+  private String getWorkflowIdForStart(ChildWorkflowOptions options) {
+    String workflowId = options.getWorkflowId();
+    if (workflowId == null) {
+      workflowId = Workflow.randomUUID().toString();
+    }
+    return workflowId;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -333,7 +333,12 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     CompletablePromise<WorkflowExecution> execution = Workflow.newPromise();
     Promise<Optional<Payloads>> output =
         executeChildWorkflow(
-            input.getWorkflowType(), input.getOptions(), input.getHeader(), payloads, execution);
+            input.getWorkflowId(),
+            input.getWorkflowType(),
+            input.getOptions(),
+            input.getHeader(),
+            payloads,
+            execution);
     Promise<R> result =
         output.thenApply(
             (b) -> converter.fromPayloads(0, b, input.getResultClass(), input.getResultType()));
@@ -341,6 +346,7 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
   }
 
   private Promise<Optional<Payloads>> executeChildWorkflow(
+      String workflowId,
       String name,
       ChildWorkflowOptions options,
       Header header,
@@ -361,10 +367,6 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     final StartChildWorkflowExecutionCommandAttributes.Builder attributes =
         StartChildWorkflowExecutionCommandAttributes.newBuilder()
             .setWorkflowType(WorkflowType.newBuilder().setName(name).build());
-    String workflowId = options.getWorkflowId();
-    if (workflowId == null) {
-      workflowId = randomUUID().toString();
-    }
     attributes.setWorkflowId(workflowId);
     attributes.setNamespace(OptionsUtils.safeGet(options.getNamespace()));
     if (input.isPresent()) {


### PR DESCRIPTION
This PR moves generation of child `workflowId` into `ChildWorkflowStubImpl` the same way it's done in WorkflowStubImpl: 
https://github.com/temporalio/sdk-java/blob/c802327089fe63694e1baca059a750e970d90b72/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java#L109

This makes child workflowId known and available for Outbound Interceptors 