### PR TITLE
Flaky test: testChildWorkflowWithCronSchedule

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
@@ -29,6 +29,7 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflowWithCronScheduleImpl;
 import java.time.Duration;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -70,7 +71,9 @@ public class WorkflowWithCronScheduleTest {
     }
 
     // Run 3 failed. So on run 4 we get the last completion result from run 2.
-    assertEquals("run 2", TestWorkflowWithCronScheduleImpl.lastCompletionResult);
+    Map<Integer, String> lastCompletionResults =
+        TestWorkflowWithCronScheduleImpl.lastCompletionResults.get(testName.getMethodName());
+    assertEquals("run 2", lastCompletionResults.get(4));
     // The last failure ought to be the one from run 3
     assertTrue(TestWorkflowWithCronScheduleImpl.lastFail.isPresent());
     assertTrue(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
@@ -32,6 +32,7 @@ import io.temporal.workflow.shared.TestWorkflowWithCronScheduleImpl;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowWithCronSchedule;
 import java.time.Duration;
+import java.util.HashMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -57,7 +58,7 @@ public class ChildWorkflowWithCronScheduleTest {
             .getWorkflowClient()
             .newUntypedWorkflowStub(
                 "TestWorkflow1", newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
-    client.start(testName.getMethodName());
+    client.start(testName.toString());
     testWorkflowRule.getTestEnvironment().sleep(Duration.ofHours(3));
     client.cancel();
 
@@ -69,7 +70,9 @@ public class ChildWorkflowWithCronScheduleTest {
     }
 
     // Run 3 failed. So on run 4 we get the last completion result from run 2.
-    assertEquals("run 2", TestWorkflowWithCronScheduleImpl.lastCompletionResults[4]);
+    HashMap<Integer, String> lastCompletionResults =
+        TestWorkflowWithCronScheduleImpl.lastCompletionResults.get(testName.toString());
+    assertEquals("run 2", lastCompletionResults.get(4));
   }
 
   public static class TestCronParentWorkflow implements TestWorkflow1 {
@@ -77,8 +80,8 @@ public class ChildWorkflowWithCronScheduleTest {
         Workflow.newChildWorkflowStub(TestWorkflowWithCronSchedule.class);
 
     @Override
-    public String execute(String taskQueue) {
-      return cronChild.execute(taskQueue);
+    public String execute(String testName) {
+      return cronChild.execute(testName);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
@@ -56,11 +56,7 @@ public class ChildWorkflowWithCronScheduleTest {
         testWorkflowRule
             .getWorkflowClient()
             .newUntypedWorkflowStub(
-                "TestWorkflow1",
-                newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
-                    .toBuilder()
-                    .setWorkflowRunTimeout(Duration.ofHours(10))
-                    .build());
+                "TestWorkflow1", newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
     client.start(testName.getMethodName());
     testWorkflowRule.getTestEnvironment().sleep(Duration.ofHours(3));
     client.cancel();
@@ -73,7 +69,7 @@ public class ChildWorkflowWithCronScheduleTest {
     }
 
     // Run 3 failed. So on run 4 we get the last completion result from run 2.
-    assertEquals("run 2", TestWorkflowWithCronScheduleImpl.lastCompletionResult);
+    assertEquals("run 2", TestWorkflowWithCronScheduleImpl.lastCompletionResults[4]);
   }
 
   public static class TestCronParentWorkflow implements TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
@@ -32,7 +32,7 @@ import io.temporal.workflow.shared.TestWorkflowWithCronScheduleImpl;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowWithCronSchedule;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -58,7 +58,7 @@ public class ChildWorkflowWithCronScheduleTest {
             .getWorkflowClient()
             .newUntypedWorkflowStub(
                 "TestWorkflow1", newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
-    client.start(testName.toString());
+    client.start(testName.getMethodName());
     testWorkflowRule.getTestEnvironment().sleep(Duration.ofHours(3));
     client.cancel();
 
@@ -70,8 +70,8 @@ public class ChildWorkflowWithCronScheduleTest {
     }
 
     // Run 3 failed. So on run 4 we get the last completion result from run 2.
-    HashMap<Integer, String> lastCompletionResults =
-        TestWorkflowWithCronScheduleImpl.lastCompletionResults.get(testName.toString());
+    Map<Integer, String> lastCompletionResults =
+        TestWorkflowWithCronScheduleImpl.lastCompletionResults.get(testName.getMethodName());
     assertEquals("run 2", lastCompletionResults.get(4));
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflowWithCronScheduleImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflowWithCronScheduleImpl.java
@@ -25,6 +25,8 @@ import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowWithCronSchedule;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,7 +36,8 @@ import org.slf4j.Logger;
 public class TestWorkflowWithCronScheduleImpl implements TestWorkflowWithCronSchedule {
 
   public static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
-  public static String[] lastCompletionResults = new String[10];
+  public static final Hashtable<String, HashMap<Integer, String>> lastCompletionResults =
+      new Hashtable<>();
   public static String lastCompletionResult;
   public static Optional<Exception> lastFail;
 
@@ -54,10 +57,12 @@ public class TestWorkflowWithCronScheduleImpl implements TestWorkflowWithCronSch
     if (count == null) {
       count = new AtomicInteger();
       retryCount.put(testName, count);
+      lastCompletionResults.put(testName, new HashMap<Integer, String>());
     }
-    int c = count.incrementAndGet();
 
-    lastCompletionResults[c] = lastCompletionResult;
+    int c = count.incrementAndGet();
+    lastCompletionResults.get(testName).put(c, lastCompletionResult);
+
     if (c == 3) {
       throw ApplicationFailure.newFailure("simulated error", "test");
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflowWithCronScheduleImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflowWithCronScheduleImpl.java
@@ -26,7 +26,6 @@ import io.temporal.workflow.shared.TestWorkflows.TestWorkflowWithCronSchedule;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,9 +35,8 @@ import org.slf4j.Logger;
 public class TestWorkflowWithCronScheduleImpl implements TestWorkflowWithCronSchedule {
 
   public static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
-  public static final Hashtable<String, HashMap<Integer, String>> lastCompletionResults =
-      new Hashtable<>();
-  public static String lastCompletionResult;
+  public static final Map<String, Map<Integer, String>> lastCompletionResults =
+      new ConcurrentHashMap<>();
   public static Optional<Exception> lastFail;
 
   @Override
@@ -50,26 +48,19 @@ public class TestWorkflowWithCronScheduleImpl implements TestWorkflowWithCronSch
       return null;
     }
 
-    lastCompletionResult = Workflow.getLastCompletionResult(String.class);
     lastFail = Workflow.getPreviousRunFailure();
+    int count = retryCount.computeIfAbsent(testName, k -> new AtomicInteger()).incrementAndGet();
+    lastCompletionResults
+        .computeIfAbsent(testName, k -> new HashMap<>())
+        .put(count, Workflow.getLastCompletionResult(String.class));
 
-    AtomicInteger count = retryCount.get(testName);
-    if (count == null) {
-      count = new AtomicInteger();
-      retryCount.put(testName, count);
-      lastCompletionResults.put(testName, new HashMap<Integer, String>());
-    }
-
-    int c = count.incrementAndGet();
-    lastCompletionResults.get(testName).put(c, lastCompletionResult);
-
-    if (c == 3) {
+    if (count == 3) {
       throw ApplicationFailure.newFailure("simulated error", "test");
     }
 
     SimpleDateFormat sdf = new SimpleDateFormat("MMM dd,yyyy HH:mm:ss.SSS");
     Date now = new Date(Workflow.currentTimeMillis());
     log.debug("TestWorkflowWithCronScheduleImpl run at " + sdf.format(now));
-    return "run " + c;
+    return "run " + count;
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflowWithCronScheduleImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflowWithCronScheduleImpl.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 public class TestWorkflowWithCronScheduleImpl implements TestWorkflowWithCronSchedule {
 
   public static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
+  public static String[] lastCompletionResults = new String[10];
   public static String lastCompletionResult;
   public static Optional<Exception> lastFail;
 
@@ -56,6 +57,7 @@ public class TestWorkflowWithCronScheduleImpl implements TestWorkflowWithCronSch
     }
     int c = count.incrementAndGet();
 
+    lastCompletionResults[c] = lastCompletionResult;
     if (c == 3) {
       throw ApplicationFailure.newFailure("simulated error", "test");
     }

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
-    testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.31'
+    testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.32'
 }
 
 task testServiceServer(type: CreateStartScripts) {


### PR DESCRIPTION
## What was changed
Added an array that records lastCompletionResult for every run.

## Why?
Couldn't guarantee how many runs the cron workflow would perform, hence relying on timers to get the lastCompletionResult of the correct run was not working consistently