### PR TITLE
Prohibit use of WorkflowClient from workflow code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.9' apply false
     id 'net.ltgt.errorprone' version '2.0.1' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'name.remal.check-updates' version '1.3.1' apply false
+    id 'name.remal.check-updates' version '1.3.5' apply false
     id 'com.palantir.git-version' version '0.12.2' apply false
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityCompletionClientImpl.java
@@ -26,6 +26,8 @@ import io.temporal.internal.external.ManualActivityCompletionClientFactory;
 import io.temporal.workflow.Functions;
 import java.util.Optional;
 
+import static io.temporal.internal.sync.WorkflowInternal.enforceNonWorkflowThread;
+
 class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   private final ManualActivityCompletionClientFactory factory;
@@ -40,6 +42,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   @Override
   public <R> void complete(byte[] taskToken, R result) {
+    enforceNonWorkflowThread();
     try {
       factory.getClient(taskToken).complete(result);
     } finally {
@@ -49,6 +52,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   @Override
   public <R> void complete(String workflowId, Optional<String> runId, String activityId, R result) {
+    enforceNonWorkflowThread();
     try {
       factory.getClient(toExecution(workflowId, runId), activityId).complete(result);
     } finally {
@@ -58,6 +62,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   @Override
   public void completeExceptionally(byte[] taskToken, Exception result) {
+    enforceNonWorkflowThread();
     try {
       factory.getClient(taskToken).fail(result);
     } finally {
@@ -68,6 +73,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
   @Override
   public void completeExceptionally(
       String workflowId, Optional<String> runId, String activityId, Exception result) {
+    enforceNonWorkflowThread();
     try {
       factory.getClient(toExecution(workflowId, runId), activityId).fail(result);
     } finally {
@@ -77,6 +83,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   @Override
   public <V> void reportCancellation(byte[] taskToken, V details) {
+    enforceNonWorkflowThread();
     try {
       factory.getClient(taskToken).reportCancellation(details);
     } finally {
@@ -87,6 +94,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
   @Override
   public <V> void reportCancellation(
       String workflowId, Optional<String> runId, String activityId, V details) {
+    enforceNonWorkflowThread();
     try {
       factory.getClient(toExecution(workflowId, runId), activityId).reportCancellation(details);
     } finally {
@@ -96,12 +104,14 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
 
   @Override
   public <V> void heartbeat(byte[] taskToken, V details) throws ActivityCompletionException {
+    enforceNonWorkflowThread();
     factory.getClient(taskToken).recordHeartbeat(details);
   }
 
   @Override
   public <V> void heartbeat(String workflowId, Optional<String> runId, String activityId, V details)
       throws ActivityCompletionException {
+    enforceNonWorkflowThread();
     factory.getClient(toExecution(workflowId, runId), activityId).recordHeartbeat(details);
   }
 
@@ -110,6 +120,7 @@ class ActivityCompletionClientImpl implements ActivityCompletionClient {
   }
 
   private static WorkflowExecution toExecution(String workflowId, Optional<String> runId) {
+    enforceNonWorkflowThread();
     return WorkflowExecution.newBuilder()
         .setWorkflowId(workflowId)
         .setRunId(runId.orElse(""))

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
@@ -50,6 +50,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static io.temporal.internal.sync.WorkflowInternal.enforceNonWorkflowThread;
+
 public final class WorkflowClientInternal implements WorkflowClient {
 
   private final GenericWorkflowClientExternalImpl genericClient;
@@ -426,11 +428,5 @@ public final class WorkflowClientInternal implements WorkflowClient {
       A5 arg5,
       A6 arg6) {
     return execute(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
-  }
-
-  private static void enforceNonWorkflowThread() {
-    if (DeterministicRunnerImpl.currentThreadInternalIfPresent().isPresent()) {
-      throw new IllegalStateException("Cannot be called from workflow thread.");
-    }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -501,4 +501,10 @@ public final class WorkflowInternal {
         .getPreviousRunFailure()
         .map(f -> FailureConverter.failureToException(f, DataConverter.getDefaultInstance()));
   }
+
+  public static void enforceNonWorkflowThread() {
+    if (DeterministicRunnerImpl.currentThreadInternalIfPresent().isPresent()) {
+      throw new IllegalStateException("Cannot be called from workflow thread.");
+    }
+  }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/InvalidCallsFromWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/InvalidCallsFromWorkflowTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.ITestNamedChild;
+import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import io.temporal.workflow.shared.TestWorkflows.TestNamedChild;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class InvalidCallsFromWorkflowTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestParentWorkflow.class, TestNamedChild.class)
+          .build();
+
+  @Test
+  public void testWorkflowClientCallFromWorkflow() {
+    NoArgsWorkflow client = testWorkflowRule.newWorkflowStubTimeoutOptions(NoArgsWorkflow.class);
+    client.execute();
+  }
+
+  public static class TestParentWorkflow implements NoArgsWorkflow {
+
+    @Override
+    public void execute() {
+      ITestNamedChild child = Workflow.newChildWorkflowStub(ITestNamedChild.class);
+      try {
+        WorkflowClient.execute(child::execute, "hello");
+      } catch (IllegalStateException e) {
+        assertTrue(e.getMessage().startsWith("Cannot be called from workflow thread."));
+      }
+      try {
+        WorkflowClient.start(child::execute, "world");
+      } catch (IllegalStateException e) {
+        assertTrue(e.getMessage().startsWith("Cannot be called from workflow thread."));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What was changed
Added explicit checks that throw exception from WorkflowClient and Activity APIs if they are called from workflow threads.

## Why?
New users might not be aware of nondeterministic requirements and might use WorkflowClient and Activity interfaces from the workflow code.

## Checklist
1. Closes #402 

2. How was this tested:
Unit test