### PR TITLE
Removes slf4j-simple from api scope of temporal-testing

### DIFF
--- a/temporal-testing-junit4/build.gradle
+++ b/temporal-testing-junit4/build.gradle
@@ -4,5 +4,7 @@ dependencies {
     api project(':temporal-testing')
 
     api group: 'junit', name: 'junit', version: '4.13.2'
+
+    testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
 }
 

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -5,7 +5,6 @@ plugins {
 description = '''Temporal Workflow Java SDK testing'''
 
 dependencies {
-    api group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
     api project(':temporal-sdk')
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
@@ -13,6 +12,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
 }
 
 task testServiceServer(type: CreateStartScripts) {


### PR DESCRIPTION
## What was changed
slf4j-simple was removed from the api scope of temporal-testing

## Why?
The temporal-testing module was declaring slf4j-simple in api scope, resulting
in any consumers having slf4j on their compile and runtime classpaths. Previously
there was a gradle dependency configuration rule to remove that dependency, but
I mistakenly removed that during the gradle refactoring changes in 521a992 without
noticing it in the test classpaths.

This change moves the dependency to testRuntimeOnly so that temporal-testing has
logging configured for test execution, and adds it to temporal-testing-junit4 as
testRuntimeOnly as well.

Other consumers for temporal-testing were already explicitly declaring testImplementation
dependencies on logback-classic.

## Checklist

1. How was this tested:
* ensured sdk still builds and tests pass
* used `./gradlew temporal-testing-junit4:dependencies --configuration runtimeClaspath` to verify slf4j-simple is no longer present
