### PR TITLE
Fix TestWorkflowRule#Builder#setWorkerFactoryOptions method signature in accordance with Builder interface

### DIFF
--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -154,8 +154,9 @@ public class TestWorkflowRule implements TestRule {
       return this;
     }
 
-    public void setWorkerFactoryOptions(WorkerFactoryOptions options) {
+    public Builder setWorkerFactoryOptions(WorkerFactoryOptions options) {
       this.workerFactoryOptions = options;
+      return this;
     }
 
     /**


### PR DESCRIPTION
`TestWorkflowRule#Builder#setWorkerFactoryOptions` right now returns void which is a valid setter, but it supposes to be a builder method. This PR fixes the signature of this method in compliance with Builder contract and to be consistent with other setters of TestWorkflowRule#Builder.