### PR TITLE
A test to reproduce timers and cancelations SDK issue

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
@@ -50,6 +50,7 @@ import io.temporal.workflow.Functions;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -160,6 +161,16 @@ public class SDKTestWorkflowRule implements TestRule {
 
     public Builder setTestTimeoutSeconds(long testTimeoutSeconds) {
       testWorkflowRuleBuilder.setTestTimeoutSeconds(testTimeoutSeconds);
+      return this;
+    }
+
+    public Builder setInitialTimeMillis(long initialTimeMillis) {
+      testWorkflowRuleBuilder.setInitialTimeMillis(initialTimeMillis);
+      return this;
+    }
+
+    public Builder setInitialTime(Instant initialTime) {
+      testWorkflowRuleBuilder.setInitialTime(initialTime);
       return this;
     }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndCancelTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndCancelTimerTest.java
@@ -1,0 +1,237 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import static io.temporal.api.enums.v1.EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.temporal.client.BatchRequest;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.Promise;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.WorkflowQueue;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestOptions;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.StringJoiner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public class GetVersionAndCancelTimerTest {
+
+  private static final String WORKFLOW_ID = "workflow-id";
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ReminderWorkflowImpl.class)
+          .setWorkerOptions(WorkerOptions.newBuilder().build())
+          .setInitialTime(Instant.parse("2020-01-01T00:00:00Z"))
+          .build();
+
+  @Test
+  public void testGetVersionAndCancelTimer() {
+    ReminderWorkflow workflowStub = newWorkflowStub();
+
+    WorkflowClient.start(workflowStub::start);
+
+    Instant now = now();
+
+    scheduleReminder(now.plusSeconds(30), "Reminder 1");
+    scheduleReminder(now.plusSeconds(6), "Reminder 2");
+
+    WorkflowStub untypedWorkflowStub = WorkflowStub.fromTyped(workflowStub);
+
+    untypedWorkflowStub.getResult(Void.TYPE);
+
+    testWorkflowRule.assertNoHistoryEvent(
+        untypedWorkflowStub.getExecution(), EVENT_TYPE_WORKFLOW_TASK_FAILED);
+  }
+
+  private Instant now() {
+    return Instant.ofEpochMilli(testWorkflowRule.getTestEnvironment().currentTimeMillis());
+  }
+
+  private void scheduleReminder(Instant reminderTime, String reminderText) {
+    ReminderWorkflow stub = newWorkflowStub();
+    BatchRequest request = testWorkflowRule.getWorkflowClient().newSignalWithStartRequest();
+    request.add(stub::start);
+    request.add(stub::scheduleReminder, new ScheduleReminderSignal(reminderTime, reminderText));
+    testWorkflowRule.getWorkflowClient().signalWithStart(request);
+  }
+
+  private ReminderWorkflow newWorkflowStub() {
+    WorkflowOptions options =
+        TestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+            .toBuilder()
+            .setWorkflowId(WORKFLOW_ID)
+            .build();
+    return testWorkflowRule.getWorkflowClient().newWorkflowStub(ReminderWorkflow.class, options);
+  }
+
+  @WorkflowInterface
+  public interface ReminderWorkflow {
+
+    @WorkflowMethod
+    void start();
+
+    @SignalMethod
+    void scheduleReminder(ScheduleReminderSignal signal);
+  }
+
+  public static final class ScheduleReminderSignal {
+
+    private final Instant reminderTime;
+    private final String reminderText;
+
+    @JsonCreator
+    public ScheduleReminderSignal(
+        @JsonProperty("reminderTime") Instant reminderTime,
+        @JsonProperty("reminderText") String reminderText) {
+      this.reminderTime = reminderTime;
+      this.reminderText = reminderText;
+    }
+
+    @JsonProperty("reminderTime")
+    public Instant getReminderTime() {
+      return reminderTime;
+    }
+
+    @JsonProperty("reminderText")
+    public String getReminderText() {
+      return reminderText;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ScheduleReminderSignal that = (ScheduleReminderSignal) o;
+      return Objects.equals(reminderTime, that.reminderTime)
+          && Objects.equals(reminderText, that.reminderText);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(reminderTime, reminderText);
+    }
+
+    @Override
+    public String toString() {
+      return new StringJoiner(", ", ScheduleReminderSignal.class.getSimpleName() + "[", "]")
+          .add("reminderTime=" + reminderTime)
+          .add("reminderText='" + reminderText + "'")
+          .toString();
+    }
+  }
+
+  public static final class ReminderWorkflowImpl implements ReminderWorkflow {
+
+    private static final Logger logger = Workflow.getLogger(ReminderWorkflowImpl.class);
+
+    private final WorkflowQueue<ScheduleReminderSignal> signalQueue = Workflow.newWorkflowQueue(10);
+
+    private Promise<Void> activeReminder;
+    private CancellationScope activeScope;
+
+    @Override
+    public void start() {
+      logger.info("<{}> Workflow started", now());
+      ScheduleReminderSignal signalToProcess = signalQueue.take();
+      while (signalToProcess != null) {
+        logger.info("<{}> Will process signal {}", now(), signalToProcess);
+        processScheduleReminder(signalToProcess);
+
+        Workflow.await(
+            () ->
+                signalQueue.peek() != null
+                    || activeReminder == null
+                    || activeReminder.isCompleted());
+
+        signalToProcess = signalQueue.poll();
+      }
+      logger.info("<{}> Workflow completed", now());
+    }
+
+    @Override
+    public void scheduleReminder(ScheduleReminderSignal signal) {
+      logger.info("<{}> Got signal {}", now(), signal);
+      signalQueue.put(signal);
+      logger.info("<{}> Enqueued signal {}", now(), signal);
+    }
+
+    private void processScheduleReminder(ScheduleReminderSignal signal) {
+      if (activeScope != null) {
+        logger.info("<{}> Cancelling previous reminder", now());
+        activeScope.cancel("New reminder");
+        if (activeReminder != null) {
+          try {
+            // Consume the cancelled promise to avoid noisy warnings
+            activeReminder.get();
+          } catch (Exception ignored) {
+          }
+        }
+      }
+
+      activeScope =
+          Workflow.newCancellationScope(
+              () -> {
+                Duration reminderSleepDuration = Duration.between(now(), signal.getReminderTime());
+                if (reminderSleepDuration.isNegative()) {
+                  logger.info(
+                      "<{}> Got a request {} for an outdated reminder, ignoring it", now(), signal);
+                  activeReminder = null;
+                  return;
+                }
+                logger.info(
+                    "<{}> Scheduled a reminder for time {}", now(), signal.getReminderTime());
+                activeReminder =
+                    Workflow.newTimer(reminderSleepDuration)
+                        .thenApply(
+                            (t) -> {
+                              logger.info("<{}> Reminder: {}", now(), signal.getReminderText());
+                              return null;
+                            });
+              });
+      activeScope.run();
+
+      Workflow.getVersion("some-change", Workflow.DEFAULT_VERSION, 1);
+    }
+
+    private Instant now() {
+      return Instant.ofEpochMilli(Workflow.currentTimeMillis());
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndCancelTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndCancelTimerTest.java
@@ -61,8 +61,10 @@ public class GetVersionAndCancelTimerTest {
 
     Instant now = now();
 
-    workflowStub.scheduleReminder(new ScheduleReminderSignal(now.plusSeconds(30), "Reminder 1"));
-    workflowStub.scheduleReminder(new ScheduleReminderSignal(now.plusSeconds(10), "Reminder 2"));
+    workflowStub.scheduleReminder(
+        new ScheduleReminderSignal(now.plusSeconds(2), "Reminder 1 in 2s"));
+    workflowStub.scheduleReminder(
+        new ScheduleReminderSignal(now.plusSeconds(4), "Reminder 2 in 4s"));
 
     WorkflowStub untypedWorkflowStub = WorkflowStub.fromTyped(workflowStub);
 


### PR DESCRIPTION
## What was changed

This PR is not intended to be merged as it. It provides a test to reproduce some weird corner cases of scheduling/canceling timers and evaluating versions in the scope of a single workflow task.

The test contains a seemingly valid workflow that should successfully run with no issues. It seems, however, that one of the workflow tasks fails with the `Version is already set to 1` error, and on the next retry a signal is delivered to the workflow for the second time.

Here's how workflow's logs look like without version evaluation

```
20:32:09.234 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.555Z> Workflow started
20:32:09.277 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Got signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:30.554Z, reminderText='Reminder 1']
20:32:09.278 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Enqueued signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:30.554Z, reminderText='Reminder 1']
20:32:09.278 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Got signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.554Z, reminderText='Reminder 2']
20:32:09.279 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Enqueued signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.554Z, reminderText='Reminder 2']
20:32:09.279 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Will process signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:30.554Z, reminderText='Reminder 1']
20:32:09.279 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Scheduled a reminder for time 2020-01-01T00:00:30.554Z
20:32:09.295 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Will process signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.554Z, reminderText='Reminder 2']
20:32:09.295 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Cancelling previous reminder
20:32:09.298 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.677Z> Scheduled a reminder for time 2020-01-01T00:00:10.554Z
20:32:09.308 [timer-callback] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.612Z> Reminder: Reminder 2
20:32:09.308 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.612Z> Workflow completed
```

And here's the same workflow with `Workflow.getVersion()` call added:

```
20:33:16.302 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.460Z> Workflow started
20:33:16.345 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Got signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:30.459Z, reminderText='Reminder 1']
20:33:16.346 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Enqueued signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:30.459Z, reminderText='Reminder 1']
20:33:16.346 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Got signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.459Z, reminderText='Reminder 2']
20:33:16.347 [signal scheduleReminder] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Enqueued signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.459Z, reminderText='Reminder 2']
20:33:16.347 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Will process signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:30.459Z, reminderText='Reminder 1']
20:33:16.347 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Scheduled a reminder for time 2020-01-01T00:00:30.459Z
20:33:16.379 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Will process signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.459Z, reminderText='Reminder 2']
20:33:16.379 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Cancelling previous reminder
20:33:16.382 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:00.571Z> Scheduled a reminder for time 2020-01-01T00:00:10.459Z
20:33:16.398 [Workflow Executor taskQueue="WorkflowTest-testGetVersionAndCancelTimer-e2f358d8-156b-45dc-b66d-dfd479976aa5", namespace="UnitTest": 1] ERROR i.t.i.r.ReplayWorkflowTaskHandler - Workflow task failure. startedEventId=14, WorkflowId=b07ced6e-22fe-430d-80dc-2c775448307d, RunId=87eb09d6-2f53-4109-8352-05b766bce0da. If see continuously the workflow might be stuck.
io.temporal.internal.replay.InternalWorkflowTaskException: Failure handling event 10 of 'EVENT_TYPE_MARKER_RECORDED' type. IsReplaying=true, PreviousStartedEventId=8, workflowTaskStartedEventId=14, Currently Processing StartedEventId=8
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleEvent(WorkflowStateMachines.java:193)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleEvent(ReplayWorkflowRunTaskHandler.java:140)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleWorkflowTaskImpl(ReplayWorkflowRunTaskHandler.java:180)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleWorkflowTask(ReplayWorkflowRunTaskHandler.java:150)
	at io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTaskWithEmbeddedQuery(ReplayWorkflowTaskHandler.java:201)
	at io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTask(ReplayWorkflowTaskHandler.java:114)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:319)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:279)
	at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:73)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalStateException: Version is already set to 1. The most probable cause is retroactive addition of a getVersion call with an existing 'changeId'
	at io.temporal.internal.statemachines.VersionStateMachine.updateVersionFromEvent(VersionStateMachine.java:273)
	at io.temporal.internal.statemachines.VersionStateMachine.handleNonMatchingEvent(VersionStateMachine.java:325)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleVersionMarker(WorkflowStateMachines.java:302)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleCommandEvent(WorkflowStateMachines.java:250)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleEventImpl(WorkflowStateMachines.java:199)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleEvent(WorkflowStateMachines.java:178)
	... 11 common frames omitted
20:33:16.423 [timer-callback] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.558Z> Reminder: Reminder 1
20:33:16.423 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.558Z> Will process signal ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.459Z, reminderText='Reminder 2']
20:33:16.423 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.558Z> Cancelling previous reminder
20:33:16.423 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.558Z> Got a request ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.459Z, reminderText='Reminder 2'] for an outdated reminder, ignoring it
20:33:16.424 [workflow-method] INFO  i.t.w.v.GetVersionAndCancelTimerTest$ReminderWorkflowImpl - <2020-01-01T00:00:10.558Z> Workflow completed
```

Note that:

1. `<2020-01-01T00:00:10.558Z> Reminder: Reminder 1` - the time is taken from "Reminder 2" event but the message is from "Reminder 1"
2. `<2020-01-01T00:00:10.558Z> Got a request ScheduleReminderSignal[reminderTime=2020-01-01T00:00:10.459Z, reminderText='Reminder 2'] for an outdated reminder, ignoring it` - "Reminder 2" event is delivered to the workflow for the second time.


## Why?

This test is as simple reproducer for an issue we see in production as I could get.
