### PR TITLE
Polish JUnit5 extension: per-test initial time, dynamic workflows and activities

### DIFF
--- a/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -77,7 +77,7 @@ public class TestWorkflowExtension
 
   private static final String TEST_ENVIRONMENT_KEY = "testEnvironment";
   private static final String WORKER_KEY = "worker";
-  private static final String TASK_QUEUE_KEY = "taskQueue";
+  private static final String WORKFLOW_OPTIONS_KEY = "workflowOptions";
 
   private final WorkerOptions workerOptions;
   private final WorkflowClientOptions workflowClientOptions;
@@ -143,24 +143,20 @@ public class TestWorkflowExtension
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
 
-    TestWorkflowEnvironment testEnvironment = getTestEnvironment(extensionContext);
-
     Class<?> parameterType = parameterContext.getParameter().getType();
     if (parameterType == TestWorkflowEnvironment.class) {
-      return testEnvironment;
+      return getTestEnvironment(extensionContext);
     } else if (parameterType == WorkflowClient.class) {
-      return testEnvironment.getWorkflowClient();
+      return getTestEnvironment(extensionContext).getWorkflowClient();
     } else if (parameterType == WorkflowOptions.class) {
-      String taskQueue = getTaskQueue(extensionContext);
-      return WorkflowOptions.newBuilder().setTaskQueue(taskQueue).build();
+      return getWorkflowOptions(extensionContext);
     } else if (parameterType == Worker.class) {
       return getWorker(extensionContext);
     } else {
       // Workflow stub
-      String taskQueue = getTaskQueue(extensionContext);
-      WorkflowOptions workflowOptions =
-          WorkflowOptions.newBuilder().setTaskQueue(taskQueue).build();
-      return testEnvironment.getWorkflowClient().newWorkflowStub(parameterType, workflowOptions);
+      return getTestEnvironment(extensionContext)
+          .getWorkflowClient()
+          .newWorkflowStub(parameterType, getWorkflowOptions(extensionContext));
     }
   }
 
@@ -187,7 +183,7 @@ public class TestWorkflowExtension
 
     setTestEnvironment(context, testEnvironment);
     setWorker(context, worker);
-    setTaskQueue(context, taskQueue);
+    setWorkflowOptions(context, WorkflowOptions.newBuilder().setTaskQueue(taskQueue).build());
   }
 
   @Override
@@ -219,12 +215,12 @@ public class TestWorkflowExtension
     getStore(context).put(WORKER_KEY, worker);
   }
 
