### PR TITLE
Cancel child fix

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -515,6 +515,7 @@ public final class WorkflowStateMachines {
             RequestCancelExternalWorkflowExecutionCommandAttributes.newBuilder()
                 .setWorkflowId(attributes.getWorkflowId())
                 .setNamespace(attributes.getNamespace())
+                .setChildWorkflowOnly(true)
                 .build(),
             (r, e) -> { // TODO(maxim): Decide what to do if an error is passed to the callback.
               if (cancellationType == ChildWorkflowCancellationType.WAIT_CANCELLATION_REQUESTED) {
@@ -550,7 +551,7 @@ public final class WorkflowStateMachines {
   }
 
   /**
-   * @param attributes attributes to use to cancel external worklfow
+   * @param attributes attributes to use to cancel external workflow
    * @param completionCallback one of ExternalWorkflowExecutionCancelRequestedEvent,
    */
   public void requestCancelExternalWorkflowExecution(


### PR DESCRIPTION
## What was changed
Cancelation happens iff the workflow signaling is the parent.

## Checklist
1. Closes #501 

2. How was this tested:
This bug is very difficult to reproduce - no test so far
