### PR TITLE
Switch SelfAdvancingTimerImplTest to use fixed clock to reduce flakes and  improve the quality of checks

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimerImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimerImpl.java
@@ -22,6 +22,7 @@ package io.temporal.internal.testservice;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.temporal.workflow.Functions;
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -153,15 +154,15 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
     }
   }
 
-  private static class LockEvent {
-    String caller;
-    LockEventType lockType;
-    long timestamp;
+  private class LockEvent {
+    final String caller;
+    final LockEventType lockType;
+    final long timestamp;
 
     public LockEvent(String caller, LockEventType lockType) {
       this.caller = caller;
       this.lockType = lockType;
-      timestamp = System.currentTimeMillis();
+      this.timestamp = systemClock.millis();
     }
   }
 
@@ -209,6 +210,7 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
   }
 
   private static final Logger log = LoggerFactory.getLogger(SelfAdvancingTimerImpl.class);
+  private final Clock systemClock;
   private final LongSupplier clock =
       () -> {
         long timeMillis = this.currentTimeMillis();
@@ -235,8 +237,9 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
   private final Thread timerPump = new Thread(new TimerPump(), "SelfAdvancingTimer Pump");
   private LockHandle timeLockOnEmptyQueueHandle;
 
-  public SelfAdvancingTimerImpl(long initialTime) {
-    currentTime = initialTime == 0 ? System.currentTimeMillis() : initialTime;
+  public SelfAdvancingTimerImpl(long initialTime, Clock systemClock) {
+    this.systemClock = systemClock;
+    currentTime = initialTime == 0 ? systemClock.millis() : initialTime;
     executor.setRejectedExecutionHandler(new CallerRunsPolicy());
     // Queue is initially empty. The code assumes that in this case skipping is already locked.
     timeLockOnEmptyQueueHandle = lockTimeSkipping("SelfAdvancingTimerImpl constructor empty-queue");
@@ -248,7 +251,7 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
       if (timeLastLocked < 0 || systemTimeLastLocked < 0) {
         throw new IllegalStateException("Invalid timeLastLocked or systemTimeLastLocked");
       }
-      currentTime = timeLastLocked + (System.currentTimeMillis() - systemTimeLastLocked);
+      currentTime = timeLastLocked + (systemClock.millis() - systemTimeLastLocked);
     } else {
       TimerTask task = tasks.peek();
       if (task != null && !task.isCanceled() && task.getExecutionTime() > currentTime) {
@@ -280,6 +283,9 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
     Functions.Proc cancellationHandle;
     lock.lock();
     try {
+      // get a last time in case the last TimePump update was relatively long time ago
+      updateTimeLocked();
+
       long executionTime = delay.toMillis() + currentTime;
       TimerTask timerTask = new TimerTask(executionTime, task, taskInfo);
       cancellationHandle = () -> timerTask.cancel();
@@ -321,7 +327,7 @@ final class SelfAdvancingTimerImpl implements SelfAdvancingTimer {
   private LockHandle lockTimeSkippingLocked(String caller) {
     if (lockCount++ == 0) {
       timeLastLocked = currentTime;
-      systemTimeLastLocked = System.currentTimeMillis();
+      systemTimeLastLocked = systemClock.millis();
     }
     LockEvent event = new LockEvent(caller, LockEventType.LOCK);
     lockEvents.add(event);

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -42,6 +42,7 @@ import io.temporal.failure.ApplicationFailure;
 import io.temporal.internal.common.WorkflowExecutionUtils;
 import io.temporal.internal.testservice.RequestContext.Timer;
 import io.temporal.workflow.Functions;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -177,7 +178,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   }
 
   public TestWorkflowStoreImpl(long initialTimeMillis) {
-    timerService = new SelfAdvancingTimerImpl(initialTimeMillis);
+    timerService = new SelfAdvancingTimerImpl(initialTimeMillis, Clock.systemDefaultZone());
     // locked until the first save
     emptyHistoryLockHandle = timerService.lockTimeSkipping("TestWorkflowStoreImpl constructor");
   }


### PR DESCRIPTION
## What was changed
Switch SelfAdvancingTimerImplTest to use fixed clock to reduce flakes and improve the quality of checks
SelfAdvancingTimerImpl now updates the time before scheduling

## Why?
Fixed mocked clock remove test flakes that could happen because of the load.
It also improves the quality of the test, switching to the fixed clock allowed to catch a problem that `SelfAdvancingTimerImpl#schedule` could use an outdated timestamp.

Closes #726
