### PR TITLE
Cleaned up code persisting RetryOptions into side effect

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -480,8 +480,15 @@ public interface WorkflowOutboundCallsInterceptor {
 
   <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func);
 
+  /**
+   * @see Workflow#mutableSideEffect(String, Class, BiPredicate, Func)
+   */
   <R> R mutableSideEffect(
-      String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func);
+      String id,
+      Class<R> resultClass,
+      Type resultType,
+      BiPredicate<? super R, ? super R> shouldUpdate,
+      Func<R> func);
 
   int getVersion(String changeId, int minSupported, int maxSupported);
 

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
@@ -95,8 +95,12 @@ public class WorkflowOutboundCallsInterceptorBase implements WorkflowOutboundCal
 
   @Override
   public <R> R mutableSideEffect(
-      String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
-    return next.mutableSideEffect(id, resultClass, resultType, updated, func);
+      String id,
+      Class<R> resultClass,
+      Type resultType,
+      BiPredicate<? super R, ? super R> shouldUpdate,
+      Func<R> func) {
+    return next.mutableSideEffect(id, resultClass, resultType, shouldUpdate, func);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -420,8 +420,13 @@ public final class WorkflowInternal {
   }
 
   public static <R> R mutableSideEffect(
-      String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
-    return getWorkflowInterceptor().mutableSideEffect(id, resultClass, resultType, updated, func);
+      String id,
+      Class<R> resultClass,
+      Type resultType,
+      BiPredicate<? super R, ? super R> shouldUpdate,
+      Func<R> func) {
+    return getWorkflowInterceptor()
+        .mutableSideEffect(id, resultClass, resultType, shouldUpdate, func);
   }
 
   public static int getVersion(String changeId, int minSupported, int maxSupported) {

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -800,16 +800,19 @@ public final class Workflow {
    * {@link Error} causing failure of the current workflow task.
    *
    * @param id unique identifier of this side effect
-   * @param updated used to decide if a new value should be recorded. A func result is recorded only
-   *     if call to updated with stored and a new value as arguments returns true. It is not called
-   *     for the first value.
    * @param resultClass class of the side effect
+   * @param shouldUpdate used to decide if a new value should be recorded. A func result is recorded
+   *     only if call to updated with stored and a new value as arguments returns true. It is not
+   *     called for the first stored value.
    * @param func function that produces a value. This function can contain non-deterministic code.
    * @see #sideEffect(Class, Functions.Func)
    */
   public static <R> R mutableSideEffect(
-      String id, Class<R> resultClass, BiPredicate<R, R> updated, Func<R> func) {
-    return WorkflowInternal.mutableSideEffect(id, resultClass, resultClass, updated, func);
+      String id,
+      Class<R> resultClass,
+      BiPredicate<? super R, ? super R> shouldUpdate,
+      Func<R> func) {
+    return WorkflowInternal.mutableSideEffect(id, resultClass, resultClass, shouldUpdate, func);
   }
 
   /**
@@ -834,17 +837,21 @@ public final class Workflow {
    * {@link Error} causing failure of the current workflow task.
    *
    * @param id unique identifier of this side effect
-   * @param updated used to decide if a new value should be recorded. A func result is recorded only
-   *     if call to updated with stored and a new value as arguments returns true. It is not called
-   *     for the first value.
    * @param resultClass class of the side effect
    * @param resultType type of the side effect. Differs from resultClass for generic types.
+   * @param shouldUpdate used to decide if a new value should be recorded. A func result is recorded
+   *     only if call to updated with stored and a new value as arguments returns true. It is not
+   *     called for the first value.
    * @param func function that produces a value. This function can contain non-deterministic code.
    * @see #sideEffect(Class, Functions.Func)
    */
   public static <R> R mutableSideEffect(
-      String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
-    return WorkflowInternal.mutableSideEffect(id, resultClass, resultType, updated, func);
+      String id,
+      Class<R> resultClass,
+      Type resultType,
+      BiPredicate<? super R, ? super R> shouldUpdate,
+      Func<R> func) {
+    return WorkflowInternal.mutableSideEffect(id, resultClass, resultType, shouldUpdate, func);
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncRetryOptionsChangeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncRetryOptionsChangeTest.java
@@ -85,6 +85,9 @@ public class AsyncRetryOptionsChangeTest {
     public String execute() {
       RetryOptions retryOptions;
       if (WorkflowUnsafe.isReplaying()) {
+        // this change to 3 maximum attempts should be ignored and initial RetryOptions with
+        // maximumAttempts=2
+        // that was persisted into a side effect should be used instead
         retryOptions =
             RetryOptions.newBuilder()
                 .setMaximumInterval(Duration.ofSeconds(1))
@@ -110,9 +113,6 @@ public class AsyncRetryOptionsChangeTest {
                 return Workflow.newFailedPromise(new IllegalThreadStateException("simulated"));
               })
           .get();
-      trace.add("beforeSleep");
-      Workflow.sleep(60000);
-      trace.add("done");
       return "";
     }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -399,7 +399,11 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
 
     @Override
     public <R> R mutableSideEffect(
-        String id, Class<R> resultClass, Type resultType, BiPredicate<R, R> updated, Func<R> func) {
+        String id,
+        Class<R> resultClass,
+        Type resultType,
+        BiPredicate<? super R, ? super R> shouldUpdate,
+        Func<R> func) {
       throw new UnsupportedOperationException("not implemented");
     }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/TracingWorkerInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/TracingWorkerInterceptor.java
@@ -258,12 +258,12 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
         String id,
         Class<R> resultClass,
         Type resultType,
-        BiPredicate<R, R> updated,
+        BiPredicate<? super R, ? super R> shouldUpdate,
         Functions.Func<R> func) {
       if (!WorkflowUnsafe.isReplaying()) {
         trace.add("mutableSideEffect");
       }
-      return next.mutableSideEffect(id, resultClass, resultType, updated, func);
+      return next.mutableSideEffect(id, resultClass, resultType, shouldUpdate, func);
     }
 
     @Override


### PR DESCRIPTION
## What was changed
Some optimizations and cleanup of code persisting RetryOptions into side effects.
Also, some clarifying comments were added.

## Why?
The current code is misleading and will break if SerializableRetryOptions gets a non-default implementation of `equals`.