### PR TITLE
[Proposal] Decouple WorkflowOutboundCallsInterceptor from WorkflowInboundCallsInterceptor

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkerInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkerInterceptor.java
@@ -25,7 +25,9 @@ package io.temporal.common.interceptors;
  * <p>TODO(maxim): JavaDoc with sample
  */
 public interface WorkerInterceptor {
-  WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next);
+  WorkflowInboundCallsInterceptor interceptWorkflowInbound(WorkflowInboundCallsInterceptor next);
+
+  WorkflowOutboundCallsInterceptor interceptWorkflowOutbound(WorkflowOutboundCallsInterceptor next);
 
   ActivityInboundCallsInterceptor interceptActivity(ActivityInboundCallsInterceptor next);
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptor.java
@@ -109,12 +109,8 @@ public interface WorkflowInboundCallsInterceptor {
     }
   }
 
-  /**
-   * Called when workflow class is instantiated.
-   *
-   * @param outboundCalls interceptor for calls that workflow makes to the SDK
-   */
-  void init(WorkflowOutboundCallsInterceptor outboundCalls);
+  /** Called when workflow class is instantiated. */
+  void init();
 
   /**
    * Called when workflow main method is called.

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptorBase.java
@@ -28,8 +28,8 @@ public class WorkflowInboundCallsInterceptorBase implements WorkflowInboundCalls
   }
 
   @Override
-  public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
-    next.init(outboundCalls);
+  public void init() {
+    next.init();
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
 
 /**
  * Can be used to intercept workflow code calls to the Temporal APIs. An instance should be created
- * through {@link WorkerInterceptor#interceptWorkflow(WorkflowInboundCallsInterceptor)}. An
+ * through {@link WorkerInterceptor#interceptWorkflowInbound(WorkflowInboundCallsInterceptor)}. An
  * interceptor instance must forward all the calls to the next interceptor passed to the
  * interceptExecuteWorkflow call.
  *
@@ -434,6 +434,9 @@ public interface WorkflowOutboundCallsInterceptor {
       return handler;
     }
   }
+
+  /** Called when workflow class is instantiated. */
+  void init();
 
   <R> ActivityOutput<R> executeActivity(ActivityInput<R> input);
 

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
@@ -39,6 +39,11 @@ public class WorkflowOutboundCallsInterceptorBase implements WorkflowOutboundCal
   }
 
   @Override
+  public void init() {
+    next.init();
+  }
+
+  @Override
   public <R> ActivityOutput<R> executeActivity(ActivityInput<R> input) {
     return next.executeActivity(input);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -134,6 +134,9 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
   }
 
   @Override
+  public void init() {}
+
+  @Override
   public <T> ActivityOutput<T> executeActivity(ActivityInput<T> input) {
     Optional<Payloads> args = converter.toPayloads(input.getArgs());
     Promise<Optional<Payloads>> binaryResult =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowOutboundCallsInterceptor.java
@@ -48,6 +48,11 @@ public class SignalWorkflowOutboundCallsInterceptor implements WorkflowOutboundC
   }
 
   @Override
+  public void init() {
+    next.init();
+  }
+
+  @Override
   public <T> ActivityOutput<T> executeActivity(ActivityInput<T> input) {
     return next.executeActivity(input);
   }

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TracingWorkerInterceptor.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TracingWorkerInterceptor.java
@@ -84,15 +84,18 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
   }
 
   @Override
-  public WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next) {
+  public WorkflowOutboundCallsInterceptor interceptWorkflowOutbound(
+      WorkflowOutboundCallsInterceptor next) {
+    return new TracingWorkflowOutboundCallsInterceptor(trace, next);
+  }
+
+  @Override
+  public WorkflowInboundCallsInterceptor interceptWorkflowInbound(
+      WorkflowInboundCallsInterceptor next) {
     if (!Workflow.isReplaying()) {
       trace.add("interceptExecuteWorkflow " + Workflow.getInfo().getWorkflowId());
     }
     return new WorkflowInboundCallsInterceptorBase(next) {
-      @Override
-      public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
-        next.init(new TracingWorkflowOutboundCallsInterceptor(trace, outboundCalls));
-      }
 
       @Override
       public void handleSignal(SignalInput input) {
@@ -143,6 +146,11 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
       assertNotNull(workflowInfo);
       this.trace = trace;
       this.next = Objects.requireNonNull(next);
+    }
+
+    @Override
+    public void init() {
+      next.init();
     }
 
     @Override

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -225,6 +225,9 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
   private class TestActivityExecutor implements WorkflowOutboundCallsInterceptor {
 
     @Override
+    public void init() {}
+
+    @Override
     public <T> ActivityOutput<T> executeActivity(ActivityInput<T> i) {
       Optional<Payloads> payloads =
           testEnvironmentOptions


### PR DESCRIPTION
We made a significant breaking change in interceptors in the current release and I propose this change as a part of improving and cleaning up interceptors interfaces.
Right now to define WorkflowOutboundCallsInterceptor you need to define and create it inside WorkflowInboundCallsInterceptor#init() which doesn't make too much sense at all, these two interfaces are not even related and shouldn't be coupled in this manner.

This PR decouples WorkflowInboundCallsInterceptor and WorkflowOutboundCallsInterceptor and allows WorkerInterceptor to define them independently, which keeps things cleaner, at the same time keeping an ability for them to be defined in pairs (inbound/outbound) when it's desired in the same place.