### PR TITLE
Fix OpenTracingOptions.SpanBuilderProvider setTracer method

### DIFF
--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
@@ -62,8 +62,9 @@ public class OpenTracingOptions {
 
     private Builder() {}
 
-    public void setTracer(Tracer tracer) {
+    public Builder setTracer(Tracer tracer) {
       this.tracer = tracer;
+      return this;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed the signature of the OpenTracingOptions.SpanBuilderProvider setTracer method
## Why?
This is done so we can use the builder approach to set both the tracer and the span builder provider (the same way)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
