### PR TITLE
Make the deadlock detection timeout configurable

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -35,9 +35,12 @@ interface DeterministicRunner {
   boolean debugMode = System.getenv("TEMPORAL_DEBUG") != null;
 
   long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 1000;
+  long deadlockDetectionTimeout = Long.parseLong(System.getenv().getOrDefault(
+      "DEADLOCK_DETECTION_TIMEOUT",
+      String.valueOf(DEFAULT_DEADLOCK_DETECTION_TIMEOUT)));
 
   static long getDeadlockDetectionTimeout() {
-    return debugMode ? Long.MAX_VALUE : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+    return debugMode ? Long.MAX_VALUE : deadlockDetectionTimeout;
   }
 
   static DeterministicRunner newRunner(Runnable root) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -34,13 +34,10 @@ interface DeterministicRunner {
 
   boolean debugMode = System.getenv("TEMPORAL_DEBUG") != null;
 
-  long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 1000;
-  long deadlockDetectionTimeout = Long.parseLong(System.getenv().getOrDefault(
-      "DEADLOCK_DETECTION_TIMEOUT",
-      String.valueOf(DEFAULT_DEADLOCK_DETECTION_TIMEOUT)));
+  long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 3000;
 
   static long getDeadlockDetectionTimeout() {
-    return debugMode ? Long.MAX_VALUE : deadlockDetectionTimeout;
+    return debugMode ? Long.MAX_VALUE : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
   }
 
   static DeterministicRunner newRunner(Runnable root) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
Make the fixed deadlock detection timeout configurable.

## Why?
We see that some code in our workflows takes longer to execute during the first run, most likely due to hotspot compilation combined with other containers starting up.

This may happen to any workflow and is not related to calling Thread.sleep or anything similar. Making the default timeout configurable gives users the option to adapt the threshold. Setting TEMPORAL_DEBUG=true is not desirable as it would disable a useful feature.

## Checklist

1. Closes issue: None, but it's related to https://github.com/temporalio/sdk-java/pull/296

2. How was this tested:
Workflow with a >1000ms wait time

3. Any docs updates needed?
Possibly https://docs.temporal.io/docs/java/testing-and-debugging/ is you want to mention it there