### PR TITLE
Test service now enforces 1 Minute timeout on long polls

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/worker/CleanWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/CleanWorkerShutdownTest.java
@@ -41,7 +41,7 @@ import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.workflow.Workflow;
-import io.temporal.workflow.shared.TestActivities.TestActivity2;
+import io.temporal.workflow.shared.TestActivities.NoArgsReturnsStringActivity;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowReturnString;
 import java.time.Duration;
 import java.util.List;
@@ -296,9 +296,9 @@ public class CleanWorkerShutdownTest {
 
   public static class TestWorkflowImpl implements TestWorkflowReturnString {
 
-    private final TestActivity2 activities =
+    private final NoArgsReturnsStringActivity activities =
         Workflow.newActivityStub(
-            TestActivity2.class,
+            NoArgsReturnsStringActivity.class,
             ActivityOptions.newBuilder()
                 .setScheduleToCloseTimeout(Duration.ofSeconds(100))
                 .build());
@@ -309,7 +309,7 @@ public class CleanWorkerShutdownTest {
     }
   }
 
-  public static class ActivitiesImpl implements TestActivity2 {
+  public static class ActivitiesImpl implements NoArgsReturnsStringActivity {
     private final CompletableFuture<Boolean> started;
 
     public ActivitiesImpl(CompletableFuture<Boolean> started) {
@@ -329,7 +329,7 @@ public class CleanWorkerShutdownTest {
     }
   }
 
-  public static class HeartbeatingActivitiesImpl implements TestActivity2 {
+  public static class HeartbeatingActivitiesImpl implements NoArgsReturnsStringActivity {
     private final CompletableFuture<Boolean> started;
 
     public HeartbeatingActivitiesImpl(CompletableFuture<Boolean> started) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/LongRunningWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LongRunningWorkflowTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.*;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LongRunningWorkflowTest {
+  private final SleepActivitySleepingLongerThanLongPollTimeoutImpl sleepActivities =
+      new SleepActivitySleepingLongerThanLongPollTimeoutImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(LongRunningWorkflowImpl.class)
+          .setActivityImplementations(sleepActivities)
+          .setTestTimeoutSeconds(
+              WorkflowServiceStubsOptions.DEFAULT_POLL_RPC_TIMEOUT.plus(Duration.ofSeconds(20)).toMillis())
+          .build();
+
+  /**
+   * Workflow execution and block on blocking stub takes longer than long poll timeout. Check that
+   * we don't throw any exceptions and retry the long poll until the result is available.
+   */
+  @Test
+  public void testAwaitingForWorkflowResultLongerThanLongPollTimeout() {
+    TestWorkflows.TestWorkflowReturnString longRunningWorkflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class);
+
+    assertEquals("ok", longRunningWorkflow.execute());
+  }
+
+  public static class LongRunningWorkflowImpl implements TestWorkflows.TestWorkflowReturnString {
+    private final ActivityOptions activityOptions =
+        ActivityOptions.newBuilder().setScheduleToCloseTimeout(Duration.ofHours(1)).build();
+
+    private final TestActivities.NoArgsReturnsStringActivity activities =
+        Workflow.newActivityStub(TestActivities.NoArgsReturnsStringActivity.class, activityOptions);
+
+    @Override
+    public String execute() {
+      return activities.execute();
+    }
+  }
+
+  public static class SleepActivitySleepingLongerThanLongPollTimeoutImpl
+      implements TestActivities.NoArgsReturnsStringActivity {
+    @Override
+    public String execute() {
+      try {
+        Thread.sleep(
+            WorkflowServiceStubsOptions.DEFAULT_POLL_RPC_TIMEOUT
+                .plus(Duration.ofSeconds(10))
+                .toMillis());
+      } catch (InterruptedException e) {
+        fail("unexpected interrupted exception");
+        Thread.currentThread().interrupt();
+        return "not ok";
+      }
+      return "ok";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
@@ -63,7 +63,7 @@ public class TestActivities {
   }
 
   @ActivityInterface
-  public interface TestActivity2 {
+  public interface NoArgsReturnsStringActivity {
     String execute();
   }
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -33,20 +33,26 @@ import java.util.Objects;
 
 public class WorkflowServiceStubsOptions {
 
-  private static final String LOCAL_DOCKER_TARGET = "127.0.0.1:7233";
+  public static final String DEFAULT_LOCAL_DOCKER_TARGET = "127.0.0.1:7233";
 
   /** Default RPC timeout used for all non-long-poll calls. */
-  private static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofSeconds(10);
+  /**
+   * RPC timeout used for all long poll calls on Temporal Server side. Long poll returns with an
+   * empty result after this server timeout.
+   */
+  public static final Duration DEFAULT_SERVER_LONG_POLL_RPC_TIMEOUT = Duration.ofSeconds(60);
   /** Default RPC timeout used for all long poll calls. */
-  private static final Duration DEFAULT_POLL_RPC_TIMEOUT = Duration.ofSeconds(70);
+  public static final Duration DEFAULT_POLL_RPC_TIMEOUT =
+      DEFAULT_SERVER_LONG_POLL_RPC_TIMEOUT.plus(Duration.ofSeconds(10));
   /** Default RPC timeout for QueryWorkflow */
-  private static final Duration DEFAULT_QUERY_RPC_TIMEOUT = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_QUERY_RPC_TIMEOUT = Duration.ofSeconds(10);
   /** Default timeout that will be used to reset connection backoff. */
-  private static final Duration DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY = Duration.ofSeconds(10);
   /**
    * Default timeout that will be used to enter idle channel state and reconnect to temporal server.
    */
-  private static final Duration DEFAULT_GRPC_RECONNECT_FREQUENCY = Duration.ofMinutes(1);
+  public static final Duration DEFAULT_GRPC_RECONNECT_FREQUENCY = Duration.ofMinutes(1);
 
   private static final WorkflowServiceStubsOptions DEFAULT_INSTANCE =
       WorkflowServiceStubsOptions.newBuilder().build();
@@ -185,7 +191,9 @@ public class WorkflowServiceStubsOptions {
     }
 
     this.target =
-        builder.target == null && builder.channel == null ? LOCAL_DOCKER_TARGET : builder.target;
+        builder.target == null && builder.channel == null
+            ? DEFAULT_LOCAL_DOCKER_TARGET
+            : builder.target;
     this.sslContext = builder.sslContext;
     this.enableHttps = builder.enableHttps;
     this.channel = builder.channel;

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/ActiveOnEnvVariableRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/ActiveOnEnvVariableRule.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testing.internal;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ActiveOnEnvVariableRule implements TestRule {
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+
+        base.evaluate();
+      }
+    };
+  }
+}


### PR DESCRIPTION
## What was changed
Test service now enforces 1 Minute timeout on long polls.

## Why?
Temporal Server enforces 1 Minute timeout on long polls, after which it returns an empty result, and the client is expected to retry the request.
This PR brings Test Service implementation in sync with the main implementation on this aspect. 

Closes #707

How was this tested:
`LongRunningWorkflowTest`