-  private String getTaskQueue(ExtensionContext context) {
-    return getStore(context).get(TASK_QUEUE_KEY, String.class);
+  private WorkflowOptions getWorkflowOptions(ExtensionContext context) {
+    return getStore(context).get(WORKFLOW_OPTIONS_KEY, WorkflowOptions.class);
   }
 
-  private void setTaskQueue(ExtensionContext context, String taskQueue) {
-    getStore(context).put(TASK_QUEUE_KEY, taskQueue);
+  private void setWorkflowOptions(ExtensionContext context, WorkflowOptions taskQueue) {
+    getStore(context).put(WORKFLOW_OPTIONS_KEY, taskQueue);
   }
 
   private ExtensionContext.Store getStore(ExtensionContext context) {

--- a/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing-junit5/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
  * JUnit Jupiter extension that simplifies testing of Temporal workflows.
@@ -162,13 +163,17 @@ public class TestWorkflowExtension
 
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
+    long currentInitialTimeMillis =
+        AnnotationSupport.findAnnotation(context.getElement(), WorkflowInitialTime.class)
+            .map(annotation -> Instant.parse(annotation.value()).toEpochMilli())
+            .orElse(initialTimeMillis);
     TestEnvironmentOptions testOptions =
         TestEnvironmentOptions.newBuilder()
             .setWorkflowClientOptions(workflowClientOptions)
             .setWorkerFactoryOptions(workerFactoryOptions)
             .setUseExternalService(useExternalService)
             .setTarget(target)
-            .setInitialTimeMillis(initialTimeMillis)
+            .setInitialTimeMillis(currentInitialTimeMillis)
             .build();
     TestWorkflowEnvironment testEnvironment = TestWorkflowEnvironment.newInstance(testOptions);
     String taskQueue =

--- a/temporal-testing-junit5/src/main/java/io/temporal/testing/WorkflowInitialTime.java
+++ b/temporal-testing-junit5/src/main/java/io/temporal/testing/WorkflowInitialTime.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Overrides the initial timestamp used by the {@link TestWorkflowExtension} */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface WorkflowInitialTime {
+
+  String value();
+}

--- a/temporal-testing-junit5/src/test/java/io/temporal/testing/TestActivityExtensionDynamicTest.java
+++ b/temporal-testing-junit5/src/test/java/io/temporal/testing/TestActivityExtensionDynamicTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.DynamicActivity;
+import io.temporal.common.converter.EncodedValues;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TestActivityExtensionDynamicTest {
+
+  @RegisterExtension
+  public static final TestActivityExtension activityExtension =
+      TestActivityExtension.newBuilder()
+          .setActivityImplementations(new MyDynamicActivityImpl())
+          .build();
+
+  @ActivityInterface
+  public interface MyActivity {
+
+    @ActivityMethod(name = "OverriddenActivityMethod")
+    String activity1(String input);
+  }
+
+  private static class MyDynamicActivityImpl implements DynamicActivity {
+
+    @Override
+    public Object execute(EncodedValues args) {
+      return Activity.getExecutionContext().getInfo().getActivityType()
+          + "-"
+          + args.get(0, String.class);
+    }
+  }
+
+  @Test
+  public void extensionShouldResolveDynamicActivitiesParameters(MyActivity activity) {
+    assertEquals("OverriddenActivityMethod-input1", activity.activity1("input1"));
+  }
+}

--- a/temporal-testing-junit5/src/test/java/io/temporal/testing/TestActivityExtensionTest.java
+++ b/temporal-testing-junit5/src/test/java/io/temporal/testing/TestActivityExtensionTest.java
@@ -29,7 +29,7 @@ import io.temporal.activity.ActivityMethod;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ActivityExtensionTest {
+public class TestActivityExtensionTest {
 
   @RegisterExtension
   public static final TestActivityExtension activityExtension =

--- a/temporal-testing-junit5/src/test/java/io/temporal/testing/TestWorkflowExtensionDynamicTest.java
+++ b/temporal-testing-junit5/src/test/java/io/temporal/testing/TestWorkflowExtensionDynamicTest.java
@@ -19,24 +19,22 @@
 
 package io.temporal.testing;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityInfo;
-import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityOptions;
+import io.temporal.activity.DynamicActivity;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.worker.Worker;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.converter.EncodedValues;
+import io.temporal.workflow.ActivityStub;
+import io.temporal.workflow.DynamicWorkflow;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -44,24 +42,20 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
-public class TestWorkflowExtensionTest {
+public class TestWorkflowExtensionDynamicTest {
 
   @RegisterExtension
   public static final TestWorkflowExtension testWorkflow =
       TestWorkflowExtension.newBuilder()
-          .setWorkflowTypes(HelloWorkflowImpl.class)
-          .setActivityImplementations(new HelloActivityImpl())
-          .setInitialTime(Instant.parse("2021-10-10T10:01:00Z"))
+          .setWorkflowTypes(HelloDynamicWorkflowImpl.class)
+          .setActivityImplementations(new HelloDynamicActivityImpl())
           .build();
 
-  @ActivityInterface
-  public interface HelloActivity {
-    String buildGreeting(String name);
-  }
+  public static class HelloDynamicActivityImpl implements DynamicActivity {
 
-  public static class HelloActivityImpl implements HelloActivity {
     @Override
-    public String buildGreeting(String name) {
+    public Object execute(EncodedValues args) {
+      String name = args.get(0, String.class);
       ActivityInfo activityInfo = Activity.getExecutionContext().getInfo();
       return String.format(
           "Hello %s from activity %s and workflow %s",
@@ -71,48 +65,43 @@ public class TestWorkflowExtensionTest {
 
   @WorkflowInterface
   public interface HelloWorkflow {
+
     @WorkflowMethod
     String sayHello(String name);
   }
 
-  public static class HelloWorkflowImpl implements HelloWorkflow {
+  public static class HelloDynamicWorkflowImpl implements DynamicWorkflow {
 
-    private static final Logger logger = Workflow.getLogger(HelloWorkflowImpl.class);
+    private static final Logger logger = Workflow.getLogger(HelloDynamicWorkflowImpl.class);
 
-    private final HelloActivity helloActivity =
-        Workflow.newActivityStub(
-            HelloActivity.class,
+    private final ActivityStub activity =
+        Workflow.newUntypedActivityStub(
             ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofMinutes(1)).build());
 
     @Override
-    public String sayHello(String name) {
+    public Object execute(EncodedValues args) {
+      String name = args.get(0, String.class);
       logger.info("Hello, {}", name);
       Workflow.sleep(Duration.ofHours(1));
-      return helloActivity.buildGreeting(name);
+      return activity.execute("BuildGreeting", String.class, name);
     }
   }
 
   @Test
-  @WorkflowInitialTime("2020-01-01T01:00:00Z")
-  public void extensionShouldLaunchTestEnvironmentAndResolveParameters(
-      TestWorkflowEnvironment testEnv,
-      WorkflowClient workflowClient,
-      WorkflowOptions workflowOptions,
-      Worker worker,
-      HelloWorkflow workflow) {
+  public void extensionShouldResolveDynamicWorkflowParameters(HelloWorkflow workflow) {
+    assertEquals(
+        "Hello World from activity BuildGreeting and workflow HelloWorkflow",
+        workflow.sayHello("World"));
+  }
 
-    assertAll(
-        () -> assertTrue(testEnv.isStarted()),
-        () -> assertNotNull(workflowClient),
-        () -> assertNotNull(workflowOptions.getTaskQueue()),
-        () -> assertNotNull(worker),
-        () ->
-            assertEquals(
-                Instant.parse("2020-01-01T01:00:00Z"),
-                Instant.ofEpochMilli(testEnv.currentTimeMillis()).truncatedTo(ChronoUnit.HOURS)),
-        () ->
-            assertEquals(
-                "Hello World from activity BuildGreeting and workflow HelloWorkflow",
-                workflow.sayHello("World")));
+  @Test
+  public void extensionShouldSupportLaunchingViaUntypedWorkflowStubs(
+      WorkflowClient workflowClient, WorkflowOptions workflowOptions) {
+    WorkflowStub workflow =
+        workflowClient.newUntypedWorkflowStub("AnotherHelloWorkflow", workflowOptions);
+    workflow.start("World");
+    assertEquals(
+        "Hello World from activity BuildGreeting and workflow AnotherHelloWorkflow",
+        workflow.getResult(String.class));
   }
 }

--- a/temporal-testing-junit5/src/test/java/io/temporal/testing/TestWorkflowExtensionTest.java
+++ b/temporal-testing-junit5/src/test/java/io/temporal/testing/TestWorkflowExtensionTest.java
@@ -35,6 +35,8 @@ import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -48,6 +50,7 @@ public class TestWorkflowExtensionTest {
       TestWorkflowExtension.newBuilder()
           .setWorkflowTypes(HelloWorkflowImpl.class)
           .setActivityImplementations(new HelloActivityImpl())
+          .setInitialTime(Instant.parse("2021-10-10T10:01:00Z"))
           .build();
 
   @ActivityInterface
@@ -90,6 +93,7 @@ public class TestWorkflowExtensionTest {
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @WorkflowInitialTime("2020-01-01T01:00:00Z")
   public void extensionShouldLaunchTestEnvironmentAndResolveParameters(
       TestWorkflowEnvironment testEnv,
       WorkflowClient workflowClient,
@@ -102,6 +106,10 @@ public class TestWorkflowExtensionTest {
         () -> assertNotNull(workflowClient),
         () -> assertNotNull(workflowOptions.getTaskQueue()),
         () -> assertNotNull(worker),
+        () ->
+            assertEquals(
+                Instant.parse("2020-01-01T01:00:00Z"),
+                Instant.ofEpochMilli(testEnv.currentTimeMillis()).truncatedTo(ChronoUnit.HOURS)),
         () ->
             assertEquals(
                 "Hello World from activity BuildGreeting and workflow HelloWorkflow",


### PR DESCRIPTION
## What was changed

* The `TestWorkflowExtension` is changed to support per-test overrides for the virtual time used by the `TestWorkflowEnvironment`.
* Somewhat unrelated, the extension code is polished a bit: the whole `WorkflowOptions` is stored in the extension context instead of just the task queue name, to reduce some code duplication.
* Extend `TestWorkflowExtension` and `TestActivityExtension` to support dynamic workflow/activity scenarios.

## Why?

One of our workflows has time-sensitive logic and we'd like to test it in multiple scenarios that differ in the initial workflow time. Right now we either have to fall back to manually managing `TestWorkflowEnvironment` or to split those scenarios into multiple test classes.

## Checklist

1. **Closes** —
2. **How was this tested:** extended existing unit test
3. **Any docs updates needed?** Longer-term, both JUnit 4 and JUnit 5 extensions could be documented on the [Java SDK testing and debugging](https://docs.temporal.io/docs/java/testing-and-debugging) page.
