### PR TITLE
Set current time before processing commands

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,14 +9,4 @@ steps:
       - docker-compose#v3.0.0:
           run: unit-test-test-service
           config: docker/buildkite/docker-compose.yaml
-  - label: ":java: Unit test with docker service"
-    agents:
-      queue: "default"
-      docker: "*"
-    command: "./gradlew --no-daemon test"
-    timeout_in_minutes: 15
-    plugins:
-      - docker-compose#v3.0.0:
-          run: unit-test-docker
-          config: docker/buildkite/docker-compose.yaml
   - wait

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "temporal-serviceclient/src/main/proto"]
 	path = temporal-serviceclient/src/main/proto
-	url = git@github.com:temporalio/api.git
+	url = https://github.com/temporalio/api.git

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -789,6 +789,7 @@ public final class WorkflowStateMachines {
     @Override
     public void workflowTaskStarted(
         long startedEventId, long currentTimeMillis, boolean nonProcessedWorkflowTask) {
+      setCurrentTimeMillis(currentTimeMillis);
       // If some new commands are pending and there are no more command events.
       for (CancellableCommand cancellableCommand : commands) {
         if (cancellableCommand == null) {
@@ -805,7 +806,6 @@ public final class WorkflowStateMachines {
         }
       }
       WorkflowStateMachines.this.currentStartedEventId = startedEventId;
-      setCurrentTimeMillis(currentTimeMillis);
       eventLoop();
     }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -62,7 +62,7 @@ public class GetVersionAndTimerTest {
     assertTrue(
         "endInstant "
             + endInstant
-            + " should be more than 2 hours away from startInstant "
+            + " should be more than 5 seconds away from startInstant "
             + startInstant,
         endInstant.isAfter(startInstant.plus(Duration.ofSeconds(5))));
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetVersionAndTimerTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRuleWithoutVersion =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TimedWorkflowWithoutVersionImpl.class)
+          .build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRuleWithVersion =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TimedWorkflowWithVersionImpl.class).build();
+
+  @Test
+  public void testTimedWorkflowWithoutVersionImpl() {
+    testTimedWorkflow(testWorkflowRuleWithoutVersion);
+  }
+
+  @Test
+  public void testTimedWorkflowWithVersionImpl() {
+    testTimedWorkflow(testWorkflowRuleWithVersion);
+  }
+
+  private void testTimedWorkflow(SDKTestWorkflowRule rule) {
+    TimedWorkflow workflowStub = rule.newWorkflowStubTimeoutOptions(TimedWorkflow.class);
+
+    Instant startInstant = Instant.ofEpochMilli(rule.getTestEnvironment().currentTimeMillis());
+
+    Instant endInstant = workflowStub.startAndWait();
+
+    assertTrue(
+        "endInstant "
+            + endInstant
+            + " should be more than 2 hours away from startInstant "
+            + startInstant,
+        endInstant.isAfter(startInstant.plus(Duration.ofHours(2))));
+  }
+
+  @WorkflowInterface
+  public interface TimedWorkflow {
+
+    @WorkflowMethod
+    Instant startAndWait();
+  }
+
+  abstract static class TimedWorkflowImpl implements TimedWorkflow {
+    @Override
+    public Instant startAndWait() {
+      getVersion();
+
+      Workflow.newTimer(Duration.ofMinutes(1))
+          .thenApply(
+              (v) -> {
+                getVersion();
+                return v;
+              });
+
+      Workflow.sleep(Duration.ofHours(2));
+
+      return Instant.ofEpochMilli(Workflow.currentTimeMillis());
+    }
+
+    protected abstract void getVersion();
+  }
+
+  public static class TimedWorkflowWithoutVersionImpl extends TimedWorkflowImpl
+      implements TimedWorkflow {
+
+    @Override
+    protected void getVersion() {
+      // Do nothing
+    }
+  }
+
+  public static class TimedWorkflowWithVersionImpl extends TimedWorkflowImpl
+      implements TimedWorkflow {
+
+    @Override
+    protected void getVersion() {
+      Workflow.getVersion("id", Workflow.DEFAULT_VERSION, 1);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -27,7 +27,6 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import java.time.Duration;
 import java.time.Instant;
-
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -27,6 +27,8 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import java.time.Duration;
 import java.time.Instant;
+
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -44,11 +46,13 @@ public class GetVersionAndTimerTest {
 
   @Test
   public void testTimedWorkflowWithoutVersionImpl() {
+    Assume.assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
     testTimedWorkflow(testWorkflowRuleWithoutVersion);
   }
 
   @Test
   public void testTimedWorkflowWithVersionImpl() {
+    Assume.assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
     testTimedWorkflow(testWorkflowRuleWithVersion);
   }
 
@@ -62,9 +66,9 @@ public class GetVersionAndTimerTest {
     assertTrue(
         "endInstant "
             + endInstant
-            + " should be more than 5 seconds away from startInstant "
+            + " should be more than 2 hours away from startInstant "
             + startInstant,
-        endInstant.isAfter(startInstant.plus(Duration.ofSeconds(5))));
+        endInstant.isAfter(startInstant.plus(Duration.ofHours(2))));
   }
 
   @WorkflowInterface
@@ -79,14 +83,14 @@ public class GetVersionAndTimerTest {
     public Instant startAndWait() {
       getVersion();
 
-      Workflow.newTimer(Duration.ofSeconds(1))
+      Workflow.newTimer(Duration.ofMinutes(1))
           .thenApply(
               (v) -> {
                 getVersion();
                 return v;
               });
 
-      Workflow.sleep(Duration.ofSeconds(5));
+      Workflow.sleep(Duration.ofHours(2));
 
       return Instant.ofEpochMilli(Workflow.currentTimeMillis());
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -64,7 +64,7 @@ public class GetVersionAndTimerTest {
             + endInstant
             + " should be more than 2 hours away from startInstant "
             + startInstant,
-        endInstant.isAfter(startInstant.plus(Duration.ofHours(2))));
+        endInstant.isAfter(startInstant.plus(Duration.ofSeconds(5))));
   }
 
   @WorkflowInterface
@@ -79,14 +79,14 @@ public class GetVersionAndTimerTest {
     public Instant startAndWait() {
       getVersion();
 
-      Workflow.newTimer(Duration.ofMinutes(1))
+      Workflow.newTimer(Duration.ofSeconds(1))
           .thenApply(
               (v) -> {
                 getVersion();
                 return v;
               });
 
-      Workflow.sleep(Duration.ofHours(2));
+      Workflow.sleep(Duration.ofSeconds(5));
 
       return Instant.ofEpochMilli(Workflow.currentTimeMillis());
     }


### PR DESCRIPTION
This should address the problem described [here](https://github.com/temporalio/sdk-java/pull/447#issuecomment-828912253) by setting current workflow time before command processing happens. Before this change it was possible to trigger event loop before correct time was set, which means that workflow code would see the previous time instead of a new one.
Here we simply move `setCurrentTimeMillis(currentTimeMillis)` to the top of the `workflowTaskStarted` function. Thanks to  @GreyTeardrop for contributing a test that reproduces an issue, which I've included here.