### PR TITLE
Improve testLocalActivitiesWorkflowTaskHeartbeat flakiness

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatTest.java
@@ -42,6 +42,15 @@ public class LongLocalActivityWorkflowTaskHeartbeatTest {
           .setActivityImplementations(activitiesImpl)
           .build();
 
+  /**
+   * Emulates a workflow that triggers a long local activity, that sleeps longer than Workflow Task
+   * Timeout.
+   *
+   * <p>This test makes sure than such a workflow and workflow task is not getting timed out by
+   * performing heartbeats even while it takes longer than Workflow Task Timeout.
+   *
+   * @see LocalActivitiesWorkflowTaskHeartbeatTest
+   */
   @Test
   public void testLongLocalActivityWorkflowTaskHeartbeat() {
     WorkflowOptions options =


### PR DESCRIPTION
Removed pointless parallel workflows in `testLocalActivitiesWorkflowTaskHeartbeat` and decreased the number of sequential activities to improve the runtime of the test.
Add javadocs to `testLocalActivitiesWorkflowTaskHeartbeat` and `testLongLocalActivityWorkflowTaskHeartbeat`

Closes #693