### PR TITLE
Fix "empty queue" section of javadoc on QueueConsumer#poll and QueueConsumer#peek

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/workflow/QueueConsumer.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/QueueConsumer.java
@@ -45,16 +45,14 @@ public interface QueueConsumer<E> {
   /**
    * Retrieves and removes the head of this queue if it is not empty without blocking.
    *
-   * @return the head of this queue, or {@code null} if the specified waiting time elapses before an
-   *     element is available
+   * @return the head of this queue, or {@code null} if the queue is empty
    */
   E poll();
 
   /**
    * Retrieves the head of this queue keeping it in the queue if it is not empty without blocking.
    *
-   * @return the head of this queue, or {@code null} if the specified waiting time elapses before an
-   *     element is available
+   * @return the head of this queue, or {@code null} if the queue is empty
    */
   E peek();
 


### PR DESCRIPTION
## What was changed

`QueueConsumer#poll` and `QueueConsumer#peek` methods that don't accept Duration as an input have wording about "the specified waiting time" in their Javadoc, while no waiting time is specified for them. This fix makes the Javadoc consistent with the actual behavior of these methods.