### PR TITLE
Change docker hub repo to temporaliotest

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "8126:8126"
 
   temporal:
-    image: temporalio/auto-setup:latest
+    image: temporaliotest/auto-setup:latest
     logging:
       driver: none
     ports:


### PR DESCRIPTION
After https://github.com/temporalio/temporal/pull/1740 `temporalio/auto-setup:latest` points to latest release not latest `master` commit.