### PR TITLE
Cleanup the way Pollers handle InterruptedExceptions

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
@@ -78,14 +78,6 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
               .build());
     }
 
-    if (taskQueueActivitiesPerSecond > 0) {
-      pollRequest.setTaskQueueMetadata(
-          TaskQueueMetadata.newBuilder()
-              .setMaxTasksPerSecond(
-                  DoubleValue.newBuilder().setValue(taskQueueActivitiesPerSecond).build())
-              .build());
-    }
-
     if (log.isTraceEnabled()) {
       log.trace("poll request begin: " + pollRequest);
     }
@@ -95,8 +87,10 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
     try {
       pollSemaphore.acquire();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return null;
     }
+
     try {
       response =
           service

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityPollTask.java
@@ -44,9 +44,9 @@ final class LocalActivityPollTask
         log.trace("LocalActivity Task poll returned: " + task.getActivityId());
       }
       return task;
-
     } catch (InterruptedException e) {
-      throw new RuntimeException("local activity poll task interrupted", e);
+      Thread.currentThread().interrupt();
+      return null;
     }
   }
 
@@ -67,6 +67,7 @@ final class LocalActivityPollTask
       }
       return accepted;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return false;
     }
   }


### PR DESCRIPTION
## What was changed:

Code in Worker's `Poller` and `PollerTask`s was cleaned up to one unified way of handling `InterruptedException`.

Before `LocalActivityPollTask` and `ActivityPollTask` had a full mix of correct and incorrect handling of `InterruptedException`:
- It was swallowed and ignored
- it was replaced with RuntimeException
- interrupted flag was raised (the only correct way and Pollers got it through GRPC stub implementation)
See [the article](https://dzone.com/articles/how-to-handle-the-interruptedexception for more context.) for more context about appropriate ways of handling `InterruptedException`.

Now `PollerTask`s are refactored to one approach (same as GRPC) - raising interrupted flag. And `Poller` was refactored to the more explicit way of handling interruptions.

## Closes

This PR also includes a small cleanup of ActivityPollTask and closes Issue #204