### PR TITLE
Make rpc retry log levels configurable

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcAsyncRetryer.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcAsyncRetryer.java
@@ -19,6 +19,8 @@
 
 package io.temporal.internal.retryer;
 
+import static io.temporal.internal.retryer.GrpcRetryerUtils.logWithLevel;
+
 import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.StatusRuntimeException;
@@ -154,7 +156,7 @@ class GrpcAsyncRetryer {
       return;
     }
 
-    log.debug("Retrying after failure", currentException);
+    logWithLevel(log, options.getLogLevel(), currentException);
 
     retry(options, function, attempt + 1, startTime, throttler, statusRuntimeException, resultCF);
   }

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
 
 class GrpcRetryerUtils {
   /**
@@ -100,5 +101,20 @@ class GrpcRetryerUtils {
     return (maxAttempts > 0 && attempt >= maxAttempts)
         || (expirationDuration != null && currentTimeMillis - startTimeMs >= expirationInterval)
         || (grpcContextDeadline != null && grpcContextDeadline.isExpired());
+  }
+
+  static void logWithLevel(Logger log, RpcRetryOptions.LogLevel logLevel, Throwable lastException) {
+    String message = "Retrying after failure";
+    if (logLevel == RpcRetryOptions.LogLevel.TRACE) {
+      log.trace(message, lastException);
+    } else if (logLevel == RpcRetryOptions.LogLevel.DEBUG) {
+      log.debug(message, lastException);
+    } else if (logLevel == RpcRetryOptions.LogLevel.INFO) {
+      log.info(message, lastException);
+    } else if (logLevel == RpcRetryOptions.LogLevel.WARN) {
+      log.warn(message, lastException);
+    } else if (logLevel == RpcRetryOptions.LogLevel.ERROR) {
+      log.error(message, lastException);
+    }
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcSyncRetryer.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcSyncRetryer.java
@@ -19,6 +19,8 @@
 
 package io.temporal.internal.retryer;
 
+import static io.temporal.internal.retryer.GrpcRetryerUtils.logWithLevel;
+
 import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.StatusRuntimeException;
@@ -53,7 +55,7 @@ class GrpcSyncRetryer {
     do {
       attempt++;
       if (lastException != null) {
-        log.warn("Retrying after failure", lastException);
+        logWithLevel(log, options.getLogLevel(), lastException);
       }
 
       try {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -47,6 +47,18 @@ public final class RpcRetryOptions {
 
   private static final RpcRetryOptions DEFAULT_INSTANCE;
 
+  public LogLevel getLogLevel() {
+    return logLevel;
+  }
+
+  public enum LogLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR;
+  }
+
   static {
     DEFAULT_INSTANCE = RpcRetryOptions.newBuilder().build();
   }
@@ -95,6 +107,8 @@ public final class RpcRetryOptions {
 
     private List<DoNotRetryItem> doNotRetry = new ArrayList<>();
 
+    private LogLevel logLevel = LogLevel.WARN;
+
     private Builder() {}
 
     private Builder(RpcRetryOptions options) {
@@ -107,6 +121,7 @@ public final class RpcRetryOptions {
       this.initialInterval = options.getInitialInterval();
       this.maximumInterval = options.getMaximumInterval();
       this.doNotRetry = options.getDoNotRetry();
+      this.logLevel = options.getLogLevel();
     }
 
     /**
@@ -201,6 +216,11 @@ public final class RpcRetryOptions {
       return this;
     }
 
+    public Builder setLogLevel(LogLevel logLevel) {
+      this.logLevel = logLevel;
+      return this;
+    }
+
     /** The parameter options takes precedence. */
     public Builder setRetryOptions(RpcRetryOptions o) {
       if (o == null) {
@@ -244,7 +264,8 @@ public final class RpcRetryOptions {
           expiration,
           maximumAttempts,
           maximumInterval,
-          doNotRetry);
+          doNotRetry,
+          logLevel);
     }
 
     public RpcRetryOptions buildWithDefaultsFrom(RpcRetryOptions rpcRetryOptions) {
@@ -273,7 +294,13 @@ public final class RpcRetryOptions {
       }
       RpcRetryOptions result =
           new RpcRetryOptions(
-              initialInterval, backoff, expiration, maximumAttempts, maximumInterval, doNotRetry);
+              initialInterval,
+              backoff,
+              expiration,
+              maximumAttempts,
+              maximumInterval,
+              doNotRetry,
+              logLevel);
       result.validate();
       return result;
     }
@@ -291,19 +318,23 @@ public final class RpcRetryOptions {
 
   private final List<DoNotRetryItem> doNotRetry;
 
+  private final LogLevel logLevel;
+
   private RpcRetryOptions(
       Duration initialInterval,
       double backoffCoefficient,
       Duration expiration,
       int maximumAttempts,
       Duration maximumInterval,
-      List<DoNotRetryItem> doNotRetry) {
+      List<DoNotRetryItem> doNotRetry,
+      LogLevel logLevel) {
     this.initialInterval = initialInterval;
     this.backoffCoefficient = backoffCoefficient;
     this.expiration = expiration;
     this.maximumAttempts = maximumAttempts;
     this.maximumInterval = maximumInterval;
     this.doNotRetry = doNotRetry != null ? Collections.unmodifiableList(doNotRetry) : null;
+    this.logLevel = logLevel;
   }
 
   public Duration getInitialInterval() {


### PR DESCRIPTION
## What was changed
New RPC retry option has been added that allows setting log level for RPC errors.

## Why?
Some users may not like defaults.

## Checklist

1. Closes #618

2. How was this tested:
Manually + unit test that verifies that options can be passed without any issues.

3. Any docs updates needed?
No