### PR TITLE
Use method annotation name override for equality check

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalMethodOverloadTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalMethodOverloadTest.java
@@ -26,14 +26,13 @@ import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class SignalMethodOverrideTest {
+public class SignalMethodOverloadTest {
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestSignalMethodOverrideImpl.class).build();
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestSignalMethodOverloadImpl.class).build();
 
-  public class TestSignalMethodOverrideImpl
-      implements SignalMethodOverrideTest.TestSignalMethodOverride {
+  public static class TestSignalMethodOverloadImpl implements TestSignalMethodOverload {
     @Override
     public void execute() {}
 
@@ -45,7 +44,7 @@ public class SignalMethodOverrideTest {
   }
 
   @WorkflowInterface
-  public interface TestSignalMethodOverride {
+  public interface TestSignalMethodOverload {
     @WorkflowMethod
     void execute();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalMethodOverrideTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalMethodOverrideTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.signalTests;
+
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.shared.SDKTestWorkflowRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SignalMethodOverrideTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestSignalMethodOverrideImpl.class).build();
+
+  public class TestSignalMethodOverrideImpl
+      implements SignalMethodOverrideTest.TestSignalMethodOverride {
+    @Override
+    public void execute() {}
+
+    @Override
+    public void foo() {}
+
+    @Override
+    public void foo(String bar) {}
+  }
+
+  @WorkflowInterface
+  public interface TestSignalMethodOverride {
+    @WorkflowMethod
+    void execute();
+
+    @SignalMethod
+    void foo();
+
+    @SignalMethod(name = "foobar")
+    void foo(String bar);
+  }
+
+  // Being able to create a workflow worker and register workflow with two signal methods with the
+  // same function name is the test by itself.
+  // By doing this we are verifying that java.lang.IllegalArgumentException: Duplicated methods
+  // (overloads are not allowed) is not thrown.
+  @Test
+  public void testSignalMethodOverride() {}
+}


### PR DESCRIPTION
## What was changed
Added name override from the annotation to equality check.

## Why?
Previously workflows with overloaded signal functions were not allowed due to the fact that we only used function name as an equality key.

## Checklist

1. Closes #591

2. How was this tested: new unit test

3. Any docs updates needed?
no