### PR TITLE
Revert "WorkflowQueue.take takes element from the tail of the queue instead of its head

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowQueueImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowQueueImpl.java
@@ -42,7 +42,7 @@ final class WorkflowQueueImpl<E> implements WorkflowQueue<E> {
   @Override
   public E take() {
     WorkflowThread.await("WorkflowQueue.take", () -> !queue.isEmpty());
-    return queue.poll();
+    return queue.pollLast();
   }
 
   @Override
@@ -53,7 +53,7 @@ final class WorkflowQueueImpl<E> implements WorkflowQueue<E> {
           CancellationScope.throwCanceled();
           return !queue.isEmpty();
         });
-    return queue.poll();
+    return queue.pollLast();
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -386,28 +386,4 @@ public class WorkflowInternalQueueTest {
     trace.setExpected(expected);
     r.close();
   }
-
-  @Test
-  public void testQueueOrder() throws Throwable {
-    WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(3);
-    int[] result = new int[3];
-    DeterministicRunner r =
-        DeterministicRunner.newRunner(
-            () -> {
-              queue.put(1);
-              queue.put(2);
-              queue.put(3);
-              result[0] = queue.take();
-              result[1] = queue.poll();
-              result[2] = queue.poll();
-            });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
-    r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
-
-    int[] expected = new int[] {1, 2, 3};
-    assertArrayEquals(expected, result);
-
-    r.close();
-  }
 }


### PR DESCRIPTION
Reverts temporalio/sdk-java#569
This fix will introduce problems in workflows replaying that was using an old implementation.
This fix has to be tabled and wait for a major release that will not maintain backward compatibility.