### PR TITLE
Stop enforcing TestWorkflowRule timeout when run in JVM debug mode, respect JUnit(timeout) over TestRule timeout

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/DebugModeUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/DebugModeUtils.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.common;
+
+public class  DebugModeUtils {
+  private static final boolean TEMPORAL_DEBUG_MODE = readTemporalDebugModeFromEnvVar();
+
+  public static boolean isTemporalDebugModeOn() {
+    return TEMPORAL_DEBUG_MODE;
+  }
+
+  private static boolean readTemporalDebugModeFromEnvVar() {
+    String temporalDebugValue = System.getenv("TEMPORAL_DEBUG");
+    if (temporalDebugValue == null) {
+      return false;
+    }
+    temporalDebugValue = temporalDebugValue.trim();
+    return  (!Boolean.FALSE.toString().equalsIgnoreCase(temporalDebugValue) && !"0".equals(temporalDebugValue));
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -19,24 +19,25 @@
 
 package io.temporal.internal.sync;
 
+import io.temporal.internal.common.DebugModeUtils;
 import io.temporal.internal.replay.WorkflowExecutorCache;
 import io.temporal.workflow.CancellationScope;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 
 /**
- * Executes code passed to {@link #newRunner(Runnable)} as well as threads created from it using
- * {@link WorkflowThread#newThread(Runnable, boolean)} deterministically. Requires use of provided
- * wrappers for synchronization and notification instead of native ones.
+ * Executes code passed to {@link #newRunner} as well as threads created from it using {@link
+ * WorkflowThread#newThread(Runnable, boolean)} deterministically. Requires use of provided wrappers
+ * for synchronization and notification instead of native ones.
  */
 interface DeterministicRunner {
-
-  boolean debugMode = System.getenv("TEMPORAL_DEBUG") != null;
 
   long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 1000;
 
   static long getDeadlockDetectionTimeout() {
-    return debugMode ? Long.MAX_VALUE : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
+    return DebugModeUtils.isTemporalDebugModeOn()
+        ? Long.MAX_VALUE
+        : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
   }
 
   static DeterministicRunner newRunner(SyncWorkflowContext workflowContext, Runnable root) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DeadlockDetectorTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.internal.common.DebugModeUtils;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.WorkflowImplementationOptions;
 import io.temporal.workflow.shared.SDKTestWorkflowRule;
@@ -35,8 +36,7 @@ import org.junit.Test;
 
 public class DeadlockDetectorTest {
 
-  private boolean debugMode = System.getenv("TEMPORAL_DEBUG") != null;
-  private WorkflowImplementationOptions workflowImplementationOptions =
+  private final WorkflowImplementationOptions workflowImplementationOptions =
       WorkflowImplementationOptions.newBuilder()
           .setFailWorkflowExceptionTypes(Throwable.class)
           .build();
@@ -67,11 +67,11 @@ public class DeadlockDetectorTest {
                 .build());
     try {
       workflow.execute(2000);
-      if (!debugMode) {
+      if (!DebugModeUtils.isTemporalDebugModeOn()) {
         fail("not reachable in non-debug mode");
       }
     } catch (WorkflowFailedException e) {
-      if (debugMode) {
+      if (DebugModeUtils.isTemporalDebugModeOn()) {
         fail("not reachable in debug mode");
       }
       Throwable failure = e;
@@ -95,11 +95,11 @@ public class DeadlockDetectorTest {
                 .build());
     try {
       workflow.execute(750);
-      if (!debugMode) {
+      if (!DebugModeUtils.isTemporalDebugModeOn()) {
         fail("not reachable in non-debug mode");
       }
     } catch (WorkflowFailedException e) {
-      if (debugMode) {
+      if (DebugModeUtils.isTemporalDebugModeOn()) {
         fail("not reachable in debug mode");
       }
       Throwable failure = e;


### PR DESCRIPTION
## What was changed
We now don't apply `globalTimeout` in `TestWorkflowRule` in case an explicit `@Test(timeout)` is provided.
We now also don't enforce `globalTimeout` if TEMPORAL_DEBUG env variable is set.

## Why?
Now during breakpoints-based debugging, there is no way to turn off the default 10 seconds limit which is annoying and hurts productivity.
Also, there is no reason to enforce global timeout if the test has a timeout specified on a test level, we always should prioritize more specific settings.

Resolves #632, resolves #612