### PR TITLE
Do not override Micrometer's naming conventions

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/reporter/MicrometerClientStatsReporter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/reporter/MicrometerClientStatsReporter.java
@@ -27,7 +27,6 @@ import com.uber.m3.util.Duration;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.config.NamingConvention;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +38,6 @@ public class MicrometerClientStatsReporter implements StatsReporter {
 
   public MicrometerClientStatsReporter(MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry);
-    registry.config().namingConvention(NamingConvention.snakeCase);
   }
 
   @Override


### PR DESCRIPTION
## What was changed:

`MicrometerClientStatsReporter` no longer sets `namingConvention` on the `MeterRegistry` passed to it.

## Why?

The `MeterRegistry` passed to the `MicrometerClientStatsReporter` might have some naming convention already set, and the creation of `MicrometerClientStatsReporter` would override it.

Also, the `snakeCase` convention is the default one for any `MeterRegistry`, so an explicit set would only be required if specific registry sets some other convention, in which case it might make sense to keep it as it.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: fixes #432
2. How was this tested: unit test; ran client application with the altered version of `MicrometerClientStatsReporter`.

