### PR TITLE
Add getWorker method to TestWorkflowRule

### DIFF
--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -350,7 +350,7 @@ public class TestWorkflowRule implements TestRule {
   /**
    * Returns the default worker created for each test method.
    * This worker listens to the default task queue which is obtainable
-   * via the {@link #getTaskQueue()} method
+   * via the {@link #getTaskQueue()} method.
    */
   public Worker getWorker() {
     return testEnvironment.getWorkerFactory().getWorker(getTaskQueue());

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -347,7 +347,11 @@ public class TestWorkflowRule implements TestRule {
     return this.blockingStub().getWorkflowExecutionHistory(request).getHistory();
   }
 
-  /** Returns the worker */
+  /**
+   * Returns the default worker created for each test method.
+   * This worker listens to the default task queue which is obtainable
+   * via the {@link #getTaskQueue()} method
+   */
   public Worker getWorker() {
     return testEnvironment.getWorkerFactory().getWorker(getTaskQueue());
   }

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -346,4 +346,9 @@ public class TestWorkflowRule implements TestRule {
             .build();
     return this.blockingStub().getWorkflowExecutionHistory(request).getHistory();
   }
+
+  /** Returns the worker */
+  public Worker getWorker() {
+    return testEnvironment.getWorkerFactory().getWorker(getTaskQueue());
+  }
 }


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added getWorker method to TestWorkflowRule.

## Why?
<!-- Tell your future self why have you made these changes -->
Currently if you have multiple tests where you want to register different activities (one might use real activities impl and another test might want to use a mock for example) you have to do:

      TestWorkflowRule.newBuilder()
                .setWorkflowTypes(GreetingWorkflowImpl.class)
                .setDoNotStart(true)
                .build();

and then in each test method to register activity:

            workflowRule
                    .getTestEnvironment()
                    .getWorkerFactory()
                    .getWorker(workflowRule.getTaskQueue())
                    .registerActivitiesImplementations(new GreetingActivitiesImpl());

This adds a convenience getWorker method so registering activities in test methods can be just

          workflowRule.getWorker().registerActivitiesImplementations(new GreetingActivitiesImpl());

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
