### PR TITLE
User-facing TestWorkflowRule doesn't enforce test timeouts anymore

### DIFF
--- a/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinAsyncChildWorkflowTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinAsyncChildWorkflowTest.kt
@@ -26,7 +26,7 @@ import io.temporal.common.converter.JacksonJsonPayloadConverter
 import io.temporal.common.converter.KotlinObjectMapperFactory
 import io.temporal.internal.async.FunctionWrappingUtil
 import io.temporal.internal.sync.AsyncInternal
-import io.temporal.testing.TestWorkflowRule
+import io.temporal.testing.internal.SDKTestWorkflowRule
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -35,7 +35,7 @@ class KotlinAsyncChildWorkflowTest {
 
   @Rule
   @JvmField
-  var testWorkflowRule: TestWorkflowRule = TestWorkflowRule.newBuilder()
+  var testWorkflowRule: SDKTestWorkflowRule = SDKTestWorkflowRule.newBuilder()
     .setWorkflowTypes(ParentWorkflowImpl::class.java, ChildWorkflowImpl::class.java)
     .setWorkflowClientOptions(
       WorkflowClientOptions.newBuilder()

--- a/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinAsyncCompanionFunctionTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinAsyncCompanionFunctionTest.kt
@@ -26,9 +26,9 @@ import io.temporal.common.converter.JacksonJsonPayloadConverter
 import io.temporal.common.converter.KotlinObjectMapperFactory
 import io.temporal.internal.async.FunctionWrappingUtil
 import io.temporal.internal.sync.AsyncInternal
-import io.temporal.testing.TestWorkflowRule
-import junit.framework.Assert.assertTrue
+import io.temporal.testing.internal.SDKTestWorkflowRule
 import org.junit.Assert
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicBoolean
@@ -46,7 +46,7 @@ class KotlinAsyncCompanionFunctionTest {
 
   @Rule
   @JvmField
-  var testWorkflowRule: TestWorkflowRule = TestWorkflowRule.newBuilder()
+  var testWorkflowRule: SDKTestWorkflowRule = SDKTestWorkflowRule.newBuilder()
     .setWorkflowTypes(CompanionFunctionReferenceWorkflowImpl::class.java)
     .setWorkflowClientOptions(
       WorkflowClientOptions.newBuilder()

--- a/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinAsyncLambdaTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinAsyncLambdaTest.kt
@@ -26,9 +26,9 @@ import io.temporal.common.converter.JacksonJsonPayloadConverter
 import io.temporal.common.converter.KotlinObjectMapperFactory
 import io.temporal.internal.async.FunctionWrappingUtil
 import io.temporal.internal.sync.AsyncInternal
-import io.temporal.testing.TestWorkflowRule
-import junit.framework.Assert.assertTrue
+import io.temporal.testing.internal.SDKTestWorkflowRule
 import org.junit.Assert
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicBoolean
@@ -41,7 +41,7 @@ class KotlinAsyncLambdaTest {
 
   @Rule
   @JvmField
-  var testWorkflowRule: TestWorkflowRule = TestWorkflowRule.newBuilder()
+  var testWorkflowRule: SDKTestWorkflowRule = SDKTestWorkflowRule.newBuilder()
     .setWorkflowTypes(LambdaWorkflowImpl::class.java)
     .setWorkflowClientOptions(
       WorkflowClientOptions.newBuilder()

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/ActivityFailureTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/ActivityFailureTest.java
@@ -19,7 +19,7 @@
 
 package io.temporal.opentracing;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import io.opentracing.Scope;
 import io.opentracing.mock.MockSpan;
@@ -34,7 +34,7 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ApplicationFailure;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -53,8 +53,8 @@ public class ActivityFailureTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor())

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/CustomSpanNamingTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/CustomSpanNamingTest.java
@@ -35,7 +35,7 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.opentracing.internal.ActionTypeAndNameSpanBuilderProvider;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -55,8 +55,8 @@ public class CustomSpanNamingTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/LocalActivityTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/LocalActivityTest.java
@@ -32,7 +32,7 @@ import io.temporal.activity.LocalActivityOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -50,8 +50,8 @@ public class LocalActivityTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor())

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/NoClientSpanTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/NoClientSpanTest.java
@@ -30,7 +30,7 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -47,8 +47,8 @@ public class NoClientSpanTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor())

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/SpanContextPropagationTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/SpanContextPropagationTest.java
@@ -19,9 +19,7 @@
 
 package io.temporal.opentracing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import io.opentracing.Scope;
 import io.opentracing.Span;
@@ -37,9 +35,11 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.ApplicationFailure;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
-import io.temporal.workflow.*;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
 import org.junit.After;
 import org.junit.Before;
@@ -54,8 +54,8 @@ public class SpanContextPropagationTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor())

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/WorkflowReplayTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/WorkflowReplayTest.java
@@ -33,7 +33,7 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -52,8 +52,8 @@ public class WorkflowReplayTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor())

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/WorkflowRetryTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/WorkflowRetryTest.java
@@ -34,7 +34,7 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ApplicationFailure;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -53,8 +53,8 @@ public class WorkflowRetryTest {
       new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor())

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/integration/JaegerTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/integration/JaegerTest.java
@@ -36,15 +36,21 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.opentracing.*;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.opentracing.OpenTracingClientInterceptor;
+import io.temporal.opentracing.OpenTracingOptions;
+import io.temporal.opentracing.OpenTracingSpanContextCodec;
+import io.temporal.opentracing.OpenTracingWorkerInterceptor;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
 import java.util.List;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class JaegerTest {
   private static final OpenTracingOptions JAEGER_COMPATIBLE_CONFIG =
@@ -57,8 +63,8 @@ public class JaegerTest {
   private Tracer tracer;
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder()
                   .setInterceptors(new OpenTracingClientInterceptor(JAEGER_COMPATIBLE_CONFIG))

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowRetryAfterActivityFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowRetryAfterActivityFailureTest.java
@@ -29,7 +29,7 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.TerminatedFailure;
-import io.temporal.testing.TestWorkflowRule;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestActivities.TestActivity1;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
@@ -42,8 +42,8 @@ public class WorkflowRetryAfterActivityFailureTest {
   private static AtomicInteger failureCounter = new AtomicInteger(1);
 
   @Rule
-  public TestWorkflowRule testWorkflowRule =
-      TestWorkflowRule.newBuilder()
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(WorkflowImpl.class)
           .setActivityImplementations(new FailingActivityImpl())
           .build();

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
@@ -29,10 +29,6 @@ public class SDKTestOptions {
   // stepping through code in a debugger without timing out.
   private static final boolean DEBUGGER_TIMEOUTS = false;
 
-  public static WorkflowOptions newWorkflowOptionsForTaskQueue(String taskQueue) {
-    return WorkflowOptions.newBuilder().setTaskQueue(taskQueue).build();
-  }
-
   public static WorkflowOptions newWorkflowOptionsForTaskQueue200sTimeout(String taskQueue) {
     return WorkflowOptions.newBuilder()
         .setWorkflowRunTimeout(Duration.ofSeconds(200))


### PR DESCRIPTION
## What was changed
TestWorkflowRule#setTestTimeoutSeconds is deprecated and transformed to noop.
Existing timeout logic is moved to SDKTestWorkflowRule and should be used only in internal Temporal tests.
Also moved handy   `newWorkflowStub(Class<T> workflow)` and `newUntypedWorkflowStub(String workflow)` from SDK TestWorkflowRule to TestWorkflowRule, because they can be handy for our users.

## Why?
As described in #634, Temporal Test rule shouldn't reimplement basic unit test framework functionality. And default timeout of 10 seconds could be annoying for users in some cases because users have to find a way to disable it.


1. Closes #634