### PR TITLE
Ensure proper thread safety in AuthorizationTokenTest to fix flaky test

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AuthorizationTokenTest {
-
   private static final Logger log = LoggerFactory.getLogger(AuthorizationTokenTest.class);
   private static final String TASK_QUEUE = "test-workflow";
   private static final String AUTH_TOKEN = "Bearer <token>";
@@ -62,7 +61,7 @@ public class AuthorizationTokenTest {
         }
       };
 
-  private final List<GrpcRequest> loggedRequests = new ArrayList<>();
+  private final List<GrpcRequest> loggedRequests = Collections.synchronizedList(new ArrayList<>());
 
   @Before
   public void setUp() {
@@ -148,11 +147,11 @@ public class AuthorizationTokenTest {
     }
   }
 
-  class GrpcRequest {
-    String methodName;
-    String authTokenValue;
+  private static class GrpcRequest {
+    final String methodName;
+    final String authTokenValue;
 
-    public GrpcRequest(String methodName, String authTokenValue) {
+    GrpcRequest(String methodName, String authTokenValue) {
       this.methodName = methodName;
       this.authTokenValue = authTokenValue;
     }

--- a/temporal-serviceclient/src/main/java/io/temporal/authorization/AuthorizationTokenSupplier.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/authorization/AuthorizationTokenSupplier.java
@@ -21,6 +21,7 @@ package io.temporal.authorization;
 
 /**
  * Supplies tokens that will be sent to the Temporal server to perform authorization.
+ * Implementations have to be thread-safe.
  *
  * <p>The default JWT ClaimMapper expects authorization tokens to be in the following format:
  *
@@ -32,5 +33,6 @@ package io.temporal.authorization;
  *     JWT</a>
  */
 public interface AuthorizationTokenSupplier {
+  /** @return token to be passed in authorization header */
   String supply();
 }


### PR DESCRIPTION
Fix NullPointer in a new flaky AuthorizationTokenTest that I can explain only by memory synchronization issues.