### PR TITLE
Use default data converter for search attributes and memo

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.client;
 
-import static io.temporal.internal.common.HeaderUtils.convertMapFromObjectToBytes;
+import static io.temporal.internal.common.HeaderUtils.intoPayloadMapWithDefaultConverter;
 import static io.temporal.internal.common.HeaderUtils.toHeaderGrpc;
 import static io.temporal.internal.common.SerializerUtils.toRetryPolicy;
 
@@ -85,12 +85,12 @@ final class RootWorkflowClientHelper {
     }
     if (options.getMemo() != null) {
       request.setMemo(
-          Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(options.getMemo())));
+          Memo.newBuilder().putAllFields(intoPayloadMapWithDefaultConverter(options.getMemo())));
     }
     if (options.getSearchAttributes() != null) {
       request.setSearchAttributes(
           SearchAttributes.newBuilder()
-              .putAllIndexedFields(convertMapFromObjectToBytes(options.getSearchAttributes())));
+              .putAllIndexedFields(intoPayloadMapWithDefaultConverter(options.getSearchAttributes())));
     }
 
     Header grpcHeader =

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
@@ -84,7 +84,8 @@ final class RootWorkflowClientHelper {
       request.setCronSchedule(options.getCronSchedule());
     }
     if (options.getMemo() != null) {
-      request.setMemo(Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(options.getMemo())));
+      request.setMemo(
+          Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(options.getMemo())));
     }
     if (options.getSearchAttributes() != null) {
       request.setSearchAttributes(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
@@ -31,7 +31,6 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.context.ContextPropagator;
-import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import java.util.*;
@@ -85,12 +84,12 @@ final class RootWorkflowClientHelper {
       request.setCronSchedule(options.getCronSchedule());
     }
     if (options.getMemo() != null) {
-      request.setMemo(Memo.newBuilder().putAllFields(convertFromObjectToBytes(options.getMemo())));
+      request.setMemo(Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(options.getMemo())));
     }
     if (options.getSearchAttributes() != null) {
       request.setSearchAttributes(
           SearchAttributes.newBuilder()
-              .putAllIndexedFields(convertFromObjectToBytes(options.getSearchAttributes())));
+              .putAllIndexedFields(convertMapFromObjectToBytes(options.getSearchAttributes())));
     }
 
     Header grpcHeader =
