### PR TITLE
Add logback-test to kotlin module to decrease verbosity of building logs on docker from netty

### DIFF
--- a/temporal-kotlin/src/test/resources/logback-test.xml
+++ b/temporal-kotlin/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<!--
+     Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+
+     Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+     Modifications copyright (C) 2017 Uber Technologies, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License"). You may not
+     use this file except in compliance with the License. A copy of the License is
+     located at
+
+     http://aws.amazon.com/apache2.0
+
+     or in the "license" file accompanying this file. This file is distributed on
+     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+     express or implied. See the License for the specific language governing
+     permissions and limitations under the License.
+-->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="io.grpc.netty" level="INFO"/>
+    <!-- Modify root log level to get more info -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
During docker build the log is filled with netty output during the build of kotlin module.
Adding our standard test logback config to decrease verbosity of tempotal-kotlin build with docker.