### PR TITLE
Rework how DeterministicRunnerImpl and SyncWorkflowContext handle creation of workflow root and method threads

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptor.java
@@ -19,6 +19,8 @@
 
 package io.temporal.common.interceptors;
 
+import javax.annotation.Nullable;
+
 /**
  * Intercepts calls to the workflow execution. Executes under workflow context. So all the
  * restrictions on the workflow code should be obeyed.
@@ -128,4 +130,24 @@ public interface WorkflowInboundCallsInterceptor {
 
   /** Called when a workflow is queried. */
   QueryOutput handleQuery(QueryInput input);
+
+  /**
+   * Intercepts creation of the workflow main method thread
+   *
+   * @param runnable thread function to run
+   * @param name name of the thread, optional
+   * @return created workflow thread. Should be treated as a pass-through object that shouldn't be
+   *     manipulated in any way by the interceptor code.
+   */
+  Object newWorkflowMethodThread(Runnable runnable, @Nullable String name);
+
+  /**
+   * Intercepts creation of a workflow callback thread
+   *
+   * @param runnable thread function to run
+   * @param name name of the thread, optional
+   * @return created workflow thread. Should be treated as a pass-through object that shouldn't be
+   *     manipulated in any way by the interceptor code.
+   */
+  Object newCallbackThread(Runnable runnable, @Nullable String name);
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptorBase.java
@@ -46,4 +46,14 @@ public class WorkflowInboundCallsInterceptorBase implements WorkflowInboundCalls
   public QueryOutput handleQuery(QueryInput input) {
     return next.handleQuery(input);
   }
