### PR TITLE
Make TestWorkflowService#continueAsNew respect headers of the original StartWorkflowExecutionRequest

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -874,6 +874,9 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     if (previousRunStartRequest.hasRetryPolicy()) {
       startRequestBuilder.setRetryPolicy(previousRunStartRequest.getRetryPolicy());
     }
+    if (previousRunStartRequest.hasHeader()) {
+      startRequestBuilder.setHeader(previousRunStartRequest.getHeader());
+    }
     if (a.hasInput()) {
       startRequestBuilder.setInput(a.getInput());
     }


### PR DESCRIPTION
## What was changed:
`TestWorkflowService#continueAsNew` now uses header from the original `StartWorkflowExecutionRequest` for the new `StartWorkflowRequest`.

## Why?
Headers are kinda hidden input parameters (or a context) of the workflow and should be transferred into the new execution without omitting.

## Closes
Issue #420