### PR TITLE
Dependency Update

### DIFF
--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 //    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
 //    id 'org.jetbrains.kotlin.jvm' version '1.4.21'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.21'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.30'
 
     id 'org.jlleitschuh.gradle.ktlint' version '10.1.0'
 }
@@ -11,7 +11,7 @@ description = '''Temporal Workflow Java SDK Kotlin'''
 ext {
 //    kotlinVersion = '1.3.72'
 //    kotlinVersion = '1.4.21'
-    kotlinVersion = '1.5.21'
+    kotlinVersion = '1.5.30'
 }
 
 compileKotlin {
@@ -31,8 +31,8 @@ dependencies {
 
     implementation project(':temporal-sdk')
 
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.4'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.12.4'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.5'
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.12.5'
 
     testImplementation project(':temporal-testing')
     testImplementation project(':temporal-testing-junit4')

--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
     testImplementation group: 'io.jaegertracing', name: 'jaeger-client', version: '1.6.0'
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -8,14 +8,14 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.4'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.4'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.5'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
 }
 
 task registerNamespace(type: JavaExec) {

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    api 'io.grpc:grpc-protobuf:1.40.0'
-    api 'io.grpc:grpc-stub:1.40.0'
-    api 'io.grpc:grpc-core:1.40.0'
-    api 'io.grpc:grpc-netty-shaded:1.40.0'
-    api 'io.grpc:grpc-services:1.40.0'
+    api 'io.grpc:grpc-protobuf:1.40.1'
+    api 'io.grpc:grpc-stub:1.40.1'
+    api 'io.grpc:grpc-core:1.40.1'
+    api 'io.grpc:grpc-netty-shaded:1.40.1'
+    api 'io.grpc:grpc-services:1.40.1'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.17.3'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
@@ -19,7 +19,7 @@ dependencies {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
@@ -47,7 +47,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.40.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.40.1'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
> Task :temporal-kotlin:checkDependencyUpdates
New dependency version: com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.12.4 -> 2.12.5
New dependency version: com.fasterxml.jackson.module:jackson-module-kotlin: 2.12.4 -> 2.12.5
New dependency version: com.pinterest:ktlint: 0.41.0 -> 0.42.1
New dependency version: org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable: 1.5.21 -> 1.5.30
New dependency version: org.jetbrains.kotlin:kotlin-stdlib: 1.5.21 -> 1.5.30
New dependency version: org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin: 1.5.21 -> 1.5.30

> Task :temporal-opentracing:checkDependencyUpdates
New dependency version: org.mockito:mockito-core: 3.12.1 -> 3.12.4

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.fasterxml.jackson.core:jackson-databind: 2.12.4 -> 2.12.5
New dependency version: com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.12.4 -> 2.12.5
New dependency version: org.mockito:mockito-core: 3.12.1 -> 3.12.4

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.11.1
New dependency version: io.grpc:grpc-core: 1.40.0 -> 1.40.1
New dependency version: io.grpc:grpc-netty-shaded: 1.40.0 -> 1.40.1
New dependency version: io.grpc:grpc-protobuf: 1.40.0 -> 1.40.1
New dependency version: io.grpc:grpc-services: 1.40.0 -> 1.40.1
New dependency version: io.grpc:grpc-stub: 1.40.0 -> 1.40.1
New dependency version: io.grpc:protoc-gen-grpc-java: 1.40.0 -> 1.40.1
New dependency version: org.mockito:mockito-core: 3.12.1 -> 3.12.4

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.2/userguide/command_line_interface.html#sec:command_line_warnings