### PR TITLE
Java-canary warning fix

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkflowImplementationOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkflowImplementationOptions.java
@@ -64,7 +64,8 @@ public final class WorkflowImplementationOptions {
      * matched. For example to fail workflow on any exception pass {@link Throwable} class to this
      * method.
      */
-    public Builder setFailWorkflowExceptionTypes(
+    @SafeVarargs
+    public final Builder setFailWorkflowExceptionTypes(
         Class<? extends Throwable>... failWorkflowExceptionTypes) {
       this.failWorkflowExceptionTypes = failWorkflowExceptionTypes;
       return this;


### PR DESCRIPTION
## What was changed
Added an annotation that fixes this warning in java-canary:
warning: [unchecked] unchecked generic array creation for varargs parameter of type Class<? extends Throwable>[]
            .setFailWorkflowExceptionTypes(Throwable.class)
