### PR TITLE
Call health check on intercepted channel

### DIFF
--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
@@ -30,32 +30,16 @@ public class HealthCheckTest {
 
   private static final boolean useDockerService =
       Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
-  private static final String HEALTH_CHECK_SERVICE_NAME =
-      "temporal.api.workflowservice.v1.WorkflowService";
 
   @Test
   public void testHealthCheck() {
     if (useDockerService) {
       try {
-        WorkflowServiceStubsImpl service =
-            (WorkflowServiceStubsImpl) WorkflowServiceStubs.newInstance();
-        service.checkHealth(HEALTH_CHECK_SERVICE_NAME);
+        // Stub creation triggers health check by default, unless disableHealthCheck flag is set in
+        // the WorkflowServiceStubsOptions.
+        WorkflowServiceStubs.newInstance();
       } catch (Exception e) {
         Assert.fail("Health check failed");
-      }
-    }
-  }
-
-  @Test
-  public void testUnhealthyStatus() {
-    if (useDockerService) {
-      try {
-        WorkflowServiceStubsImpl service =
-            (WorkflowServiceStubsImpl) WorkflowServiceStubs.newInstance();
-        service.checkHealth("IncorrectServiceName");
-        Assert.fail("Health check for IncorrectServiceName should fail");
-      } catch (RuntimeException e) {
-        Assert.assertTrue(e.getMessage().startsWith("Health check returned unhealthy status: "));
       }
     }
   }


### PR DESCRIPTION
## What was changed
Health check is now getting called on the intercepted channel, which allows attaching custom headers.

## Why?
From what Emin Demirci wrote:
```
It seem that the newly introduced healthchecks are not honoring the configured stub interceptors. In case of server requires an authentication and those authentication tokens retrieved via client interceptors, healtcheck mechanism gets unauthorized request errors. 
My suggestion would be either:
* Exclude the healthcheck endpoint from the list of authenticated endpoints
* Change java-sdk to use the intercepted channels while setting up the healthcheck grpc stub instead of the plain one.
```