### PR TITLE
Dependency Update

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -23,7 +23,7 @@ subprojects {
 
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-        errorprone('com.google.errorprone:error_prone_core:2.8.1')
+        errorprone('com.google.errorprone:error_prone_core:2.9.0')
     }
 
     compileJava {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.1'
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
     testImplementation group: 'io.jaegertracing', name: 'jaeger-client', version: '1.6.0'
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -2,7 +2,7 @@ description = '''Temporal Workflow Java SDK'''
 
 dependencies {
     api project(':temporal-serviceclient')
-    api group: 'com.google.code.gson', name: 'gson', version: '2.8.7'
+    api group: 'com.google.code.gson', name: 'gson', version: '2.8.8'
     api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.3'
 
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
@@ -15,7 +15,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.1'
 }
 
 task registerNamespace(type: JavaExec) {

--- a/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
@@ -59,8 +59,8 @@ public final class ApplicationFailure extends TemporalFailure {
   /**
    * New ApplicationFailure with {@link #isNonRetryable()} flag set to false.
    *
-   * <p>Note that this exception still may not be retried by the service if its type is included
-   * in the doNotRetry property of the correspondent retry policy.
+   * <p>Note that this exception still may not be retried by the service if its type is included in
+   * the doNotRetry property of the correspondent retry policy.
    *
    * @param message optional error message
    * @param type optional error type that is used by {@link
@@ -75,8 +75,8 @@ public final class ApplicationFailure extends TemporalFailure {
   /**
    * New ApplicationFailure with {@link #isNonRetryable()} flag set to false.
    *
-   * <p>Note that this exception still may not be retried by the service if its type is included
-   * in the doNotRetry property of the correspondent retry policy.
+   * <p>Note that this exception still may not be retried by the service if its type is included in
+   * the doNotRetry property of the correspondent retry policy.
    *
    * @param message optional error message
    * @param type optional error type that is used by {@link
@@ -111,7 +111,8 @@ public final class ApplicationFailure extends TemporalFailure {
   /**
    * New ApplicationFailure with {@link #isNonRetryable()} flag set to true.
    *
-   * <p>This exception will not be retried even if it is absent from the retry policy doNotRetry list.
+   * <p>This exception will not be retried even if it is absent from the retry policy doNotRetry
+   * list.
    *
    * @param message optional error message
    * @param type error type

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    api 'io.grpc:grpc-protobuf:1.39.0'
-    api 'io.grpc:grpc-stub:1.39.0'
-    api 'io.grpc:grpc-core:1.39.0'
-    api 'io.grpc:grpc-netty-shaded:1.39.0'
-    api 'io.grpc:grpc-services:1.39.0'
+    api 'io.grpc:grpc-protobuf:1.40.0'
+    api 'io.grpc:grpc-stub:1.40.0'
+    api 'io.grpc:grpc-core:1.40.0'
+    api 'io.grpc:grpc-netty-shaded:1.40.0'
+    api 'io.grpc:grpc-services:1.40.0'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.3'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
@@ -19,7 +19,7 @@ dependencies {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
@@ -47,7 +47,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.39.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.40.0'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
> Task :temporal-kotlin:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0
New dependency version: com.pinterest:ktlint: 0.41.0 -> 0.42.1

> Task :temporal-kotlin:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)

> Task :temporal-opentracing:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0
New dependency version: org.mockito:mockito-core: 3.11.2 -> 3.12.1

> Task :temporal-opentracing:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.google.code.gson:gson: 2.8.7 -> 2.8.8
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0
New dependency version: org.mockito:mockito-core: 3.11.2 -> 3.12.1

> Task :temporal-sdk:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.11.1
New dependency version: io.grpc:grpc-core: 1.39.0 -> 1.40.0
New dependency version: io.grpc:grpc-netty-shaded: 1.39.0 -> 1.40.0
New dependency version: io.grpc:grpc-protobuf: 1.39.0 -> 1.40.0
New dependency version: io.grpc:grpc-services: 1.39.0 -> 1.40.0
New dependency version: io.grpc:grpc-stub: 1.39.0 -> 1.40.0
New dependency version: io.grpc:protoc-gen-grpc-java: 1.39.0 -> 1.40.0
New dependency version: org.mockito:mockito-core: 3.11.2 -> 3.12.1

> Task :temporal-serviceclient:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)

> Task :temporal-testing:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0

> Task :temporal-testing:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)

> Task :temporal-testing-junit4:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0

> Task :temporal-testing-junit4:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)

> Task :temporal-testing-junit5:checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.8.1 -> 2.9.0

> Task :temporal-testing-junit5:checkGradleUpdates
New Gradle version is available: 7.2 (downloadUrl: https://services.gradle.org/distributions/gradle-7.2-bin.zip)