### PR TITLE
Update ProtobufJsonPayloadConverter.java

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
@@ -57,7 +57,7 @@ public final class ProtobufJsonPayloadConverter implements PayloadConverter {
     if (!(value instanceof MessageOrBuilder)) {
       return Optional.empty();
     }
-    JsonFormat.Printer printer = JsonFormat.printer();
+
     try {
       String data = printer.print((MessageOrBuilder) value);
       return Optional.of(

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
@@ -38,7 +38,7 @@ public final class ProtobufJsonPayloadConverter implements PayloadConverter {
   private final JsonFormat.Parser parser;
 
   public ProtobufJsonPayloadConverter() {
-    printer = JsonFormat.printer().preservingProtoFieldNames();
+    printer = JsonFormat.printer();
     parser = JsonFormat.parser().ignoringUnknownFields();
   }
 


### PR DESCRIPTION
Regarding #551 - bugfix - use preconfigured printer rather than default JsonFormat.printer();

## What was changed
Bugfix - In JavaSDK, ProtobufJsonPayloadConverter allows you to configure both printer and parser. Yet, the preconfigured printer has not been used to convert Object to data. Default JsonFormat printer has been used instead.

## Why?
Bugfix to allow configurable printer to be used (as designed, it can be passed as constructor param).

## Checklist
1. Closes #551

2. How was this tested:
Passed custom JsonFormat.Printer to constructor and see it being used.

