### PR TITLE
Local type

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -51,6 +51,7 @@ public final class LocalActivityOptions {
     private Duration localRetryThreshold;
     private Duration startToCloseTimeout;
     private RetryOptions retryOptions;
+    private boolean doNotIncludeArgumentsIntoMarker;
 
     /** Copy Builder fields from the options. */
     private Builder(LocalActivityOptions options) {
@@ -60,7 +61,8 @@ public final class LocalActivityOptions {
       this.scheduleToCloseTimeout = options.getScheduleToCloseTimeout();
       this.localRetryThreshold = options.getLocalRetryThreshold();
       this.startToCloseTimeout = options.getStartToCloseTimeout();
-      this.retryOptions = options.retryOptions;
+      this.retryOptions = options.getRetryOptions();
+      this.doNotIncludeArgumentsIntoMarker = options.isDoNotIncludeArgumentsIntoMarker();
     }
 
     /** Overall timeout workflow is willing to wait for activity to complete. */
@@ -112,9 +114,28 @@ public final class LocalActivityOptions {
       return this;
     }
 
+    /**
+     * When set to true the serialized arguments of the local activity are not included into the
+     * Marker Event that stores local activity invocation result.
+     *
+     * <p>The serialized arguments are included only for human troubleshooting as they are never
+     * read by the SDK code. So in some cases it is worth not including them to reduce the history
+     * size.
+     *
+     * <p>Default is false.
+     */
+    public Builder setDoNotIncludeArgumentsIntoMarker(boolean doNotIncludeArgumentsIntoMarker) {
+      this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;
+      return this;
+    }
+
     public LocalActivityOptions build() {
       return new LocalActivityOptions(
-          startToCloseTimeout, localRetryThreshold, scheduleToCloseTimeout, retryOptions);
+          startToCloseTimeout,
+          localRetryThreshold,
+          scheduleToCloseTimeout,
+          retryOptions,
+          doNotIncludeArgumentsIntoMarker);
     }
 
     public LocalActivityOptions validateAndBuildWithDefaults() {
@@ -126,7 +147,8 @@ public final class LocalActivityOptions {
           startToCloseTimeout,
           localRetryThreshold,
           scheduleToCloseTimeout,
-          RetryOptions.newBuilder(retryOptions).validateBuildWithDefaults());
+          RetryOptions.newBuilder(retryOptions).validateBuildWithDefaults(),
+          doNotIncludeArgumentsIntoMarker);
     }
   }
 
