### PR TITLE
Test env sleep

### DIFF
--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
 }
 
 license {

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }
 
 license {

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -462,7 +462,7 @@ class StateMachines {
         .add(CANCELLATION_REQUESTED, TIME_OUT, TIMED_OUT, StateMachines::timeoutWorkflow);
   }
 
-  static StateMachine<WorkflowTaskData> newCommandStateMachine(
+  static StateMachine<WorkflowTaskData> newWorkflowTaskStateMachine(
       TestWorkflowStore store, StartWorkflowExecutionRequest startRequest) {
     return new StateMachine<>(new WorkflowTaskData(store, startRequest))
         .add(NONE, INITIATE, INITIATED, StateMachines::scheduleWorkflowTask)

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentSleepTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentSleepTest.java
@@ -1,0 +1,144 @@
+package io.temporal.testing;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.worker.Worker;
+import io.temporal.workflow.QueryMethod;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public class TestWorkflowEnvironmentSleepTest {
+
+  @WorkflowInterface
+  public interface ExampleWorkflow {
+    @WorkflowMethod
+    String execute();
+
+    @SignalMethod
+    void updateState(String state);
+
+    @QueryMethod
+    String queryState();
+  }
+
+  public static class ExampleWorkflowImpl implements ExampleWorkflow {
+    Logger logger = Workflow.getLogger(ExampleWorkflowImpl.class);
+    private String state;
+    private boolean completed;
+    private boolean terminated;
+    private boolean error;
+
+    public ExampleWorkflowImpl() {
+      this.state = "INITIALIZED";
+      this.completed = false;
+      this.terminated = false;
+      this.error = false;
+    }
+
+    @Override
+    public String execute() {
+      state = "WAITING_FOR_SIGNAL";
+      while (state.equals("WAITING_FOR_SIGNAL")) {
+        Workflow.await(Duration.ofMinutes(20L), () -> (completed || terminated || error));
+        if (terminated) {
+          state = "TERMINATED";
+          return state;
+        } else if (error) {
+          state = "ERROR";
+          return state;
+        } else if (completed) {
+          state = "PRELIM_COMPLETED";
+        }
+      }
+      state = "WAITING_FOR_MORE_SIGNAL_OR_TIMER_TO_END";
+      System.out.println("Before SLEEP ----------");
+      Workflow.sleep(Duration.ofMinutes(20));
+      //    Workflow.await(Duration.ofMinutes(20L), () -> (error));
+      if (error) {
+        state = "ERROR";
+        return state;
+      } else {
+        state = "COMPLETED";
+      }
+      return state;
+    }
+
+    @Override
+    public void updateState(String newState) {
+      switch (newState) {
+        case "PRELIM_COMPLETED":
+          completed = true;
+          break;
+        case "TERMINATED":
+          terminated = true;
+          break;
+        case "ERROR":
+          error = true;
+          break;
+        default:
+          logger.error("Unknown state: {}", newState);
+          break;
+      }
+    }
+
+    @Override
+    public String queryState() {
+      return state;
+    }
+  }
+
+  private TestWorkflowEnvironment testEnv;
+  private Worker worker;
+  private WorkflowClient client;
+  private ExampleWorkflow workflow;
+  private static final String WORKFLOW_TASK_QUEUE = "EXAMPLE";
+
+  @Before
+  public void setUp() {
+    testEnv = TestWorkflowEnvironment.newInstance();
+    worker = testEnv.newWorker(WORKFLOW_TASK_QUEUE);
+    client = testEnv.getWorkflowClient();
+    worker.registerWorkflowImplementationTypes(ExampleWorkflowImpl.class);
+    workflow =
+        client.newWorkflowStub(
+            ExampleWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setWorkflowExecutionTimeout(Duration.ofDays(2))
+                .setTaskQueue(WORKFLOW_TASK_QUEUE)
+                .build());
+    testEnv.start();
+  }
+
+  @Test
+  public void testTerminatedUpdateStatus() {
+    WorkflowClient.start(workflow::execute);
+    workflow.updateState("TERMINATED");
+    assertEquals("TERMINATED", workflow.queryState());
+  }
+
+  @Test(timeout = 2000)
+  public void testCompletedThenTimerCompletes() throws InterruptedException {
+    WorkflowClient.start(workflow::execute);
+    workflow.updateState("PRELIM_COMPLETED");
+    //    while (!workflow.queryState().equals("WAITING_FOR_MORE_SIGNAL_OR_TIMER_TO_END")) {
+    //      Thread.sleep(2000);
+    //    }
+    // this line hangs without the @Timeout rule
+    testEnv.sleep(Duration.ofMinutes(25L));
+    assertEquals("COMPLETED", workflow.queryState());
+  }
+
+  @After
+  public void tearDown() {
+    testEnv.close();
+  }
+}

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentSleepTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentSleepTest.java
@@ -1,11 +1,8 @@
 package io.temporal.testing;
 
-import static org.junit.Assert.assertEquals;
-
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.worker.Worker;
-import io.temporal.workflow.QueryMethod;
 import io.temporal.workflow.SignalMethod;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -14,86 +11,26 @@ import java.time.Duration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
 
 public class TestWorkflowEnvironmentSleepTest {
 
   @WorkflowInterface
   public interface ExampleWorkflow {
     @WorkflowMethod
-    String execute();
+    void execute();
 
     @SignalMethod
     void updateState(String state);
-
-    @QueryMethod
-    String queryState();
   }
 
   public static class ExampleWorkflowImpl implements ExampleWorkflow {
-    Logger logger = Workflow.getLogger(ExampleWorkflowImpl.class);
-    private String state;
-    private boolean completed;
-    private boolean terminated;
-    private boolean error;
-
-    public ExampleWorkflowImpl() {
-      this.state = "INITIALIZED";
-      this.completed = false;
-      this.terminated = false;
-      this.error = false;
-    }
-
     @Override
-    public String execute() {
-      state = "WAITING_FOR_SIGNAL";
-      while (state.equals("WAITING_FOR_SIGNAL")) {
-        Workflow.await(Duration.ofMinutes(20L), () -> (completed || terminated || error));
-        if (terminated) {
-          state = "TERMINATED";
-          return state;
-        } else if (error) {
-          state = "ERROR";
-          return state;
-        } else if (completed) {
-          state = "PRELIM_COMPLETED";
-        }
-      }
-      state = "WAITING_FOR_MORE_SIGNAL_OR_TIMER_TO_END";
-      System.out.println("Before SLEEP ----------");
+    public void execute() {
       Workflow.sleep(Duration.ofMinutes(20));
-      //    Workflow.await(Duration.ofMinutes(20L), () -> (error));
-      if (error) {
-        state = "ERROR";
-        return state;
-      } else {
-        state = "COMPLETED";
-      }
-      return state;
     }
 
     @Override
-    public void updateState(String newState) {
-      switch (newState) {
-        case "PRELIM_COMPLETED":
-          completed = true;
-          break;
-        case "TERMINATED":
-          terminated = true;
-          break;
-        case "ERROR":
-          error = true;
-          break;
-        default:
-          logger.error("Unknown state: {}", newState);
-          break;
-      }
-    }
-
-    @Override
-    public String queryState() {
-      return state;
-    }
+    public void updateState(String newState) {}
   }
 
   private TestWorkflowEnvironment testEnv;
@@ -111,30 +48,16 @@ public class TestWorkflowEnvironmentSleepTest {
     workflow =
         client.newWorkflowStub(
             ExampleWorkflow.class,
-            WorkflowOptions.newBuilder()
-                .setWorkflowExecutionTimeout(Duration.ofDays(2))
-                .setTaskQueue(WORKFLOW_TASK_QUEUE)
-                .build());
+            WorkflowOptions.newBuilder().setTaskQueue(WORKFLOW_TASK_QUEUE).build());
     testEnv.start();
-  }
-
-  @Test
-  public void testTerminatedUpdateStatus() {
-    WorkflowClient.start(workflow::execute);
-    workflow.updateState("TERMINATED");
-    assertEquals("TERMINATED", workflow.queryState());
   }
 
   @Test(timeout = 2000)
   public void testCompletedThenTimerCompletes() throws InterruptedException {
     WorkflowClient.start(workflow::execute);
+    // commenting out signal makes the test pass
     workflow.updateState("PRELIM_COMPLETED");
-    //    while (!workflow.queryState().equals("WAITING_FOR_MORE_SIGNAL_OR_TIMER_TO_END")) {
-    //      Thread.sleep(2000);
-    //    }
-    // this line hangs without the @Timeout rule
-    testEnv.sleep(Duration.ofMinutes(25L));
-    assertEquals("COMPLETED", workflow.queryState());
+    testEnv.sleep(Duration.ofMinutes(50L));
   }
 
   @After

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentSleepTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentSleepTest.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package io.temporal.testing;
 
 import io.temporal.client.WorkflowClient;
@@ -10,9 +29,24 @@ import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public class TestWorkflowEnvironmentSleepTest {
+
+  @Rule
+  public TestWatcher watchman =
+      new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+          if (testEnv != null) {
+            System.err.println(testEnv.getDiagnostics());
+            testEnv.close();
+          }
+        }
+      };
 
   @WorkflowInterface
   public interface ExampleWorkflow {
@@ -20,7 +54,7 @@ public class TestWorkflowEnvironmentSleepTest {
     void execute();
 
     @SignalMethod
-    void updateState(String state);
+    void signal();
   }
 
   public static class ExampleWorkflowImpl implements ExampleWorkflow {
@@ -30,7 +64,7 @@ public class TestWorkflowEnvironmentSleepTest {
     }
 
     @Override
-    public void updateState(String newState) {}
+    public void signal() {}
   }
 
   private TestWorkflowEnvironment testEnv;
@@ -53,10 +87,9 @@ public class TestWorkflowEnvironmentSleepTest {
   }
 
   @Test(timeout = 2000)
-  public void testCompletedThenTimerCompletes() throws InterruptedException {
+  public void testSignalAfterStartThenSleep() {
     WorkflowClient.start(workflow::execute);
-    // commenting out signal makes the test pass
-    workflow.updateState("PRELIM_COMPLETED");
+    workflow.signal();
     testEnv.sleep(Duration.ofMinutes(50L));
   }
 

--- a/temporal-testing/src/test/java/resources/logback-test.xml
+++ b/temporal-testing/src/test/java/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<!--
+     Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+
+     Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+     Modifications copyright (C) 2017 Uber Technologies, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License"). You may not
+     use this file except in compliance with the License. A copy of the License is
+     located at
+
+     http://aws.amazon.com/apache2.0
+
+     or in the "license" file accompanying this file. This file is distributed on
+     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+     express or implied. See the License for the specific language governing
+     permissions and limitations under the License.
+-->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="io.grpc.netty" level="INFO"/>
+    <!-- Modify root log level to get more info -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## What was changed:

The unit test time skipping was double-locking clock when scheduling a workflow task if there was already an outstanding workflow task.

1. Closes issue: 
Fixes https://github.com/temporalio/sdk-java/issues/459.

2. How was this tested:
A unit test that reproduced the problem was added.
