### PR TITLE
Thread shutdown not working correctly in TestEnv

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -306,6 +306,7 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
       laCompletion = localActivityCompletionQueue.poll(maxWaitTime, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       // TODO(maxim): interrupt when worker shutdown is called
+      Thread.currentThread().interrupt();
       throw new IllegalStateException("interrupted", e);
     }
     if (laCompletion == null) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -406,6 +406,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
       try {
         future.get();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new Error("Unexpected interrupt", e);
       } catch (ExecutionException e) {
         throw new Error("Unexpected failure stopping coroutine", e);

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -86,6 +86,7 @@ class WorkflowThreadContext {
       }
     } catch (InterruptedException e) {
       // Throwing Error in workflow code aborts workflow task without failing workflow.
+      Thread.currentThread().interrupt();
       throw new Error("Unexpected interrupt", e);
     } finally {
       setStatus(Status.RUNNING);
@@ -142,6 +143,7 @@ class WorkflowThreadContext {
         evaluationCondition.await();
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new Error("Unexpected interrupt", e);
     } finally {
       evaluationFunction = null;
@@ -237,6 +239,7 @@ class WorkflowThreadContext {
       }
       return !remainedBlocked;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       if (!isDestroyRequested()) {
         throw new Error("Unexpected interrupt", e);
       }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/BlockCallerPolicy.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/BlockCallerPolicy.java
@@ -35,6 +35,7 @@ class BlockCallerPolicy implements RejectedExecutionHandler {
       // block until there's room
       executor.getQueue().put(r);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RejectedExecutionException("Unexpected InterruptedException", e);
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollWorkflowTaskDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollWorkflowTaskDispatcher.java
@@ -58,13 +58,13 @@ public final class PollWorkflowTaskDispatcher
   }
 
   @Override
-  public void process(PollWorkflowTaskQueueResponse t) {
+  public void process(PollWorkflowTaskQueueResponse task) {
     if (isShutdown()) {
       throw new RejectedExecutionException("shutdown");
     }
-    String taskQueueName = t.getWorkflowExecutionTaskQueue().getName();
+    String taskQueueName = task.getWorkflowExecutionTaskQueue().getName();
     if (subscribers.containsKey(taskQueueName)) {
-      subscribers.get(taskQueueName).apply(t);
+      subscribers.get(taskQueueName).apply(task);
     } else {
       Exception exception =
           new Exception(
@@ -74,7 +74,7 @@ public final class PollWorkflowTaskDispatcher
       RespondWorkflowTaskFailedRequest request =
           RespondWorkflowTaskFailedRequest.newBuilder()
               .setNamespace(namespace)
-              .setTaskToken(t.getTaskToken())
+              .setTaskToken(task.getTaskToken())
               .setCause(WorkflowTaskFailedCause.WORKFLOW_TASK_FAILED_CAUSE_RESET_STICKY_TASK_QUEUE)
               .setFailure(FailureConverter.exceptionToFailure(exception))
               .build();

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -806,6 +806,7 @@ public class WorkflowTestingTest {
         try {
           Thread.sleep(500);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           e.printStackTrace();
         }
         Activity.getExecutionContext().heartbeat(System.currentTimeMillis() - start);
@@ -860,6 +861,7 @@ public class WorkflowTestingTest {
       try {
         Thread.sleep(500);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
       Workflow.await(() -> signalInput != null);
@@ -882,7 +884,7 @@ public class WorkflowTestingTest {
         try {
           Thread.sleep(50);
         } catch (InterruptedException e) {
-          // NOOP
+          Thread.currentThread().interrupt();
         }
       }
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowRunLockManagerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowRunLockManagerTest.java
@@ -67,6 +67,7 @@ public class WorkflowRunLockManagerTest {
     try {
       Thread.sleep(1000);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException("interrupted");
     } finally {
       runLockManager.unlock(runId);

--- a/temporal-sdk/src/test/java/io/temporal/worker/CleanWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/CleanWorkerShutdownTest.java
@@ -322,6 +322,7 @@ public class CleanWorkerShutdownTest {
         started.complete(true);
         Thread.sleep(1000);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         return "interrupted";
       }
       return "completed";
@@ -344,6 +345,7 @@ public class CleanWorkerShutdownTest {
       } catch (ActivityWorkerShutdownException e) {
         return "workershutdown";
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         return "interrupted";
       }
       return "completed";

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -195,7 +195,7 @@ public class WorkerStressTests {
       return useExternalService ? factory.getWorkflowClient() : testEnv.getWorkflowClient();
     }
 
-    private void close() throws InterruptedException {
+    private void close() {
       if (factory != null) {
         factory.shutdown();
         factory.awaitTermination(10, TimeUnit.SECONDS);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
@@ -120,6 +120,7 @@ public class DeadlockDetectorTest {
       try {
         Thread.sleep(millis);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw Workflow.wrap(e);
       }
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
@@ -31,7 +31,6 @@ import io.temporal.testing.WorkflowReplayer;
 import io.temporal.workflow.Async;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
-import io.temporal.workflow.shared.TestActivities;
 import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
 import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
@@ -100,8 +99,7 @@ public class AsyncActivityRetryTest {
                       .setMaximumAttempts(3)
                       .build())
               .build();
-      this.activities =
-          Workflow.newActivityStub(TestActivities.VariousTestActivities.class, options);
+      this.activities = Workflow.newActivityStub(VariousTestActivities.class, options);
       Async.procedure(activities::heartbeatAndThrowIO).get();
       return "ignored";
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/interceptorsTests/InterceptorExceptionTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/interceptorsTests/InterceptorExceptionTests.java
@@ -29,10 +29,12 @@ import io.temporal.common.interceptors.WorkflowClientCallsInterceptorBase;
 import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class InterceptorsExceptionsTests {
+public class InterceptorExceptionTests {
+
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
@@ -42,6 +44,12 @@ public class InterceptorsExceptionsTests {
                   .setInterceptors(new ExceptionOnStartThrowingClientInterceptor())
                   .validateAndBuildWithDefaults())
           .build();
+
+  @After
+  @SuppressWarnings("deprecation")
+  public void tearDown() {
+    testWorkflowRule.getTestEnvironment().shutdownTestService();
+  }
 
   @Test
   public void testExceptionOnStart() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/interceptorsTests/InterceptorExceptionTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/interceptorsTests/InterceptorExceptionTests.java
@@ -45,6 +45,10 @@ public class InterceptorExceptionTests {
                   .validateAndBuildWithDefaults())
           .build();
 
+  /**
+   * Initiates Test Service shutdown as temporary to solution to long poll thread shutdown. See
+   * issue: https://github.com/temporalio/sdk-java/issues/608
+   */
   @After
   @SuppressWarnings("deprecation")
   public void tearDown() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/SDKTestWorkflowRule.java
@@ -353,6 +353,7 @@ public class SDKTestWorkflowRule implements TestRule {
         try {
           result.get();
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
           throw e.getCause();
         }
@@ -365,6 +366,7 @@ public class SDKTestWorkflowRule implements TestRule {
       try {
         Thread.sleep(d.toMillis());
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException("Interrupted", e);
       }
     } else {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
@@ -205,6 +205,7 @@ public class TestActivities {
       try {
         Thread.sleep(milliseconds);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw Activity.wrap(new RuntimeException("interrupted", new Throwable("simulated")));
       }
       invocations.add("sleepActivity");
@@ -230,11 +231,12 @@ public class TestActivities {
               }
               completionClient.complete(taskToken, "activity");
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
             } catch (ActivityNotExistsException | ActivityCanceledException e) {
               try {
                 Thread.sleep(500);
               } catch (InterruptedException interruptedException) {
-                // noop
+                Thread.currentThread().interrupt();
               }
               completionClient.reportCancellation(taskToken, null);
             }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
@@ -174,7 +174,7 @@ public class TestWorkflows {
     public String execute(String taskQueue, int delay) {
       NoArgsActivity activity =
           Workflow.newActivityStub(
-              TestActivities.NoArgsActivity.class,
+              NoArgsActivity.class,
               ActivityOptions.newBuilder()
                   .setTaskQueue(taskQueue)
                   .setScheduleToCloseTimeout(Duration.ofSeconds(5))

--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalDuringLastWorkflowTaskTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalDuringLastWorkflowTaskTest.java
@@ -65,6 +65,7 @@ public class SignalDuringLastWorkflowTaskTest {
             try {
               sendSignal.get(2, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               throw new RuntimeException(e);
             }
             client.signal("Signal Input");
@@ -94,6 +95,7 @@ public class SignalDuringLastWorkflowTaskTest {
         try {
           Thread.sleep(1000);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }
       }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -320,6 +320,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       }
       return true;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return false;
     }
   }

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
@@ -144,11 +144,11 @@ interface TestWorkflowStore {
 
   void registerDelayedCallback(Duration delay, Runnable r);
 
-  /** @return empty if deadline exprired */
+  /** @return empty if deadline expired */
   Optional<PollWorkflowTaskQueueResponse.Builder> pollWorkflowTaskQueue(
       PollWorkflowTaskQueueRequest pollRequest, Deadline deadline);
 
-  /** @return empty if deadline exprired */
+  /** @return empty if deadline expired */
   Optional<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
       PollActivityTaskQueueRequest pollRequest, Deadline deadline);
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -180,6 +180,14 @@ public interface TestWorkflowEnvironment {
   boolean isTerminated();
 
   /**
+   * Initiates Test Service shutdown. This method is temporarily exposed to solve long poll thread
+   * shutdown for {@link
+   * io.temporal.workflow.interceptorsTests.InterceptorExceptionTests#testExceptionOnStart()}.
+   */
+  @Deprecated
+  void shutdownTestService();
+
+  /**
    * Initiates an orderly shutdown in which polls are stopped and already received workflow and
    * activity tasks are executed. After the shutdown calls to {@link
    * io.temporal.activity.ActivityExecutionContext#heartbeat(Object)} start throwing {@link

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -182,7 +182,8 @@ public interface TestWorkflowEnvironment {
   /**
    * Initiates Test Service shutdown. This method is temporarily exposed to solve long poll thread
    * shutdown for {@link
-   * io.temporal.workflow.interceptorsTests.InterceptorExceptionTests#testExceptionOnStart()}.
+   * io.temporal.workflow.interceptorsTests.InterceptorExceptionTests#testExceptionOnStart()}. See
+   * issue: https://github.com/temporalio/sdk-java/issues/608
    */
   @Deprecated
   void shutdownTestService();

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -148,9 +148,11 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
 
   @Override
   public void close() {
+    // Invoke service.close() before shutting down the worker factories to prevent threads hanging
+    // due to the failure being interrupted (which isn't guaranteed by JVM).
+    service.close();
     workerFactory.shutdownNow();
     workerFactory.awaitTermination(10, TimeUnit.SECONDS);
-    service.close();
     if (Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"))) {
       workflowServiceStubs.shutdown();
     } else {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -148,11 +148,9 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
 
   @Override
   public void close() {
-    // Invoke service.close() before shutting down the worker factories to prevent threads hanging
-    // due to the failure being interrupted (which isn't guaranteed by JVM).
-    service.close();
     workerFactory.shutdownNow();
     workerFactory.awaitTermination(10, TimeUnit.SECONDS);
+    service.close();
     if (Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"))) {
       workflowServiceStubs.shutdown();
     } else {
@@ -179,6 +177,12 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
   @Override
   public boolean isTerminated() {
     return workerFactory.isTerminated();
+  }
+
+  @Override
+  @Deprecated
+  public void shutdownTestService() {
+    service.close();
   }
 
   @Override


### PR DESCRIPTION
## What was changed
Added a flag to signal that the poller thread was asked to shutdown and replaced the long poll with shorter polls that keep checking that flag.

## Why?
Thread shutdown is not reliable

## Checklist

1. Closes #455 