@@ -134,16 +156,19 @@ public final class LocalActivityOptions {
   private final Duration localRetryThreshold;
   private final Duration startToCloseTimeout;
   private final RetryOptions retryOptions;
+  private boolean doNotIncludeArgumentsIntoMarker;
 
   private LocalActivityOptions(
       Duration startToCloseTimeout,
       Duration localRetryThreshold,
       Duration scheduleToCloseTimeout,
-      RetryOptions retryOptions) {
+      RetryOptions retryOptions,
+      boolean doNotIncludeArgumentsIntoMarker) {
     this.localRetryThreshold = localRetryThreshold;
     this.scheduleToCloseTimeout = scheduleToCloseTimeout;
     this.startToCloseTimeout = startToCloseTimeout;
     this.retryOptions = retryOptions;
+    this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;
   }
 
   public Duration getScheduleToCloseTimeout() {
@@ -162,6 +187,10 @@ public final class LocalActivityOptions {
     return retryOptions;
   }
 
+  public boolean isDoNotIncludeArgumentsIntoMarker() {
+    return doNotIncludeArgumentsIntoMarker;
+  }
+
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -169,16 +198,23 @@ public final class LocalActivityOptions {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof LocalActivityOptions)) return false;
     LocalActivityOptions that = (LocalActivityOptions) o;
-    return Objects.equal(scheduleToCloseTimeout, that.scheduleToCloseTimeout)
+    return doNotIncludeArgumentsIntoMarker == that.doNotIncludeArgumentsIntoMarker
+        && Objects.equal(scheduleToCloseTimeout, that.scheduleToCloseTimeout)
+        && Objects.equal(localRetryThreshold, that.localRetryThreshold)
         && Objects.equal(startToCloseTimeout, that.startToCloseTimeout)
         && Objects.equal(retryOptions, that.retryOptions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(scheduleToCloseTimeout, startToCloseTimeout, retryOptions);
+    return Objects.hashCode(
+        scheduleToCloseTimeout,
+        localRetryThreshold,
+        startToCloseTimeout,
+        retryOptions,
+        doNotIncludeArgumentsIntoMarker);
   }
 
   @Override
@@ -186,10 +222,14 @@ public final class LocalActivityOptions {
     return "LocalActivityOptions{"
         + "scheduleToCloseTimeout="
         + scheduleToCloseTimeout
+        + ", localRetryThreshold="
+        + localRetryThreshold
         + ", startToCloseTimeout="
         + startToCloseTimeout
         + ", retryOptions="
         + retryOptions
+        + ", doNotIncludeArgumentsIntoMarker="
+        + doNotIncludeArgumentsIntoMarker
         + '}';
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ExecuteLocalActivityParameters.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ExecuteLocalActivityParameters.java
@@ -26,11 +26,15 @@ public class ExecuteLocalActivityParameters {
 
   private final PollActivityTaskQueueResponse.Builder activityTask;
   private final Duration localRetryThreshold;
+  private boolean doNotIncludeArgumentsIntoMarker;
 
   public ExecuteLocalActivityParameters(
-      PollActivityTaskQueueResponse.Builder activityTask, Duration localRetryThreshold) {
+      PollActivityTaskQueueResponse.Builder activityTask,
+      Duration localRetryThreshold,
+      boolean doNotIncludeArgumentsIntoMarker) {
     this.activityTask = activityTask;
     this.localRetryThreshold = localRetryThreshold;
+    this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;
   }
 
   public PollActivityTaskQueueResponse.Builder getActivityTask() {
@@ -39,6 +43,10 @@ public class ExecuteLocalActivityParameters {
 
   public Duration getLocalRetryThreshold() {
     return localRetryThreshold;
+  }
+
+  public boolean isDoNotIncludeArgumentsIntoMarker() {
+    return doNotIncludeArgumentsIntoMarker;
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityStateMachine.java
@@ -50,9 +50,11 @@ final class LocalActivityStateMachine
 
   static final String LOCAL_ACTIVITY_MARKER_NAME = "LocalActivity";
   static final String MARKER_ACTIVITY_ID_KEY = "activityId";
-  static final String MARKER_ACTIVITY_TYPE_KEY = "activityType";
-  static final String MARKER_ACTIVITY_INPUT_KEY = "activityInput";
+  static final String MARKER_ACTIVITY_TYPE_KEY = "type";
+  static final String MARKER_ACTIVITY_INPUT_KEY = "input";
+  static final String MARKER_ACTIVITY_RESULT_KEY = "result";
   static final String MARKER_TIME_KEY = "time";
+  // Deprecated in favor of result. Still present for backwards compatibility.
   static final String MARKER_DATA_KEY = "data";
 
   private final DataConverter dataConverter = DataConverter.getDefaultInstance();
@@ -251,7 +253,7 @@ final class LocalActivityStateMachine
         if (completed.hasResult()) {
           Payloads p = completed.getResult();
           laResult = Optional.of(p);
-          details.put(MARKER_DATA_KEY, p);
+          details.put(MARKER_ACTIVITY_RESULT_KEY, p);
         } else {
           laResult = Optional.empty();
         }
@@ -311,7 +313,12 @@ final class LocalActivityStateMachine
       callback.apply(null, attributes.getFailure());
       return;
     }
-    Optional<Payloads> fromMaker = Optional.ofNullable(map.get(MARKER_DATA_KEY));
+    Payloads result = map.get(MARKER_ACTIVITY_RESULT_KEY);
+    if (result == null) {
+      // Support old histories that used "data" as a key for "result".
+      result = map.get(MARKER_DATA_KEY);
+    }
+    Optional<Payloads> fromMaker = Optional.ofNullable(result);
     callback.apply(fromMaker, null);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -324,7 +324,8 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     if (localRetryThreshold == null) {
       localRetryThreshold = context.getWorkflowTaskTimeout().multipliedBy(6);
     }
-    return new ExecuteLocalActivityParameters(activityTask, localRetryThreshold);
+    return new ExecuteLocalActivityParameters(
+        activityTask, localRetryThreshold, options.isDoNotIncludeArgumentsIntoMarker());
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -21,7 +21,7 @@ package io.temporal.internal.statemachines;
 
 import static io.temporal.internal.statemachines.LocalActivityStateMachine.LOCAL_ACTIVITY_MARKER_NAME;
 import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_ACTIVITY_ID_KEY;
-import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_DATA_KEY;
+import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_ACTIVITY_RESULT_KEY;
 import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_TIME_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -210,7 +210,7 @@ public class LocalActivityStateMachineTest {
                   .get(0)
                   .getRecordMarkerCommandAttributes()
                   .getDetailsMap()
-                  .get(MARKER_DATA_KEY));
+                  .get(MARKER_ACTIVITY_RESULT_KEY));
       assertEquals("result2", converter.fromPayloads(0, dataActivity2, String.class, String.class));
       Optional<Payloads> dataActivity3 =
           Optional.of(
@@ -218,7 +218,7 @@ public class LocalActivityStateMachineTest {
                   .get(1)
                   .getRecordMarkerCommandAttributes()
                   .getDetailsMap()
-                  .get(MARKER_DATA_KEY));
+                  .get(MARKER_ACTIVITY_RESULT_KEY));
       assertEquals("result3", converter.fromPayloads(0, dataActivity3, String.class, String.class));
     }
     {
@@ -247,7 +247,7 @@ public class LocalActivityStateMachineTest {
                   .get(0)
                   .getRecordMarkerCommandAttributes()
                   .getDetailsMap()
-                  .get(MARKER_DATA_KEY));
+                  .get(MARKER_ACTIVITY_RESULT_KEY));
       assertEquals("result1", converter.fromPayloads(0, data, String.class, String.class));
       assertEquals(
           CommandType.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION, commands.get(1).getCommandType());

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -19,8 +19,13 @@
 
 package io.temporal.internal.statemachines;
 
-import static io.temporal.internal.statemachines.LocalActivityStateMachine.*;
-import static org.junit.Assert.*;
+import static io.temporal.internal.statemachines.LocalActivityStateMachine.LOCAL_ACTIVITY_MARKER_NAME;
+import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_ACTIVITY_ID_KEY;
+import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_DATA_KEY;
+import static io.temporal.internal.statemachines.LocalActivityStateMachine.MARKER_TIME_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.temporal.api.command.v1.Command;
 import io.temporal.api.common.v1.ActivityType;
@@ -86,19 +91,22 @@ public class LocalActivityStateMachineTest {
                 PollActivityTaskQueueResponse.newBuilder()
                     .setActivityId("id1")
                     .setActivityType(ActivityType.newBuilder().setName("activity1")),
-                null);
+                null,
+                true);
         ExecuteLocalActivityParameters parameters2 =
             new ExecuteLocalActivityParameters(
                 PollActivityTaskQueueResponse.newBuilder()
                     .setActivityId("id2")
                     .setActivityType(ActivityType.newBuilder().setName("activity2")),
-                null);
+                null,
+                false);
         ExecuteLocalActivityParameters parameters3 =
             new ExecuteLocalActivityParameters(
                 PollActivityTaskQueueResponse.newBuilder()
                     .setActivityId("id3")
                     .setActivityType(ActivityType.newBuilder().setName("activity3")),
-                null);
+                null,
+                true);
 
         builder
             .<Optional<Payloads>, Failure>add2(
@@ -271,7 +279,8 @@ public class LocalActivityStateMachineTest {
                 PollActivityTaskQueueResponse.newBuilder()
                     .setActivityId("id1")
                     .setActivityType(ActivityType.newBuilder().setName("activity1")),
-                null);
+                null,
+                false);
         builder
             .<Optional<Payloads>, Failure>add2(
                 (r, c) -> stateMachines.scheduleLocalActivityTask(parameters1, c))

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BinaryChecksumSetWhenTaskCompletedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BinaryChecksumSetWhenTaskCompletedTest.java
@@ -53,8 +53,7 @@ public class BinaryChecksumSetWhenTaskCompletedTest {
     WorkflowStub stub = WorkflowStub.fromTyped(client);
     SDKTestWorkflowRule.waitForOKQuery(stub);
 
-    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
-        execution, EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED);
+    testWorkflowRule.assertHistoryEvent(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED);
   }
 
   public static class SimpleTestWorkflow implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BinaryChecksumSetWhenTaskCompletedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BinaryChecksumSetWhenTaskCompletedTest.java
