### PR TITLE
Dependency Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'com.github.sherter.google-java-format' version '0.9' apply false
-    id 'net.ltgt.errorprone' version '2.0.1' apply false
+    id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'name.remal.check-updates' version '1.3.1' apply false
+    id 'name.remal.check-updates' version '1.4.0' apply false
     id 'com.palantir.git-version' version '0.12.2' apply false
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -3,7 +3,7 @@ description = '''Temporal Workflow Java SDK'''
 dependencies {
     api project(':temporal-serviceclient')
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.7'
-    api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.0'
+    api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.1'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    api 'io.grpc:grpc-protobuf:1.38.1'
-    api 'io.grpc:grpc-stub:1.38.1'
-    api 'io.grpc:grpc-core:1.38.1'
-    api 'io.grpc:grpc-netty-shaded:1.38.1'
-    api 'io.grpc:grpc-services:1.38.1'
+    api 'io.grpc:grpc-protobuf:1.39.0'
+    api 'io.grpc:grpc-stub:1.39.0'
+    api 'io.grpc:grpc-core:1.39.0'
+    api 'io.grpc:grpc-netty-shaded:1.39.0'
+    api 'io.grpc:grpc-services:1.39.0'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.3'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.31'
@@ -47,7 +47,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.38.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.39.0'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
> Task :temporal-sdk:checkDependencyUpdates
New dependency version: io.micrometer:micrometer-core: 1.7.0 -> 1.7.1

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.10.0
New dependency version: io.grpc:grpc-core: 1.38.1 -> 1.39.0
New dependency version: io.grpc:grpc-netty-shaded: 1.38.1 -> 1.39.0
New dependency version: io.grpc:grpc-protobuf: 1.38.1 -> 1.39.0
New dependency version: io.grpc:grpc-services: 1.38.1 -> 1.39.0
New dependency version: io.grpc:grpc-stub: 1.38.1 -> 1.39.0
New dependency version: io.grpc:protoc-gen-grpc-java: 1.38.1 -> 1.39.0