### PR TITLE
Dependency Update

### DIFF
--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.10.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.0'
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.10.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.0'
 }
 
 task registerNamespace(type: JavaExec) {

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -12,14 +12,14 @@ dependencies {
     api 'io.grpc:grpc-core:1.38.0'
     api 'io.grpc:grpc-netty-shaded:1.38.0'
     api 'io.grpc:grpc-services:1.38.0'
-    api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.1'
+    api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.3'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.10.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
@@ -43,7 +43,7 @@ jar {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.17.2'
+        artifact = 'com.google.protobuf:protoc:3.17.3'
     }
     plugins {
         grpc {


### PR DESCRIPTION
> Task :temporal-opentracing:checkDependencyUpdates
New dependency version: org.mockito:mockito-core: 3.10.0 -> 3.11.0

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: org.mockito:mockito-core: 3.10.0 -> 3.11.0

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.google.protobuf:protobuf-java-util: 3.17.1 -> 3.17.3
New dependency version: com.google.protobuf:protoc: 3.17.2 -> 3.17.3
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.10.0
New dependency version: org.mockito:mockito-core: 3.10.0 -> 3.11.0