### PR TITLE
getVersion sometimes works incorrectly when used inside a Timer

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/TimerTwoConcurrentFiresTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/TimerTwoConcurrentFiresTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TimerTwoConcurrentFiresTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestTimerTwoConcurrentFiresWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testTimerTwoConcurrentFires() {
+    TestWorkflows.TestWorkflow1 client =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    client.execute(testWorkflowRule.getTaskQueue());
+  }
+
+  public static class TestTimerTwoConcurrentFiresWorkflowImpl
+      implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      Workflow.newTimer(Duration.ofMinutes(1));
+      Workflow.newTimer(Duration.ofMinutes(1));
+
+      Workflow.sleep(Duration.ofMinutes(10));
+
+      return "";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -77,23 +77,16 @@ public class GetVersionAndTimerTest {
   abstract static class TimedWorkflowImpl implements TimedWorkflow {
     @Override
     public Instant startAndWait() {
-      Workflow.newTimer(Duration.ofMinutes(10))
+      getVersion();
+
+      Workflow.newTimer(Duration.ofMinutes(1))
           .thenApply(
               (v) -> {
                 getVersion();
                 return v;
               });
 
-      Workflow.sleep(Duration.ofHours(1));
-
-      Workflow.newTimer(Duration.ofMinutes(10))
-          .thenApply(
-              (v) -> {
-                getVersion();
-                return v;
-              });
-
-      Workflow.sleep(Duration.ofHours(1));
+      Workflow.sleep(Duration.ofHours(2));
 
       return Instant.ofEpochMilli(Workflow.currentTimeMillis());
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetVersionAndTimerTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRuleWithoutVersion =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TimedWorkflowWithoutVersionImpl.class)
+          .build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRuleWithVersion =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TimedWorkflowWithVersionImpl.class).build();
+
+  @Test
+  public void testTimedWorkflowWithoutVersionImpl() {
+    testTimedWorkflow(testWorkflowRuleWithoutVersion);
+  }
+
+  @Test
+  public void testTimedWorkflowWithVersionImpl() {
+    testTimedWorkflow(testWorkflowRuleWithVersion);
+  }
+
+  private void testTimedWorkflow(SDKTestWorkflowRule rule) {
+    TimedWorkflow workflowStub = rule.newWorkflowStubTimeoutOptions(TimedWorkflow.class);
+
+    Instant startInstant = Instant.ofEpochMilli(rule.getTestEnvironment().currentTimeMillis());
+
+    Instant endInstant = workflowStub.startAndWait();
+
+    assertTrue(
+        "endInstant "
+            + endInstant
+            + " should be more than 2 hours away from startInstant "
+            + startInstant,
+        endInstant.isAfter(startInstant.plus(Duration.ofHours(2))));
+  }
+
+  @WorkflowInterface
+  public interface TimedWorkflow {
+
+    @WorkflowMethod
+    Instant startAndWait();
+  }
+
+  abstract static class TimedWorkflowImpl implements TimedWorkflow {
+    @Override
+    public Instant startAndWait() {
+      Workflow.newTimer(Duration.ofMinutes(10))
+          .thenApply(
+              (v) -> {
+                getVersion();
+                return v;
+              });
+
+      Workflow.sleep(Duration.ofHours(1));
+
+      Workflow.newTimer(Duration.ofMinutes(10))
+          .thenApply(
+              (v) -> {
+                getVersion();
+                return v;
+              });
+
+      Workflow.sleep(Duration.ofHours(1));
+
+      return Instant.ofEpochMilli(Workflow.currentTimeMillis());
+    }
+
+    protected abstract void getVersion();
+  }
+
+  public static class TimedWorkflowWithoutVersionImpl extends TimedWorkflowImpl
+      implements TimedWorkflow {
+
+    @Override
+    protected void getVersion() {
+      // Do nothing
+    }
+  }
+
+  public static class TimedWorkflowWithVersionImpl extends TimedWorkflowImpl
+      implements TimedWorkflow {
+
+    @Override
+    protected void getVersion() {
+      Workflow.getVersion("id", Workflow.DEFAULT_VERSION, 1);
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This is not a merge request but a bug report. Please do not merge as-is.

We've recently discovered a couple of issues with the way timers and versions interact with each other. With a help of the test from this PR, I seem to be able to isolate one of the issues.

~~The test illustrates a workflow that starts 2 timers, sleeps twice, and potentially calls `getVersion` from timer callbacks. The test includes 2 implementations of the same workflow that differ only in whether they call `Workflow.getVersion` from the callbacks.~~
**Update**: The test illustrates a workflow that calls `getVersion` from the main workflow thread, starts a timer, and calls `getVersion` from the timer callback. The test includes 2 implementations of the same workflow that differ only in whether they call `Workflow.getVersion` from or not.

If no `getVersion` is called, the test results are what we would expect to get. The time at the end of the workflow is at least 2 hours later than the time at the start of the workflow.

However, if timer callbacks include `getVersion` calls then the test fails.

This test seems to be the simplest reproduction case I was able to get. ~~Both timers and both `getVersion` calls are required, otherwise, all tests succeed. Timers also have to be separated by a `Workflow.sleep` call, otherwise, both tests time out (which might be another issue?)~~
**Update**: A call from the main workflow thread and a call from a timer callback thread seems to be enough to break workflow's virtual time. All elements seem to be required now.

I've also one more test to reproduces another test environment issue. Seems like if 2 timers are fired at the same time the workflow hangs. The `TimerTwoConcurrentFiresTest` test fails with `test timed out after 10 seconds`. If timers are set to fire at 2 different intervals the test succeeds.