@@ -19,14 +19,9 @@
 
 package io.temporal.workflow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import io.temporal.activity.ActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowStub;
@@ -57,18 +52,9 @@ public class BinaryChecksumSetWhenTaskCompletedTest {
         WorkflowClient.start(client::execute, testWorkflowRule.getTaskQueue());
     WorkflowStub stub = WorkflowStub.fromTyped(client);
     SDKTestWorkflowRule.waitForOKQuery(stub);
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
 
-    boolean foundCompletedTask = false;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED) {
-        assertEquals(
-            SDKTestWorkflowRule.BINARY_CHECKSUM,
-            event.getWorkflowTaskCompletedEventAttributes().getBinaryChecksum());
-        foundCompletedTask = true;
-      }
-    }
-    assertTrue(foundCompletedTask);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+        execution, EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED);
   }
 
   public static class SimpleTestWorkflow implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/UpsertSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/UpsertSearchAttributesTest.java
@@ -25,8 +25,6 @@ import static org.junit.Assert.assertNull;
 import io.temporal.api.common.v1.SearchAttributes;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
 import io.temporal.internal.common.SearchAttributesUtil;
 import io.temporal.testing.TracingWorkerInterceptor;
@@ -64,16 +62,8 @@ public class UpsertSearchAttributesTest {
             "upsertSearchAttributes",
             "executeActivity Activity",
             "activity Activity");
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    boolean found = false;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES == event.getEventType()) {
-        found = true;
-        break;
-      }
-    }
-    Assert.assertTrue("EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES found in the history", found);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+        execution, EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES);
   }
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/workflow/UpsertSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/UpsertSearchAttributesTest.java
@@ -62,7 +62,7 @@ public class UpsertSearchAttributesTest {
             "upsertSearchAttributes",
             "executeActivity Activity",
             "activity Activity");
