### PR TITLE
Dependency Update

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-        errorprone('com.google.errorprone:error_prone_core:2.8.0')
+        errorprone('com.google.errorprone:error_prone_core:2.8.1')
     }
 
     compileJava {

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -3,7 +3,7 @@ description = '''Temporal Workflow Java SDK'''
 dependencies {
     api project(':temporal-serviceclient')
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.7'
-    api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.2'
+    api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.3'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'


### PR DESCRIPTION
> Task :temporal-kotlin:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1
New dependency version: com.pinterest:ktlint: 0.41.0 -> 0.42.1

> Task :temporal-opentracing:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1
New dependency version: io.micrometer:micrometer-core: 1.7.2 -> 1.7.3

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.11.1

> Task :temporal-testing:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1

> Task :temporal-testing-junit4:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1

> Task :temporal-testing-junit5:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.0 -> 2.8.1