### PR TITLE
Remove target when setting channel in workflow test environment options

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -104,6 +104,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       options =
           WorkflowServiceStubsOptions.newBuilder(options)
               .setChannel(InProcessChannelBuilder.forName(serverName).directExecutor().build())
+              .setTarget(null)
               .build();
     } else {
       inProcessServer = null;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -104,6 +104,9 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       options =
           WorkflowServiceStubsOptions.newBuilder(options)
               .setChannel(InProcessChannelBuilder.forName(serverName).directExecutor().build())
+              // target might be set already, especially if options were built with defaults. Need
+              // to set it to null since we don't allow both channel and target be set at the same
+              // time.
               .setTarget(null)
               .build();
     } else {

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentCreationTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentCreationTest.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package io.temporal.testing;
 
 import io.temporal.client.WorkflowClientOptions;

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentCreationTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentCreationTest.java
@@ -1,0 +1,21 @@
+package io.temporal.testing;
+
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.worker.WorkerFactoryOptions;
+import org.junit.Test;
+
+public class TestWorkflowEnvironmentCreationTest {
+
+  @Test
+  public void testCreateWithValidatedDefaultOptions() {
+    WorkflowClientOptions workflowClientOptions =
+        WorkflowClientOptions.newBuilder().validateAndBuildWithDefaults();
+    WorkerFactoryOptions workerFactoryOptions =
+        WorkerFactoryOptions.newBuilder().validateAndBuildWithDefaults();
+    TestWorkflowEnvironment.newInstance(
+        TestEnvironmentOptions.newBuilder()
+            .setWorkflowClientOptions(workflowClientOptions)
+            .setWorkerFactoryOptions(workerFactoryOptions)
+            .validateAndBuildWithDefaults());
+  }
+}


### PR DESCRIPTION
## What was changed
Setting target to null when channel is set in the test workflow environment options.

## Why?
When you call validateAndBuildWithDefaults on TestEnvironmentOptions builder it creates default service options with default target address, which then gets passed to the WorkflowServiceStubsImpl that also adds a channel for the in-memory service, which causes the error you are seeing (both target and channel set). 
## Checklist

1. Closes #749

2. How was this tested:
Added a unit test similar to the one provided by the user.

3. Any docs updates needed?
No