### PR TITLE
Fix health check attributes

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -239,7 +239,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
 
   @VisibleForTesting
   void checkHealth(String serviceName) {
-    if (options.getDisableHealthCheck()) {
+    if (!options.getDisableHealthCheck()) {
       RpcRetryOptions retryOptions =
           RpcRetryOptions.newBuilder()
               .setExpiration(getOptions().getHealthCheckTimeout())

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -166,7 +166,7 @@ public class WorkflowServiceStubsOptions {
     this.headers = builder.headers;
     this.metricsScope = builder.metricsScope;
     this.disableHealthCheck = builder.disableHealthCheck;
-    this.healthCheckAttemptTimeout = builder.HealthCheckAttemptTimeout;
+    this.healthCheckAttemptTimeout = builder.healthCheckAttemptTimeout;
     this.healthCheckTimeout = builder.healthCheckTimeout;
     this.enableKeepAlive = builder.enableKeepAlive;
     this.keepAliveTime = builder.keepAliveTime;
@@ -210,9 +210,9 @@ public class WorkflowServiceStubsOptions {
     this.metricsScope = builder.metricsScope == null ? new NoopScope() : builder.metricsScope;
     this.disableHealthCheck = builder.disableHealthCheck;
     this.healthCheckAttemptTimeout =
-        builder.healthCheckTimeout == null
+        builder.healthCheckAttemptTimeout == null
             ? Duration.ofSeconds(5)
-            : builder.HealthCheckAttemptTimeout;
+            : builder.healthCheckAttemptTimeout;
     this.healthCheckTimeout =
         builder.healthCheckTimeout == null ? Duration.ofSeconds(10) : builder.healthCheckTimeout;
     this.enableKeepAlive = builder.enableKeepAlive;
@@ -239,7 +239,7 @@ public class WorkflowServiceStubsOptions {
     return enableHttps;
   }
 
-  /** @return true when client checks endpoint to make sure that the server is accessible. */
+  /** @return false when client checks endpoint to make sure that the server is accessible. */
   public boolean getDisableHealthCheck() {
     return disableHealthCheck;
   }
@@ -352,7 +352,7 @@ public class WorkflowServiceStubsOptions {
     private boolean enableHttps;
     private String target;
     private boolean disableHealthCheck;
-    private Duration HealthCheckAttemptTimeout;
+    private Duration healthCheckAttemptTimeout;
     private Duration healthCheckTimeout;
     private boolean enableKeepAlive;
     private Duration keepAliveTime;
@@ -395,7 +395,7 @@ public class WorkflowServiceStubsOptions {
       this.headers = options.headers;
       this.metricsScope = options.metricsScope;
       this.disableHealthCheck = options.disableHealthCheck;
-      this.HealthCheckAttemptTimeout = options.healthCheckAttemptTimeout;
+      this.healthCheckAttemptTimeout = options.healthCheckAttemptTimeout;
       this.healthCheckTimeout = options.healthCheckTimeout;
       this.enableKeepAlive = options.enableKeepAlive;
       this.keepAliveTime = options.keepAliveTime;
@@ -545,7 +545,7 @@ public class WorkflowServiceStubsOptions {
     }
 
     /**
-     * If true, enables client to make a request to health check endpoint to make sure that the
+     * If false, enables client to make a request to health check endpoint to make sure that the
      * server is accessible.
      */
     public Builder setDisableHealthCheck(boolean disableHealthCheck) {
@@ -553,9 +553,9 @@ public class WorkflowServiceStubsOptions {
       return this;
     }
 
-    /** Set the time to wait between service responses on each health check. */
-    public Builder setEnableKeepAlive(Duration HealthCheckAttemptTimeout) {
-      this.HealthCheckAttemptTimeout = HealthCheckAttemptTimeout;
+    /** Set the time to wait between service responses on each health check */
+    public Builder setHealthCheckAttemptTimeout(Duration healthCheckAttemptTimeout) {
+      this.healthCheckAttemptTimeout = healthCheckAttemptTimeout;
       return this;
     }
 

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
@@ -48,6 +48,7 @@ public class HealthCheckTest {
                   WorkflowServiceStubsOptions.newBuilder().setDisableHealthCheck(false).build());
       try {
         service.checkHealth("IncorrectServiceName");
+        Assert.fail("Health check for IncorrectServiceName should fail");
       } catch (RuntimeException e) {
         Assert.assertTrue(e.getMessage().startsWith("Health check returned unhealthy status: "));
       }

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -137,7 +137,10 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
       stubs =
           WorkflowServiceStubs.newInstance(
-              WorkflowServiceStubsOptions.newBuilder().setChannel(channel).build());
+              WorkflowServiceStubsOptions.newBuilder()
+                  .setChannel(channel)
+                  .setDisableHealthCheck(true)
+                  .build());
     }
 
     public final String serverName;

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -116,6 +116,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
                 .setChannel(channel)
                 .setMetricsScope(options.getMetricsScope())
                 .setQueryRpcTimeout(Duration.ofSeconds(60))
+                .setDisableHealthCheck(true)
                 .build());
     activityTaskHandler =
         new POJOActivityTaskHandler(

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -84,6 +84,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
               service,
               WorkflowServiceStubsOptions.newBuilder()
                   .setMetricsScope(options.getMetricsScope())
+                  .setDisableHealthCheck(true)
                   .build());
     }
     WorkflowClient client = WorkflowClient.newInstance(workflowServiceStubs, workflowClientOptions);


### PR DESCRIPTION
## What was changed

This PR fixes small typos and semantic issues with the health check feature introduced in version 1.0.8.

1. It seems like the property named `disableHealthCheck` actually enabled health checks. The `HealthCheckTest` used to pass as the `service.checkHealth("IncorrectServiceName")` method did nothing when `disableHealthCheck` was `false`.
2. There's a typo in `WorkflowServiceStubsOptions.Builder`'s method name for `healthCheckAttemptTimeout`.
3. `WorkflowServiceStubsOptions` checks wrong attribute for `null` before assigning default value for `healthCheckAttemptTimeout`.
4. In-memory service does not support health checks so `TestWorkflowService`, `TestWorkflowEnvironmentInternal`, and `TestActivityEnvironmentInternal` have to disable it.

## Why?

I've noticed these issues while exposing new attributes added by 1.0.8 as Spring Boot application properties.

## Checklist

1. **Closes issue**: -

2. **How was this tested**: updated unit test.

3. **Any docs updates needed?** Javadocs are updated with proper semantics of the `disableHealthCheck` attribute.
