### PR TITLE
docs: Fix heartbeat spelling in ActivityExecutionContext

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
@@ -73,8 +73,8 @@ public interface ActivityExecutionContext {
    * Task for the next retry attempt. The Activity implementation can extract the details via {@link
    * #getHeartbeatDetails(Class)}() and resume progress.
    *
-   * @param detailsClass Class of the heartbeat details
-   * @param detailsType Type of the Heatbeat details
+   * @param detailsClass Class of the Heartbeat details
+   * @param detailsType Type of the Heartbeat details
    */
   <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass, Type detailsType);
 


### PR DESCRIPTION
## What was changed

* Correct Heartbeat spelling in ActivityExecutionContext
* Capitalize Heartbeat for consistency

## Why?

missing `r`