### PR TITLE
Avoid throwing IllegalStateException in NoopSuspendableWorker

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopSuspendableWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopSuspendableWorker.java
@@ -64,14 +64,10 @@ class NoopSuspendableWorker implements SuspendableWorker {
   }
 
   @Override
-  public void suspendPolling() {
-    throw new IllegalStateException("Non suspendable");
-  }
+  public void suspendPolling() {}
 
   @Override
-  public void resumePolling() {
-    throw new IllegalStateException("Non resumable");
-  }
+  public void resumePolling() {}
 
   @Override
   public boolean isSuspended() {


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

`NoopSuspendableWorker` no longer throws `IllegalStateException`s when `suspendPolling()` or `resumePolling()` is called.

## Why?
<!-- Tell your future self why have you made these changes -->

`LocalActivityWorker` does not create a "real" poller if no activity implementations are added to the parent worker.  It also does not guard against calling `suspendPolling()` or `resumePolling()` on the noop poller.  As this seems like an implementation detail that users of the library should not need to know about, throwing an exception is probably not the best move here; since it is a noop implementation, it should probably just do nothing.

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Untested, but given the limited number of places where these methods are called, this seems like a safe change, unless there is a specific reason why this needs to throw that I'm not aware of.