### PR TITLE
Fix a potential NullPointer in exception processing inside WorkflowStubImpl

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowException.java
@@ -23,6 +23,7 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.failure.TemporalException;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 /** Base exception for all workflow failures. */
 public abstract class WorkflowException extends TemporalException {
@@ -30,7 +31,8 @@ public abstract class WorkflowException extends TemporalException {
   private final WorkflowExecution execution;
   private final Optional<String> workflowType;
 
-  protected WorkflowException(WorkflowExecution execution, String workflowType, Throwable cause) {
+  protected WorkflowException(
+      @Nonnull WorkflowExecution execution, String workflowType, Throwable cause) {
     super(getMessage(execution, workflowType), cause);
     this.execution = Objects.requireNonNull(execution);
     this.workflowType = Optional.ofNullable(workflowType);

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowServiceException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowServiceException.java
@@ -20,10 +20,11 @@
 package io.temporal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;
+import javax.annotation.Nonnull;
 
 public class WorkflowServiceException extends WorkflowException {
   public WorkflowServiceException(
-      WorkflowExecution execution, String workflowType, Throwable cause) {
+      @Nonnull WorkflowExecution execution, String workflowType, Throwable cause) {
     super(execution, workflowType, cause);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
@@ -29,6 +29,12 @@ import java.util.List;
 
 public class TestWorkflows {
   @WorkflowInterface
+  public interface NoArgsWorkflow {
+    @WorkflowMethod
+    void execute();
+  }
+
+  @WorkflowInterface
   public interface TestWorkflow {
     @WorkflowMethod
     void execute(ChildWorkflowCancellationType cancellationType);


### PR DESCRIPTION
## What was changed:

Address the problem with `WorkflowStubImpl#startWithOptions` and `WorkflowStubImpl#signalWithStartWithOptions` passing `workflowExecution` that could be not initialized into NotNull `workflowExecution` param of `WorkflowServiceException` constructor

## Why?

Preserves an original exception from an Interceptor if it happens instead of replacing it with a meaningless NullPointer.