### PR TITLE
Prevent confusing NPE when throwing deadlock errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,6 @@ To generate licence headers execute
 ./gradlew licenseFormat
 ```
 
-## Commit Messages
-
-Overcommit adds some requirements to your commit messages. At Uber, we follow the
-[Chris Beams](http://chris.beams.io/posts/git-commit/) guide to writing git
-commit messages. Read it, follow it, learn it, love it.
-
 ## Test and Build
 
 Testing and building temporal-java-sdk requires running temporal docker locally, execute:

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
@@ -22,7 +22,7 @@ package io.temporal.internal.sync;
 /**
  * A workflow tasks are allowed to execute only some limited amount of time without interruption. If
  * workflow task runs longer than specified interval without yielding (like calling an Activity), it
- * will fail automatically with this exceptions. This is done to detect deadlocks in workflows and
+ * will fail automatically with this exception. This is done to detect deadlocks in workflows and
  * based on the assumptions that workflow code shouldn't be blocking.
  */
 public class PotentialDeadlockException extends RuntimeException {
@@ -41,7 +41,9 @@ public class PotentialDeadlockException extends RuntimeException {
         null,
         true,
         true);
-    setStackTrace(stackTrace);
+    if (stackTrace != null) {
+      setStackTrace(stackTrace);
+    }
     this.workflowThreadContext = workflowThreadContext;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -230,6 +230,11 @@ public class WorkflowThreadContext {
       yieldCondition.signal();
       while (status == Status.RUNNING || status == Status.CREATED) {
         if (!runCondition.await(deadlockDetectionTimeout, TimeUnit.MILLISECONDS)) {
+          // There's a potential race here where the thread can get cleared out before the condvar
+          // times out.
+          if (currentThread == null) {
+            throw new PotentialDeadlockException("UnknownThread", null, this);
+          }
           throw new PotentialDeadlockException(
               currentThread.getName(), currentThread.getStackTrace(), this);
         }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix NPE that could be generated in the middle of generating a deadlock exception

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
