### PR TITLE
Option to set initial time for workflow test

### DIFF
--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -141,7 +141,7 @@ public class TestWorkflowRule implements TestRule {
     private boolean useExternalService;
     private boolean doNotStart;
     private long testTimeoutSeconds;
-    private long initialTimeMillis = 0;
+    private long initialTimeMillis;
 
     private Class<?>[] workflowTypes;
     private Object[] activityImplementations;

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -30,6 +30,7 @@ import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.WorkflowImplementationOptions;
+import java.time.Instant;
 import java.util.UUID;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
@@ -123,6 +124,7 @@ public class TestWorkflowRule implements TestRule {
             .setWorkerFactoryOptions(workerFactoryOptions)
             .setUseExternalService(useExternalService)
             .setTarget(builder.target)
+            .setInitialTimeMillis(builder.initialTimeMillis)
             .build();
 
     testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
@@ -139,6 +141,7 @@ public class TestWorkflowRule implements TestRule {
     private boolean useExternalService;
     private boolean doNotStart;
     private long testTimeoutSeconds;
+    private long initialTimeMillis = 0;
 
     private Class<?>[] workflowTypes;
     private Object[] activityImplementations;
@@ -216,6 +219,26 @@ public class TestWorkflowRule implements TestRule {
     /** Global test timeout. Default is 10 seconds. */
     public Builder setTestTimeoutSeconds(long testTimeoutSeconds) {
       this.testTimeoutSeconds = testTimeoutSeconds;
+      return this;
+    }
+
+    /**
+     * Set the initial time for the workflow virtual clock, milliseconds since epoch.
+     *
+     * <p>Default is current time
+     */
+    public Builder setInitialTimeMillis(long initialTimeMillis) {
+      this.initialTimeMillis = initialTimeMillis;
+      return this;
+    }
+
+    /**
+     * Set the initial time for the workflow virtual clock.
+     *
+     * <p>Default is current time
+     */
+    public Builder setInitialTime(Instant initialTime) {
+      this.initialTimeMillis = initialTime.toEpochMilli();
       return this;
     }
 

--- a/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -242,7 +242,7 @@ public class TestWorkflowExtension
     private boolean useExternalService = false;
     private String target = null;
     private boolean doNotStart = false;
-    private long initialTimeMillis = 0;
+    private long initialTimeMillis;
 
     private Builder() {}
 

--- a/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -28,6 +28,7 @@ import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerOptions;
 import java.lang.reflect.Constructor;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -84,6 +85,7 @@ public class TestWorkflowExtension
   private final boolean useExternalService;
   private final String target;
   private final boolean doNotStart;
+  private final long initialTimeMillis;
 
   private final Set<Class<?>> supportedParameterTypes = new HashSet<>();
 
@@ -100,6 +102,7 @@ public class TestWorkflowExtension
     useExternalService = builder.useExternalService;
     target = builder.target;
     doNotStart = builder.doNotStart;
+    initialTimeMillis = builder.initialTimeMillis;
 
     supportedParameterTypes.add(TestWorkflowEnvironment.class);
     supportedParameterTypes.add(WorkflowClient.class);
@@ -165,6 +168,7 @@ public class TestWorkflowExtension
             .setWorkflowClientOptions(workflowClientOptions)
             .setUseExternalService(useExternalService)
             .setTarget(target)
+            .setInitialTimeMillis(initialTimeMillis)
             .build();
     TestWorkflowEnvironment testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
     String taskQueue =
@@ -238,6 +242,7 @@ public class TestWorkflowExtension
     private boolean useExternalService = false;
     private String target = null;
     private boolean doNotStart = false;
+    private long initialTimeMillis = 0;
 
     private Builder() {}
 
@@ -327,6 +332,26 @@ public class TestWorkflowExtension
      */
     public Builder setDoNotStart(boolean doNotStart) {
       this.doNotStart = doNotStart;
+      return this;
+    }
+
+    /**
+     * Set the initial time for the workflow virtual clock, milliseconds since epoch.
+     *
+     * <p>Default is current time
+     */
+    public Builder setInitialTimeMillis(long initialTimeMillis) {
+      this.initialTimeMillis = initialTimeMillis;
+      return this;
+    }
+
+    /**
+     * Set the initial time for the workflow virtual clock.
+     *
+     * <p>Default is current time
+     */
+    public Builder setInitialTime(Instant initialTime) {
+      this.initialTimeMillis = initialTime.toEpochMilli();
       return this;
     }
 

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -119,7 +119,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
 
   private final Lock lock = new ReentrantLock();
 
-  private final TestWorkflowStore store = new TestWorkflowStoreImpl();
+  private final TestWorkflowStore store;
 
   private final Map<ExecutionId, TestWorkflowMutableState> executions = new HashMap<>();
 
@@ -136,15 +136,20 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     return stubs;
   }
 
+  public TestWorkflowService() {
+    this(0);
+  }
+
   public TestWorkflowService(boolean lockTimeSkipping) {
-    this();
+    this(0);
     if (lockTimeSkipping) {
       this.lockTimeSkipping("constructor");
     }
   }
 
   // TODO: Shutdown.
-  public TestWorkflowService() {
+  public TestWorkflowService(long initialTimeMillis) {
+    store = new TestWorkflowStoreImpl(initialTimeMillis);
     serverName = InProcessServerBuilder.generateName();
     try {
       InProcessServerBuilder.forName(serverName).directExecutor().addService(this).build().start();

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -176,10 +176,10 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   private final Map<TaskQueueId, BlockingQueue<PollWorkflowTaskQueueResponse.Builder>>
       workflowTaskQueues = new HashMap<>();
 
-  private final SelfAdvancingTimer timerService =
-      new SelfAdvancingTimerImpl(System.currentTimeMillis());
+  private final SelfAdvancingTimer timerService;
 
-  public TestWorkflowStoreImpl() {
+  public TestWorkflowStoreImpl(long initialTimeMillis) {
+    timerService = new SelfAdvancingTimerImpl(initialTimeMillis);
     // locked until the first save
     timerService.lockTimeSkipping("TestWorkflowStoreImpl constructor");
   }

--- a/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
@@ -24,6 +24,7 @@ import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.Scope;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.worker.WorkerFactoryOptions;
+import java.time.Instant;
 
 @VisibleForTesting
 public final class TestEnvironmentOptions {
@@ -57,6 +58,8 @@ public final class TestEnvironmentOptions {
     private boolean useExternalService;
 
     private String target;
+
+    private long initialTimeMillis = 0;
 
     private Builder() {}
 
@@ -103,9 +106,34 @@ public final class TestEnvironmentOptions {
       return this;
     }
 
+    /**
+     * Set the initial time for the workflow virtual clock, milliseconds since epoch.
+     *
+     * <p>Default is current time
+     */
+    public Builder setInitialTimeMillis(long initialTimeMillis) {
+      this.initialTimeMillis = initialTimeMillis;
+      return this;
+    }
+
+    /**
+     * Set the initial time for the workflow virtual clock.
+     *
+     * <p>Default is current time
+     */
+    public Builder setInitialTime(Instant initialTime) {
+      this.initialTimeMillis = initialTime.toEpochMilli();
+      return this;
+    }
+
     public TestEnvironmentOptions build() {
       return new TestEnvironmentOptions(
-          workflowClientOptions, workerFactoryOptions, useExternalService, target, metricsScope);
+          workflowClientOptions,
+          workerFactoryOptions,
+          useExternalService,
+          target,
+          initialTimeMillis,
+          metricsScope);
     }
 
     public TestEnvironmentOptions validateAndBuildWithDefaults() {
@@ -114,6 +142,7 @@ public final class TestEnvironmentOptions {
           WorkerFactoryOptions.newBuilder(workerFactoryOptions).validateAndBuildWithDefaults(),
           useExternalService,
           target,
+          initialTimeMillis,
           metricsScope == null ? new NoopScope() : metricsScope);
     }
   }
@@ -123,18 +152,21 @@ public final class TestEnvironmentOptions {
   private final Scope metricsScope;
   private final boolean useExternalService;
   private final String target;
+  private final long initialTimeMillis;
 
   private TestEnvironmentOptions(
       WorkflowClientOptions workflowClientOptions,
       WorkerFactoryOptions workerFactoryOptions,
       boolean useExternalService,
       String target,
+      long initialTimeMillis,
       Scope metricsScope) {
     this.workflowClientOptions = workflowClientOptions;
     this.workerFactoryOptions = workerFactoryOptions;
     this.metricsScope = metricsScope;
     this.useExternalService = useExternalService;
     this.target = target;
+    this.initialTimeMillis = initialTimeMillis;
   }
 
   public WorkerFactoryOptions getWorkerFactoryOptions() {
@@ -157,6 +189,10 @@ public final class TestEnvironmentOptions {
     return target;
   }
 
+  public long getInitialTimeMillis() {
+    return initialTimeMillis;
+  }
+
   @Override
   public String toString() {
     return "TestEnvironmentOptions{"
@@ -168,6 +204,8 @@ public final class TestEnvironmentOptions {
         + useExternalService
         + ", target="
         + target
+        + ", initialTimeMillis="
+        + initialTimeMillis
         + '}';
   }
 }

--- a/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
@@ -59,7 +59,7 @@ public final class TestEnvironmentOptions {
 
     private String target;
 
-    private long initialTimeMillis = 0;
+    private long initialTimeMillis;
 
     private Builder() {}
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -68,7 +68,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     workerFactoryOptions =
         WorkerFactoryOptions.newBuilder(testEnvironmentOptions.getWorkerFactoryOptions())
             .validateAndBuildWithDefaults();
-    service = new TestWorkflowService();
+    service = new TestWorkflowService(testEnvironmentOptions.getInitialTimeMillis());
     timeLockingInterceptor = new TimeLockingInterceptor(service);
     service.lockTimeSkipping("TestWorkflowEnvironmentInternal constructor");
 

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentInitialTimeTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentInitialTimeTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testing;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.worker.Worker;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class TestWorkflowEnvironmentInitialTimeTest {
+
+  private static final Instant WORKFLOW_START_TIME = Instant.parse("2020-01-01T00:00:00Z");
+  private static final Duration WORKFLOW_DURATION = Duration.ofHours(10);
+  private static final Instant WORKFLOW_END_TIME = Instant.parse("2020-01-01T10:00:00Z");
+
+  @Rule
+  public TestWatcher watchman =
+      new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+          if (testEnv != null) {
+            System.err.println(testEnv.getDiagnostics());
+            testEnv.close();
+          }
+        }
+      };
+
+  @WorkflowInterface
+  public interface TimeDependentWorkflow {
+    @WorkflowMethod
+    Instant waitAndCheckTime(Duration waitDuration);
+  }
+
+  public static class TimeDependentWorkflowImpl implements TimeDependentWorkflow {
+    @Override
+    public Instant waitAndCheckTime(Duration waitDuration) {
+      Workflow.sleep(waitDuration);
+      return Instant.ofEpochMilli(Workflow.currentTimeMillis());
+    }
+  }
+
+  private TestWorkflowEnvironment testEnv;
+  private TimeDependentWorkflow workflow;
+  private static final String WORKFLOW_TASK_QUEUE = "EXAMPLE";
+
+  @Before
+  public void setUp() {
+
+    TestEnvironmentOptions testEnvOptions =
+        TestEnvironmentOptions.newBuilder().setInitialTime(WORKFLOW_START_TIME).build();
+    testEnv = TestWorkflowEnvironment.newInstance(testEnvOptions);
+
+    Worker worker = testEnv.newWorker(WORKFLOW_TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TimeDependentWorkflowImpl.class);
+
+    WorkflowClient client = testEnv.getWorkflowClient();
+    workflow =
+        client.newWorkflowStub(
+            TimeDependentWorkflow.class,
+            WorkflowOptions.newBuilder().setTaskQueue(WORKFLOW_TASK_QUEUE).build());
+    testEnv.start();
+  }
+
+  @Test(timeout = 2000)
+  public void testSignalAfterStartThenSleep() {
+    Instant workflowEndTime = workflow.waitAndCheckTime(WORKFLOW_DURATION);
+    assertEquals(WORKFLOW_END_TIME, workflowEndTime.truncatedTo(ChronoUnit.HOURS));
+  }
+
+  @After
+  public void tearDown() {
+    testEnv.close();
+  }
+}


### PR DESCRIPTION
## What was changed

Add a new `initialTime` attribute to the `TestEnvironmentOptions` and expose it via `TestWorkflowRule` and `TestWorkflowExtension`. If set, that attribute specifies the initial time to use for the workflow virtual clock.

The current behavior to use current system time as the initial workflow time is kept as a default.

## Why?

This change enables testing wall clock time-sensitive workflow logic, specifically workflows that are sensitive to the time they are started at. At the moment the time skipping is locked until the workflow is started, and the time the workflow time is set to the current system time, so there's no easy way to test how the workflow behaves if it's e.g. started at the midnight etc.

## Checklist

1. Closes issue: -

2. How was this tested: unit test.

3. Any docs updates needed? Javadocs are added for new methods.
