### PR TITLE
Dependency Update

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-        errorprone('com.google.errorprone:error_prone_core:2.7.1')
+        errorprone('com.google.errorprone:error_prone_core:2.8.0')
     }
 
     compileJava {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation project(":temporal-testing")
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
     testImplementation project(':temporal-testing-junit4')
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
 }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -14,11 +14,11 @@ dependencies {
     api 'io.grpc:grpc-services:1.39.0'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.3'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
-    api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.31'
+    api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }

--- a/temporal-testing-junit5/build.gradle
+++ b/temporal-testing-junit5/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api platform('org.junit:junit-bom:5.7.2')
     api group: 'org.junit.jupiter', name: 'junit-jupiter-api'
 
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter'
 }
 

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.4'
+    testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.31'
 }
 


### PR DESCRIPTION
> Task :temporal-opentracing:checkDependencyUpdates
New dependency version: ch.qos.logback:logback-classic: 1.2.4 -> 1.2.5
New dependency version: com.google.errorprone:error_prone_core: 2.7.1 -> 2.8.0

> Task :temporal-opentracing:checkGradleUpdates
New Gradle version is available: 7.1.1 (downloadUrl: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip)

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: ch.qos.logback:logback-classic: 1.2.4 -> 1.2.5
New dependency version: com.google.errorprone:error_prone_core: 2.7.1 -> 2.8.0

> Task :temporal-sdk:checkGradleUpdates
New Gradle version is available: 7.1.1 (downloadUrl: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip)

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: ch.qos.logback:logback-classic: 1.2.4 -> 1.2.5
New dependency version: com.google.errorprone:error_prone_core: 2.7.1 -> 2.8.0
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.10.0
New dependency version: org.slf4j:slf4j-api: 1.7.31 -> 1.7.32

> Task :temporal-serviceclient:checkGradleUpdates
New Gradle version is available: 7.1.1 (downloadUrl: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip)

> Task :temporal-testing:checkDependencyUpdates
New dependency version: ch.qos.logback:logback-classic: 1.2.4 -> 1.2.5
New dependency version: com.google.errorprone:error_prone_core: 2.7.1 -> 2.8.0
New dependency version: org.slf4j:slf4j-simple: 1.7.31 -> 1.7.32

> Task :temporal-testing:checkGradleUpdates
New Gradle version is available: 7.1.1 (downloadUrl: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip)

> Task :temporal-testing-junit4:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.7.1 -> 2.8.0
New dependency version: org.slf4j:slf4j-simple: 1.7.31 -> 1.7.32

> Task :temporal-testing-junit4:checkGradleUpdates
New Gradle version is available: 7.1.1 (downloadUrl: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip)

> Task :temporal-testing-junit5:checkDependencyUpdates
New dependency version: ch.qos.logback:logback-classic: 1.2.4 -> 1.2.5
New dependency version: com.google.errorprone:error_prone_core: 2.7.1 -> 2.8.0

> Task :temporal-testing-junit5:checkGradleUpdates
New Gradle version is available: 7.1.1 (downloadUrl: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip)