### PR TITLE
Fix handling of Version events in WorkflowStateMachines in case of cancelled commands in a queue

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/EntityStateMachineBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/EntityStateMachineBase.java
@@ -64,7 +64,7 @@ class EntityStateMachineBase<State, ExplicitEvent, Data> implements EntityStateM
     } finally {
       this.currentEvent = null;
     }
-    return null;
+    return WorkflowStateMachines.HandleEventStatus.OK;
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StateMachineCommandUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StateMachineCommandUtils.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.statemachines;
+
+import io.temporal.api.command.v1.Command;
+import io.temporal.api.command.v1.RecordMarkerCommandAttributes;
+import io.temporal.api.enums.v1.CommandType;
+
+public class StateMachineCommandUtils {
+  public static final Command RECORD_MARKER_FAKE_COMMAND =
+      StateMachineCommandUtils.createRecordMarker(
+          RecordMarkerCommandAttributes.getDefaultInstance());
+
+  public static Command createRecordMarker(RecordMarkerCommandAttributes attributes) {
+    return Command.newBuilder()
+        .setCommandType(CommandType.COMMAND_TYPE_RECORD_MARKER)
+        .setRecordMarkerCommandAttributes(attributes)
+        .build();
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/AsyncWorkflowBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/AsyncWorkflowBuilder.java
@@ -22,6 +22,15 @@ package io.temporal.internal.statemachines;
 import io.temporal.workflow.Functions;
 import java.util.Queue;
 
+/**
+ * Represents a step in a workflow which takes {@code <T>} as an input value from the previous step
+ * and triggers registered callbacks with its output.
+ *
+ * <p>Provides several {@code add} functions, each works with a {@code proc} parameter of a specific
+ * type which corresponds to different types of callbacks accepted by state machines.
+ *
+ * @param <T> input value of the step
+ */
 interface AsyncWorkflowBuilder<T> {
 
   class Pair<T1, T2> {
@@ -42,12 +51,52 @@ interface AsyncWorkflowBuilder<T> {
     }
   }
 
+  /**
+   * Adds a function {@code proc} to the processing of {@code <T>} and also creates a new step
+   * {@code AsyncWorkflowBuilder<R>} that accepts types {@code <R>} as an input.
+   *
+   * <p>Use this method to pass {@code proc} that triggers a state machine function / transition
+   * that accepts a callback with single value. The value this state machine passes to this callback
+   * will be transferred to the next step {@code AsyncWorkflowBuilder<R>} provided as a return value
+   * of this method.
+   *
+   * @param proc function that processes input {@code <T>} from the previous step and passes newly
+   *     generated outputs (inputs for the next step) into a callback {@code Functions.Proc1<R>} to
+   *     trigger the AsyncWorkflowBuilder returned from this function
+   * @return the next step AsyncWorkflowBuilder<R>> that gets as an input whatever {@code proc}
+   *     provides to its callback
+   */
   <R> AsyncWorkflowBuilder<R> add1(Functions.Proc2<T, Functions.Proc1<R>> proc);
 
+  /**
+   * Adds a function {@code proc} to the callbacks and also creates a new step {@code
+   * AsyncWorkflowBuilder<Pair<R1, R2>>} that accepts types {@code Pair<R1, R2>} as an input. The
+   * {@code Pair<R1, R2>} usually represent a pair of {@code <Value, Error>}
+   *
+   * <p>Use this method to pass {@code proc} that triggers a state machine function / transition
+   * that accepts a callback with two values (usually it's a pair of Value and Error). The pair this
+   * state machine passes to this callback will be transferred to the next step {@code
+   * AsyncWorkflowBuilder<Pair<R1, R2>>} provided as a return value of this method.
+   *
+   * @param proc function that processes input {@code <T>} from the previous step and passes newly
+   *     generated output pairs (inputs for the next step) into a callback {@code
+   *     Functions.Proc2<R1, R2>} to trigger the AsyncWorkflowBuilder returned from this function.
+   * @return the next step AsyncWorkflowBuilder<Pair<R1, R2>> that gets as an input whatever {@code
+   *     proc} provides to its callback
+   */
   <R1, R2> AsyncWorkflowBuilder<Pair<R1, R2>> add2(
       Functions.Proc2<T, Functions.Proc2<R1, R2>> proc);
 
-  void add(Functions.Proc1<T> proc);
+  /**
+   * Adds a function {@code proc} to the processing of {@code <T>}
+   *
+   * <p>Use this method to pass {@code proc} that triggers a state machine function / transition
+   * that doesn't accept any callbacks and only accepts an input value.
+   *
+   * @param proc function to add into callbacks
+   * @return this
+   */
+  AsyncWorkflowBuilder<T> add(Functions.Proc1<T> proc);
 
   static <T> AsyncWorkflowBuilder newScheduler(Queue<Functions.Proc> dispatchQueue, T value) {
     AsyncWorkflowBuilderImpl scheduler = new AsyncWorkflowBuilderImpl(dispatchQueue);

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/AsyncWorkflowBuilderImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/AsyncWorkflowBuilderImpl.java
@@ -51,7 +51,7 @@ class AsyncWorkflowBuilderImpl<T> implements AsyncWorkflowBuilder<T> {
 
   @Override
   public <R> AsyncWorkflowBuilder<R> add1(Functions.Proc2<T, Functions.Proc1<R>> proc) {
-    AsyncWorkflowBuilderImpl<R> scheduler = new AsyncWorkflowBuilderImpl<R>(scheduled);
+    AsyncWorkflowBuilderImpl<R> scheduler = new AsyncWorkflowBuilderImpl<>(scheduled);
     callbacks.add((value) -> schedule(() -> proc.apply(value, scheduler.callback)));
     return scheduler;
   }
@@ -63,12 +63,13 @@ class AsyncWorkflowBuilderImpl<T> implements AsyncWorkflowBuilder<T> {
     callbacks.add(
         (value) ->
             schedule(
-                () -> proc.apply(value, (t1, t2) -> scheduler.callback.apply(new Pair(t1, t2)))));
+                () -> proc.apply(value, (t1, t2) -> scheduler.callback.apply(new Pair<>(t1, t2)))));
     return scheduler;
   }
 
   @Override
-  public void add(Functions.Proc1<T> proc) {
+  public AsyncWorkflowBuilder<T> add(Functions.Proc1<T> proc) {
     callbacks.add((result) -> schedule(() -> proc.apply(result)));
+    return this;
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestEntityManagerListenerBase.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestEntityManagerListenerBase.java
@@ -26,8 +26,6 @@ import java.util.Queue;
 
 abstract class TestEntityManagerListenerBase implements EntityManagerListener {
 
-  boolean invoked;
-
   private final Queue<Functions.Proc> callbacks = new ArrayDeque<>();
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
@@ -213,7 +213,7 @@ public class TestActivities {
         Thread.sleep(milliseconds);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw Activity.wrap(new RuntimeException("interrupted", new Throwable("simulated")));
+        throw Activity.wrap(e);
       }
       invocations.add("sleepActivity");
       return "sleepActivity" + input;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAfterScopeCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAfterScopeCancellationTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import static io.temporal.api.enums.v1.EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * This test provides a localized reproduction for a state machine issue
+ * https://github.com/temporalio/sdk-java/issues/615 This test has a corresponding state machine
+ * unit test {@link
+ * io.temporal.internal.statemachines.VersionStateMachineTest#testRecordAfterCommandCancellation}
+ */
+public class GetVersionAfterScopeCancellationTest {
+
+  public static final class ReminderWorkflowImpl implements ReminderWorkflow {
+
+    @Override
+    public void start() {
+      Workflow.sleep(Duration.ofDays(1));
+    }
+
+    @Override
+    public void signal() {
+      CancellationScope activeScope1 =
+          Workflow.newCancellationScope(() -> Workflow.newTimer(Duration.ofHours(4)));
+      activeScope1.run();
+
+      Workflow.getVersion("some-change", Workflow.DEFAULT_VERSION, 1);
+
+      activeScope1.cancel();
+
+      // it's critical for this duration to be short for the test to fail originally (4s or less)
+      Duration secondScopeTimerDuration = Duration.ofSeconds(4);
+      Workflow.newTimer(secondScopeTimerDuration);
+    }
+  }
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ReminderWorkflowImpl.class)
+          .setWorkerOptions(WorkerOptions.newBuilder().build())
+          .build();
+
+  @Test
+  public void testGetVersionAndCancelTimer() {
+    ReminderWorkflow workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(ReminderWorkflow.class);
+
+    WorkflowClient.start(workflowStub::start);
+    workflowStub.signal();
+
+    WorkflowStub untypedWorkflowStub = WorkflowStub.fromTyped(workflowStub);
+    untypedWorkflowStub.getResult(Void.TYPE);
+
+    testWorkflowRule.assertNoHistoryEvent(
+        untypedWorkflowStub.getExecution(), EVENT_TYPE_WORKFLOW_TASK_FAILED);
+  }
+
+  @WorkflowInterface
+  public interface ReminderWorkflow {
+
+    @WorkflowMethod
+    void start();
+
+    @SignalMethod
+    void signal();
+  }
+}


### PR DESCRIPTION
## What was changed
`WorkflowStateMachines` now handles a situation with Versioning `EVENT_TYPE_MARKER_RECORDED` matching a commands buffer containing canceled commands correctly (by consuming and skipping them)

## Why?
The current implementation fails to match a Versioning `EVENT_TYPE_MARKER_RECORDED` History Event with a right command if there are canceled commands before it in the commands sink. This is a root cause of an issue described in  Issue #583.

1. Closes
PR #583
Issue #615