### PR TITLE
Makes buildkite run ./gradlew check instead of ./gradlew test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "./gradlew --no-daemon test"
+    command: "./gradlew --no-daemon check"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.0.0:


### PR DESCRIPTION
## What was changed
Now buildkite runs `./gradlew test` which misses checks step happening after tests. This changes it to `./gradlew check`

## Why?
Now we are missing checks of license headers in buildkite.