### PR TITLE
Add error handling for dynamic workflow failure

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -116,7 +116,9 @@ class SyncWorkflow implements ReplayWorkflow {
             result,
             lastFailure);
 
-    workflowProc = new WorkflowExecuteRunnable(syncContext, workflow, startEvent);
+    workflowProc =
+        new WorkflowExecuteRunnable(
+            syncContext, workflow, startEvent, workflowImplementationOptions);
     // The following order is ensured by this code and DeterministicRunner implementation:
     // 1. workflow.initialize
     // 2. signal handler (if signalWithStart was called)

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowExecuteRunnable.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowExecuteRunnable.java
@@ -19,16 +19,33 @@
 
 package io.temporal.internal.sync;
 
+import static io.temporal.internal.sync.WorkflowInternal.unwrap;
+import static io.temporal.serviceclient.CheckedExceptionWrapper.wrap;
+
 import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
+import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.Header;
+import io.temporal.failure.FailureConverter;
+import io.temporal.failure.TemporalFailure;
+import io.temporal.internal.worker.WorkflowExecutionException;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInfo;
 import java.util.Objects;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class WorkflowExecuteRunnable implements Runnable {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowExecuteRunnable.class);
+
   private final SyncWorkflowContext context;
   private final SyncWorkflowDefinition workflow;
   private final WorkflowExecutionStartedEventAttributes attributes;
+  private final WorkflowImplementationOptions implementationOptions;
 
   private Optional<Payloads> output = Optional.empty();
   private boolean done;
@@ -36,7 +53,9 @@ class WorkflowExecuteRunnable implements Runnable {
   public WorkflowExecuteRunnable(
       SyncWorkflowContext context,
       SyncWorkflowDefinition workflow,
-      WorkflowExecutionStartedEventAttributes attributes) {
+      WorkflowExecutionStartedEventAttributes attributes,
+      WorkflowImplementationOptions options) {
+    this.implementationOptions = options;
     Objects.requireNonNull(context);
     Objects.requireNonNull(workflow);
     Objects.requireNonNull(attributes);
@@ -51,6 +70,32 @@ class WorkflowExecuteRunnable implements Runnable {
       Optional<Payloads> input =
           attributes.hasInput() ? Optional.of(attributes.getInput()) : Optional.empty();
       output = workflow.execute(new Header(attributes.getHeader()), input);
+    } catch (Throwable e) {
+      if (e instanceof DestroyWorkflowThreadError) {
+        throw (DestroyWorkflowThreadError) e;
+      }
+      Throwable exception = unwrap(e);
+
+      Class<? extends Throwable>[] failTypes =
+          implementationOptions.getFailWorkflowExceptionTypes();
+      if (exception instanceof TemporalFailure) {
+        logWorkflowExecutionException(Workflow.getInfo(), exception);
+        throw mapToWorkflowExecutionException(exception, context.getDataConverter());
+      }
+      for (Class<? extends Throwable> failType : failTypes) {
+        if (failType.isAssignableFrom(exception.getClass())) {
+          // fail workflow
+          if (log.isErrorEnabled()) {
+            boolean cancelRequested =
+                WorkflowInternal.getRootWorkflowContext().getContext().isCancelRequested();
+            if (!cancelRequested || !FailureConverter.isCanceledCause(exception)) {
+              logWorkflowExecutionException(Workflow.getInfo(), exception);
+            }
+          }
+          throw mapToWorkflowExecutionException(exception, context.getDataConverter());
+        }
+      }
+      throw wrap(exception);
     } finally {
       done = true;
     }
@@ -74,5 +119,30 @@ class WorkflowExecuteRunnable implements Runnable {
 
   public Optional<Payloads> handleQuery(String type, Optional<Payloads> args) {
     return context.handleQuery(type, args);
+  }
+
+  private void logWorkflowExecutionException(WorkflowInfo info, Throwable exception) {
+    log.error(
+        "Workflow execution failure "
+            + "WorkflowId="
+            + info.getWorkflowId()
+            + ", RunId="
+            + info.getRunId()
+            + ", WorkflowType="
+            + info.getWorkflowType(),
+        exception);
+  }
+
+  static WorkflowExecutionException mapToWorkflowExecutionException(
+      Throwable exception, DataConverter dataConverter) {
+    Throwable e = exception;
+    while (e != null) {
+      if (e instanceof TemporalFailure) {
+        ((TemporalFailure) e).setDataConverter(dataConverter);
+      }
+      e = e.getCause();
+    }
+    Failure failure = FailureConverter.exceptionToFailure(exception);
+    return new WorkflowExecutionException(failure);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowTest.java
@@ -127,7 +127,7 @@ public class DynamicWorkflowTest {
     assertEquals("activityType2-activityType1-startArg0-workflowFoo", result);
   }
 
-  @Test
+  @Test(expected = WorkflowFailedException.class)
   public void testDynamicWorkflowFailure() {
     TestWorkflowEnvironment testEnvironment = testWorkflowRule.getTestEnvironment();
     testEnvironment
@@ -141,11 +141,6 @@ public class DynamicWorkflowTest {
     WorkflowStub workflow =
         testWorkflowRule.getWorkflowClient().newUntypedWorkflowStub("workflowFoo", workflowOptions);
     workflow.start("startArg0", true /* fail */);
-    try {
-      workflow.getResult(String.class);
-      fail("failure expected");
-    } catch (WorkflowFailedException e) {
-      // expected
-    }
+    workflow.getResult(String.class);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatFailureTest.java
@@ -69,7 +69,8 @@ public class LongLocalActivityWorkflowTaskHeartbeatFailureTest {
             .getWorkflowClient()
             .newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class, options);
     String result = workflowStub.execute();
-    //Shouldn't this workflow never successfully finish, because local activity suppose the fail the hearbeat every single time?
+    // Shouldn't this workflow never successfully finish, because local activity suppose the fail
+    // the hearbeat every single time?
     Assert.assertEquals("sleepActivity123", result);
     Assert.assertEquals(activitiesImpl.toString(), REPLAY_COUNT, activitiesImpl.invocations.size());
   }


### PR DESCRIPTION
## What was changed
DynamicWorkflow was missing appropriate error handling. Moved error handling from POJOWorkflowImplementationFactory to WorkflowExecuteRunnable to cover both POJO and DynamicWorkflow implementations.


## Checklist

1. Closes https://github.com/temporalio/sdk-java/issues/716
2. How was this tested: Added a unit test to check that DynamicWorkflow fails correctly.