@@ -99,10 +98,6 @@ final class RootWorkflowClientHelper {
     request.setHeader(grpcHeader);
 
     return request.build();
-  }
-
-  private Map<String, Payload> convertFromObjectToBytes(Map<String, Object> map) {
-    return convertMapFromObjectToBytes(map, DataConverter.getDefaultInstance());
   }
 
   private io.temporal.common.interceptors.Header extractContextsAndConvertToBytes(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
@@ -31,6 +31,7 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.context.ContextPropagator;
+import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import java.util.*;
@@ -101,7 +102,7 @@ final class RootWorkflowClientHelper {
   }
 
   private Map<String, Payload> convertFromObjectToBytes(Map<String, Object> map) {
-    return convertMapFromObjectToBytes(map, clientOptions.getDataConverter());
+    return convertMapFromObjectToBytes(map, DataConverter.getDefaultInstance());
   }
 
   private io.temporal.common.interceptors.Header extractContextsAndConvertToBytes(

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
@@ -40,8 +40,7 @@ public class HeaderUtils {
     return builder.build();
   }
 
-  public static Map<String, Payload> convertMapFromObjectToBytes(
-      Map<String, Object> map) {
+  public static Map<String, Payload> convertMapFromObjectToBytes(Map<String, Object> map) {
     if (map == null) {
       return null;
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
@@ -40,7 +40,12 @@ public class HeaderUtils {
     return builder.build();
   }
 
-  public static Map<String, Payload> convertMapFromObjectToBytes(Map<String, Object> map) {
+  /*
+   * Converts a Map<String, Object> into a Map<String, Payload> by applying default data converter on each value.
+   * Note that this does not use user defined converters and should be used only for things like search attributes and
+   * memo that need to be converted back from bytes on the server.
+   */
+  public static Map<String, Payload> intoPayloadMapWithDefaultConverter(Map<String, Object> map) {
     if (map == null) {
       return null;
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
@@ -41,10 +41,11 @@ public class HeaderUtils {
   }
 
   public static Map<String, Payload> convertMapFromObjectToBytes(
-      Map<String, Object> map, DataConverter dataConverter) {
+      Map<String, Object> map) {
     if (map == null) {
       return null;
     }
+    DataConverter dataConverter = DataConverter.getDefaultInstance();
     Map<String, Payload> result = new HashMap<>();
     for (Map.Entry<String, Object> item : map.entrySet()) {
       try {

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -91,7 +91,8 @@ public final class InternalUtils {
   }
 
   public static SearchAttributes convertMapToSearchAttributes(
-      Map<String, Object> searchAttributes, DataConverter converter) {
+      Map<String, Object> searchAttributes) {
+    DataConverter converter = DataConverter.getDefaultInstance();
     Map<String, Payload> mapOfByteBuffer = new HashMap<>();
     searchAttributes.forEach(
         (key, value) -> mapOfByteBuffer.put(key, converter.toPayload(value).get()));

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -732,16 +732,13 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
       }
       Map<String, Object> memo = ops.getMemo();
       if (memo != null) {
-        attributes.setMemo(
-            Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(memo, getDataConverter())));
+        attributes.setMemo(Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(memo)));
       }
       Map<String, Object> searchAttributes = ops.getSearchAttributes();
       if (searchAttributes != null) {
         attributes.setSearchAttributes(
             SearchAttributes.newBuilder()
-                .putAllIndexedFields(
-                    convertMapFromObjectToBytes(
-                        searchAttributes, DataConverter.getDefaultInstance())));
+                .putAllIndexedFields(convertMapFromObjectToBytes(searchAttributes)));
       }
     }
     Optional<Payloads> payloads = getDataConverter().toPayloads(input.getArgs());

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -740,7 +740,8 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
         attributes.setSearchAttributes(
             SearchAttributes.newBuilder()
                 .putAllIndexedFields(
-                    convertMapFromObjectToBytes(searchAttributes, getDataConverter())));
+                    convertMapFromObjectToBytes(
+                        searchAttributes, DataConverter.getDefaultInstance())));
       }
     }
     Optional<Payloads> payloads = getDataConverter().toPayloads(input.getArgs());
@@ -790,8 +791,7 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
       throw new IllegalArgumentException("Empty search attributes");
     }
 
-    SearchAttributes attr =
-        InternalUtils.convertMapToSearchAttributes(searchAttributes, getDataConverter());
+    SearchAttributes attr = InternalUtils.convertMapToSearchAttributes(searchAttributes);
     context.upsertSearchAttributes(attr);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -19,7 +19,7 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.common.HeaderUtils.convertMapFromObjectToBytes;
+import static io.temporal.internal.common.HeaderUtils.intoPayloadMapWithDefaultConverter;
 import static io.temporal.internal.common.HeaderUtils.toHeaderGrpc;
 import static io.temporal.internal.common.SerializerUtils.toRetryPolicy;
 
@@ -732,13 +732,13 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
       }
       Map<String, Object> memo = ops.getMemo();
       if (memo != null) {
-        attributes.setMemo(Memo.newBuilder().putAllFields(convertMapFromObjectToBytes(memo)));
+        attributes.setMemo(Memo.newBuilder().putAllFields(intoPayloadMapWithDefaultConverter(memo)));
       }
       Map<String, Object> searchAttributes = ops.getSearchAttributes();
       if (searchAttributes != null) {
         attributes.setSearchAttributes(
             SearchAttributes.newBuilder()
-                .putAllIndexedFields(convertMapFromObjectToBytes(searchAttributes)));
+                .putAllIndexedFields(intoPayloadMapWithDefaultConverter(searchAttributes)));
       }
     }
     Optional<Payloads> payloads = getDataConverter().toPayloads(input.getArgs());

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/InternalUtilsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/InternalUtilsTest.java
@@ -22,7 +22,6 @@ package io.temporal.internal.common;
 import static junit.framework.TestCase.assertEquals;
 
 import io.temporal.api.common.v1.SearchAttributes;