+
+  @Override
+  public Object newWorkflowMethodThread(Runnable runnable, String name) {
+    return next.newWorkflowMethodThread(runnable, name);
+  }
+
+  @Override
+  public Object newCallbackThread(Runnable runnable, String name) {
+    return next.newCallbackThread(runnable, name);
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -22,13 +22,8 @@ package io.temporal.common.interceptors;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.workflow.ChildWorkflowOptions;
-import io.temporal.workflow.ContinueAsNewOptions;
-import io.temporal.workflow.DynamicQueryHandler;
-import io.temporal.workflow.DynamicSignalHandler;
-import io.temporal.workflow.Functions;
+import io.temporal.workflow.*;
 import io.temporal.workflow.Functions.Func;
-import io.temporal.workflow.Promise;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.List;
@@ -483,7 +478,18 @@ public interface WorkflowOutboundCallsInterceptor {
 
   void upsertSearchAttributes(Map<String, Object> searchAttributes);
 
-  Object newThread(Runnable runnable, boolean detached, String name);
+  /**
+   * Intercepts creation of the workflow child thread.
+   *
+   * <p>Please note, that "workflow child thread" and "child workflow" are different and independent
+   * concepts.
+   *
+   * @param runnable thread function to run
+   * @param detached if this thread is detached from the parent {@link CancellationScope}
+   * @param name name of the thread
+   * @return created WorkflowThread
+   */
+  Object newChildThread(Runnable runnable, boolean detached, String name);
 
   long currentTimeMillis();
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
@@ -140,8 +140,8 @@ public class WorkflowOutboundCallsInterceptorBase implements WorkflowOutboundCal
   }
 
   @Override
-  public Object newThread(Runnable runnable, boolean detached, String name) {
-    return next.newThread(runnable, detached, name);
+  public Object newChildThread(Runnable runnable, boolean detached, String name) {
+    return next.newChildThread(runnable, detached, name);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/AsyncInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/AsyncInternal.java
@@ -293,15 +293,15 @@ public final class AsyncInternal {
       }
     } else {
       CompletablePromise<R> result = Workflow.newPromise();
-      WorkflowInternal.newThread(
-              false,
+      WorkflowThread.newThread(
               () -> {
                 try {
                   result.complete(func.apply());
                 } catch (Exception e) {
                   result.completeExceptionally(Workflow.wrap(e));
                 }
-              })
+              },
+              false)
           .start();
       return result;
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/BaseRootWorkflowInboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/BaseRootWorkflowInboundCallsInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.sync;
+
+import io.temporal.common.interceptors.WorkflowInboundCallsInterceptor;
+import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
+
+/**
+ * Provides core functionality for a root WorkflowInboundCallsInterceptor that is reused by specific
+ * root RootWorkflowInboundCallsInterceptor implementations inside {@link
+ * DynamicSyncWorkflowDefinition#} and {@link POJOWorkflowImplementationFactory}
+ *
+ * <p>Root {@code WorkflowInboundCallsInterceptor} is an interceptor that should be at the end of
+ * the {@code WorkflowInboundCallsInterceptor} interceptors chain and which encapsulates calls into
+ * Temporal internals while providing a WorkflowInboundCallsInterceptor interface for chaining on
+ * top of it.
+ */
+public abstract class BaseRootWorkflowInboundCallsInterceptor
+    implements WorkflowInboundCallsInterceptor {
+  protected final SyncWorkflowContext workflowContext;
+
+  public BaseRootWorkflowInboundCallsInterceptor(SyncWorkflowContext workflowContext) {
+    this.workflowContext = workflowContext;
+  }
+
+  @Override
+  public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
+    workflowContext.initHeadOutboundCallsInterceptor(outboundCalls);
+  }
+
+  @Override
+  public void handleSignal(SignalInput input) {
+    workflowContext.handleInterceptedSignal(input);
+  }
+
+  @Override
+  public QueryOutput handleQuery(QueryInput input) {
+    return workflowContext.handleInterceptedQuery(input);
+  }
+
+  @Override
+  public Object newWorkflowMethodThread(Runnable runnable, String name) {
+    return workflowContext.newWorkflowMethodThreadIntercepted(runnable, name);
+  }
+
+  @Override
+  public Object newCallbackThread(Runnable runnable, String name) {
+    return workflowContext.newWorkflowCallbackThreadIntercepted(runnable, name);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -127,14 +127,11 @@ class SyncWorkflow implements ReplayWorkflow {
             syncContext,
             () -> {
               workflow.initialize();
-              WorkflowInternal.newThread(
-                      false,
-                      DeterministicRunnerImpl.WORKFLOW_ROOT_THREAD_NAME,
-                      () -> workflowProc.run())
+              WorkflowInternal.newWorkflowMethodThread(
+                      () -> workflowProc.run(), DeterministicRunnerImpl.WORKFLOW_MAIN_THREAD_NAME)
                   .start();
             },
             cache);
-    runner.setInterceptorHead(syncContext.getWorkflowInterceptor());
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 /** Thread that is scheduled deterministically by {@link DeterministicRunner}. */
-interface WorkflowThread extends CancellationScope {
+public interface WorkflowThread extends CancellationScope {
 
   /**
    * Block current thread until unblockCondition is evaluated to true. This method is intended for
@@ -60,8 +60,8 @@ interface WorkflowThread extends CancellationScope {
     return (WorkflowThread)
         currentThreadInternal()
             .getWorkflowContext()
-            .getWorkflowInterceptor()
-            .newThread(runnable, detached, name);
+            .getWorkflowOutboundInterceptor()
+            .newChildThread(runnable, detached, name);
   }
 
   void start();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -28,7 +28,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
 
-class WorkflowThreadContext {
+public class WorkflowThreadContext {
 
   // Shared runner lock
   private final Lock lock;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -394,7 +394,17 @@ class WorkflowThreadImpl implements WorkflowThread {
     // These numbers might change if implementation changes.
     int omitTop = 5;
     int omitBottom = 7;
+    // TODO it's not a good idea to rely on the name to understand the thread type. Instead of that
+    // we would better
+    // assign an explicit thread type enum to the threads. This will be especially important when we
+    // refactor
+    // root and workflow-method
+    // thread names into names that will include workflowId
     if (DeterministicRunnerImpl.WORKFLOW_ROOT_THREAD_NAME.equals(getName())) {
+      // TODO revisit this number
+      omitBottom = 11;
+    } else if (DeterministicRunnerImpl.WORKFLOW_MAIN_THREAD_NAME.equals(getName())) {
+      // TODO revisit this number
       omitBottom = 11;
     }
     StackTraceElement[] stackTrace = thread.getStackTrace();

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -76,7 +76,6 @@ public class DeterministicRunnerTest {
   private boolean unblock1;
   private boolean unblock2;
   private Throwable failure;
-  private long currentTime;
   private ExecutorService threadPool;
 
   @Before
@@ -85,7 +84,6 @@ public class DeterministicRunnerTest {
     unblock2 = false;
     failure = null;
     status = "initial";
-    currentTime = 0;
     threadPool = new ThreadPoolExecutor(1, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
   }
 
@@ -96,9 +94,10 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testYield() throws Throwable {
+  public void testYield() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               status = "started";
               WorkflowThread.await("reason1", () -> unblock1);
@@ -141,7 +140,7 @@ public class DeterministicRunnerTest {
     DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool,
-            null,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("started");
               Workflow.retry(
@@ -179,9 +178,10 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testRootFailure() throws Throwable {
+  public void testRootFailure() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               status = "started";
               WorkflowThread.await("reason1", () -> unblock1);
@@ -201,9 +201,10 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testDispatcherStop() throws Throwable {
+  public void testDispatcherStop() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               status = "started";
               WorkflowThread.await("reason1", () -> unblock1);
@@ -229,9 +230,10 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testDispatcherExit() throws Throwable {
+  public void testDispatcherExit() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               Promise<Void> thread1 =
@@ -268,10 +270,11 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testRootCancellation() throws Throwable {
+  public void testRootCancellation() {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               WorkflowThread.await(
@@ -294,10 +297,11 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testExplicitScopeCancellation() throws Throwable {
+  public void testExplicitScopeCancellation() {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               CompletablePromise<Void> var = Workflow.newPromise();
@@ -340,6 +344,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               CompletablePromise<Void> var = Workflow.newPromise();
@@ -391,10 +396,11 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testExplicitThreadCancellation() throws Throwable {
+  public void testExplicitThreadCancellation() {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               CompletablePromise<String> threadDone = Workflow.newPromise();
@@ -434,10 +440,11 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testExplicitCancellationOnFailure() throws Throwable {
+  public void testExplicitCancellationOnFailure() {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               Workflow.newCancellationScope(
@@ -492,10 +499,11 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testDetachedCancellation() throws Throwable {
+  public void testDetachedCancellation() {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
               CompletablePromise<Void> done = Workflow.newPromise();
@@ -546,9 +554,10 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testChild() throws Throwable {
+  public void testChild() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> async =
                   Async.procedure(
@@ -602,8 +611,11 @@ public class DeterministicRunnerTest {
   }
 
   @Test
-  public void testChildTree() throws Throwable {
-    DeterministicRunner d = new DeterministicRunnerImpl(new TestChildTreeRunnable(0)::apply);
+  public void testChildTree() {
+    DeterministicRunner d =
+        new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            new TestChildTreeRunnable(0)::apply);
     d.runUntilAllBlocked(getDeadlockDetectionTimeout());
     unblock1 = true;
     d.runUntilAllBlocked(getDeadlockDetectionTimeout());
@@ -711,7 +723,7 @@ public class DeterministicRunnerTest {
     DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool,
-            null,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> thread =
                   Async.procedure(
@@ -736,7 +748,7 @@ public class DeterministicRunnerTest {
     DeterministicRunnerImpl d2 =
         new DeterministicRunnerImpl(
             threadPool,
-            null,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> thread =
                   Async.procedure(
@@ -791,7 +803,7 @@ public class DeterministicRunnerTest {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
             threadPool,
-            null,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> async = Async.procedure(() -> status = "started");
               async.get();

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
@@ -49,17 +49,17 @@ public class PromiseTest {
   @Rule public final Tracer trace = new Tracer();
 
   @Test
-  public void testFailure() throws Throwable {
+  public void testFailure() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<Boolean> f = Workflow.newPromise();
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false, () -> f.completeExceptionally(new IllegalArgumentException("foo")))
+              WorkflowThread.newThread(
+                      () -> f.completeExceptionally(new IllegalArgumentException("foo")), false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         try {
                           f.get();
@@ -69,7 +69,8 @@ public class PromiseTest {
                           assertEquals(IllegalArgumentException.class, e.getClass());
                           trace.add("thread1 get failure");
                         }
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -82,13 +83,14 @@ public class PromiseTest {
   }
 
   @Test
-  public void testGet() throws Throwable {
+  public void testGet() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
               trace.add("root begin");
-              WorkflowInternal.newThread(false, () -> f.complete("thread1")).start();
+              WorkflowThread.newThread(() -> f.complete("thread1"), false).start();
               trace.add(f.get());
               trace.add("root done");
             });
@@ -101,13 +103,14 @@ public class PromiseTest {
   }
 
   @Test
-  public void testCancellableGet() throws Throwable {
+  public void testCancellableGet() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
               trace.add("root begin");
-              WorkflowInternal.newThread(false, () -> f.complete("thread1")).start();
+              WorkflowThread.newThread(() -> f.complete("thread1"), false).start();
               trace.add(f.cancellableGet());
               trace.add("root done");
             });
@@ -120,9 +123,10 @@ public class PromiseTest {
   }
 
   @Test
-  public void testCancellableGetCancellation() throws Throwable {
+  public void testCancellableGetCancellation() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
               trace.add("root begin");
@@ -193,34 +197,35 @@ public class PromiseTest {
   }
 
   @Test
-  public void testMultiple() throws Throwable {
+  public void testMultiple() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<Boolean> f1 = Workflow.newPromise();
               CompletablePromise<Boolean> f2 = Workflow.newPromise();
               CompletablePromise<Boolean> f3 = Workflow.newPromise();
 
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         assertTrue(f1.get());
                         trace.add("thread1 f1");
                         f2.complete(true);
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         assertTrue(f2.get());
                         trace.add("thread2 f2");
                         f3.complete(true);
                         trace.add("thread2 done");
-                      })
+                      },
+                      false)
                   .start();
               f1.complete(true);
               assertFalse(f1.complete(false));
@@ -246,9 +251,10 @@ public class PromiseTest {
   }
 
   @Test
-  public void tstAsync() throws Throwable {
+  public void tstAsync() {
     DeterministicRunner runner =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<String> f1 = Workflow.newPromise();
@@ -279,9 +285,10 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAsyncFailure() throws Throwable {
+  public void testAsyncFailure() {
     DeterministicRunner runner =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<String> f1 = Workflow.newPromise();
@@ -321,38 +328,39 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAllOf() throws Throwable {
+  public void testAllOf() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<String> f1 = Workflow.newPromise();
               CompletablePromise<String> f2 = Workflow.newPromise();
               CompletablePromise<String> f3 = Workflow.newPromise();
 
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         f1.complete("value1");
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread3 begin");
                         f3.complete("value3");
                         trace.add("thread3 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         f2.complete("value2");
                         trace.add("thread2 done");
-                      })
+                      },
+                      false)
                   .start();
               List<Promise<String>> promises = new ArrayList<>();
               promises.add(f1);
@@ -380,9 +388,10 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAllOfImmediatelyReady() throws Throwable {
+  public void testAllOfImmediatelyReady() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               {
@@ -421,38 +430,39 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAnyOf() throws Throwable {
+  public void testAnyOf() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<String> f1 = Workflow.newPromise();
               CompletablePromise<String> f2 = Workflow.newPromise();
               CompletablePromise<String> f3 = Workflow.newPromise();
 
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         f1.complete("value1");
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread3 begin");
                         f3.complete("value3");
                         trace.add("thread3 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         f2.complete("value2");
                         trace.add("thread2 done");
-                      })
+                      },
+                      false)
                   .start();
               List<Promise<String>> promises = new ArrayList<>();
               promises.add(f1);
@@ -481,38 +491,39 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAllOfArray() throws Throwable {
+  public void testAllOfArray() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<String> f1 = Workflow.newPromise();
               CompletablePromise<Integer> f2 = Workflow.newPromise();
               CompletablePromise<Boolean> f3 = Workflow.newPromise();
 
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         f1.complete("value1");
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread3 begin");
                         f3.complete(true);
                         trace.add("thread3 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         f2.complete(111);
                         trace.add("thread2 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root before allOf");
               assertFalse(f1.isCompleted());
@@ -541,38 +552,39 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAnyOfArray() throws Throwable {
+  public void testAnyOfArray() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               CompletablePromise<String> f1 = Workflow.newPromise();
               CompletablePromise<Integer> f2 = Workflow.newPromise();
               CompletablePromise<Boolean> f3 = Workflow.newPromise();
 
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         f1.complete("value1");
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread3 begin");
                         f3.complete(true);
                         trace.add("thread3 done");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         f2.complete(111);
                         trace.add("thread2 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root before allOf");
               assertFalse(f1.isCompleted());
@@ -602,9 +614,10 @@ public class PromiseTest {
   }
 
   @Test
-  public void testAnyOfImmediatelyReady() throws Throwable {
+  public void testAnyOfImmediatelyReady() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
               {

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
@@ -43,24 +43,25 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testTakeBlocking() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         assertTrue(f.take());
                         trace.add("thread1 take success");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         f.put(true);
                         trace.add("thread2 put success");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -82,11 +83,11 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -95,7 +96,8 @@ public class WorkflowInternalDeprecatedQueueTest {
                           trace.add("thread1 CanceledException");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -115,11 +117,11 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testCancellableTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -128,7 +130,8 @@ public class WorkflowInternalDeprecatedQueueTest {
                           trace.add("thread1 CanceledFailure");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -158,8 +161,7 @@ public class WorkflowInternalDeprecatedQueueTest {
       WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
       trace.add("root begin");
       WorkflowThread thread1 =
-          WorkflowInternal.newThread(
-              false,
+          WorkflowThread.newThread(
               () -> {
                 trace.add("thread1 begin");
                 Workflow.sleep(2000);
@@ -167,19 +169,20 @@ public class WorkflowInternalDeprecatedQueueTest {
                 trace.add("thread1 take1 success");
                 assertFalse(f.take());
                 trace.add("thread1 take2 success");
-              });
+              },
+              false);
 
       thread1.start();
       WorkflowThread thread2 =
-          WorkflowInternal.newThread(
-              false,
+          WorkflowThread.newThread(
               () -> {
                 trace.add("thread2 begin");
                 f.put(true);
                 trace.add("thread2 put1 success");
                 f.put(false);
                 trace.add("thread2 put2 success");
-              });
+              },
+              false);
       thread2.start();
       trace.add("root done");
       Workflow.await(() -> thread1.isDone() && thread2.isDone());
@@ -188,7 +191,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   }
 
   @Test
-  public void testPutBlocking() throws Throwable {
+  public void testPutBlocking() {
     TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
     String testTaskQueue = "testTaskQueue";
     Worker worker = testEnv.newWorker(testTaskQueue);
@@ -270,11 +273,11 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testPutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -284,7 +287,8 @@ public class WorkflowInternalDeprecatedQueueTest {
                           trace.add("thread1 CanceledFailure");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -304,11 +308,11 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testCancellablePutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -318,7 +322,8 @@ public class WorkflowInternalDeprecatedQueueTest {
                           trace.add("thread1 CanceledFailure");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -338,11 +343,11 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testMap() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         QueueConsumer<String> mapped = queue.map((s) -> s + "-mapped");
                         trace.add("thread1 begin");
@@ -350,7 +355,8 @@ public class WorkflowInternalDeprecatedQueueTest {
                           trace.add("thread1 " + mapped.take());
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root thread1 started");
               for (int i = 0; i < 10; i++) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -46,24 +46,25 @@ public class WorkflowInternalQueueTest {
   public void testTakeBlocking() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         assertTrue(f.take());
                         trace.add("thread1 take success");
-                      })
+                      },
+                      false)
                   .start();
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread2 begin");
                         f.put(true);
                         trace.add("thread2 put success");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -85,11 +86,11 @@ public class WorkflowInternalQueueTest {
   public void testTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -98,7 +99,8 @@ public class WorkflowInternalQueueTest {
                           trace.add("thread1 CanceledException");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -118,11 +120,11 @@ public class WorkflowInternalQueueTest {
   public void testCancellableTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -131,7 +133,8 @@ public class WorkflowInternalQueueTest {
                           trace.add("thread1 CanceledFailure");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -161,8 +164,7 @@ public class WorkflowInternalQueueTest {
       WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
       trace.add("root begin");
       WorkflowThread thread1 =
-          WorkflowInternal.newThread(
-              false,
+          WorkflowThread.newThread(
               () -> {
                 trace.add("thread1 begin");
                 Workflow.sleep(2000);
@@ -170,19 +172,20 @@ public class WorkflowInternalQueueTest {
                 trace.add("thread1 take1 success");
                 assertFalse(f.take());
                 trace.add("thread1 take2 success");
-              });
+              },
+              false);
 
       thread1.start();
       WorkflowThread thread2 =
-          WorkflowInternal.newThread(
-              false,
+          WorkflowThread.newThread(
               () -> {
                 trace.add("thread2 begin");
                 f.put(true);
                 trace.add("thread2 put1 success");
                 f.put(false);
                 trace.add("thread2 put2 success");
-              });
+              },
+              false);
       thread2.start();
       trace.add("root done");
       Workflow.await(() -> thread1.isDone() && thread2.isDone());
@@ -273,11 +276,11 @@ public class WorkflowInternalQueueTest {
   public void testPutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -287,7 +290,8 @@ public class WorkflowInternalQueueTest {
                           trace.add("thread1 CanceledFailure");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -307,11 +311,11 @@ public class WorkflowInternalQueueTest {
   public void testCancellablePutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
                         try {
@@ -321,7 +325,8 @@ public class WorkflowInternalQueueTest {
                           trace.add("thread1 CanceledFailure");
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root done");
             });
@@ -341,11 +346,11 @@ public class WorkflowInternalQueueTest {
   public void testMap() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Integer> queue = WorkflowInternal.newWorkflowQueue(1);
               trace.add("root begin");
-              WorkflowInternal.newThread(
-                      false,
+              WorkflowThread.newThread(
                       () -> {
                         QueueConsumer<String> mapped = queue.map((s) -> s + "-mapped");
                         trace.add("thread1 begin");
@@ -353,7 +358,8 @@ public class WorkflowInternalQueueTest {
                           trace.add("thread1 " + mapped.take());
                         }
                         trace.add("thread1 done");
-                      })
+                      },
+                      false)
                   .start();
               trace.add("root thread1 started");
               for (int i = 0; i < 10; i++) {
@@ -393,6 +399,7 @@ public class WorkflowInternalQueueTest {
     int[] result = new int[3];
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               queue.put(1);
               queue.put(2);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowOutboundCallsInterceptor.java
@@ -161,8 +161,8 @@ public class SignalWorkflowOutboundCallsInterceptor implements WorkflowOutboundC
   }
 
   @Override
-  public Object newThread(Runnable runnable, boolean detached, String name) {
-    return next.newThread(runnable, detached, name);
+  public Object newChildThread(Runnable runnable, boolean detached, String name) {
+    return next.newChildThread(runnable, detached, name);
   }
 
   @Override

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TracingWorkerInterceptor.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TracingWorkerInterceptor.java
@@ -104,6 +104,14 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
         trace.add("handleQuery " + input.getQueryName());
         return super.handleQuery(input);
       }
+
+      @Override
+      public Object newWorkflowMethodThread(Runnable runnable, String name) {
+        if (!Workflow.isReplaying()) {
+          trace.add("newThread " + name);
+        }
+        return next.newWorkflowMethodThread(runnable, name);
+      }
     };
   }
 
@@ -336,11 +344,11 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
     }
 
     @Override
-    public Object newThread(Runnable runnable, boolean detached, String name) {
+    public Object newChildThread(Runnable runnable, boolean detached, String name) {
       if (!Workflow.isReplaying()) {
         trace.add("newThread " + name);
       }
-      return next.newThread(runnable, detached, name);
+      return next.newChildThread(runnable, detached, name);
     }
 
     @Override

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
@@ -38,6 +38,7 @@ public class DeterministicRunnerWrapper implements InvocationHandler {
     CompletableFuture<Object> result = new CompletableFuture<>();
     DeterministicRunner runner =
         new DeterministicRunnerImpl(
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               try {
                 result.complete(invocationHandler.invoke(proxy, method, args));

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -1,0 +1,276 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.sync;
+
+import com.uber.m3.tally.NoopScope;
+import com.uber.m3.tally.Scope;
+import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes;
+import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.common.v1.SearchAttributes;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.common.v1.WorkflowType;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.common.context.ContextPropagator;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.internal.replay.ExecuteActivityParameters;
+import io.temporal.internal.replay.ExecuteLocalActivityParameters;
+import io.temporal.internal.replay.ReplayWorkflowContext;
+import io.temporal.internal.replay.StartChildWorkflowExecutionParameters;
+import io.temporal.workflow.Functions;
+import java.time.Duration;
+import java.util.*;
+
+public class DummySyncWorkflowContext {
+  public static SyncWorkflowContext newDummySyncWorkflowContext() {
+    SyncWorkflowContext context =
+        new SyncWorkflowContext(
+            new DummyReplayWorkflowContext(), DataConverter.getDefaultInstance(), null, null, null);
+    context.initHeadOutboundCallsInterceptor(context);
+    context.initHeadInboundCallsInterceptor(
+        new BaseRootWorkflowInboundCallsInterceptor(context) {
+          @Override
+          public WorkflowOutput execute(WorkflowInput input) {
+            throw new UnsupportedOperationException(
+                "#execute is not implemented or needed for low level DeterministicRunner tests");
+          }
+        });
+    return context;
+  }
+
+  private static final class DummyReplayWorkflowContext implements ReplayWorkflowContext {
+
+    private final Timer timer = new Timer();
+
+    @Override
+    public WorkflowExecution getWorkflowExecution() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public WorkflowExecution getParentWorkflowExecution() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public WorkflowType getWorkflowType() {
+      return WorkflowType.newBuilder().setName("dummy-workflow").build();
+    }
+
+    @Override
+    public boolean isCancelRequested() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public ContinueAsNewWorkflowExecutionCommandAttributes getContinueAsNewOnCompletion() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void setContinueAsNewOnCompletion(
+        ContinueAsNewWorkflowExecutionCommandAttributes attributes) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Optional<String> getContinuedExecutionRunId() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public String getTaskQueue() {
+      return "dummy-task-queue";
+    }
+
+    @Override
+    public String getNamespace() {
+      return "dummy-namespace";
+    }
+
+    @Override
+    public String getWorkflowId() {
+      return "dummy-workflow-id";
+    }
+
+    @Override
+    public String getRunId() {
+      return "dummy-run-id";
+    }
+
+    @Override
+    public Duration getWorkflowRunTimeout() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Duration getWorkflowExecutionTimeout() {
+      return Duration.ZERO;
+    }
+
+    @Override
+    public long getRunStartedTimestampMillis() {
+      return 0;
+    }
+
+    @Override
+    public long getWorkflowExecutionExpirationTimestampMillis() {
+      return 0;
+    }
+
+    @Override
+    public Duration getWorkflowTaskTimeout() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public SearchAttributes getSearchAttributes() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Map<String, Object> getPropagatedContexts() {
+      return null;
+    }
+
+    @Override
+    public List<ContextPropagator> getContextPropagators() {
+      return null;
+    }
+
+    @Override
+    public Functions.Proc1<Exception> scheduleActivityTask(
+        ExecuteActivityParameters parameters,
+        Functions.Proc2<Optional<Payloads>, Failure> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Functions.Proc scheduleLocalActivityTask(
+        ExecuteLocalActivityParameters parameters,
+        Functions.Proc2<Optional<Payloads>, Failure> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Functions.Proc1<Exception> startChildWorkflow(
+        StartChildWorkflowExecutionParameters parameters,
+        Functions.Proc1<WorkflowExecution> executionCallback,
+        Functions.Proc2<Optional<Payloads>, Exception> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Functions.Proc1<Exception> signalExternalWorkflowExecution(
+        SignalExternalWorkflowExecutionCommandAttributes.Builder attributes,
+        Functions.Proc2<Void, Failure> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void requestCancelExternalWorkflowExecution(
+        WorkflowExecution execution, Functions.Proc2<Void, RuntimeException> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void continueAsNewOnCompletion(
+        ContinueAsNewWorkflowExecutionCommandAttributes attributes) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public long currentTimeMillis() {
+      return System.currentTimeMillis();
+    }
+
+    @Override
+    public Functions.Proc1<RuntimeException> newTimer(
+        Duration delay, Functions.Proc1<RuntimeException> callback) {
+      timer.schedule(
+          new TimerTask() {
+            @Override
+            public void run() {
+              callback.apply(null);
+            }
+          },
+          delay.toMillis());
+      return (e) -> {
+        callback.apply(new CanceledFailure(null));
+      };
+    }
+
+    @Override
+    public void sideEffect(
+        Functions.Func<Optional<Payloads>> func, Functions.Proc1<Optional<Payloads>> callback) {
+      callback.apply(func.apply());
+    }
+
+    @Override
+    public void mutableSideEffect(
+        String id,
+        Functions.Func1<Optional<Payloads>, Optional<Payloads>> func,
+        Functions.Proc1<Optional<Payloads>> callback) {
+      callback.apply(func.apply(Optional.empty()));
+    }
+
+    @Override
+    public boolean isReplaying() {
+      return false;
+    }
+
+    @Override
+    public void getVersion(
+        String changeId, int minSupported, int maxSupported, Functions.Proc1<Integer> callback) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Random newRandom() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Scope getMetricsScope() {
+      return new NoopScope();
+    }
+
+    @Override
+    public boolean getEnableLoggingInReplay() {
+      return false;
+    }
+
+    @Override
+    public UUID randomUUID() {
+      return UUID.randomUUID();
+    }
+
+    @Override
+    public void upsertSearchAttributes(SearchAttributes searchAttributes) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public int getAttempt() {
+      return 1;
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -456,7 +456,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     }
 
     @Override
-    public Object newThread(Runnable runnable, boolean detached, String name) {
+    public Object newChildThread(Runnable runnable, boolean detached, String name) {
       throw new UnsupportedOperationException("not implemented");
     }
 


### PR DESCRIPTION
Refactored workflow root thread into a separate code path making it explicitly different from workflow-method thread and child workflows.
Added WorkflowInboundCallsInterceptor#newWorkflowMethodThread intercepting creation of the main workflow-method thread.
Added WorkflowInboundCallsInterceptor#newCallbackThread intercepting creation of a callback thread.
WorkflowOutboundCallsInterceptor#newThread is renamed into WorkflowOutboundCallsInterceptor#newChildThread and now it intercepts only new workflow child threads and doesn't intercept creation of the main workflow-method thread.
Fixed situation that the same "workflow-method" name was used for workflow initializer thread (now called "workflow-root") and for the thread that is used to run a workflow method (continued to be "workflow-method").

This PR is a first step to address issue #537