### PR TITLE
Added configurable OpenTracingSpanContextCodec to OpenTracingOptions

### DIFF
--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -17,4 +17,5 @@ dependencies {
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
+    testImplementation group: 'io.jaegertracing', name: 'jaeger-client', version: '1.6.0'
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingClientInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingClientInterceptor.java
@@ -21,11 +21,14 @@ package io.temporal.opentracing;
 
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
+import io.temporal.opentracing.internal.ContextAccessor;
 import io.temporal.opentracing.internal.OpenTracingWorkflowClientCallsInterceptor;
 import io.temporal.opentracing.internal.SpanFactory;
 
 public class OpenTracingClientInterceptor extends WorkflowClientInterceptorBase {
   private final OpenTracingOptions options;
+  private final SpanFactory spanFactory;
+  private final ContextAccessor contextAccessor;
 
   public OpenTracingClientInterceptor() {
     this(OpenTracingOptions.getDefaultInstance());
@@ -33,11 +36,14 @@ public class OpenTracingClientInterceptor extends WorkflowClientInterceptorBase 
 
   public OpenTracingClientInterceptor(OpenTracingOptions options) {
     this.options = options;
+    this.spanFactory = new SpanFactory(options);
+    this.contextAccessor = new ContextAccessor(options);
   }
 
   @Override
   public WorkflowClientCallsInterceptor workflowClientCallsInterceptor(
       WorkflowClientCallsInterceptor next) {
-    return new OpenTracingWorkflowClientCallsInterceptor(next, options, new SpanFactory(options));
+    return new OpenTracingWorkflowClientCallsInterceptor(
+        next, options, spanFactory, contextAccessor);
   }
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingSpanContextCodec.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingSpanContextCodec.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.temporal.opentracing.codec.TextMapCodec;
+import io.temporal.opentracing.codec.TextMapInjectExtractCodec;
+import java.util.Map;
+
+/**
+ * Provides an interface for pluggable implementations that provide encoding/decoding of OpenTracing
+ * {@link SpanContext}s back and forth to {@code Map<String, String>} that can be transported inside
+ * Temporal Headers
+ */
+public interface OpenTracingSpanContextCodec {
+  // default implementation
+  OpenTracingSpanContextCodec TEXT_MAP_INJECT_EXTRACT_CODEC = TextMapInjectExtractCodec.INSTANCE;
+  OpenTracingSpanContextCodec TEXT_MAP_CODEC = TextMapCodec.INSTANCE;
+
+  Map<String, String> encode(SpanContext spanContext, Tracer tracer);
+
+  SpanContext decode(Map<String, String> serializedSpanContext, Tracer tracer);
+}

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingWorkerInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingWorkerInterceptor.java
@@ -20,12 +20,15 @@
 package io.temporal.opentracing;
 
 import io.temporal.common.interceptors.*;
+import io.temporal.opentracing.internal.ContextAccessor;
 import io.temporal.opentracing.internal.OpenTracingActivityInboundCallsInterceptor;
 import io.temporal.opentracing.internal.OpenTracingWorkflowInboundCallsInterceptor;
 import io.temporal.opentracing.internal.SpanFactory;
 
 public class OpenTracingWorkerInterceptor implements WorkerInterceptor {
   private final OpenTracingOptions options;
+  private final SpanFactory spanFactory;
+  private final ContextAccessor contextAccessor;
 
   public OpenTracingWorkerInterceptor() {
     this(OpenTracingOptions.getDefaultInstance());
@@ -33,15 +36,19 @@ public class OpenTracingWorkerInterceptor implements WorkerInterceptor {
 
   public OpenTracingWorkerInterceptor(OpenTracingOptions options) {
     this.options = options;
+    this.spanFactory = new SpanFactory(options);
+    this.contextAccessor = new ContextAccessor(options);
   }
 
   @Override
   public WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next) {
-    return new OpenTracingWorkflowInboundCallsInterceptor(next, options, new SpanFactory(options));
+    return new OpenTracingWorkflowInboundCallsInterceptor(
+        next, options, spanFactory, contextAccessor);
   }
 
   @Override
   public ActivityInboundCallsInterceptor interceptActivity(ActivityInboundCallsInterceptor next) {
-    return new OpenTracingActivityInboundCallsInterceptor(next, options, new SpanFactory(options));
+    return new OpenTracingActivityInboundCallsInterceptor(
+        next, options, spanFactory, contextAccessor);
   }
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/codec/TextMapCodec.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/codec/TextMapCodec.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing.codec;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapAdapter;
+import io.temporal.opentracing.OpenTracingSpanContextCodec;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This Encoder uses {@link io.opentracing.propagation.Format.Builtin#TEXT_MAP} for both
+ * serialization and deserialization. This is not a default strategy, for default strategy see
+ * {@link TextMapInjectExtractCodec}. This strategy was added as a workaround if the specific
+ * opentracing client implementation doesn't support {@link
+ * io.opentracing.propagation.Format.Builtin#TEXT_MAP_INJECT} and {@link
+ * io.opentracing.propagation.Format.Builtin#TEXT_MAP_EXTRACT}
+ */
+public class TextMapCodec implements OpenTracingSpanContextCodec {
+  public static final TextMapCodec INSTANCE = new TextMapCodec();
+
+  @Override
+  public Map<String, String> encode(SpanContext spanContext, Tracer tracer) {
+    Map<String, String> serialized = new HashMap<>();
+    tracer.inject(spanContext, Format.Builtin.TEXT_MAP, new TextMapAdapter(serialized));
+    return serialized;
+  }
+
+  @Override
+  public SpanContext decode(Map<String, String> serializedSpanContext, Tracer tracer) {
+    return tracer.extract(Format.Builtin.TEXT_MAP, new TextMapAdapter(serializedSpanContext));
+  }
+}

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/codec/TextMapInjectExtractCodec.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/codec/TextMapInjectExtractCodec.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing.codec;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import io.opentracing.propagation.TextMapInjectAdapter;
+import io.temporal.opentracing.OpenTracingSpanContextCodec;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is the default implementation that uses {@link
+ * io.opentracing.propagation.Format.Builtin#TEXT_MAP_INJECT} and {@link
+ * io.opentracing.propagation.Format.Builtin#TEXT_MAP_EXTRACT} specific formats for serialization
+ * and deserialization respectively
+ */
+public class TextMapInjectExtractCodec implements OpenTracingSpanContextCodec {
+  public static final TextMapInjectExtractCodec INSTANCE = new TextMapInjectExtractCodec();
+
+  @Override
+  public Map<String, String> encode(SpanContext spanContext, Tracer tracer) {
+    Map<String, String> serialized = new HashMap<>();
+    tracer.inject(
+        spanContext, Format.Builtin.TEXT_MAP_INJECT, new TextMapInjectAdapter(serialized));
+    return serialized;
+  }
+
+  @Override
+  public SpanContext decode(Map<String, String> serializedSpanContext, Tracer tracer) {
+    return tracer.extract(
+        Format.Builtin.TEXT_MAP_EXTRACT, new TextMapExtractAdapter(serializedSpanContext));
+  }
+}

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
@@ -35,6 +35,8 @@ import java.util.Map;
  * ID, as tags depending on the context of the operation.
  */
 public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider {
+  public static final ActionTypeAndNameSpanBuilderProvider INSTANCE =
+      new ActionTypeAndNameSpanBuilderProvider();
 
   private static final String PREFIX_DELIMITER = ":";
 

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ContextAccessor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ContextAccessor.java
@@ -22,36 +22,34 @@ package io.temporal.opentracing.internal;
 import com.google.common.reflect.TypeToken;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.propagation.*;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.Header;
+import io.temporal.opentracing.OpenTracingOptions;
+import io.temporal.opentracing.OpenTracingSpanContextCodec;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-class OpenTracingContextAccessor {
+public class ContextAccessor {
   private static final String TRACER_HEADER_KEY = "_tracer-data";
   private static final Type HASH_MAP_STRING_STRING_TYPE =
       new TypeToken<HashMap<String, String>>() {}.getType();
 
-  public static void writeSpanContextToHeader(
-      SpanContext spanContext, Header header, Tracer tracer) {
-    Map<String, String> serializedSpanContext = serializeSpanContextToMap(spanContext, tracer);
+  private final OpenTracingSpanContextCodec codec;
+
+  public ContextAccessor(OpenTracingOptions options) {
+    this.codec = options.getSpanContextCodec();
+  }
+
+  public void writeSpanContextToHeader(SpanContext spanContext, Header header, Tracer tracer) {
+    Map<String, String> serializedSpanContext = codec.encode(spanContext, tracer);
     Optional<Payload> payload = DataConverter.getDefaultInstance().toPayload(serializedSpanContext);
     header.getValues().put(TRACER_HEADER_KEY, payload.get());
   }
 
-  private static Map<String, String> serializeSpanContextToMap(
-      SpanContext spanContext, Tracer tracer) {
-    Map<String, String> serialized = new HashMap<>();
-    tracer.inject(
-        spanContext, Format.Builtin.TEXT_MAP_INJECT, new TextMapInjectAdapter(serialized));
-    return serialized;
-  }
-
-  public static SpanContext readSpanContextFromHeader(Header header, Tracer tracer) {
+  public SpanContext readSpanContextFromHeader(Header header, Tracer tracer) {
     Payload payload = header.getValues().get(TRACER_HEADER_KEY);
     if (payload == null) {
       return null;
@@ -59,12 +57,6 @@ class OpenTracingContextAccessor {
     Map<String, String> serializedSpanContext =
         DataConverter.getDefaultInstance()
             .fromPayload(payload, HashMap.class, HASH_MAP_STRING_STRING_TYPE);
-    return deserializeSpanContextFromMap(serializedSpanContext, tracer);
-  }
-
-  private static SpanContext deserializeSpanContextFromMap(
-      Map<String, String> serializedSpanContext, Tracer tracer) {
-    return tracer.extract(
-        Format.Builtin.TEXT_MAP_EXTRACT, new TextMapExtractAdapter(serializedSpanContext));
+    return codec.decode(serializedSpanContext, tracer);
   }
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -33,12 +33,19 @@ public class OpenTracingActivityInboundCallsInterceptor
     extends ActivityInboundCallsInterceptorBase {
   private final OpenTracingOptions options;
   private final SpanFactory spanFactory;
+  private final Tracer tracer;
+  private final ContextAccessor contextAccessor;
 
   public OpenTracingActivityInboundCallsInterceptor(
-      ActivityInboundCallsInterceptor next, OpenTracingOptions options, SpanFactory spanFactory) {
+      ActivityInboundCallsInterceptor next,
+      OpenTracingOptions options,
+      SpanFactory spanFactory,
+      ContextAccessor contextAccessor) {
     super(next);
     this.options = options;
     this.spanFactory = spanFactory;
+    this.tracer = options.getTracer();
+    this.contextAccessor = contextAccessor;
   }
 
   private ActivityExecutionContext activityExecutionContext;
@@ -54,9 +61,8 @@ public class OpenTracingActivityInboundCallsInterceptor
 
   @Override
   public ActivityOutput execute(ActivityInput input) {
-    Tracer tracer = options.getTracer();
     SpanContext rootSpanContext =
-        OpenTracingContextAccessor.readSpanContextFromHeader(input.getHeader(), tracer);
+        contextAccessor.readSpanContextFromHeader(input.getHeader(), tracer);
     ActivityInfo activityInfo = activityExecutionContext.getInfo();
     Span activityRunSpan =
         spanFactory

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
@@ -30,12 +30,17 @@ import io.temporal.opentracing.SpanOperationType;
 public class OpenTracingWorkflowClientCallsInterceptor extends WorkflowClientCallsInterceptorBase {
   private final SpanFactory spanFactory;
   private final Tracer tracer;
+  private final ContextAccessor contextAccessor;
 
   public OpenTracingWorkflowClientCallsInterceptor(
-      WorkflowClientCallsInterceptor next, OpenTracingOptions options, SpanFactory spanFactory) {
+      WorkflowClientCallsInterceptor next,
+      OpenTracingOptions options,
+      SpanFactory spanFactory,
+      ContextAccessor contextAccessor) {
     super(next);
     this.spanFactory = spanFactory;
     this.tracer = options.getTracer();
+    this.contextAccessor = contextAccessor;
   }
 
   @Override
@@ -63,7 +68,7 @@ public class OpenTracingWorkflowClientCallsInterceptor extends WorkflowClientCal
   private Span createAndPassWorkflowStartSpan(
       WorkflowStartInput input, SpanOperationType operationType) {
     Span span = createWorkflowStartSpanBuilder(input, operationType).start();
-    OpenTracingContextAccessor.writeSpanContextToHeader(span.context(), input.getHeader(), tracer);
+    contextAccessor.writeSpanContextToHeader(span.context(), input.getHeader(), tracer);
     return span;
   }
 

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowInboundCallsInterceptor.java
@@ -33,25 +33,31 @@ public class OpenTracingWorkflowInboundCallsInterceptor
     extends WorkflowInboundCallsInterceptorBase {
   private final OpenTracingOptions options;
   private final SpanFactory spanFactory;
+  private final ContextAccessor contextAccessor;
 
   public OpenTracingWorkflowInboundCallsInterceptor(
-      WorkflowInboundCallsInterceptor next, OpenTracingOptions options, SpanFactory spanFactory) {
+      WorkflowInboundCallsInterceptor next,
+      OpenTracingOptions options,
+      SpanFactory spanFactory,
+      ContextAccessor contextAccessor) {
     super(next);
     this.options = options;
     this.spanFactory = spanFactory;
+    this.contextAccessor = contextAccessor;
   }
 
   @Override
   public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
     super.init(
-        new OpenTracingWorkflowOutboundCallsInterceptor(outboundCalls, options, spanFactory));
+        new OpenTracingWorkflowOutboundCallsInterceptor(
+            outboundCalls, options, spanFactory, contextAccessor));
   }
 
   @Override
   public WorkflowOutput execute(WorkflowInput input) {
     Tracer tracer = options.getTracer();
     SpanContext rootSpanContext =
-        OpenTracingContextAccessor.readSpanContextFromHeader(input.getHeader(), tracer);
+        contextAccessor.readSpanContextFromHeader(input.getHeader(), tracer);
     Span workflowRunSpan =
         spanFactory
             .createWorkflowRunSpan(

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowOutboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowOutboundCallsInterceptor.java
@@ -33,12 +33,17 @@ public class OpenTracingWorkflowOutboundCallsInterceptor
     extends WorkflowOutboundCallsInterceptorBase {
   private final SpanFactory spanFactory;
   private final Tracer tracer;
+  private final ContextAccessor contextAccessor;
 
   public OpenTracingWorkflowOutboundCallsInterceptor(
-      WorkflowOutboundCallsInterceptor next, OpenTracingOptions options, SpanFactory spanFactory) {
+      WorkflowOutboundCallsInterceptor next,
+      OpenTracingOptions options,
+      SpanFactory spanFactory,
+      ContextAccessor contextAccessor) {
     super(next);
     this.spanFactory = spanFactory;
     this.tracer = options.getTracer();
+    this.contextAccessor = contextAccessor;
   }
 
   @Override
@@ -87,7 +92,7 @@ public class OpenTracingWorkflowOutboundCallsInterceptor
 
   private Span createAndPassActivityStartSpan(String activityName, Header header) {
     Span span = createActivityStartSpanBuilder(activityName).start();
-    OpenTracingContextAccessor.writeSpanContextToHeader(span.context(), header, tracer);
+    contextAccessor.writeSpanContextToHeader(span.context(), header, tracer);
     return span;
   }
 
@@ -103,7 +108,7 @@ public class OpenTracingWorkflowOutboundCallsInterceptor
 
   private <R> Span createAndPassChildWorkflowStartSpan(ChildWorkflowInput<R> input) {
     Span span = createChildWorkflowStartSpanBuilder(tracer, input).start();
-    OpenTracingContextAccessor.writeSpanContextToHeader(span.context(), input.getHeader(), tracer);
+    contextAccessor.writeSpanContextToHeader(span.context(), input.getHeader(), tracer);
     return span;
   }
 

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/provider/DataDogOpenTracingSpanBuilderProvider.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/provider/DataDogOpenTracingSpanBuilderProvider.java
@@ -37,6 +37,8 @@ import java.util.Map;
  * for the datadog standard tag names.
  */
 public class DataDogOpenTracingSpanBuilderProvider extends ActionTypeAndNameSpanBuilderProvider {
+  public static final DataDogOpenTracingSpanBuilderProvider INSTANCE =
+      new DataDogOpenTracingSpanBuilderProvider();
 
   private static final String DD_RESOURCE_NAME_TAG = "resource.name";
 

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/integration/JaegerTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/integration/JaegerTest.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing.integration;
+
+import static org.junit.Assert.*;
+
+import io.jaegertracing.internal.JaegerSpan;
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.InMemoryReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.jaegertracing.spi.Sampler;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.opentracing.*;
+import io.temporal.testing.TestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import java.util.List;
+import org.junit.*;
+
+public class JaegerTest {
+  private static final OpenTracingOptions JAEGER_COMPATIBLE_CONFIG =
+      OpenTracingOptions.newBuilder()
+          .setSpanContextCodec(OpenTracingSpanContextCodec.TEXT_MAP_CODEC)
+          .build();
+
+  private InMemoryReporter reporter;
+  private Sampler sampler;
+  private Tracer tracer;
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder()
+                  .setInterceptors(new OpenTracingClientInterceptor(JAEGER_COMPATIBLE_CONFIG))
+                  .validateAndBuildWithDefaults())
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new OpenTracingWorkerInterceptor(JAEGER_COMPATIBLE_CONFIG))
+                  .validateAndBuildWithDefaults())
+          .setWorkflowTypes(WorkflowImpl.class)
+          .setActivityImplementations(new ActivityImpl())
+          .build();
+
+  @Before
+  public void setUp() {
+    reporter = new InMemoryReporter();
+    sampler = new ConstSampler(true);
+    tracer =
+        new JaegerTracer.Builder("temporal-test")
+            .withReporter(reporter)
+            .withSampler(sampler)
+            .build();
+
+    GlobalTracer.registerIfAbsent(tracer);
+  }
+
+  @After
+  public void tearDown() {
+    reporter.close();
+    sampler.close();
+    tracer.close();
+  }
+
+  @ActivityInterface
+  public interface TestActivity {
+    @ActivityMethod
+    String activity(String input);
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String workflow(String input);
+  }
+
+  public static class ActivityImpl implements TestActivity {
+    @Override
+    public String activity(String input) {
+      return "bar";
+    }
+  }
+
+  public static class WorkflowImpl implements TestWorkflow {
+    private final TestActivity activity =
+        Workflow.newActivityStub(
+            TestActivity.class,
+            ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofMinutes(1))
+                .validateAndBuildWithDefaults());
+
+    @Override
+    public String workflow(String input) {
+      return activity.activity(input);
+    }
+  }
+
+  @Test
+  public void trivialTest() {
+    Span span = tracer.buildSpan("ClientFunction").start();
+
+    WorkflowClient client = testWorkflowRule.getWorkflowClient();
+    try (Scope scope = tracer.scopeManager().activate(span)) {
+      TestWorkflow workflow =
+          client.newWorkflowStub(
+              TestWorkflow.class,
+              WorkflowOptions.newBuilder()
+                  .setTaskQueue(testWorkflowRule.getTaskQueue())
+                  .validateBuildWithDefaults());
+      assertEquals("bar", workflow.workflow("input"));
+    } finally {
+      span.finish();
+    }
+
+    List<JaegerSpan> reportedSpans = reporter.getSpans();
+    assertNotNull(reportedSpans);
+    assertTrue(reportedSpans.size() > 1);
+  }
+}


### PR DESCRIPTION
## What was changed
Added configurable `OpenTracingSpanContextCodec` to `OpenTracingOptions` and two implementations. 
One default: `TextMapInjectExtractCodec` that implements the old original behavior
One new: `TextMapCodec` that implements encoding using OpenTracing's TEXT_MAP Format.

## Why?
Jeager doesn't support `TEXT_MAP_INJECT` and `TEXT_MAP_EXTRACT` OpenTracing encoding formats. See https://github.com/jaegertracing/jaeger-client-java/issues/789
To provide a workaround we implement encoding using another strategy.

1. Closes
Issue #621

2. How was this tested:
Jaeger-specific integration test