### PR TITLE
Prohibit use of WorkflowClient from workflow code

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/ProhibitedCallsFromWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ProhibitedCallsFromWorkflowTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.ITestNamedChild;
+import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import io.temporal.workflow.shared.TestWorkflows.TestNamedChild;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ProhibitedCallsFromWorkflowTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflow.class, TestNamedChild.class)
+          .build();
+
+  private static WorkflowClient workflowClient;
+
+  @Before
+  public void setUp() throws Exception {
+    workflowClient = testWorkflowRule.getWorkflowClient();
+  }
+
+  @Test
+  public void testWorkflowClientCallFromWorkflow() {
+    NoArgsWorkflow client = testWorkflowRule.newWorkflowStubTimeoutOptions(NoArgsWorkflow.class);
+    client.execute();
+  }
+
+  public static class TestWorkflow implements NoArgsWorkflow {
+    @Override
+    public void execute() {
+      ITestNamedChild child = Workflow.newChildWorkflowStub(ITestNamedChild.class);
+      try {
+        WorkflowClient.execute(child::execute, "hello");
+        fail("should be unreachable, we expect an exception");
+      } catch (IllegalStateException e) {
+        assertTrue(e.getMessage().startsWith("Cannot be called from workflow thread."));
+      }
+      try {
+        WorkflowClient.start(child::execute, "world");
+        fail("should be unreachable, we expect an exception");
+      } catch (IllegalStateException e) {
+        assertTrue(e.getMessage().startsWith("Cannot be called from workflow thread."));
+      }
+      try {
+        // let's imagine that the workflow code somehow got a WorkflowClient instance (from DI for
+        // example).
+        // Let's make sure it still can't trigger it's methods
+        workflowClient.getOptions();
+        fail("should be unreachable, we expect an exception");
+      } catch (IllegalStateException e) {
+        assertTrue(e.getMessage().startsWith("Cannot be called from workflow thread."));
+      }
+    }
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/conf/EnvironmentVariableNames.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/conf/EnvironmentVariableNames.java
@@ -1,0 +1,17 @@
+package io.temporal.conf;
+
+public final class EnvironmentVariableNames {
+  /**
+   * Specify this env variable to disable checks and enforcement for classes that are not intended
+   * to be accessed from workflow code.
+   *
+   * <p>Not specifying it or setting it to "false" (case insensitive) leaves the checks enforced.
+   *
+   * <p>This option is exposed for backwards compatibility only and should never be enabled for any
+   * new code or application.
+   */
+  public static final String DISABLE_NON_WORKFLOW_CODE_ENFORCEMENTS =
+      "TEMPORAL_DISABLE_NON_WORKFLOW_CODE_ENFORCEMENTS";
+
+  private EnvironmentVariableNames() {}
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/WorkflowThreadMarker.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/WorkflowThreadMarker.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal;
+
+import io.temporal.conf.EnvironmentVariableNames;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+
+/**
+ * Provides an access to information about a thread type the current code executes in to perform
+ * different type of access checks inside Temporal library code.
+ *
+ * <p>Note: This class is a singleton and is not intended for an extension.
+ *
+ * <p>Note: This class shouldn't be accessed in any way by the application code.
+ */
+public abstract class WorkflowThreadMarker {
+  protected static final ThreadLocal<Boolean> isWorkflowThreadThreadLocal =
+      ThreadLocal.withInitial(() -> false);
+
+  private static final boolean enableEnforcements;
+
+  static {
+    String envValue =
+        System.getenv(EnvironmentVariableNames.DISABLE_NON_WORKFLOW_CODE_ENFORCEMENTS);
+    enableEnforcements = envValue == null || "false".equalsIgnoreCase(envValue);
+  }
+
+  /** @return true if the current thread is workflow thread */
+  public static boolean isWorkflowThread() {
+    return isWorkflowThreadThreadLocal.get();
+  }
+
+  /**
+   * Throws {@link IllegalStateException} if it's called from workflow thread.
+   *
+   * @see io.temporal.conf.EnvironmentVariableNames#DISABLE_NON_WORKFLOW_CODE_ENFORCEMENTS
+   */
+  public static void enforceNonWorkflowThread() {
+    if (enableEnforcements && isWorkflowThread()) {
+      throw new IllegalStateException("Cannot be called from workflow thread.");
+    }
+  }
+
+  /**
+   * Create a proxy that checks all methods executions if they are done from a workflow thread and
+   * makes them throw an IllegalStateException if they are indeed triggered from workflow code
+   *
+   * @param instance an instance to wrap
+   * @param iface an interface the {@code instance} implements and that proxy should implement and
+   *     intercept
+   * @return a proxy that makes sure that it's methods can't be called from workflow thread
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T protectFromWorkflowThread(T instance, Class<T> iface) {
+    return (T)
+        Proxy.newProxyInstance(
+            iface.getClassLoader(),
+            new Class<?>[] {iface},
+            (proxy, method, args) -> {
+              enforceNonWorkflowThread();
+              try {
+                return method.invoke(instance, args);
+              } catch (InvocationTargetException e) {
+                throw e.getCause();
+              }
+            });
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubs.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubs.java
@@ -19,7 +19,10 @@
 
 package io.temporal.serviceclient;
 
+import static io.temporal.internal.WorkflowThreadMarker.enforceNonWorkflowThread;
+
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
+import io.temporal.internal.WorkflowThreadMarker;
 import java.util.concurrent.TimeUnit;
 
 /** Initializes and holds gRPC blocking and future stubs. */
@@ -30,12 +33,12 @@ public interface WorkflowServiceStubs {
    * the locally running temporal service.
    */
   static WorkflowServiceStubs newInstance() {
-    return new WorkflowServiceStubsImpl(null, WorkflowServiceStubsOptions.getDefaultInstance());
+    return newInstance(WorkflowServiceStubsOptions.getDefaultInstance());
   }
 
   /** Create gRPC connection stubs using provided options. */
   static WorkflowServiceStubs newInstance(WorkflowServiceStubsOptions options) {
-    return new WorkflowServiceStubsImpl(null, options);
+    return newInstance(null, options);
   }
 
   /**
@@ -44,7 +47,9 @@ public interface WorkflowServiceStubs {
    */
   static WorkflowServiceStubs newInstance(
       WorkflowServiceGrpc.WorkflowServiceImplBase service, WorkflowServiceStubsOptions options) {
-    return new WorkflowServiceStubsImpl(service, options);
+    enforceNonWorkflowThread();
+    return WorkflowThreadMarker.protectFromWorkflowThread(
+        new WorkflowServiceStubsImpl(service, options), WorkflowServiceStubs.class);
   }
 
   /** @return Blocking (synchronous) stub that allows direct calls to service. */

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
@@ -19,19 +19,16 @@
 
 package io.temporal.internal.sync;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-@VisibleForTesting
 public class DeterministicRunnerWrapper implements InvocationHandler {
 
   private final InvocationHandler invocationHandler;
 
-  @VisibleForTesting
   public DeterministicRunnerWrapper(InvocationHandler invocationHandler) {
     this.invocationHandler = Objects.requireNonNull(invocationHandler);
   }


### PR DESCRIPTION
## What was changed
Now the usage of `WorkflowClient`, `ActivityCompletionClient`, and `WorkflowServiceStubs` is prohibited from workflow code.

It's an alternative PR to the original PR #550. 

The main difference is that this PR doesn't rely on magic thread names to understand that we are inside a workflow thread, but a marker utility class was implemented that is published by DeterministicRunner and available to serviceclient code.

It includes a fix for `TestActivityEnvironmentInternal` to execute activities code in a separate thread pool, not in a main thread of DeterministicRunnerImpl to emulate the behavior of our real worker setup and allow a correct work of implemented checks for ActivityCompletionClient (this class is actively used in activities code)

Also, this PR uses proxies to 

- ensure the right type of a calling thread for each non-static method of `WorkflowClient`, `ActivityCompletionClient`, and `WorkflowServiceStubs` instances
- decrease copy-paste
- minimize mistakes in the future.

## Why?
New users might not be aware of nondeterministic requirements and might use WorkflowClient and Activity interfaces from the workflow code.

Closes #402