### PR TITLE
Add getTestWatcher method to TestWorkflowRule

### DIFF
--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -354,4 +354,27 @@ public class TestWorkflowRule implements TestRule {
   public Worker getWorker() {
     return testEnvironment.getWorkerFactory().getWorker(getTaskQueue());
   }
+
+  /**
+   * Returns the default test watcher impl that can be used is your tests. It simplifies the test watcher
+   * creation to just:
+   * <pre><code>
+   *   @Rule
+   *   public TestWatcher watchman = testWorkflowRule.getTestWatcher();
+   *   </code></pre>
+   *
+   * @return default test watcher impl
+   */
+  public TestWatcher getTestWatcher() {
+    return
+      new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+          if (getTestEnvironment() != null) {
+            System.err.println(getTestEnvironment().getDiagnostics());
+            getTestEnvironment().shutdown();
+          }
+        }
+      };
+  }
 }


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Addition of getTestWatcher method to TestWorkflowRule 
## Why?
Currently if you use testworkflowrule you have to create test watcher rule as such for example:

```java
  @Rule
  public TestWorkflowRule testWorkflowRule = ...

  @Rule
  public TestWatcher watchman =
      new TestWatcher() {
        @Override
        protected void failed(Throwable e, Description description) {
          if (testWorkflowRule.getTestEnvironment() != null) {
            System.err.println(testWorkflowRule.getTestEnvironment().getDiagnostics());
            testWorkflowRule.getTestEnvironment().shutdown();
          }
        }
      };
```

This simplifies it to:

```
  @Rule
  public TestWorkflowRule testWorkflowRule = ...

  @Rule
  public TestWatcher watchman = testWorkflowRule.getTestWatcher();
```         

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
