### PR TITLE
LargeHistoryTest is unignored

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/LargeHistoryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LargeHistoryTest.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -46,7 +45,6 @@ public class LargeHistoryTest {
           .build();
 
   @Test
-  @Ignore // Requires DEBUG_TIMEOUTS=true
   public void testLargeHistory() {
     final int activityCount = 1000;
     TestWorkflow3 workflowStub =


### PR DESCRIPTION
## What was changed
`LargeHistoryTest` is unignored.

## Why?
The test is ignored without an obvious reason for that.