### PR TITLE
Expose a fixed implementation of WorkflowQueue as a new method of Workflow class

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -91,7 +91,24 @@ public final class WorkflowInternal {
     return getWorkflowInterceptor().newTimer(duration);
   }
 
+  /**
+   * @param capacity the maximum size of the queue
+   * @return new instance of {@link WorkflowQueue}
+   * @deprecated this method created a deprecated implementation of the queue that has some methods
+   *     implemented incorrectly. Please use {@link #newWorkflowQueue(int)} instead.
+   */
+  @Deprecated
   public static <E> WorkflowQueue<E> newQueue(int capacity) {
+    return new WorkflowQueueDeprecatedImpl<>(capacity);
+  }
+
+  /**
+   * Creates a {@link WorkflowQueue} implementation that can be used from workflow code.
+   *
+   * @param capacity the maximum size of the queue
+   * @return new instance of {@link WorkflowQueue}
+   */
+  public static <E> WorkflowQueue<E> newWorkflowQueue(int capacity) {
     return new WorkflowQueueImpl<>(capacity);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowQueueDeprecatedImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowQueueDeprecatedImpl.java
@@ -1,0 +1,228 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.sync;
+
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.Functions;
+import io.temporal.workflow.QueueConsumer;
+import io.temporal.workflow.WorkflowQueue;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * @deprecated it's an old implementation of {@link WorkflowQueue} with incorrectly implemented
+ *     {@link #take} and {@link #cancellableTake} that is left for backwards-compatibility with
+ *     workflows that already use old implementation. {@link WorkflowQueueImpl} should be used
+ *     instead.
+ *     <p>This class is to be deleted in the next major release that doesn't have to maintain
+ *     backwards compatibility.
+ */
+@Deprecated
+final class WorkflowQueueDeprecatedImpl<E> implements WorkflowQueue<E> {
+
+  private final Deque<E> queue = new ArrayDeque<>();
+  private final int capacity;
+
+  public WorkflowQueueDeprecatedImpl(int capacity) {
+    if (capacity < 1) {
+      throw new IllegalArgumentException("Capacity less than 1: " + capacity);
+    }
+    this.capacity = capacity;
+  }
+
+  @Override
+  public E take() {
+    WorkflowThread.await("WorkflowQueue.take", () -> !queue.isEmpty());
+    // this implementation is incorrect and has been fixed in WorkflowQueueImpl
+    return queue.pollLast();
+  }
+
+  @Override
+  public E cancellableTake() {
+    WorkflowThread.await(
+        "WorkflowQueue.cancellableTake",
+        () -> {
+          CancellationScope.throwCanceled();
+          return !queue.isEmpty();
+        });
+    // this implementation is incorrect and has been fixed in WorkflowQueueImpl
+    return queue.pollLast();
+  }
+
+  @Override
+  public E poll() {
+    if (queue.isEmpty()) {
+      return null;
+    }
+    return queue.remove();
+  }
+
+  @Override
+  public E peek() {
+    if (queue.isEmpty()) {
+      return null;
+    }
+    return queue.peek();
+  }
+
+  @Override
+  public E poll(Duration timeout) {
+    WorkflowInternal.await(timeout, "WorkflowQueue.poll", () -> !queue.isEmpty());
+
+    if (queue.isEmpty()) {
+      return null;
+    }
+    return queue.remove();
+  }
+
+  @Override
+  public E cancellablePoll(Duration timeout) {
+    WorkflowInternal.await(
+        timeout,
+        "WorkflowQueue.cancellablePoll",
+        () -> {
+          CancellationScope.throwCanceled();
+          return !queue.isEmpty();
+        });
+
+    if (queue.isEmpty()) {
+      return null;
+    }
+    return queue.remove();
+  }
+
+  @Override
+  public boolean offer(E e) {
+    if (queue.size() == capacity) {
+      return false;
+    }
+    queue.addLast(e);
+    return true;
+  }
+
+  @Override
+  public void put(E e) {
+    WorkflowThread.await("WorkflowQueue.put", () -> queue.size() < capacity);
+    queue.addLast(e);
+  }
+
+  @Override
+  public void cancellablePut(E e) {
+    WorkflowThread.await(
+        "WorkflowQueue.cancellablePut",
+        () -> {
+          CancellationScope.throwCanceled();
+          return queue.size() < capacity;
+        });
+    queue.addLast(e);
+  }
+
+  @Override
+  public boolean offer(E e, Duration timeout) {
+    WorkflowInternal.await(timeout, "WorkflowQueue.offer", () -> queue.size() < capacity);
+    if (queue.size() >= capacity) {
+      return false;
+    }
+    queue.addLast(e);
+    return true;
+  }
+
+  @Override
+  public boolean cancellableOffer(E e, Duration timeout) {
+    WorkflowInternal.await(
+        timeout, "WorkflowQueue.cancellableOffer", () -> queue.size() < capacity);
+    if (queue.size() >= capacity) {
+      return false;
+    }
+    queue.addLast(e);
+    return true;
+  }
+
+  @Override
+  public <R> QueueConsumer<R> map(Functions.Func1<? super E, ? extends R> mapper) {
+    return new MappedQueueConsumer<R, E>(this, mapper);
+  }
+
+  private static class MappedQueueConsumer<R, E> implements QueueConsumer<R> {
+
+    private final QueueConsumer<E> source;
+    private final Functions.Func1<? super E, ? extends R> mapper;
+
+    public MappedQueueConsumer(
+        QueueConsumer<E> source, Functions.Func1<? super E, ? extends R> mapper) {
+      this.source = source;
+      this.mapper = mapper;
+    }
+
+    @Override
+    public R take() {
+      E element = source.take();
+      return mapper.apply(element);
+    }
+
+    @Override
+    public R cancellableTake() {
+      E element = source.cancellableTake();
+      return mapper.apply(element);
+    }
+
+    @Override
+    public R poll() {
+      E element = source.poll();
+      if (element == null) {
+        return null;
+      }
+      return mapper.apply(element);
+    }
+
+    @Override
+    public R peek() {
+      E element = source.peek();
+      if (element == null) {
+        return null;
+      }
+      return mapper.apply(element);
+    }
+
+    @Override
+    public R poll(Duration timeout) {
+      E element = source.poll(timeout);
+      if (element == null) {
+        return null;
+      }
+      return mapper.apply(element);
+    }
+
+    @Override
+    public R cancellablePoll(Duration timeout) {
+      E element = source.cancellablePoll(timeout);
+      if (element == null) {
+        return null;
+      }
+      return mapper.apply(element);
+    }
+
+    @Override
+    public <R1> QueueConsumer<R1> map(Functions.Func1<? super R, ? extends R1> mapper) {
+      return new MappedQueueConsumer<>(this, mapper);
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -722,8 +722,20 @@ public final class Workflow {
     return WorkflowInternal.newTimer(delay);
   }
 
+  @Deprecated
   public static <E> WorkflowQueue<E> newQueue(int capacity) {
     return WorkflowInternal.newQueue(capacity);
+  }
+
+  /**
+   * Create a new instance of a {@link WorkflowQueue} implementation that is adapted to be used from
+   * a workflow code.
+   *
+   * @param capacity the maximum size of the queue
+   * @return new instance of {@link WorkflowQueue}
+   */
+  public static <E> WorkflowQueue<E> newWorkflowQueue(int capacity) {
+    return WorkflowInternal.newWorkflowQueue(capacity);
   }
 
   public static <E> CompletablePromise<E> newPromise() {

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
@@ -26,11 +26,7 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
-import io.temporal.workflow.QueueConsumer;
-import io.temporal.workflow.Workflow;
-import io.temporal.workflow.WorkflowInterface;
-import io.temporal.workflow.WorkflowMethod;
-import io.temporal.workflow.WorkflowQueue;
+import io.temporal.workflow.*;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +34,8 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class WorkflowInternalQueueTest {
+@SuppressWarnings("deprecation")
+public class WorkflowInternalDeprecatedQueueTest {
 
   @Rule public final Tracer trace = new Tracer();
 
@@ -47,7 +44,7 @@ public class WorkflowInternalQueueTest {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
+              WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
               WorkflowInternal.newThread(
                       false,
@@ -86,7 +83,7 @@ public class WorkflowInternalQueueTest {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
+              WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
               WorkflowInternal.newThread(
                       false,
@@ -119,7 +116,7 @@ public class WorkflowInternalQueueTest {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
+              WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
               WorkflowInternal.newThread(
                       false,
@@ -158,7 +155,7 @@ public class WorkflowInternalQueueTest {
     public List<String> test() {
       List<String> trace = new ArrayList<>();
 
-      WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
+      WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
       trace.add("root begin");
       WorkflowThread thread1 =
           WorkflowInternal.newThread(
@@ -191,7 +188,7 @@ public class WorkflowInternalQueueTest {
   }
 
   @Test
-  public void testPutBlocking() {
+  public void testPutBlocking() throws Throwable {
     TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
     String testTaskQueue = "testTaskQueue";
     Worker worker = testEnv.newWorker(testTaskQueue);
@@ -223,7 +220,7 @@ public class WorkflowInternalQueueTest {
     @Override
     public List<String> test() {
       List<String> trace = new ArrayList<>();
-      WorkflowQueue<Integer> f = WorkflowInternal.newWorkflowQueue(1);
+      WorkflowQueue<Integer> f = WorkflowInternal.newQueue(1);
       trace.add("root begin");
       trace.add("peek " + f.peek());
       trace.add("offer " + f.offer(12));
@@ -274,7 +271,7 @@ public class WorkflowInternalQueueTest {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
+              WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
               WorkflowInternal.newThread(
                       false,
@@ -308,7 +305,7 @@ public class WorkflowInternalQueueTest {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
+              WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
               trace.add("root begin");
               WorkflowInternal.newThread(
                       false,
@@ -342,7 +339,7 @@ public class WorkflowInternalQueueTest {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
             () -> {
-              WorkflowQueue<Integer> queue = WorkflowInternal.newWorkflowQueue(1);
+              WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(1);
               trace.add("root begin");
               WorkflowInternal.newThread(
                       false,
@@ -384,30 +381,6 @@ public class WorkflowInternalQueueTest {
           "thread1 done",
         };
     trace.setExpected(expected);
-    r.close();
-  }
-
-  @Test
-  public void testQueueOrder() {
-    WorkflowQueue<Integer> queue = WorkflowInternal.newWorkflowQueue(3);
-    int[] result = new int[3];
-    DeterministicRunner r =
-        DeterministicRunner.newRunner(
-            () -> {
-              queue.put(1);
-              queue.put(2);
-              queue.put(3);
-              result[0] = queue.take();
-              result[1] = queue.poll();
-              result[2] = queue.poll();
-            });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
-    r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
-
-    int[] expected = new int[] {1, 2, 3};
-    assertArrayEquals(expected, result);
-
     r.close();
   }
 }


### PR DESCRIPTION
A follow-up to #569 to preserve backward compatibility with existing workflows.

## What was changed
New fixed implementation of `WorkflowQueue` is exposed in a new `Workflow.newWorkflowQueue` method preserving the behavior of the old `Workflow.newQueue` implementation, which is marked as deprecated now.

## Why?
#569 fixes implementations of some methods of WorkflowQueueImpl but does it in a backward-incompatible way with existing workflows that could be not replayable after that. 
