### PR TITLE
Cleanup LongPoll code and update Async version

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientHelper.java
@@ -24,8 +24,11 @@ import static io.temporal.internal.common.HeaderUtils.toHeaderGrpc;
 import static io.temporal.internal.common.SerializerUtils.toRetryPolicy;
 
 import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
 import io.temporal.api.common.v1.*;
+import io.temporal.api.enums.v1.HistoryEventFilterType;
 import io.temporal.api.taskqueue.v1.TaskQueue;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.StartWorkflowExecutionRequest;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
@@ -101,6 +104,17 @@ final class RootWorkflowClientHelper {
     request.setHeader(grpcHeader);
 
     return request.build();
+  }
+
+  public GetWorkflowExecutionHistoryRequest newHistoryLongPollRequest(
+      WorkflowExecution workflowExecution, ByteString pageToken) {
+    return GetWorkflowExecutionHistoryRequest.newBuilder()
+        .setNamespace(clientOptions.getNamespace())
+        .setExecution(workflowExecution)
+        .setHistoryEventFilterType(HistoryEventFilterType.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT)
+        .setWaitNewEvent(true)
+        .setNextPageToken(pageToken)
+        .build();
   }
 
   private io.temporal.common.interceptors.Header extractContextsAndConvertToBytes(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -92,7 +92,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
     Optional<Payloads> resultValue =
         WorkflowClientLongPollHelper.getWorkflowExecutionResult(
             genericClient.getService(),
-            genericClient.getNamespace(),
+            requestsHelper,
             input.getWorkflowExecution(),
             input.getWorkflowType(),
             metricsScope,
@@ -108,7 +108,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
     CompletableFuture<Optional<Payloads>> resultValue =
         WorkflowClientLongPollAsyncHelper.getWorkflowExecutionResultAsync(
             genericClient.getService(),
-            genericClient.getNamespace(),
+            requestsHelper,
             input.getWorkflowExecution(),
             input.getWorkflowType(),
             input.getTimeout(),

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientHelper.java
@@ -40,7 +40,7 @@ import java.util.Iterator;
  * WorkflowClient}, mostly because they shouldn't be a part of normal usage and exist for tests /
  * debug only.
  */
-public class WorkflowClientHelper {
+public final class WorkflowClientHelper {
 
   /** Returns workflow instance history in a human readable format. */
   public static String prettyPrintHistory(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatFailureTest.java
@@ -69,8 +69,6 @@ public class LongLocalActivityWorkflowTaskHeartbeatFailureTest {
             .getWorkflowClient()
             .newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class, options);
     String result = workflowStub.execute();
-    // Shouldn't this workflow never successfully finish, because local activity suppose the fail
-    // the hearbeat every single time?
     Assert.assertEquals("sleepActivity123", result);
     Assert.assertEquals(activitiesImpl.toString(), REPLAY_COUNT, activitiesImpl.invocations.size());
   }


### PR DESCRIPTION
## What was changed

Remove unused methods that are full duplicates of used methods
Reuse code and properties between Sync and Async versions to keep them consistent
Async version now calls the long poll with waitForNewEvents = true and updated retry options.