### PR TITLE
Update dependencies to latest

### DIFF
--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -2,7 +2,7 @@ description = '''Temporal Workflow Java SDK'''
 
 dependencies {
     api project(':temporal-serviceclient')
-    api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    api group: 'com.google.code.gson', name: 'gson', version: '2.8.7'
     api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.0'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    api 'io.grpc:grpc-protobuf:1.37.1'
-    api 'io.grpc:grpc-stub:1.37.1'
-    api 'io.grpc:grpc-core:1.37.1'
-    api 'io.grpc:grpc-netty-shaded:1.37.1'
-    api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.0'
+    api 'io.grpc:grpc-protobuf:1.38.0'
+    api 'io.grpc:grpc-stub:1.38.0'
+    api 'io.grpc:grpc-core:1.38.0'
+    api 'io.grpc:grpc-netty-shaded:1.38.0'
+    api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.1'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
     if (!JavaVersion.current().isJava8()) {
@@ -42,11 +42,11 @@ jar {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.17.0'
+        artifact = 'com.google.protobuf:protoc:3.17.2'
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.37.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.38.0'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
Before:
```
> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.google.code.gson:gson: 2.8.6 -> 2.8.7

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.google.protobuf:protobuf-java-util: 3.17.0 -> 3.17.1
New dependency version: com.google.protobuf:protoc: 3.17.0 -> 3.17.2
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.10.0
New dependency version: io.grpc:grpc-core: 1.37.1 -> 1.38.0
New dependency version: io.grpc:grpc-netty-shaded: 1.37.1 -> 1.38.0
New dependency version: io.grpc:grpc-protobuf: 1.37.1 -> 1.38.0
New dependency version: io.grpc:grpc-stub: 1.37.1 -> 1.38.0
New dependency version: io.grpc:protoc-gen-grpc-java: 1.37.1 -> 1.38.0
```
After:
```
> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.10.0
```