### PR TITLE
Fixed an issue with time skipping in case of timing out a root (not a child) workflow

### DIFF
--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation project(":temporal-testing")
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -3,7 +3,7 @@ description = '''Temporal Workflow Java SDK'''
 dependencies {
     api project(':temporal-serviceclient')
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.7'
-    api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.1'
+    api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.2'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
@@ -13,7 +13,7 @@ dependencies {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
     testImplementation project(':temporal-testing-junit4')
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
 }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.google.protobuf' version '0.8.16'
+    id 'com.google.protobuf' version '0.8.17'
 }
 
 apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
@@ -18,7 +18,7 @@ dependencies {
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }

--- a/temporal-testing-junit5/build.gradle
+++ b/temporal-testing-junit5/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api platform('org.junit:junit-bom:5.7.2')
     api group: 'org.junit.jupiter', name: 'junit-jupiter-api'
 
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter'
 }
 

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
     testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.31'
 }
 

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimer.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimer.java
@@ -23,6 +23,7 @@ import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.LongSupplier;
+import javax.annotation.Nullable;
 
 /**
  * Timer service that automatically forwards current time to the next task time when is not locked
@@ -66,4 +67,6 @@ interface SelfAdvancingTimer {
 
 interface LockHandle {
   void unlock();
+
+  void unlock(@Nullable String caller);
 }

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1637,10 +1637,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           if (activity.getState() != State.INITIATED && data.getAttempt() != attempt) {
             return;
           }
-          selfAdvancingTimer.lockTimeSkipping(
-              "activityRetryTimer " + activity.getData().scheduledEvent.getActivityId());
+          LockHandle lockHandle =
+              selfAdvancingTimer.lockTimeSkipping(
+                  "activityRetryTimer " + activity.getData().scheduledEvent.getActivityId());
           boolean unlockTimer = false;
           try {
+            // TODO this lock is getting releases somewhere on the activity completion.
+            // We should rework it on passing the lockHandle downstream and using it for the release
             update(ctx1 -> ctx1.addActivityTask(data.activityTask));
           } catch (StatusRuntimeException e) {
             // NOT_FOUND is expected as timers are not removed
@@ -1655,7 +1658,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           } finally {
             if (unlockTimer) {
               // Allow time skipping when waiting for an activity retry
-              selfAdvancingTimer.unlockTimeSkipping(
+              lockHandle.unlock(
                   "activityRetryTimer " + activity.getData().scheduledEvent.getActivityId());
             }
           }
@@ -1810,7 +1813,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             // TODO(maxim): real retry status
             workflow.action(StateMachines.Action.TIME_OUT, ctx, RetryState.RETRY_STATE_TIMEOUT, 0);
             workflowTaskStateMachine.getData().workflowCompleted = true;
-            if (parent != null) {
+            if (parent.isPresent()) {
               ctx.lockTimer("timeoutWorkflow notify parent"); // unlocked by the parent
             }
             ForkJoinPool.commonPool().execute(() -> reportWorkflowTimeoutToParent(ctx));


### PR DESCRIPTION
## What was changed
Fixed an issue with time-skipping during timing out of a not-a-child workflow without a parent.
Also includes some refactorings to use `LockHandle` more extensively to clean up the internal state of `SelfAdvancingTimerImpl`. This makes debugging of time skipping issues easier.

## Why?
#577

## Checklist
<!--- add/delete as needed --->

1. Closes #577

2. How was this tested:
`TestWorkflowEnvironmentSleepTest#testWorkflowTimeoutDuringSleep`
