### PR TITLE
Change InterruptedException logs to debug-level.

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -76,6 +76,12 @@ public final class Poller<T> implements SuspendableWorker {
             log.warn("Failure in thread " + t.getName(), e);
             return;
           }
+          if (te.getCause() instanceof InterruptedException) {
+            if (log.isDebugEnabled()) {
+              log.debug("Failure in thread " + t.getName(), e);
+            }
+            return;
+          }
         }
         log.error("Failure in thread " + t.getName(), e);
       };

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -77,9 +77,7 @@ public final class Poller<T> implements SuspendableWorker {
             return;
           }
           if (te.getCause() instanceof InterruptedException) {
-            if (log.isDebugEnabled()) {
-              log.debug("Failure in thread " + t.getName(), e);
-            }
+            log.debug("Failure in thread " + t.getName(), e);
             return;
           }
         }

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -348,9 +348,8 @@ public class TestWorkflowRule implements TestRule {
   }
 
   /**
-   * Returns the default worker created for each test method.
-   * This worker listens to the default task queue which is obtainable
-   * via the {@link #getTaskQueue()} method.
+   * Returns the default worker created for each test method. This worker listens to the default
+   * task queue which is obtainable via the {@link #getTaskQueue()} method.
    */
   public Worker getWorker() {
     return testEnvironment.getWorkerFactory().getWorker(getTaskQueue());


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Poller logs InterruptedException only at debug-level.

## Why?
Graceful worker shutdown should result in no errors in application logs.

## Checklist
1. Closes #521 
