### PR TITLE
Cleaning up Activity Javadocs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
@@ -36,7 +36,7 @@ public final class Activity {
 
   /**
    * Can be used to get information about Activity invocation and Heartbeats.
-   * Note: This static method relies on a thread local and works only in the original Activity thread.
+   * This static method relies on a local thread and works only in the original Activity thread.
    */
   public static ActivityExecutionContext getExecutionContext() {
     return ActivityInternal.getExecutionContext();

--- a/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
@@ -26,178 +26,7 @@ import io.temporal.internal.sync.ActivityInternal;
 import io.temporal.internal.sync.WorkflowInternal;
 
 /**
- * An activity is the implementation of a particular task in the business logic.
- *
- * <h2>Activity Interface</h2>
- *
- * <p>Activities are defined as methods of a plain Java interface annotated with {@literal @}{@link
- * ActivityInterface}. Each method defines a single activity type. A single workflow can use more
- * than one activity interface and call more than one activity method from the same interface. The
- * only requirement is that activity method arguments and return values are serializable to a byte
- * array using the provided {@link io.temporal.common.converter.DataConverter} implementation. The
- * default implementation uses JSON serializer, but an alternative implementation can be configured
- * through {@link io.temporal.client.WorkflowClientOptions.Builder#setDataConverter(DataConverter)}.
- *
- * <p>Example of an interface that defines four activities:
- *
- * <pre><code>
- * {@literal @}ActivityInterface
- * public interface FileProcessingActivities {
- *
- *     void upload(String bucketName, String localName, String targetName);
- *
- *     String download(String bucketName, String remoteName);
- *
- *     {@literal @}ActivityMethod(name = "Transcode")
- *     String processFile(String localName);
- *
- *     void deleteLocalFile(String fileName);
- * }
- *
- * </code></pre>
- *
- * An optional {@literal @}{@link ActivityMethod} annotation can be used to specify activity name.
- * By default the method name with the first letter capitalized is used as an activity name. So the
- * above interface defines the following activities: "Upload", "Download", "Transcode" and
- * "DeleteLocalFile".
- *
- * <h2>Activity Implementation</h2>
- *
- * <p>Activity implementation is an implementation of an activity interface. A single instance of
- * the activity's implementation is shared across multiple simultaneous activity invocations.
- * Therefore, the activity implementation code must be <i>thread safe</i>.
- *
- * <p>The values passed to activities through invocation parameters or returned through a result
- * value are recorded in the execution history. The entire execution history is transferred from the
- * Temporal service to workflow workers when a workflow state needs to recover. A large execution
- * history can thus adversely impact the performance of your workflow. Therefore, be mindful of the
- * amount of data you transfer via activity invocation parameters or return values. Other than that,
- * no additional limitations exist on activity implementations.
- *
- * <pre><code>
- * public class FileProcessingActivitiesImpl implements FileProcessingActivities {
- *
- *     private final AmazonS3 s3Client;
- *
- *     private final String localDirectory;
- *
- *     void upload(String bucketName, String localName, String targetName) {
- *         File f = new File(localName);
- *         s3Client.putObject(bucket, remoteName, f);
- *     }
- *
- *     String download(String bucketName, String remoteName, String localName) {
- *         // Implementation omitted for brevity.
- *         return downloadFileFromS3(bucketName, remoteName, localDirectory + localName);
- *     }
- *
- *     String processFile(String localName) {
- *         // Implementation omitted for brevity.
- *         return compressFile(localName);
- *     }
- *
- *     void deleteLocalFile(String fileName) {
- *         File f = new File(localDirectory + fileName);
- *         f.delete();
- *     }
- * }
- * </code></pre>
- *
- * <h3>Accessing Activity Info</h3>
- *
- * <p>The {@link Activity#getExecutionContext()} returns {@link ActivityExecutionContext} which
- * provides static getters to access information about the workflow that invoked it. Note that the
- * activity context information is stored in a thread-local variable. Therefore, calls to {@link
- * Activity#getExecutionContext()} succeeds only in the thread that invoked the activity function.
- *
- * <pre><code>
- * public class FileProcessingActivitiesImpl implements FileProcessingActivities {
- *
- *      {@literal @}Override
- *      public String download(String bucketName, String remoteName, String localName) {
- *         ActivityExecutionContext ctx = Activity.getExecutionContext();
- *         ActivityInfo info = ctx.getInfo();
- *         log.info("namespace=" +  info.getActivityNamespace());
- *         log.info("workflowId=" + info.getWorkflowId());
- *         log.info("runId=" + info.getRunId());
- *         log.info("activityId=" + info.getActivityId());
- *         log.info("activityTimeout=" + info.getStartToCloseTimeoutSeconds());
- *         return downloadFileFromS3(bucketName, remoteName, localDirectory + localName);
- *      }
- *      ...
- *  }
- * </code></pre>
- *
- * <h3>Asynchronous Activity Completion</h3>
- *
- * <p>Sometimes an activity lifecycle goes beyond a synchronous method invocation. For example, a
- * request can be put in a queue and later a reply comes and is picked up by a different worker
- * process. The whole request-reply interaction can be modeled as a single Temporal activity.
- *
- * <p>To indicate that an activity should not be completed upon its method return, call {@link
- * ActivityExecutionContext#doNotCompleteOnReturn()} from the original activity thread. Then later,
- * when replies come, complete the activity using {@link
- * io.temporal.client.ActivityCompletionClient}. To correlate activity invocation with completion
- * use either {@code TaskToken} or workflow and activity IDs.
- *
- * <pre><code>
- * public class FileProcessingActivitiesImpl implements FileProcessingActivities {
- *
- *      public String download(String bucketName, String remoteName, String localName) {
- *          ActivityExecutionContext ctx = Activity.getExecutionContext();
- *          byte[] taskToken = ctx.getInfo().getTaskToken(); // Used to correlate reply
- *          asyncDownloadFileFromS3(taskToken, bucketName, remoteName, localDirectory + localName);
- *          ctx.doNotCompleteOnReturn();
- *          return "ignored"; // Return value is ignored when doNotCompleteOnReturn was called.
- *      }
- *      ...
- * }
- * </code></pre>
- *
- * When the download is complete, the download service potentially calls back from a different
- * process:
- *
- * <pre><code>
- *     public <R> void completeActivity(byte[] taskToken, R result) {
- *         completionClient.complete(taskToken, result);
- *     }
- *
- *     public void failActivity(byte[] taskToken, Exception failure) {
- *         completionClient.completeExceptionally(taskToken, failure);
- *     }
- * </code></pre>
- *
- * <h3>Activity Heartbeating</h3>
- *
- * <p>Some activities are long running. To react to their crashes quickly, use a heartbeat
- * mechanism. Use the {@link ActivityExecutionContext#heartbeat(Object)} function to let the
- * Temporal service know that the activity is still alive. You can piggyback `details` on an
- * activity heartbeat. If an activity times out, the last value of `details` is included in the
- * ActivityTimeoutException delivered to a workflow. Then the workflow can pass the details to the
- * next activity invocation. This acts as a periodic checkpointing mechanism of an activity's
- * progress.
- *
- * <pre><code>
- * public class FileProcessingActivitiesImpl implements FileProcessingActivities {
- *
- *      {@literal @}Override
- *      public String download(String bucketName, String remoteName, String localName) {
- *         InputStream inputStream = openInputStream(file);
- *         try {
- *             byte[] bytes = new byte[MAX_BUFFER_SIZE];
- *             while ((read = inputStream.read(bytes)) != -1) {
- *                 totalRead += read;
- *                 f.write(bytes, 0, read);
- *                 // Let the service know about the download progress.
- *                 Activity.getExecutionContext().heartbeat(totalRead);
- *             }
- *         }finally{
- *             inputStream.close();
- *         }
- *      }
- *      ...
- * }
- * </code></pre>
+ * An Activity is the implementation of a particular task in the business logic.
  *
  * @see io.temporal.worker.Worker
  * @see io.temporal.workflow.Workflow
@@ -206,8 +35,7 @@ import io.temporal.internal.sync.WorkflowInternal;
 public final class Activity {
 
   /**
-   * Activity execution context. It can be used to get information about activity invocation as well
-   * for heartbeating.
+   * Can be used to get information about activity invocation and heartbeats
    *
    * <p>Note: This static method relies on a thread local and works only in the original activity
    * thread.
@@ -217,39 +45,14 @@ public final class Activity {
   }
 
   /**
-   * If there is a need to return a checked exception from an activity do not add the exception to a
-   * method signature but rethrow it using this method. The library code will unwrap it
-   * automatically when propagating exception to the caller. There is no need to wrap unchecked
-   * exceptions, but it is safe to call this method on them.
+   * Use this to rethrow a checked exception from an Activity instead of adding the exception to a method signature.
    *
-   * <p>The reason for such design is that returning originally thrown exception from a remote call
-   * (which child workflow and activity invocations are ) would not allow adding context information
-   * about a failure, like activity and child workflow id. So stubs always throw a subclass of
-   * {@link ActivityFailure} from calls to an activity and subclass of {@link ChildWorkflowFailure}
-   * from calls to a child workflow. The original exception is attached as a cause to these wrapper
-   * exceptions. So as exceptions are always wrapped adding checked ones to method signature causes
-   * more pain than benefit.
-   *
-   * <p>Throws original exception if e is {@link RuntimeException} or {@link Error}. Never returns.
-   * But return type is not empty to be able to use it as:
-   *
-   * <pre>
-   * try {
-   *     return someCall();
-   * } catch (Exception e) {
-   *     throw Activity.wrap(e);
-   * }
-   * </pre>
-   *
-   * If wrap returned void it wouldn't be possible to write <code>
-   * throw Activity.wrap</code> and compiler would complain about missing return.
-   *
-   * @return never returns as always throws.
+   * @return never returns; always throws. Throws original exception if e is {@link RuntimeException} or {@link Error}.
    */
   public static RuntimeException wrap(Throwable e) {
     return WorkflowInternal.wrap(e);
   }
 
-  /** Prohibit instantiation */
+  /** Prohibits instantiation */
   private Activity() {}
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
@@ -35,10 +35,8 @@ import io.temporal.internal.sync.WorkflowInternal;
 public final class Activity {
 
   /**
-   * Can be used to get information about activity invocation and heartbeats
-   *
-   * <p>Note: This static method relies on a thread local and works only in the original activity
-   * thread.
+   * Can be used to get information about Activity invocation and Heartbeats.
+   * Note: This static method relies on a thread local and works only in the original Activity thread.
    */
   public static ActivityExecutionContext getExecutionContext() {
     return ActivityInternal.getExecutionContext();
@@ -47,12 +45,14 @@ public final class Activity {
   /**
    * Use this to rethrow a checked exception from an Activity instead of adding the exception to a method signature.
    *
-   * @return never returns; always throws. Throws original exception if e is {@link RuntimeException} or {@link Error}.
+   * @return Never returns; always throws. Throws original exception if e is {@link RuntimeException} or {@link Error}.
    */
   public static RuntimeException wrap(Throwable e) {
     return WorkflowInternal.wrap(e);
   }
 
-  /** Prohibits instantiation */
+  /**
+   * Prohibits instantiation.
+   */
   private Activity() {}
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
@@ -19,9 +19,6 @@
 
 package io.temporal.activity;
 
-import io.temporal.common.converter.DataConverter;
-import io.temporal.failure.ActivityFailure;
-import io.temporal.failure.ChildWorkflowFailure;
 import io.temporal.internal.sync.ActivityInternal;
 import io.temporal.internal.sync.WorkflowInternal;
 
@@ -35,24 +32,24 @@ import io.temporal.internal.sync.WorkflowInternal;
 public final class Activity {
 
   /**
-   * Can be used to get information about Activity invocation and Heartbeats.
-   * This static method relies on a local thread and works only in the original Activity thread.
+   * Can be used to get information about Activity invocation and to invoke Heartbeats. This static
+   * method relies on a local thread and works only in the original Activity thread.
    */
   public static ActivityExecutionContext getExecutionContext() {
     return ActivityInternal.getExecutionContext();
   }
 
   /**
-   * Use this to rethrow a checked exception from an Activity instead of adding the exception to a method signature.
+   * Use this to rethrow a checked exception from an Activity instead of adding the exception to a
+   * method signature.
    *
-   * @return Never returns; always throws. Throws original exception if e is {@link RuntimeException} or {@link Error}.
+   * @return Never returns; always throws. Throws original exception if e is {@link
+   *     RuntimeException} or {@link Error}.
    */
   public static RuntimeException wrap(Throwable e) {
     return WorkflowInternal.wrap(e);
   }
 
-  /**
-   * Prohibits instantiation.
-   */
+  /** Prohibits instantiation. */
   private Activity() {}
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
@@ -33,7 +33,7 @@ public final class Activity {
 
   /**
    * Can be used to get information about Activity invocation and to invoke Heartbeats. This static
-   * method relies on a local thread and works only in the original Activity thread.
+   * method relies on a thread-local variable and works only in the original Activity thread.
    */
   public static ActivityExecutionContext getExecutionContext() {
     return ActivityInternal.getExecutionContext();

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -23,23 +23,23 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.workflow.CancellationScope;
 
 /**
- * Defines behaviour of the parent workflow when {@link CancellationScope} that wraps child workflow
- * execution request is canceled. The result of the cancellation independently of the type is a
- * {@link CanceledFailure} thrown from the child workflow method.
+ * Defines behaviour of the parent Workflow when {@link CancellationScope} that wraps child Workflow
+ * execution request is canceled. The result of the cancellation (independently of the type), is a
+ * {@link CanceledFailure} thrown from the child Workflow method.
  */
 public enum ActivityCancellationType {
   /**
-   * Wait for activity cancellation completion. Note that activity must heartbeat to receive a
-   * cancellation notification. This can block the cancellation for a long time if activity doesn't
+   * Wait for Activity cancellation completion. Note that Activity must heartbeat to receive a
+   * cancellation notification. This can block the cancellation for a long time if Activity doesn't
    * heartbeat or chooses to ignore the cancellation request.
    */
   WAIT_CANCELLATION_COMPLETED,
 
-  /** Initiate a cancellation request and immediately report cancellation to the workflow. */
+  /** Initiate a cancellation request and immediately report cancellation to the Workflow. */
   TRY_CANCEL,
 
   /**
-   * Do not request cancellation of the activity and immediately report cancellation to the workflow
+   * Do not request cancellation of the Activity and immediately report cancellation to the Workflow.
    */
   ABANDON,
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -19,31 +19,21 @@
 
 package io.temporal.activity;
 
-import io.temporal.failure.CanceledFailure;
-import io.temporal.workflow.CancellationScope;
-
-/**
- * Defines behaviour of the parent Workflow when the {@link CancellationScope} that wraps the child Workflow
- * execution request is canceled.
- * The result of the cancellation (independently of the type) is a {@link CanceledFailure}
- * thrown from the child Workflow method.
- */
+/** Defines activity cancellation behavior. */
 public enum ActivityCancellationType {
   /**
-   * Wait for the Activity to complete its cancellation.
-   * Note that an Activity must Heartbeat to receive a cancellation notification.
-   * This can block the cancellation for a long time if the Activity doesn't Heartbeat
-   * or chooses to ignore the cancellation request.
+   * Wait for the Activity to complete its cancellation. Note that an Activity must Heartbeat to
+   * receive a cancellation notification. This can block the cancellation for a long time if the
+   * Activity doesn't Heartbeat or chooses to ignore the cancellation request.
    */
   WAIT_CANCELLATION_COMPLETED,
 
-  /**
-   * Initiate a cancellation request and immediately report cancellation to the Workflow.
-   */
+  /** Initiate a cancellation request and immediately report cancellation to the Workflow. */
   TRY_CANCEL,
 
   /**
-   * Do not request cancellation of the Activity and immediately report cancellation to the Workflow.
+   * Do not request cancellation of the Activity and immediately report cancellation to the
+   * Workflow.
    */
   ABANDON,
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -19,7 +19,7 @@
 
 package io.temporal.activity;
 
-/** Defines activity cancellation behavior. */
+/** Defines Activity cancellation behavior. */
 public enum ActivityCancellationType {
   /**
    * Wait for the Activity to complete its cancellation. Note that an Activity must Heartbeat to

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -23,15 +23,17 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.workflow.CancellationScope;
 
 /**
- * Defines behaviour of the parent Workflow when the {@link CancellationScope} that wraps child Workflow
- * execution request is canceled. The result of the cancellation (independently of the type) is a
- * {@link CanceledFailure} thrown from the child Workflow method.
+ * Defines behaviour of the parent Workflow when the {@link CancellationScope} that wraps the child Workflow
+ * execution request is canceled.
+ * The result of the cancellation (independently of the type) is a {@link CanceledFailure}
+ * thrown from the child Workflow method.
  */
 public enum ActivityCancellationType {
   /**
-   * Wait for Activity cancellation completion. Note that an Activity must Heartbeat to receive a
-   * cancellation notification. This can block the cancellation for a long time if the Activity doesn't
-   * Heartbeat or chooses to ignore the cancellation request.
+   * Wait for the Activity to complete its cancellation.
+   * Note that an Activity must Heartbeat to receive a cancellation notification.
+   * This can block the cancellation for a long time if the Activity doesn't Heartbeat
+   * or chooses to ignore the cancellation request.
    */
   WAIT_CANCELLATION_COMPLETED,
 

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -22,7 +22,7 @@ package io.temporal.activity;
 /** Defines Activity cancellation behavior. */
 public enum ActivityCancellationType {
   /**
-   * Wait for the Activity to complete its cancellation. Note that an Activity must Heartbeat to
+   * Wait for the Activity to confirm any requested cancellation. Note that an Activity must Heartbeat to
    * receive a cancellation notification. This can block the cancellation for a long time if the
    * Activity doesn't Heartbeat or chooses to ignore the cancellation request.
    */

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -23,19 +23,21 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.workflow.CancellationScope;
 
 /**
- * Defines behaviour of the parent Workflow when {@link CancellationScope} that wraps child Workflow
- * execution request is canceled. The result of the cancellation (independently of the type), is a
+ * Defines behaviour of the parent Workflow when the {@link CancellationScope} that wraps child Workflow
+ * execution request is canceled. The result of the cancellation (independently of the type) is a
  * {@link CanceledFailure} thrown from the child Workflow method.
  */
 public enum ActivityCancellationType {
   /**
-   * Wait for Activity cancellation completion. Note that Activity must heartbeat to receive a
-   * cancellation notification. This can block the cancellation for a long time if Activity doesn't
-   * heartbeat or chooses to ignore the cancellation request.
+   * Wait for Activity cancellation completion. Note that an Activity must Heartbeat to receive a
+   * cancellation notification. This can block the cancellation for a long time if the Activity doesn't
+   * Heartbeat or chooses to ignore the cancellation request.
    */
   WAIT_CANCELLATION_COMPLETED,
 
-  /** Initiate a cancellation request and immediately report cancellation to the Workflow. */
+  /**
+   * Initiate a cancellation request and immediately report cancellation to the Workflow.
+   */
   TRY_CANCEL,
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -24,8 +24,8 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * Information about the Activity Task that the current Activity is handling. Use {@link
- * ActivityExecutionContext#getInfo()} to access.
+ * Information about the Activity Task that the current Activity is handling.
+ * Use {@link ActivityExecutionContext#getInfo()} to access.
  */
 public interface ActivityInfo {
 
@@ -46,7 +46,8 @@ public interface ActivityInfo {
   String getRunId();
 
   /**
-   * ID of the Activity. This ID can be used to complete the Activity asynchronously through {@link
+   * ID of the Activity.
+   * This ID can be used to complete the Activity asynchronously through {@link
    * io.temporal.client.ActivityCompletionClient#complete(String, Optional, String, Object)}.
    */
   String getActivityId();

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -24,34 +24,34 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * The information about the activity task that the current activity is handling. Use {@link
+ * The information about the Activity task that the current Activity is handling. Use {@link
  * ActivityExecutionContext#getInfo()} to access.
  */
 public interface ActivityInfo {
 
   /**
-   * A correlation token that can be used to complete the activity asynchronously through {@link
+   * A correlation token that can be used to complete the Activity asynchronously through {@link
    * io.temporal.client.ActivityCompletionClient#complete(byte[], Object)}.
    */
   byte[] getTaskToken();
 
-  /** WorkflowId of the workflow that scheduled the activity. */
+  /** WorkflowId of the workflow that scheduled the Activity. */
   String getWorkflowId();
 
-  /** RunId of the workflow that scheduled the activity. */
+  /** RunId of the workflow that scheduled the Activity. */
   String getRunId();
 
   /**
-   * ID of the activity. This ID can be used to complete the activity asynchronously through {@link
+   * ID of the Activity. This ID can be used to complete the Activity asynchronously through {@link
    * io.temporal.client.ActivityCompletionClient#complete(String, Optional, String, Object)}.
    */
   String getActivityId();
 
-  /** Type of the activity. */
+  /** Type of the Activity. */
   String getActivityType();
 
   /**
-   * Time when the activity was initially scheduled by the workflow.
+   * Time when the Activity was initially scheduled by the Workflow.
    *
    * @return timestamp in milliseconds
    */
@@ -74,6 +74,6 @@ public interface ActivityInfo {
   /** Activity execution attempt starting from 1. */
   int getAttempt();
 
-  /** Is this activity invoked as a local activity? */
+  /** Is this Activity invoked as a local Activity? */
   boolean isLocal();
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -24,8 +24,8 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * Information about the Activity Task that the current Activity is handling.
- * Use {@link ActivityExecutionContext#getInfo()} to access.
+ * Information about the Activity Task that the current Activity is handling. Use {@link
+ * ActivityExecutionContext#getInfo()} to access.
  */
 public interface ActivityInfo {
 
@@ -35,26 +35,19 @@ public interface ActivityInfo {
    */
   byte[] getTaskToken();
 
-  /**
-   * WorkflowId of the Workflow that scheduled the Activity.
-   */
+  /** WorkflowId of the Workflow that scheduled the Activity. */
   String getWorkflowId();
 
-  /**
-   * RunId of the Workflow that scheduled the Activity.
-   */
+  /** RunId of the Workflow that scheduled the Activity. */
   String getRunId();
 
   /**
-   * ID of the Activity.
-   * This ID can be used to complete the Activity asynchronously through {@link
+   * ID of the Activity. This ID can be used to complete the Activity asynchronously through {@link
    * io.temporal.client.ActivityCompletionClient#complete(String, Optional, String, Object)}.
    */
   String getActivityId();
 
-  /**
-   * Type of the Activity.
-   */
+  /** Type of the Activity. */
   String getActivityType();
 
   /**
@@ -78,13 +71,9 @@ public interface ActivityInfo {
 
   String getActivityNamespace();
 
-  /**
-   * Activity execution attempt. Starts from 1.
-   */
+  /** Activity execution attempt. Starts from 1. Incremented on each Activity retry. */
   int getAttempt();
 
-  /**
-   * Determines if this Activity is invoked as a local Activity.
-   */
+  /** Determines if this Activity is invoked as a local Activity. */
   boolean isLocal();
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -24,21 +24,25 @@ import java.time.Duration;
 import java.util.Optional;
 
 /**
- * The information about the Activity task that the current Activity is handling. Use {@link
+ * Information about the Activity Task that the current Activity is handling. Use {@link
  * ActivityExecutionContext#getInfo()} to access.
  */
 public interface ActivityInfo {
 
   /**
-   * A correlation token that can be used to complete the Activity asynchronously through {@link
+   * Correlation token that can be used to complete the Activity asynchronously through {@link
    * io.temporal.client.ActivityCompletionClient#complete(byte[], Object)}.
    */
   byte[] getTaskToken();
 
-  /** WorkflowId of the workflow that scheduled the Activity. */
+  /**
+   * WorkflowId of the Workflow that scheduled the Activity.
+   */
   String getWorkflowId();
 
-  /** RunId of the workflow that scheduled the Activity. */
+  /**
+   * RunId of the Workflow that scheduled the Activity.
+   */
   String getRunId();
 
   /**
@@ -47,13 +51,15 @@ public interface ActivityInfo {
    */
   String getActivityId();
 
-  /** Type of the Activity. */
+  /**
+   * Type of the Activity.
+   */
   String getActivityType();
 
   /**
    * Time when the Activity was initially scheduled by the Workflow.
    *
-   * @return timestamp in milliseconds
+   * @return Timestamp in milliseconds.
    */
   long getScheduledTimestamp();
 
@@ -71,9 +77,13 @@ public interface ActivityInfo {
 
   String getActivityNamespace();
 
-  /** Activity execution attempt starting from 1. */
+  /**
+   * Activity execution attempt. Starts from 1.
+   */
   int getAttempt();
 
-  /** Is this Activity invoked as a local Activity? */
+  /**
+   * Determines if this Activity is invoked as a local Activity.
+   */
   boolean isLocal();
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
@@ -25,23 +25,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the method is an Activity method.
- * This annotation applies only to Activity interface methods.
- * Use it to override default Activity type name.
- * Not required.
+ * Indicates that the method is an Activity method. This annotation applies only to Activity
+ * interface methods. Use it to override default Activity type name. Not required.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface ActivityMethod {
 
   /**
-   * Represents the name of the Activity type.
-   * Default value is the method's name.
-   * Also consider using {@link ActivityInterface#namePrefix}.
-   * The prefix is ignored if the name is specified.
+   * Represents the name of the Activity type. Default value is the method's name, with the first
+   * letter capitalized. Also consider using {@link ActivityInterface#namePrefix}. The prefix is
+   * ignored if the name is specified.
    *
-   * Be careful with names that contain special characters, as these names can be used as metric tags.
-   * Systems like Prometheus ignore metrics which have tags with unsupported characters.
+   * <p>Be careful with names that contain special characters, as these names can be used as metric
+   * tags. Systems like Prometheus ignore metrics which have tags with unsupported characters.
    */
   String name() default "";
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the method is an Activity method. This annotation applies only to Activity
- * interface methods. Not required. Use it to override default Activity type name.
+ * interface methods. Use it to override default Activity type name. Not required.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
@@ -34,10 +34,9 @@ public @interface ActivityMethod {
 
   /**
    * Name of the Activity type. Default is method name. Also consider using {@link
-   * ActivityInterface#namePrefix()}. Note that the prefix is ignored if the name is specified.
-   *
-   * <p>Be careful about names that contain special characters. These names can be used as metric
-   * tags. And systems like Prometheus ignore metrics which have tags with unsupported characters.
+   * ActivityInterface#namePrefix}. Note that the prefix is ignored if the name is specified.
+   * Note: Be careful with names that contain special characters. These names can be used as metric
+   * tags. Systems like Prometheus ignore metrics which have tags with unsupported characters.
    */
   String name() default "";
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
@@ -25,19 +25,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the method is an activity method. This annotation applies only to activity
- * interface methods. Not required. Use it to override default activity type name.
+ * Indicates that the method is an Activity method. This annotation applies only to Activity
+ * interface methods. Not required. Use it to override default Activity type name.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface ActivityMethod {
 
   /**
-   * Name of the activity type. Default is method name. Also consider using {@link
+   * Name of the Activity type. Default is method name. Also consider using {@link
    * ActivityInterface#namePrefix()}. Note that the prefix is ignored if the name is specified.
    *
    * <p>Be careful about names that contain special characters. These names can be used as metric
-   * tags. And systems like prometheus ignore metrics which have tags with unsupported characters.
+   * tags. And systems like Prometheus ignore metrics which have tags with unsupported characters.
    */
   String name() default "";
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityMethod.java
@@ -25,18 +25,23 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the method is an Activity method. This annotation applies only to Activity
- * interface methods. Use it to override default Activity type name. Not required.
+ * Indicates that the method is an Activity method.
+ * This annotation applies only to Activity interface methods.
+ * Use it to override default Activity type name.
+ * Not required.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface ActivityMethod {
 
   /**
-   * Name of the Activity type. Default is method name. Also consider using {@link
-   * ActivityInterface#namePrefix}. Note that the prefix is ignored if the name is specified.
-   * Note: Be careful with names that contain special characters. These names can be used as metric
-   * tags. Systems like Prometheus ignore metrics which have tags with unsupported characters.
+   * Represents the name of the Activity type.
+   * Default value is the method's name.
+   * Also consider using {@link ActivityInterface#namePrefix}.
+   * The prefix is ignored if the name is specified.
+   *
+   * Be careful with names that contain special characters, as these names can be used as metric tags.
+   * Systems like Prometheus ignore metrics which have tags with unsupported characters.
    */
   String name() default "";
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -24,14 +24,18 @@ import io.temporal.common.MethodRetry;
 import io.temporal.common.RetryOptions;
 import java.time.Duration;
 
-/** Options used to configure how a local Activity is invoked. */
+/**
+ * Options used to configure how a local Activity is invoked.
+ */
 public final class LocalActivityOptions {
 
   public static Builder newBuilder() {
     return new Builder(null);
   }
 
-  /** @param o null is allowed */
+  /**
+   * @param o Null is allowed.
+   */
   public static Builder newBuilder(LocalActivityOptions o) {
     return new Builder(o);
   }
@@ -53,7 +57,9 @@ public final class LocalActivityOptions {
     private RetryOptions retryOptions;
     private Boolean doNotIncludeArgumentsIntoMarker;
 
-    /** Copy Builder fields from the options. */
+    /**
+     * Copy Builder fields from the options.
+     */
     private Builder(LocalActivityOptions options) {
       if (options == null) {
         return;
@@ -65,7 +71,9 @@ public final class LocalActivityOptions {
       this.doNotIncludeArgumentsIntoMarker = options.isDoNotIncludeArgumentsIntoMarker();
     }
 
-    /** Overall timeout a Workflow is willing to wait for an Activity's completion. */
+    /**
+     * Overall time a Workflow is willing to wait for an Activity's completion.
+     */
     public Builder setScheduleToCloseTimeout(Duration timeout) {
       if (timeout.isZero() || timeout.isNegative()) {
         throw new IllegalArgumentException("Illegal timeout: " + timeout);
@@ -75,8 +83,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Maximum time to retry locally, while keeping Workflow task open through heartbeat.
-     * Default is 6 workflow task timeout.
+     * Maximum time to retry locally, while keeping the Workflow Task open via a Heartbeat.
+     * Default value is 6 workflow task timeout.
      */
     public Builder setLocalRetryThreshold(Duration localRetryThreshold) {
       if (localRetryThreshold.isZero() || localRetryThreshold.isNegative()) {
@@ -140,14 +148,11 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * When set to true, the serialized arguments of the local Activity are not included into the
-     * Marker Event that stores local Activity invocation result.
-     *
-     * <p>The serialized arguments are included only for human troubleshooting as they are never
-     * read by the SDK code. So in some cases it is worth not including them to reduce the history
-     * size.
-     *
-     * <p>Default is false.
+     * When set to true, the serialized arguments of the local Activity are not included in the
+     * Marker Event that stores the local Activity invocation result.
+     * The serialized arguments are included only for human troubleshooting as they are never
+     * read by the SDK code. In some cases, it is better not including them to reduce the history
+     * size. The default value is set to false.
      */
     public Builder setDoNotIncludeArgumentsIntoMarker(boolean doNotIncludeArgumentsIntoMarker) {
       this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -24,18 +24,14 @@ import io.temporal.common.MethodRetry;
 import io.temporal.common.RetryOptions;
 import java.time.Duration;
 
-/**
- * Options used to configure how a local Activity is invoked.
- */
+/** Options used to configure how a local Activity is invoked. */
 public final class LocalActivityOptions {
 
   public static Builder newBuilder() {
     return new Builder(null);
   }
 
-  /**
-   * @param o Null is allowed.
-   */
+  /** @param o null is allowed. */
   public static Builder newBuilder(LocalActivityOptions o) {
     return new Builder(o);
   }
@@ -57,9 +53,7 @@ public final class LocalActivityOptions {
     private RetryOptions retryOptions;
     private Boolean doNotIncludeArgumentsIntoMarker;
 
-    /**
-     * Copy Builder fields from the options.
-     */
+    /** Copy Builder fields from the options. */
     private Builder(LocalActivityOptions options) {
       if (options == null) {
         return;
@@ -72,7 +66,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Overall time a Workflow is willing to wait for an Activity's completion.
+     * Overall time a Workflow is willing to wait for an Activity's completion. This includes all
+     * retries.
      */
     public Builder setScheduleToCloseTimeout(Duration timeout) {
       if (timeout.isZero() || timeout.isNegative()) {
@@ -83,8 +78,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Maximum time to retry locally, while keeping the Workflow Task open via a Heartbeat.
-     * Default value is 6 workflow task timeout.
+     * Maximum time to retry locally, while keeping the Workflow Task open via a Heartbeat. Default
+     * value is Workflow Task timeout multiplied by 6.
      */
     public Builder setLocalRetryThreshold(Duration localRetryThreshold) {
       if (localRetryThreshold.isZero() || localRetryThreshold.isNegative()) {
@@ -128,8 +123,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * {@link RetryOptions} that define how an Activity is retried in case of failure.
-     * Default is null which is no retries.
+     * {@link RetryOptions} that define how an Activity is retried in case of failure. Activities
+     * use a default RetryPolicy if not provided.
      */
     public Builder setRetryOptions(RetryOptions retryOptions) {
       this.retryOptions = retryOptions;
@@ -137,8 +132,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Merges {@link MethodRetry} annotation.
-     * The values of this builder take precedence over annotated ones.
+     * Merges {@link MethodRetry} annotation. The values of this builder take precedence over
+     * annotated ones.
      */
     public Builder setMethodRetry(MethodRetry r) {
       if (r != null) {
@@ -149,11 +144,10 @@ public final class LocalActivityOptions {
 
     /**
      * When set to true, the serialized arguments of the local Activity are not included in the
-     * Marker Event that stores the local Activity's invocation result.
-     * The serialized arguments are included only for human troubleshooting as they are never
-     * read by the SDK code.
-     * In some cases, it is better not including them to reduce the history size.
-     * The default value is set to false.
+     * Marker Event that stores the local Activity's invocation result. The serialized arguments are
+     * included only for human troubleshooting as they are never read by the SDK code. In some
+     * cases, it is better to not include them to reduce the history size. The default value is set
+     * to false.
      */
     public Builder setDoNotIncludeArgumentsIntoMarker(boolean doNotIncludeArgumentsIntoMarker) {
       this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -137,8 +137,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Merges {@link MethodRetry} annotation. The values of this builder take precedence over annotation
-     * ones.
+     * Merges {@link MethodRetry} annotation.
+     * The values of this builder take precedence over annotated ones.
      */
     public Builder setMethodRetry(MethodRetry r) {
       if (r != null) {
@@ -149,10 +149,11 @@ public final class LocalActivityOptions {
 
     /**
      * When set to true, the serialized arguments of the local Activity are not included in the
-     * Marker Event that stores the local Activity invocation result.
+     * Marker Event that stores the local Activity's invocation result.
      * The serialized arguments are included only for human troubleshooting as they are never
-     * read by the SDK code. In some cases, it is better not including them to reduce the history
-     * size. The default value is set to false.
+     * read by the SDK code.
+     * In some cases, it is better not including them to reduce the history size.
+     * The default value is set to false.
      */
     public Builder setDoNotIncludeArgumentsIntoMarker(boolean doNotIncludeArgumentsIntoMarker) {
       this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -24,7 +24,7 @@ import io.temporal.common.MethodRetry;
 import io.temporal.common.RetryOptions;
 import java.time.Duration;
 
-/** Options used to configure how an local activity is invoked. */
+/** Options used to configure how a local Activity is invoked. */
 public final class LocalActivityOptions {
 
   public static Builder newBuilder() {
@@ -65,7 +65,7 @@ public final class LocalActivityOptions {
       this.doNotIncludeArgumentsIntoMarker = options.isDoNotIncludeArgumentsIntoMarker();
     }
 
-    /** Overall timeout workflow is willing to wait for activity to complete. */
+    /** Overall timeout a Workflow is willing to wait for an Activity's completion. */
     public Builder setScheduleToCloseTimeout(Duration timeout) {
       if (timeout.isZero() || timeout.isNegative()) {
         throw new IllegalArgumentException("Illegal timeout: " + timeout);
@@ -75,8 +75,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Maximum time to retry locally keeping workflow task open through heartbeat. Default is 6
-     * workflow task timeout.
+     * Maximum time to retry locally, while keeping Workflow task open through heartbeat.
+     * Default is 6 workflow task timeout.
      */
     public Builder setLocalRetryThreshold(Duration localRetryThreshold) {
       if (localRetryThreshold.isZero() || localRetryThreshold.isNegative()) {
@@ -120,8 +120,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * RetryOptions that define how activity is retried in case of failure. Default is null which is
-     * no retries.
+     * {@link RetryOptions} that define how an Activity is retried in case of failure.
+     * Default is null which is no retries.
      */
     public Builder setRetryOptions(RetryOptions retryOptions) {
       this.retryOptions = retryOptions;
@@ -129,7 +129,7 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Merges MethodRetry annotation. The values of this builder take precedence over annotation
+     * Merges {@link MethodRetry} annotation. The values of this builder take precedence over annotation
      * ones.
      */
     public Builder setMethodRetry(MethodRetry r) {
@@ -140,8 +140,8 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * When set to true the serialized arguments of the local activity are not included into the
-     * Marker Event that stores local activity invocation result.
+     * When set to true, the serialized arguments of the local Activity are not included into the
+     * Marker Event that stores local Activity invocation result.
      *
      * <p>The serialized arguments are included only for human troubleshooting as they are never
      * read by the SDK code. So in some cases it is worth not including them to reduce the history


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Javadocs cleaned up in several classes in the Activity package

## Why?
We didn't want implementation and duplicate docs (that exist in the main doc site) to be in the Javadocs as well.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 
https://www.notion.so/temporalio/Refresh-Java-SDK-reference-comments-819b790f4acd46c3a5d908dc0226aa15

2. How was this tested:
Tested locally, looking at the Javadocs view feature in IntelliJ

3. Any docs updates needed?
There were a few small edits I made to the documentation page after comparing Javadocs and documentation
https://github.com/temporalio/documentation/pull/378