-import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.DataConverterException;
 import java.io.FileOutputStream;
 import java.util.HashMap;
@@ -37,8 +36,7 @@ public class InternalUtilsTest {
     String value = "keyword";
     attr.put("CustomKeywordField", value);
 
-    SearchAttributes result =
-        InternalUtils.convertMapToSearchAttributes(attr, DataConverter.getDefaultInstance());
+    SearchAttributes result = InternalUtils.convertMapToSearchAttributes(attr);
     assertEquals(
         value,
         SearchAttributesUtil.getValueFromSearchAttributes(
@@ -49,6 +47,6 @@ public class InternalUtilsTest {
   public void testConvertMapToSearchAttributesException() throws Throwable {
     Map<String, Object> attr = new HashMap<>();
     attr.put("InvalidValue", new FileOutputStream("dummy"));
-    InternalUtils.convertMapToSearchAttributes(attr, DataConverter.getDefaultInstance());
+    InternalUtils.convertMapToSearchAttributes(attr);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/SearchAttributesUtilTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/SearchAttributesUtilTest.java
@@ -22,7 +22,6 @@ package io.temporal.internal.common;
 import static junit.framework.TestCase.assertEquals;
 
 import io.temporal.api.common.v1.SearchAttributes;
-import io.temporal.common.converter.DataConverter;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -47,8 +46,7 @@ public class SearchAttributesUtilTest {
     attr.put("CustomDoubleField", doubleVal);
     Boolean boolVal = Boolean.TRUE;
     attr.put("CustomBooleanField", boolVal);
-    SearchAttributes searchAttributes =
-        InternalUtils.convertMapToSearchAttributes(attr, DataConverter.getDefaultInstance());
+    SearchAttributes searchAttributes = InternalUtils.convertMapToSearchAttributes(attr);
 
     assertEquals(
         stringVal,
@@ -73,8 +71,7 @@ public class SearchAttributesUtilTest {
     Map<String, Object> attr = new HashMap<>();
     String stringVal = "keyword";
     attr.put("CustomKeywordField", stringVal);
-    SearchAttributes searchAttributes =
-        InternalUtils.convertMapToSearchAttributes(attr, DataConverter.getDefaultInstance());
+    SearchAttributes searchAttributes = InternalUtils.convertMapToSearchAttributes(attr);
     assertEquals(
         stringVal,
         SearchAttributesUtil.getValueFromSearchAttributes(

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/SyncWorkflowContextTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/SyncWorkflowContextTest.java
@@ -47,8 +47,7 @@ public class SyncWorkflowContextTest {
   public void testUpsertSearchAttributes() throws Throwable {
     Map<String, Object> attr = new HashMap<>();
     attr.put("CustomKeywordField", "keyword");
-    SearchAttributes serializedAttr =
-        InternalUtils.convertMapToSearchAttributes(attr, DataConverter.getDefaultInstance());
+    SearchAttributes serializedAttr = InternalUtils.convertMapToSearchAttributes(attr);
 
     context.upsertSearchAttributes(attr);
     verify(mockReplayWorkflowContext, times(1)).upsertSearchAttributes(serializedAttr);


### PR DESCRIPTION
## What was changed:
Custom data converters used with search attributes and memo result in failures down the line when we try to put data into ES.

## Why?
Proposal that may address https://github.com/temporalio/sdk-java/issues/468