-    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+    testWorkflowRule.assertHistoryEvent(
         execution, EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES);
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
@@ -21,8 +21,6 @@ package io.temporal.workflow;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
@@ -62,15 +60,12 @@ public class WorkflowTaskFailureBackoffTest {
     Assert.assertTrue("spinned on fail workflow task", elapsed > 1000);
     Assert.assertEquals("result1", result);
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
 
-    int failedTaskCount = 0;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED) {
-        failedTaskCount++;
-      }
-    }
-    Assert.assertEquals(1, failedTaskCount);
+    Assert.assertEquals(
+        1,
+        testWorkflowRule
+            .getWorkflowExecutionHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .size());
   }
 
   public static class TestWorkflowTaskFailureBackoff implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
@@ -64,7 +64,7 @@ public class WorkflowTaskFailureBackoffTest {
     Assert.assertEquals(
         1,
         testWorkflowRule
-            .getWorkflowExecutionHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
             .size());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskNPEBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskNPEBackoffTest.java
@@ -61,7 +61,7 @@ public class WorkflowTaskNPEBackoffTest {
     Assert.assertEquals(
         1,
         testWorkflowRule
-            .getWorkflowExecutionHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
             .size());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskNPEBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskNPEBackoffTest.java
@@ -21,8 +21,6 @@ package io.temporal.workflow;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
@@ -60,15 +58,11 @@ public class WorkflowTaskNPEBackoffTest {
     Assert.assertTrue("spinned on fail workflow task", elapsed > 1000);
     Assert.assertEquals("result1", result);
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    int failedTaskCount = 0;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED) {
-        failedTaskCount++;
-      }
-    }
-    Assert.assertEquals(1, failedTaskCount);
+    Assert.assertEquals(
+        1,
+        testWorkflowRule
+            .getWorkflowExecutionHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .size());
   }
 
   public static class TestWorkflowTaskNPEBackoff implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AbandonOnCancelActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AbandonOnCancelActivityTest.java
