### PR TITLE
Improve PayloadConverter javadoc regarding providing of EncodingKeys#METADATA_ENCODING_KEY

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/converter/EncodingKeys.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/EncodingKeys.java
@@ -22,8 +22,8 @@ package io.temporal.common.converter;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 
-class EncodingKeys {
-  static final String METADATA_ENCODING_KEY = "encoding";
+public class EncodingKeys {
+  public static final String METADATA_ENCODING_KEY = "encoding";
 
   static final String METADATA_ENCODING_NULL_NAME = "binary/null";
   static final ByteString METADATA_ENCODING_NULL =

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadConverter.java
@@ -34,9 +34,9 @@ public interface PayloadConverter {
 
   /**
    * Each {@link PayloadConverter} has an Encoding Type that it handles. Each {@link
-   * PayloadConverter} should add the information about it's Encoding Type into {@link Payload} it
-   * produces inside {@link #toData(Object)} by attaching under {@link
-   * EncodingKeys#METADATA_ENCODING_KEY} key to the {@code Payload}'s Metadata using {@link
+   * PayloadConverter} should add the information about its Encoding Type into the {@link Payload} it
+   * produces inside {@link #toData(Object)} by associating it with the {@link
+   * EncodingKeys#METADATA_ENCODING_KEY} key attached to the {@code Payload}'s Metadata using {@link
    * Payload.Builder#putMetadata(String, ByteString)}.
    *
    * @return encoding type that this converter handles.

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadConverter.java
@@ -19,6 +19,7 @@
 
 package io.temporal.common.converter;
 
+import com.google.protobuf.ByteString;
 import io.temporal.api.common.v1.Payload;
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -31,6 +32,15 @@ import java.util.Optional;
  */
 public interface PayloadConverter {
 
+  /**
+   * Each {@link PayloadConverter} has an Encoding Type that it handles. Each {@link
+   * PayloadConverter} should add the information about it's Encoding Type into {@link Payload} it
+   * produces inside {@link #toData(Object)} by attaching under {@link
+   * EncodingKeys#METADATA_ENCODING_KEY} key to the {@code Payload}'s Metadata using {@link
+   * Payload.Builder#putMetadata(String, ByteString)}.
+   *
+   * @return encoding type that this converter handles.
+   */
   String getEncodingType();
 
   /**
@@ -40,6 +50,7 @@ public interface PayloadConverter {
    * @return converted value
    * @throws DataConverterException if conversion of the value passed as parameter failed for any
    *     reason.
+   * @see #getEncodingType() getEncodingType javadoc for an important implementation detail
    */
   Optional<Payload> toData(Object value) throws DataConverterException;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HeaderUtils.java
@@ -41,7 +41,7 @@ public class HeaderUtils {
   }
 
   /**
-   * Converts a Map<String, Object> into a Map<String, Payload> by applying specified converter on
+   * Converts a {@code Map<String, Object>} into a {@code Map<String, Payload>} by applying specified converter on
    * each value. This util should be used for things like search attributes and memo that need to be
    * converted back from bytes on the server.
    */

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -630,7 +630,7 @@ public final class Workflow {
   /**
    * Extract Memo associated with the given key and deserialized into an object of generic type as
    * is done here: {@link DataConverter#fromPayloads(int, java.util.Optional, java.lang.Class,
-   * java.lang.reflect.Type)} Ex: To deserialize into HashMap<String, Integer> <code>
+   * java.lang.reflect.Type)} Ex: To deserialize into {@code HashMap<String, Integer>} <code>
    *  Workflow.getMemo(key, Map.class, new TypeToken<HashMap<String, Integer>>() {}.getType());
    * </code>
    *


### PR DESCRIPTION
`PayloadConverter` javadoc is improved to provide information about an important `EncodingKeys#METADATA_ENCODING_KEY` functionality that implementers of custom converters should keep in mind.

Minor fixes of formats of javadocs in other classes

`EncodingKeys#METADATA_ENCODING_KEY` made public