### PR TITLE
Query failure on terminated workflow (#391)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -412,6 +412,7 @@ public final class WorkflowStateMachines {
       case EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
         callbacks.cancel(event);
         break;
+      case EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
       case UNRECOGNIZED:
         break;
       default:

--- a/temporal-sdk/src/test/java/io/temporal/workflow/TerminatedWorkflowQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/TerminatedWorkflowQueryTest.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
+import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
+import io.temporal.workflow.shared.TestOptions;
+import io.temporal.workflow.shared.TestWorkflows.TestTraceWorkflow;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TerminatedWorkflowQueryTest {
+
+  private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestTraceWorkflowImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .setWorkflowClientOptions(WorkflowClientOptions.newBuilder().build())
+          .build();
+
+  @Test
+  public void testShouldReturnQueryResultAfterWorkflowTimeout() {
+    WorkflowOptions options =
+        TestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+            .toBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(1))
+            .build();
+    TestTraceWorkflow client =
+        testWorkflowRule.getWorkflowClient().newWorkflowStub(TestTraceWorkflow.class, options);
+
+    Assert.assertThrows(
+        "Workflow should throw because of timeout",
+        WorkflowFailedException.class,
+        () -> client.execute(SDKTestWorkflowRule.useExternalService));
+
+    Assert.assertEquals(1, client.getTrace().size());
+    Assert.assertEquals("started", client.getTrace().get(0));
+  }
+
+  public static class TestTraceWorkflowImpl implements TestTraceWorkflow {
+
+    private final List<String> trace = new ArrayList<>();
+
+    @Override
+    public String execute(boolean useExternalService) {
+      VariousTestActivities localActivities =
+          Workflow.newLocalActivityStub(
+              VariousTestActivities.class, TestOptions.newLocalActivityOptions());
+
+      trace.add("started");
+      localActivities.sleepActivity(5000, 123);
+      trace.add("finished");
+      return "";
+    }
+
+    @Override
+    public List<String> getTrace() {
+      return trace;
+    }
+  }
+}


### PR DESCRIPTION
* Add test that reproduces the issue - set shorter workflowRunTimeout than the activity needs to complete.
* The EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT seems harmless, so exception is suppressed.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a test that reproduces the issue.
Modified `WorkflowStateMachines` to ignore `EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT` instead of throwing the exception (inspired by go-sdk that generally "does not fail to be forward compatible with new events").

## Why?
I encountered this issue myself and found out it's already on github.
It happens when `@QueryMethod` is called on a terminated workflow. In my case the workflow has been terminated, because `workflowRunTimeout` has expired when activity was still running.
I decided to ignore the event instead of throwing an exception, because go-sdk does not return errors for unexpected events at all (`func ProcessEvent`)

## Checklist

1. Closes #391

2. How was this tested:
The test case that reproduces the issue has been added.
Tested with `./gradlew test` and `docker-compose -f docker/buildkite/docker-compose.yaml run unit-test-test-service`


3. Any docs updates needed?
No.