@@ -73,8 +73,7 @@ public class AbandonOnCancelActivityTest {
     activitiesImpl.assertInvocations("activityWithDelay");
     Assert.assertTrue(
         testWorkflowRule
-            .getWorkflowExecutionHistoryEvents(
-                execution, EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED)
+            .getHistoryEvents(execution, EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED)
             .isEmpty());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AbandonOnCancelActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AbandonOnCancelActivityTest.java
@@ -23,8 +23,6 @@ import io.temporal.activity.ActivityCancellationType;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowStub;
@@ -73,12 +71,11 @@ public class AbandonOnCancelActivityTest {
     long elapsed = testWorkflowRule.getTestEnvironment().currentTimeMillis() - start;
     Assert.assertTrue(String.valueOf(elapsed), elapsed < 500);
     activitiesImpl.assertInvocations("activityWithDelay");
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    for (HistoryEvent event : history.getEventsList()) {
-      Assert.assertNotEquals(
-          EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED, event.getEventType());
-    }
+    Assert.assertTrue(
+        testWorkflowRule
+            .getWorkflowExecutionHistoryEvents(
+                execution, EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED)
+            .isEmpty());
   }
 
   public static class TestAbandonOnCancelActivity implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityAndQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityAndQueryTest.java
@@ -106,7 +106,11 @@ public class LocalActivityAndQueryTest {
     public String execute(String taskQueue) {
       TestActivities localActivities =
           Workflow.newLocalActivityStub(
-              TestActivities.class, TestOptions.newLocalActivityOptions());
+              TestActivities.class,
+              TestOptions.newLocalActivityOptions()
+                  .toBuilder()
+                  .setDoNotIncludeArgumentsIntoMarker(true)
+                  .build());
       for (int i = 0; i < 5; i++) {
         localActivities.sleepActivity(1000, i);
         message = "run" + i;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityTest.java
@@ -20,17 +20,27 @@
 package io.temporal.workflow.activityTests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.converter.DataConverter;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.testing.TracingWorkerInterceptor;
 import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestActivities;
 import io.temporal.workflow.shared.TestOptions;
-import io.temporal.workflow.shared.TestWorkflows;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,9 +59,9 @@ public class LocalActivityTest {
 
   @Test
   public void testLocalActivity() {
-    TestWorkflows.TestWorkflow1 workflowStub =
-        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
-    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    LocalActivityTestWorkflow workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(LocalActivityTestWorkflow.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue(), false);
     Assert.assertEquals("test123123", result);
     Assert.assertEquals(activitiesImpl.toString(), 5, activitiesImpl.invocations.size());
     testWorkflowRule
@@ -69,14 +79,85 @@ public class LocalActivityTest {
             "local activity Activity2",
             "executeActivity Activity2",
             "activity Activity2");
+    WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
+    List<HistoryEvent> markers =
+        testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+    for (HistoryEvent marker : markers) {
+      String activityType =
+          DataConverter.getDefaultInstance()
+              .fromPayloads(
+                  0,
+                  Optional.of(
+                      marker.getMarkerRecordedEventAttributes().getDetailsMap().get("type")),
+                  String.class,
+                  String.class);
+      if (activityType.equals("Activity2")) {
+        Optional<Payloads> input =
+            Optional.of(marker.getMarkerRecordedEventAttributes().getDetailsMap().get("input"));
+        String arg0 =
+            DataConverter.getDefaultInstance().fromPayloads(0, input, String.class, String.class);
+        assertEquals("test", arg0);
+      }
+    }
   }
 
-  public static class TestLocalActivityWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+  @Test
+  public void testLocalActivityNoInput() {
+    LocalActivityTestWorkflow workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(LocalActivityTestWorkflow.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue(), true);
+    Assert.assertEquals("test123123", result);
+    Assert.assertEquals(activitiesImpl.toString(), 5, activitiesImpl.invocations.size());
+    testWorkflowRule
+        .getInterceptor(TracingWorkerInterceptor.class)
+        .setExpected(
+            "interceptExecuteWorkflow " + SDKTestWorkflowRule.UUID_REGEXP,
+            "newThread workflow-method",
+            "executeLocalActivity ThrowIO",
+            "currentTimeMillis",
+            "local activity ThrowIO",
+            "local activity ThrowIO",
+            "local activity ThrowIO",
+            "executeLocalActivity Activity2",
+            "currentTimeMillis",
+            "local activity Activity2",
+            "executeActivity Activity2",
+            "activity Activity2");
+    WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
+    List<HistoryEvent> markers =
+        testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+    for (HistoryEvent marker : markers) {
+      String activityType =
+          DataConverter.getDefaultInstance()
+              .fromPayloads(
+                  0,
+                  Optional.of(
+                      marker.getMarkerRecordedEventAttributes().getDetailsMap().get("type")),
+                  String.class,
+                  String.class);
+      if (activityType.equals("Activity2")) {
+        assertFalse(marker.getMarkerRecordedEventAttributes().getDetailsMap().containsKey("input"));
+      }
+    }
+  }
+
+  @WorkflowInterface
+  public interface LocalActivityTestWorkflow {
+
+    @WorkflowMethod
+    String execute(String taskQueue, boolean doNotIncludeArgumentsIntoMarker);
+  }
+
+  public static class TestLocalActivityWorkflowImpl implements LocalActivityTestWorkflow {
     @Override
-    public String execute(String taskQueue) {
+    public String execute(String taskQueue, boolean doNotIncludeArgumentsIntoMarker) {
       TestActivities localActivities =
           Workflow.newLocalActivityStub(
-              TestActivities.class, TestOptions.newLocalActivityOptions());
+              TestActivities.class,
+              TestOptions.newLocalActivityOptions()
+                  .toBuilder()
+                  .setDoNotIncludeArgumentsIntoMarker(doNotIncludeArgumentsIntoMarker)
+                  .build());
       try {
         localActivities.throwIO();
       } catch (ActivityFailure e) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
@@ -19,10 +19,10 @@
 
 package io.temporal.workflow.childWorkflowTests;
 
+import static org.junit.Assert.assertTrue;
+
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
@@ -57,23 +57,12 @@ public class ChildWorkflowCancellationTest {
       client.getResult(String.class);
       Assert.fail("unreachable");
     } catch (WorkflowFailedException e) {
-      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+      assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    boolean hasChildCanceled = false;
-    boolean hasChildCancelRequested = false;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType() == EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED) {
-        hasChildCanceled = true;
-      }
-      if (event.getEventType()
-          == EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED) {
-        hasChildCancelRequested = true;
-      }
-    }
-    Assert.assertTrue(hasChildCancelRequested);
-    Assert.assertFalse(hasChildCanceled);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+        execution, EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+        execution, EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
   }
 
   @Test
@@ -87,17 +76,10 @@ public class ChildWorkflowCancellationTest {
       client.getResult(String.class);
       Assert.fail("unreachable");
     } catch (WorkflowFailedException e) {
-      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+      assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    boolean hasChildCanceled = false;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType() == EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED) {
-        hasChildCanceled = true;
-      }
-    }
-    Assert.assertTrue(hasChildCanceled);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+        execution, EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
   }
 
   @Test
@@ -110,18 +92,10 @@ public class ChildWorkflowCancellationTest {
       client.getResult(String.class);
       Assert.fail("unreachable");
     } catch (WorkflowFailedException e) {
-      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+      assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    boolean hasChildCancelInitiated = false;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType()
-          == EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED) {
-        hasChildCancelInitiated = true;
-      }
-    }
-    Assert.assertFalse(hasChildCancelInitiated);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+        execution, EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
   }
 
   @Test
