### PR TITLE
Cleanup naming inside AuthorizationGrpcMetadataProvider

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
@@ -94,7 +94,7 @@ public class AuthorizationTokenTest {
                           new GrpcRequest(
                               method.getBareMethodName(),
                               headers.get(
-                                  AuthorizationGrpcMetadataProvider.JWT_AUTHORIZATION_HEADER_KEY)));
+                                  AuthorizationGrpcMetadataProvider.AUTHORIZATION_HEADER_KEY)));
                       super.start(responseListener, headers);
                     }
                   }

--- a/temporal-serviceclient/src/main/java/io/temporal/authorization/AuthorizationGrpcMetadataProvider.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/authorization/AuthorizationGrpcMetadataProvider.java
@@ -23,7 +23,7 @@ import io.grpc.Metadata;
 import io.temporal.serviceclient.GrpcMetadataProvider;
 
 public class AuthorizationGrpcMetadataProvider implements GrpcMetadataProvider {
-  public static final Metadata.Key<String> JWT_AUTHORIZATION_HEADER_KEY =
+  public static final Metadata.Key<String> AUTHORIZATION_HEADER_KEY =
       Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
 
   private final AuthorizationTokenSupplier authorizationTokenSupplier;
@@ -36,7 +36,7 @@ public class AuthorizationGrpcMetadataProvider implements GrpcMetadataProvider {
   @Override
   public Metadata getMetadata() {
     Metadata metadata = new Metadata();
-    metadata.put(JWT_AUTHORIZATION_HEADER_KEY, authorizationTokenSupplier.supply());
+    metadata.put(AUTHORIZATION_HEADER_KEY, authorizationTokenSupplier.supply());
     return metadata;
   }
 }


### PR DESCRIPTION
Just a cleanup of naming for AuthorizationGrpcMetadataProvider constant to make it not JWT specific.