### PR TITLE
Release v1.3.1

### DIFF
--- a/releases/v1.3.1
+++ b/releases/v1.3.1
@@ -1,0 +1,2 @@
+2021-09-11 - 0da3149c - GrpcRetryer now retries underlying DEADLINE_EXCEEDED if the root gRPC context deadline is not expired (#709)
+2021-09-13 - d19bdcdb - Test service now enforces 1 Minute timeout on long polls (#713)


### PR DESCRIPTION
Releasing a hotfix version of the SDK.
Includes fix related to handling DEADLINE_EXCEEDED gRPC exception - regression introduced in 1.3.0.