### PR TITLE
Cleanup DeterministicRunner constructors to improve resource management

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -40,10 +40,6 @@ interface DeterministicRunner {
         : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
   }
 
-  static DeterministicRunner newRunner(SyncWorkflowContext workflowContext, Runnable root) {
-    return new DeterministicRunnerImpl(workflowContext, root);
-  }
-
   /**
    * Create new instance of DeterministicRunner
    *

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -39,9 +39,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nonnull;
@@ -130,10 +127,6 @@ class DeterministicRunnerImpl implements DeterministicRunner {
   private Object exitValue;
   private WorkflowThread rootWorkflowThread;
   private final CancellationScopeImpl runnerCancellationScope;
-
-  DeterministicRunnerImpl(@Nonnull SyncWorkflowContext workflowContext, Runnable root) {
-    this(getDefaultThreadPool(), workflowContext, root, null);
-  }
 
   DeterministicRunnerImpl(
       ExecutorService threadPool, @Nonnull SyncWorkflowContext workflowContext, Runnable root) {
@@ -505,13 +498,6 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     } else {
       return workflowContext.getContext().getContextPropagators();
     }
-  }
-
-  private static ThreadPoolExecutor getDefaultThreadPool() {
-    ThreadPoolExecutor result =
-        new ThreadPoolExecutor(0, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
-    result.setThreadFactory(r -> new Thread(r, "deterministic runner thread"));
-    return result;
   }
 
   private static class WorkflowThreadMarkerAccessor extends WorkflowThreadMarker {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -239,9 +239,9 @@ public class WorkflowThreadContext {
         boolean awaitTimedOut =
             !runCondition.await(deadlockDetectionTimeout, TimeUnit.MILLISECONDS);
         if (awaitTimedOut
-              // check that the condition is still true after acquiring the lock back (it could be moved
-              // into DONE meanwhile)
-              && potentialDeadlockStatesLocked()) {
+            // check that the condition is still true after acquiring the lock back
+            // (it could be moved into DONE meanwhile)
+            && potentialDeadlockStatesLocked()) {
           if (currentThread != null) {
             throw new PotentialDeadlockException(
                 currentThread.getName(), currentThread.getStackTrace(), this);
@@ -275,7 +275,8 @@ public class WorkflowThreadContext {
   /**
    * Should be called under the lock.
    *
-   * @return true is current status is RUNNING or CREATED - two states we actively monitor for potential deadlocks
+   * @return true is current status is RUNNING or CREATED - two states we actively monitor for
+   *     potential deadlocks
    */
   private boolean potentialDeadlockStatesLocked() {
     return status == Status.RUNNING || status == Status.CREATED;

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
@@ -39,19 +39,30 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.IllegalFormatCodePointException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.concurrent.*;
+import org.junit.*;
 
 public class PromiseTest {
 
   @Rule public final Tracer trace = new Tracer();
 
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = new ThreadPoolExecutor(1, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    threadPool.shutdown();
+  }
+
   @Test
   public void testFailure() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<Boolean> f = Workflow.newPromise();
@@ -86,6 +97,7 @@ public class PromiseTest {
   public void testGet() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
@@ -106,6 +118,7 @@ public class PromiseTest {
   public void testCancellableGet() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
@@ -126,6 +139,7 @@ public class PromiseTest {
   public void testCancellableGetCancellation() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
@@ -200,6 +214,7 @@ public class PromiseTest {
   public void testMultiple() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -254,6 +269,7 @@ public class PromiseTest {
   public void tstAsync() {
     DeterministicRunner runner =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -288,6 +304,7 @@ public class PromiseTest {
   public void testAsyncFailure() {
     DeterministicRunner runner =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -331,6 +348,7 @@ public class PromiseTest {
   public void testAllOf() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -391,6 +409,7 @@ public class PromiseTest {
   public void testAllOfImmediatelyReady() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -433,6 +452,7 @@ public class PromiseTest {
   public void testAnyOf() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -494,6 +514,7 @@ public class PromiseTest {
   public void testAllOfArray() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -555,6 +576,7 @@ public class PromiseTest {
   public void testAnyOfArray() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -617,6 +639,7 @@ public class PromiseTest {
   public void testAnyOfImmediatelyReady() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
@@ -31,18 +31,34 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.*;
 
 @SuppressWarnings("deprecation")
 public class WorkflowInternalDeprecatedQueueTest {
 
   @Rule public final Tracer trace = new Tracer();
 
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = new ThreadPoolExecutor(1, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    threadPool.shutdown();
+  }
+
   @Test
   public void testTakeBlocking() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -83,6 +99,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -117,6 +134,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testCancellableTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -273,6 +291,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testPutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -308,6 +327,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testCancellablePutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -343,6 +363,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testMap() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(1);

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -35,17 +35,33 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.*;
 
 public class WorkflowInternalQueueTest {
 
   @Rule public final Tracer trace = new Tracer();
 
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = new ThreadPoolExecutor(1, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    threadPool.shutdown();
+  }
+
   @Test
   public void testTakeBlocking() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -86,6 +102,7 @@ public class WorkflowInternalQueueTest {
   public void testTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -120,6 +137,7 @@ public class WorkflowInternalQueueTest {
   public void testCancellableTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -276,6 +294,7 @@ public class WorkflowInternalQueueTest {
   public void testPutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -311,6 +330,7 @@ public class WorkflowInternalQueueTest {
   public void testCancellablePutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -346,6 +366,7 @@ public class WorkflowInternalQueueTest {
   public void testMap() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Integer> queue = WorkflowInternal.newWorkflowQueue(1);
@@ -399,6 +420,7 @@ public class WorkflowInternalQueueTest {
     int[] result = new int[3];
     DeterministicRunner r =
         DeterministicRunner.newRunner(
+            threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               queue.put(1);

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
@@ -22,15 +22,16 @@ package io.temporal.internal.sync;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.*;
 
 public class DeterministicRunnerWrapper implements InvocationHandler {
-
   private final InvocationHandler invocationHandler;
+  private final ExecutorService executorService;
 
-  public DeterministicRunnerWrapper(InvocationHandler invocationHandler) {
+  public DeterministicRunnerWrapper(
+      InvocationHandler invocationHandler, ExecutorService executorService) {
     this.invocationHandler = Objects.requireNonNull(invocationHandler);
+    this.executorService = Objects.requireNonNull(executorService);
   }
 
   @Override
@@ -38,6 +39,7 @@ public class DeterministicRunnerWrapper implements InvocationHandler {
     CompletableFuture<Object> result = new CompletableFuture<>();
     DeterministicRunner runner =
         new DeterministicRunnerImpl(
+            executorService,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               try {


### PR DESCRIPTION
Remove constructor of DeterministicRunner that creates a ThreadPool inside without ever closing it. This constructor was used in tests only.

## Why?
Removes test-only code from the main codebase and improve resources management in tests