### PR TITLE
WorkflowQueue.take takes element from the tail of the queue instead of its head

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowQueueImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowQueueImpl.java
@@ -42,7 +42,7 @@ final class WorkflowQueueImpl<E> implements WorkflowQueue<E> {
   @Override
   public E take() {
     WorkflowThread.await("WorkflowQueue.take", () -> !queue.isEmpty());
-    return queue.pollLast();
+    return queue.poll();
   }
 
   @Override
@@ -53,7 +53,7 @@ final class WorkflowQueueImpl<E> implements WorkflowQueue<E> {
           CancellationScope.throwCanceled();
           return !queue.isEmpty();
         });
-    return queue.pollLast();
+    return queue.poll();
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -389,23 +389,25 @@ public class WorkflowInternalQueueTest {
 
   @Test
   public void testQueueOrder() throws Throwable {
+    WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(3);
+    int[] result = new int[3];
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(3);
               queue.put(1);
               queue.put(2);
               queue.put(3);
-              trace.add(queue.take().toString());
-              trace.add(queue.poll().toString());
-              trace.add(queue.poll().toString());
+              result[0] = queue.take();
+              result[1] = queue.poll();
+              result[2] = queue.poll();
             });
     r.runUntilAllBlocked(getDeadlockDetectionTimeout());
     r.cancel("test");
     r.runUntilAllBlocked(getDeadlockDetectionTimeout());
 
-    String[] expected = new String[] {"1", "2", "3"};
-    trace.setExpected(expected);
+    int[] expected = new int[] {1, 2, 3};
+    assertArrayEquals(expected, result);
+
     r.close();
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -386,4 +386,26 @@ public class WorkflowInternalQueueTest {
     trace.setExpected(expected);
     r.close();
   }
+
+  @Test
+  public void testQueueOrder() throws Throwable {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            () -> {
+              WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(3);
+              queue.put(1);
+              queue.put(2);
+              queue.put(3);
+              trace.add(queue.take().toString());
+              trace.add(queue.poll().toString());
+              trace.add(queue.poll().toString());
+            });
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.cancel("test");
+    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+
+    String[] expected = new String[] {"1", "2", "3"};
+    trace.setExpected(expected);
+    r.close();
+  }
 }


### PR DESCRIPTION
## What was changed

`WorkflowQueue.take` does not preserve queue semantics by taking elements from the tail of the queue (the most recently added ones) instead of its head (the earliest added ones).

## Why?

Let `WorkflowQueue` maintain the expected queue semantics.

## Checklist

1. Closes -
2. How was this tested: new unit test
3. Any docs updates needed? - 