### PR TITLE
Add correct handling of interrupted exceptions in an attempt to improve problem of Issue #455

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -69,6 +69,7 @@ public final class InternalUtils {
           try {
             s.awaitTermination(timeoutMillis, TimeUnit.MILLISECONDS);
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
           }
         });
   }

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimerImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimerImpl.java
@@ -86,7 +86,7 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
       lock.lock();
       try {
         runLocked();
-      } catch (Throwable e) {
+      } catch (RuntimeException e) {
         log.error("Timer pump failed", e);
       } finally {
         lock.unlock();
@@ -133,7 +133,7 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
                     }
                   });
             }
-          } catch (Throwable e) {
+          } catch (RuntimeException e) {
             log.error("Timer task failure", e);
           }
           continue;
@@ -143,6 +143,7 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
         try {
           condition.await(timeToAwait, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           break;
         }
       }

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1989,6 +1989,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     try {
       return result.get(deadline, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return QueryWorkflowResponse.getDefaultInstance();
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
@@ -2060,6 +2061,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     try {
       return result.get(deadline, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return QueryWorkflowResponse.getDefaultInstance();
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -228,6 +228,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         client.channel.awaitTermination(1, TimeUnit.SECONDS);
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       log.debug("shutdown interrupted", e);
     }
     store.close();
@@ -1117,6 +1118,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     try {
       result.get();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } catch (ExecutionException e) {
       throw new RuntimeException(e);

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -155,6 +155,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
               newEventsCondition.await();
             }
           } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             return null;
           }
         }
@@ -347,7 +348,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
                 deadline.timeRemaining(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
       }
     } catch (InterruptedException e) {
-      // Intentionally left empty
+      Thread.currentThread().interrupt();
     }
     return Optional.ofNullable(result);
   }
@@ -369,7 +370,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
                 deadline.timeRemaining(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
       }
     } catch (InterruptedException e) {
-      // Intentionally left empty
+      Thread.currentThread().interrupt();
     }
     return Optional.ofNullable(result);
   }

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -250,11 +250,13 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     try {
       channel.awaitTermination(100, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
     mockServer.shutdown();
     try {
       mockServer.awaitTermination();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw Activity.wrap(e);
     }
   }


### PR DESCRIPTION
Issue #455 shows signs that we probably are loosing interrupted exceptions somewhere in the Pollers. This PR doesn't solve the problem completely, but adds some correct handling of InterruptedExceptions in obvious places.
This eliminates other potential problems and decreases the search space for the flaky test in Issue #455 for everybody.