### PR TITLE
Activate OpenTracing Start Spans to bind with potential underlying GRPC spans

### DIFF
--- a/temporal-opentracing/src/test/resources/logback-test.xml
+++ b/temporal-opentracing/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<!--
+     Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+
+     Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+     Modifications copyright (C) 2017 Uber Technologies, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License"). You may not
+     use this file except in compliance with the License. A copy of the License is
+     located at
+
+     http://aws.amazon.com/apache2.0
+
+     or in the "license" file accompanying this file. This file is distributed on
+     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+     express or implied. See the License for the specific language governing
+     permissions and limitations under the License.
+-->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="io.grpc.netty" level="WARN"/>
+    <!-- Modify root log level to get more info -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowStubImpl.java
@@ -126,11 +126,7 @@ class WorkflowStubImpl implements WorkflowStub {
         // an WorkflowExecution instance with just a workflowId
         workflowExecution = WorkflowExecution.newBuilder().setWorkflowId(workflowId).build();
       }
-      throw new WorkflowServiceException(
-          // if start failed with exception - there could be no valid workflow execution.
-          // WorkflowServiceException requires not null workflowExecution, so we have to provide
-          // an empty default WorkflowExecution instance
-          workflowExecution, workflowType.orElse(null), e);
+      throw new WorkflowServiceException(workflowExecution, workflowType.orElse(null), e);
     }
   }
 


### PR DESCRIPTION
## What was changed:

Add a test for tracing LocalActivity
Activate start spans in outbound interceptors to bind with underlying GRPC spans if GRPC client is instrumented

## Why?

If GRPC client is instrumented with OpenTracing - we don't want to lose its spans.