@@ -134,24 +108,12 @@ public class ChildWorkflowCancellationTest {
       client.getResult(String.class);
       Assert.fail("unreachable");
     } catch (WorkflowFailedException e) {
-      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+      assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    boolean hasChildCancelInitiated = false;
-    boolean hasChildCancelRequested = false;
-    for (HistoryEvent event : history.getEventsList()) {
-      if (event.getEventType()
-          == EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED) {
-        hasChildCancelInitiated = true;
-      }
-      if (event.getEventType()
-          == EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED) {
-        hasChildCancelRequested = true;
-      }
-    }
-    Assert.assertTrue(hasChildCancelInitiated);
-    Assert.assertFalse(hasChildCancelRequested);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+        execution, EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
+    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+        execution, EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
   }
 
   public static class TestParentWorkflowImpl implements TestWorkflows.TestWorkflow {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
@@ -59,9 +59,9 @@ public class ChildWorkflowCancellationTest {
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+    testWorkflowRule.assertHistoryEvent(
         execution, EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
-    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+    testWorkflowRule.assertNoHistoryEvent(
         execution, EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
   }
 
@@ -78,7 +78,7 @@ public class ChildWorkflowCancellationTest {
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+    testWorkflowRule.assertHistoryEvent(
         execution, EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
   }
 
@@ -94,7 +94,7 @@ public class ChildWorkflowCancellationTest {
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+    testWorkflowRule.assertNoHistoryEvent(
         execution, EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
   }
 
@@ -110,9 +110,9 @@ public class ChildWorkflowCancellationTest {
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    testWorkflowRule.assertWorkflowExecutionHistoryHasEvent(
+    testWorkflowRule.assertHistoryEvent(
         execution, EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
-    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+    testWorkflowRule.assertNoHistoryEvent(
         execution, EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/StartChildWorkflowWithCancellationScopeAndCancelParentTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/StartChildWorkflowWithCancellationScopeAndCancelParentTest.java
@@ -35,7 +35,6 @@ import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
@@ -196,15 +196,14 @@ public class SDKTestWorkflowRule implements TestRule {
     return testWorkflowRule.getTaskQueue();
   }
 
-  public History getWorkflowExecutionHistory(WorkflowExecution execution) {
+  public History getHistory(WorkflowExecution execution) {
     return testWorkflowRule.getWorkflowExecutionHistory(execution);
   }
 
   /** Returns list of all events of the given EventType found in the history. */
-  public List<HistoryEvent> getWorkflowExecutionHistoryEvents(
-      WorkflowExecution execution, EventType eventType) {
+  public List<HistoryEvent> getHistoryEvents(WorkflowExecution execution, EventType eventType) {
     List<HistoryEvent> result = new ArrayList<>();
-    History history = getWorkflowExecutionHistory(execution);
+    History history = getHistory(execution);
     for (HistoryEvent event : history.getEventsList()) {
       if (eventType == event.getEventType()) {
         result.add(event);
@@ -214,10 +213,9 @@ public class SDKTestWorkflowRule implements TestRule {
   }
 
   /** Returns the first event of the given EventType found in the history. */
-  public HistoryEvent getWorkflowExecutionHistoryEvent(
-      WorkflowExecution execution, EventType eventType) {
+  public HistoryEvent getHistoryEvent(WorkflowExecution execution, EventType eventType) {
     List<HistoryEvent> result = new ArrayList<>();
-    History history = getWorkflowExecutionHistory(execution);
+    History history = getHistory(execution);
     for (HistoryEvent event : history.getEventsList()) {
       if (eventType == event.getEventType()) {
         return event;
@@ -227,9 +225,8 @@ public class SDKTestWorkflowRule implements TestRule {
   }
 
   /** Asserts that an event of the given EventType is found in the history. */
-  public void assertWorkflowExecutionHistoryHasEvent(
-      WorkflowExecution execution, EventType eventType) {
-    History history = getWorkflowExecutionHistory(execution);
+  public void assertHistoryEvent(WorkflowExecution execution, EventType eventType) {
+    History history = getHistory(execution);
     for (HistoryEvent event : history.getEventsList()) {
       if (eventType == event.getEventType()) {
         return;
@@ -239,9 +236,8 @@ public class SDKTestWorkflowRule implements TestRule {
   }
 
   /** Asserts that an event of the given EventType is not found in the history. */
-  public void assertWorkflowExecutionHistoryHasNoEvent(
-      WorkflowExecution execution, EventType eventType) {
-    History history = getWorkflowExecutionHistory(execution);
+  public void assertNoHistoryEvent(WorkflowExecution execution, EventType eventType) {
+    History history = getHistory(execution);
     for (HistoryEvent event : history.getEventsList()) {
       if (eventType == event.getEventType()) {
         fail("Event of " + eventType + " found in the history");

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
@@ -20,13 +20,16 @@
 package io.temporal.workflow.shared;
 
 import static io.temporal.client.WorkflowClient.QUERY_TYPE_STACK_TRACE;
+import static org.junit.Assert.fail;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.io.CharSink;
 import com.google.common.io.Files;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.History;
+import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
@@ -195,6 +198,55 @@ public class SDKTestWorkflowRule implements TestRule {
 
   public History getWorkflowExecutionHistory(WorkflowExecution execution) {
     return testWorkflowRule.getWorkflowExecutionHistory(execution);
+  }
+
+  /** Returns list of all events of the given EventType found in the history. */
+  public List<HistoryEvent> getWorkflowExecutionHistoryEvents(
+      WorkflowExecution execution, EventType eventType) {
+    List<HistoryEvent> result = new ArrayList<>();
+    History history = getWorkflowExecutionHistory(execution);
+    for (HistoryEvent event : history.getEventsList()) {
+      if (eventType == event.getEventType()) {
+        result.add(event);
+      }
+    }
+    return result;
+  }
+
+  /** Returns the first event of the given EventType found in the history. */
+  public HistoryEvent getWorkflowExecutionHistoryEvent(
+      WorkflowExecution execution, EventType eventType) {
+    List<HistoryEvent> result = new ArrayList<>();
+    History history = getWorkflowExecutionHistory(execution);
+    for (HistoryEvent event : history.getEventsList()) {
+      if (eventType == event.getEventType()) {
+        return event;
+      }
+    }
+    throw new IllegalArgumentException("No event of " + eventType + " found in the history");
+  }
+
+  /** Asserts that an event of the given EventType is found in the history. */
+  public void assertWorkflowExecutionHistoryHasEvent(
+      WorkflowExecution execution, EventType eventType) {
+    History history = getWorkflowExecutionHistory(execution);
+    for (HistoryEvent event : history.getEventsList()) {
+      if (eventType == event.getEventType()) {
+        return;
+      }
+    }
+    fail("No event of " + eventType + " found in the history");
+  }
+
+  /** Asserts that an event of the given EventType is not found in the history. */
+  public void assertWorkflowExecutionHistoryHasNoEvent(
+      WorkflowExecution execution, EventType eventType) {
+    History history = getWorkflowExecutionHistory(execution);
+    for (HistoryEvent event : history.getEventsList()) {
+      if (eventType == event.getEventType()) {
+        fail("Event of " + eventType + " found in the history");
+      }
+    }
   }
 
   public WorkflowClient getWorkflowClient() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
@@ -53,8 +53,7 @@ public class GetVersionSameIdOnReplayTest {
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     workflowStub.execute(testWorkflowRule.getTaskQueue());
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
-        execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+    testWorkflowRule.assertNoHistoryEvent(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
   }
 
   public static class TestGetVersionSameIdOnReplay implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
@@ -23,15 +23,12 @@ import static org.junit.Assert.assertEquals;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.history.v1.History;
-import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowStub;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,12 +53,8 @@ public class GetVersionSameIdOnReplayTest {
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     workflowStub.execute(testWorkflowRule.getTaskQueue());
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    History history = testWorkflowRule.getWorkflowExecutionHistory(execution);
-
-    // Validate that no marker is recorded
-    for (HistoryEvent event : history.getEventsList()) {
-      Assert.assertFalse(EventType.EVENT_TYPE_MARKER_RECORDED == event.getEventType());
-    }
+    testWorkflowRule.assertWorkflowExecutionHistoryHasNoEvent(
+        execution, EventType.EVENT_TYPE_MARKER_RECORDED);
   }
 
   public static class TestGetVersionSameIdOnReplay implements TestWorkflows.TestWorkflow1 {


### PR DESCRIPTION
## What was changed:

Changes to the MarkerRecordedEvent details map.
1. Added "input" that contains activity arguments. Can be disabled through `LocalActivityOptions.doNotIncludeArgumentsIntoMarker` to reduce history size.
2. Added "type" that contains the activity type name.
3. Renamed "data" to "result" for activity result.

Also did refactoring of unit tests to reduce repetitive code.

## Why?
Debugging local activities is hard as their type and arguments are not part of the event history.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 
Fix for https://github.com/temporalio/sdk-java/issues/135.

2. How was this tested:
Looking for the "input" field in the UI.

