### PR TITLE
Move check for isTemporalDebugModeOn down to WorkflowThreadContext#runUntilBlocked to avoid missing checks on the calling side

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/DebugModeUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/DebugModeUtils.java
@@ -19,20 +19,30 @@
 
 package io.temporal.internal.common;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.temporal.internal.common.env.EnvironmentVariablesProvider;
+import io.temporal.internal.common.env.SystemEnvironmentVariablesProvider;
+
 public class DebugModeUtils {
-  private static final boolean TEMPORAL_DEBUG_MODE = readTemporalDebugModeFromEnvVar();
+  private static boolean TEMPORAL_DEBUG_MODE =
+      readTemporalDebugMode(SystemEnvironmentVariablesProvider.INSTANCE);
 
   public static boolean isTemporalDebugModeOn() {
     return TEMPORAL_DEBUG_MODE;
   }
 
-  private static boolean readTemporalDebugModeFromEnvVar() {
-    String temporalDebugValue = System.getenv("TEMPORAL_DEBUG");
+  private static boolean readTemporalDebugMode(EnvironmentVariablesProvider envProvider) {
+    String temporalDebugValue = envProvider.getenv("TEMPORAL_DEBUG");
     if (temporalDebugValue == null) {
       return false;
     }
     temporalDebugValue = temporalDebugValue.trim();
     return (!Boolean.FALSE.toString().equalsIgnoreCase(temporalDebugValue)
         && !"0".equals(temporalDebugValue));
+  }
+
+  @VisibleForTesting
+  public static void initializeForTests(EnvironmentVariablesProvider environmentVariableProvider) {
+    TEMPORAL_DEBUG_MODE = readTemporalDebugMode(environmentVariableProvider);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/env/EnvironmentVariablesProvider.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/env/EnvironmentVariablesProvider.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.common.env;
+
+/**
+ * Same contract as {@link System#getenv(String)} This class exists only to allow overriding
+ * environment variables for tests
+ */
+public interface EnvironmentVariablesProvider {
+  String getenv(String name);
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/env/SystemEnvironmentVariablesProvider.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/env/SystemEnvironmentVariablesProvider.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.common.env;
+
+public class SystemEnvironmentVariablesProvider implements EnvironmentVariablesProvider {
+  public static final EnvironmentVariablesProvider INSTANCE =
+      new SystemEnvironmentVariablesProvider();
+
+  @Override
+  public String getenv(String name) {
+    return System.getenv(name);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -19,7 +19,6 @@
 
 package io.temporal.internal.sync;
 
-import io.temporal.internal.common.DebugModeUtils;
 import io.temporal.internal.replay.WorkflowExecutorCache;
 import io.temporal.workflow.CancellationScope;
 import java.util.concurrent.ExecutorService;
@@ -32,13 +31,7 @@ import javax.annotation.Nullable;
  */
 interface DeterministicRunner {
 
-  long DEFAULT_DEADLOCK_DETECTION_TIMEOUT = 1000;
-
-  static long getDeadlockDetectionTimeout() {
-    return DebugModeUtils.isTemporalDebugModeOn()
-        ? Long.MAX_VALUE
-        : DEFAULT_DEADLOCK_DETECTION_TIMEOUT;
-  }
+  long DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS = 1000;
 
   /**
    * Create new instance of DeterministicRunner

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
@@ -82,7 +82,12 @@ public interface WorkflowThread extends CancellationScope {
 
   SyncWorkflowContext getWorkflowContext();
 
-  boolean runUntilBlocked(long deadlockDetectionTimeout);
+  /**
+   * @param deadlockDetectionTimeoutMs maximum time in milliseconds the thread can run before
+   *     calling yield.
+   * @return true if coroutine made some progress.
+   */
+  boolean runUntilBlocked(long deadlockDetectionTimeoutMs);
 
   Throwable getUnhandledException();
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -312,17 +312,12 @@ class WorkflowThreadImpl implements WorkflowThread {
     return priority;
   }
 
-  /**
-   * @return true if coroutine made some progress.
-   * @param deadlockDetectionTimeout maximum time in milliseconds the thread can run before calling
-   *     yield.
-   */
   @Override
-  public boolean runUntilBlocked(long deadlockDetectionTimeout) {
+  public boolean runUntilBlocked(long deadlockDetectionTimeoutMs) {
     if (taskFuture == null) {
       start();
     }
-    return context.runUntilBlocked(deadlockDetectionTimeout);
+    return context.runUntilBlocked(deadlockDetectionTimeoutMs);
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -19,7 +19,6 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static junit.framework.TestCase.*;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
@@ -107,17 +106,17 @@ public class DeterministicRunnerTest {
               status = "done";
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("after1", status);
     // Just check that running again doesn't make any progress.
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("after1", status);
     unblock2 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("done", status);
     assertTrue(d.isDone());
   }
@@ -157,7 +156,7 @@ public class DeterministicRunnerTest {
             });
     try {
       for (int i = 0; i < Duration.ofSeconds(400).toMillis(); i += 10) {
-        d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+        d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
       }
       fail("failure expected");
     } catch (IllegalThreadStateException e) {
@@ -190,12 +189,12 @@ public class DeterministicRunnerTest {
               throw new RuntimeException("simulated");
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
     try {
-      d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+      d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
       fail("exception expected");
     } catch (Exception ignored) {
     }
@@ -221,11 +220,11 @@ public class DeterministicRunnerTest {
               status = "done";
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("after1", status);
     d.close();
     assertTrue(d.isDone());
@@ -260,10 +259,10 @@ public class DeterministicRunnerTest {
               thread2.get();
               trace.add("root done");
             });
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertFalse(d.isDone());
     unblock2 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(d.isDone());
     assertEquals("exitValue", d.getExitValue());
     String[] expected =
@@ -289,10 +288,10 @@ public class DeterministicRunnerTest {
                   "reason1", () -> CancellationScope.current().isCancelRequested());
               trace.add("root done");
             });
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertFalse(d.isDone());
     d.cancel("I just feel like it");
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(d.isDone());
     String[] expected =
         new String[] {
@@ -329,7 +328,7 @@ public class DeterministicRunnerTest {
               }
               trace.add("root done");
             });
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(trace.toString(), d.isDone());
     String[] expected =
         new String[] {
@@ -373,7 +372,7 @@ public class DeterministicRunnerTest {
               }
               trace.add("root done");
             });
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(trace.toString(), d.isDone());
     String[] expected =
         new String[] {
@@ -433,7 +432,7 @@ public class DeterministicRunnerTest {
               trace.add("root done");
             });
 
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(d.stackTrace(), d.isDone());
     String[] expected =
         new String[] {
@@ -491,7 +490,7 @@ public class DeterministicRunnerTest {
               trace.add("root done");
             });
 
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(d.stackTrace(), d.isDone());
     String[] expected =
         new String[] {
@@ -542,10 +541,10 @@ public class DeterministicRunnerTest {
               }
               trace.add("root done");
             });
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertFalse(trace.toString(), d.isDone());
     d.cancel("I just feel like it");
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertFalse(d.isDone());
     String[] expected =
         new String[] {
@@ -554,7 +553,7 @@ public class DeterministicRunnerTest {
     trace.setExpected(expected);
     trace.assertExpected();
     unblock1 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(d.stackTrace(), d.isDone());
     expected =
         new String[] {
@@ -582,17 +581,17 @@ public class DeterministicRunnerTest {
               async.get();
             });
     assertEquals("initial", status);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("started", status);
     assertFalse(d.isDone());
     unblock1 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("after1", status);
     // Just check that running again doesn't make any progress.
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("after1", status);
     unblock2 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals("done", status);
     assertTrue(d.isDone());
   }
@@ -628,9 +627,9 @@ public class DeterministicRunnerTest {
             threadPool,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             new TestChildTreeRunnable(0)::apply);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     unblock1 = true;
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertTrue(d.isDone());
     List<String> expected = new ArrayList<>();
     for (int i = 0; i <= CHILDREN; i++) {
@@ -691,7 +690,7 @@ public class DeterministicRunnerTest {
 
     cache.getOrCreate(response, new com.uber.m3.tally.NoopScope(), () -> workflowRunTaskHandler);
     cache.addToCache(response.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals(2, threadPool.getActiveCount());
     assertEquals(1, cache.size());
 
@@ -712,7 +711,7 @@ public class DeterministicRunnerTest {
             },
             cache);
     // Act: This should kick out threads consumed by 'd'
-    d2.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d2.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     // Assert: Cache is evicted and only threads consumed by d2 remain.
     assertEquals(2, threadPool.getActiveCount());
@@ -753,7 +752,7 @@ public class DeterministicRunnerTest {
 
     cache.getOrCreate(response, new com.uber.m3.tally.NoopScope(), () -> workflowRunTaskHandler);
     cache.addToCache(response.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
-    d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals(2, threadPool.getActiveCount());
     assertEquals(1, cache.size());
 
@@ -774,7 +773,7 @@ public class DeterministicRunnerTest {
             cache);
 
     // Act: This should not kick out threads consumed by 'd' since there's enough capacity
-    d2.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    d2.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     // Assert: Cache is not evicted and all threads remain.
     assertEquals(4, threadPool.getActiveCount());
@@ -824,7 +823,7 @@ public class DeterministicRunnerTest {
     assertEquals("initial", status);
 
     try {
-      d.runUntilAllBlocked(getDeadlockDetectionTimeout());
+      d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     } catch (Throwable t) {
       assertTrue(t instanceof WorkflowRejectedExecutionError);
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
@@ -19,7 +19,6 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -85,7 +84,7 @@ public class PromiseTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin", "root done", "thread1 get failure",
@@ -106,7 +105,7 @@ public class PromiseTest {
               trace.add(f.get());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin", "thread1", "root done",
@@ -127,7 +126,7 @@ public class PromiseTest {
               trace.add(f.cancellableGet());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin", "thread1", "root done",
@@ -151,9 +150,9 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin", "root CanceledException", "root done",
@@ -248,7 +247,7 @@ public class PromiseTest {
               assertTrue(f3.get());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -294,7 +293,7 @@ public class PromiseTest {
               f1.complete("value1");
               trace.add("root done");
             });
-    runner.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    runner.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected = new String[] {"root begin", "value1.thenApply.f2Handle", "root done"};
 
     trace.setExpected(expected);
@@ -338,7 +337,7 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    runner.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    runner.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected = new String[] {"root begin", "exceptionally", "failure caught", "root done"};
 
     trace.setExpected(expected);
@@ -389,7 +388,7 @@ public class PromiseTest {
               assertTrue(f1.isCompleted() && f2.isCompleted() && f3.isCompleted());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -435,7 +434,7 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -494,7 +493,7 @@ public class PromiseTest {
               assertEquals("value1", any.get());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -556,7 +555,7 @@ public class PromiseTest {
               assertTrue(f1.isCompleted());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -619,7 +618,7 @@ public class PromiseTest {
               assertTrue(f3.isCompleted());
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -664,7 +663,7 @@ public class PromiseTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
@@ -19,7 +19,6 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowOptions;
@@ -81,7 +80,7 @@ public class WorkflowInternalDeprecatedQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -118,9 +117,9 @@ public class WorkflowInternalDeprecatedQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -153,9 +152,9 @@ public class WorkflowInternalDeprecatedQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -311,9 +310,9 @@ public class WorkflowInternalDeprecatedQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -347,9 +346,9 @@ public class WorkflowInternalDeprecatedQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -385,9 +384,9 @@ public class WorkflowInternalDeprecatedQueueTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -19,7 +19,6 @@
 
 package io.temporal.internal.sync;
 
-import static io.temporal.internal.sync.DeterministicRunner.getDeadlockDetectionTimeout;
 import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowOptions;
@@ -84,7 +83,7 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     String[] expected =
         new String[] {
           "root begin",
@@ -121,9 +120,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -156,9 +155,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -314,9 +313,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -350,9 +349,9 @@ public class WorkflowInternalQueueTest {
                   .start();
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -388,9 +387,9 @@ public class WorkflowInternalQueueTest {
               }
               trace.add("root done");
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     String[] expected =
         new String[] {
@@ -430,9 +429,9 @@ public class WorkflowInternalQueueTest {
               result[1] = queue.poll();
               result[2] = queue.poll();
             });
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     r.cancel("test");
-    r.runUntilAllBlocked(getDeadlockDetectionTimeout());
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
 
     int[] expected = new int[] {1, 2, 3};
     assertArrayEquals(expected, result);


### PR DESCRIPTION
## What was changed
Check for isTemporalDebugModeOn was moved down into `WorkflowThreadContext#runUntilBlocked` so it can't be forgotten by the calling code.

## Why?
We have a missing check for `isTemporalDebugModeOn` in `SyncWorkflow#eventLoop`, so the main event loop doesn't overwrite deadline detection timeout when it should. Instead of fixing this one usage, it's a good idea to move the check to the lower level, so the calling code doesn't have to check the flag explicitly every time.

Closes #724