### PR TITLE
Fix AbandonOnCancelActivityTest flake

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityCancellationType.java
@@ -22,31 +22,32 @@ package io.temporal.activity;
 import io.temporal.client.ActivityCompletionException;
 
 /**
- * In case of an activity's call scope cancellation the corresponding activity stub call fails with a
- * {@link io.temporal.failure.CanceledFailure}.
- * The different modes of this behavior are available and specified by this enum.
+ * In case of an activity's call scope cancellation the corresponding activity stub call fails with
+ * a {@link io.temporal.failure.CanceledFailure}. The different modes of this behavior are available
+ * and specified by this enum.
  */
 public enum ActivityCancellationType {
   /**
-   * Wait for the Activity Execution to confirm any requested cancellation.
-   * An Activity Execution must Heartbeat to receive a cancellation notification through {@link ActivityCompletionException}.
-   * This can block the cancellation of a Workflow Execution for a long time if the Activity Execution doesn't Heartbeat
-   * or chooses to ignore the cancellation request.
-   * The activity stub call will fail with {@link io.temporal.failure.CanceledFailure} only after
-   * cancellation confirmation from the Activity Execution has been received.
+   * Wait for the Activity Execution to confirm any requested cancellation. An Activity Execution
+   * must Heartbeat to receive a cancellation notification through {@link
+   * ActivityCompletionException}. This can block the cancellation of a Workflow Execution for a
+   * long time if the Activity Execution doesn't Heartbeat or chooses to ignore the cancellation
+   * request. The activity stub call will fail with {@link io.temporal.failure.CanceledFailure} only
+   * after cancellation confirmation from the Activity Execution has been received.
    */
   WAIT_CANCELLATION_COMPLETED,
 
   /**
-   * In case of activity's scope cancellation send an Activity cancellation request to the server, and report cancellation to the
-   * Workflow Execution by causing the activity stub call to fail with {@link io.temporal.failure.CanceledFailure}
+   * In case of activity's scope cancellation send an Activity cancellation request to the server,
+   * and report cancellation to the Workflow Execution by causing the activity stub call to fail
+   * with {@link io.temporal.failure.CanceledFailure}
    */
   TRY_CANCEL,
 
   /**
-   * Do not request cancellation of the Activity Execution at all (no request is sent to the server) and immediately report cancellation to
-   * the Workflow Execution by causing the activity stub call to fail with {@link io.temporal.failure.CanceledFailure}
-   * immediately.
+   * Do not request cancellation of the Activity Execution at all (no request is sent to the server)
+   * and immediately report cancellation to the Workflow Execution by causing the activity stub call
+   * to fail with {@link io.temporal.failure.CanceledFailure} immediately.
    */
   ABANDON,
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
@@ -262,58 +262,42 @@ public final class ActivityOptions {
     this.cancellationType = cancellationType;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setHeartbeatTimeout(Duration)
-   */
+  /** @see ActivityOptions.Builder#setHeartbeatTimeout(Duration) */
   public Duration getHeartbeatTimeout() {
     return heartbeatTimeout;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setScheduleToCloseTimeout(Duration)
-   */
+  /** @see ActivityOptions.Builder#setScheduleToCloseTimeout(Duration) */
   public Duration getScheduleToCloseTimeout() {
     return scheduleToCloseTimeout;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setScheduleToStartTimeout(Duration)
-   */
+  /** @see ActivityOptions.Builder#setScheduleToStartTimeout(Duration) */
   public Duration getScheduleToStartTimeout() {
     return scheduleToStartTimeout;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setStartToCloseTimeout(Duration)
-   */
+  /** @see ActivityOptions.Builder#setStartToCloseTimeout(Duration) */
   public Duration getStartToCloseTimeout() {
     return startToCloseTimeout;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setTaskQueue(String)
-   */
+  /** @see ActivityOptions.Builder#setTaskQueue(String) */
   public String getTaskQueue() {
     return taskQueue;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setRetryOptions(RetryOptions)
-   */
+  /** @see ActivityOptions.Builder#setRetryOptions(RetryOptions) */
   public RetryOptions getRetryOptions() {
     return retryOptions;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setContextPropagators(List)
-   */
+  /** @see ActivityOptions.Builder#setContextPropagators(List) */
   public List<ContextPropagator> getContextPropagators() {
     return contextPropagators;
   }
 
-  /**
-   * @see ActivityOptions.Builder#setCancellationType(ActivityCancellationType)
-   */
+  /** @see ActivityOptions.Builder#setCancellationType(ActivityCancellationType) */
   public ActivityCancellationType getCancellationType() {
     return cancellationType;
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DetachedScopeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DetachedScopeTest.java
@@ -27,10 +27,13 @@ import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivities;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivitiesImpl;
 import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
 import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,15 +42,25 @@ public class DetachedScopeTest {
 
   private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
 
+  private static final CompletionClientActivitiesImpl completionClientActivitiesImpl =
+      new CompletionClientActivitiesImpl();
+
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestDetachedCancellationScope.class)
-          .setActivityImplementations(activitiesImpl)
+          .setActivityImplementations(activitiesImpl, completionClientActivitiesImpl)
           .build();
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    completionClientActivitiesImpl.close();
+  }
 
   @Test
   public void testDetachedScope() {
+    completionClientActivitiesImpl.setCompletionClient(
+        testWorkflowRule.getWorkflowClient().newActivityCompletionClient());
     WorkflowStub client = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow1");
     client.start(testWorkflowRule.getTaskQueue());
     testWorkflowRule.sleep(Duration.ofSeconds(1)); // To let activityWithDelay start.
@@ -58,7 +71,8 @@ public class DetachedScopeTest {
     } catch (WorkflowFailedException e) {
       Assert.assertTrue(e.getCause() instanceof CanceledFailure);
     }
-    activitiesImpl.assertInvocations("activityWithDelay", "activity1", "activity2", "activity3");
+    activitiesImpl.assertInvocations("activity1", "activity2", "activity3");
+    completionClientActivitiesImpl.assertInvocations("activityWithDelay");
   }
 
   public static class TestDetachedCancellationScope implements TestWorkflow1 {
@@ -69,8 +83,14 @@ public class DetachedScopeTest {
           Workflow.newActivityStub(
               VariousTestActivities.class,
               SDKTestOptions.newActivityOptionsForTaskQueue(taskQueue));
+
+      CompletionClientActivities completionClientActivities =
+          Workflow.newActivityStub(
+              CompletionClientActivities.class,
+              SDKTestOptions.newActivityOptionsForTaskQueue(taskQueue));
+
       try {
-        testActivities.activityWithDelay(100000, true);
+        completionClientActivities.activityWithDelay(100000, true);
         fail("unreachable");
       } catch (ActivityFailure e) {
         assertTrue(e.getCause() instanceof CanceledFailure);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/HeartbeatTimeoutDetailsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/HeartbeatTimeoutDetailsTest.java
@@ -27,10 +27,11 @@ import io.temporal.api.enums.v1.TimeoutType;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.TimeoutFailure;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
-import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
-import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivities;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivitiesImpl;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,7 +41,9 @@ import org.slf4j.LoggerFactory;
 public class HeartbeatTimeoutDetailsTest {
 
   private static final Logger log = LoggerFactory.getLogger(HeartbeatTimeoutDetailsTest.class);
-  private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
+
+  private static final CompletionClientActivitiesImpl activitiesImpl =
+      new CompletionClientActivitiesImpl();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -48,6 +51,11 @@ public class HeartbeatTimeoutDetailsTest {
           .setWorkflowTypes(TestHeartbeatTimeoutDetails.class)
           .setActivityImplementations(activitiesImpl)
           .build();
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    activitiesImpl.close();
+  }
 
   @Test
   public void testHeartbeatTimeoutDetails() {
@@ -70,8 +78,8 @@ public class HeartbeatTimeoutDetailsTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(5))
               .build();
 
-      VariousTestActivities activities =
-          Workflow.newActivityStub(VariousTestActivities.class, options);
+      CompletionClientActivities activities =
+          Workflow.newActivityStub(CompletionClientActivities.class, options);
       try {
         // false for second argument means to heartbeat once to set details and then stop.
         activities.activityWithDelay(5000, false);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityTest.java
@@ -37,7 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class AsyncActivityTest {
-  private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
+  private static final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -48,8 +48,6 @@ public class AsyncActivityTest {
 
   @Test
   public void testAsyncActivity() {
-    activitiesImpl.completionClient =
-        testWorkflowRule.getWorkflowClient().newActivityCompletionClient();
     TestWorkflow1 client = testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
     String result = client.execute(testWorkflowRule.getTaskQueue());
     Assert.assertEquals("workflow", result);
@@ -69,6 +67,7 @@ public class AsyncActivityTest {
       VariousTestActivities testActivities =
           Workflow.newActivityStub(
               VariousTestActivities.class, SDKTestOptions.newActivityOptions20sScheduleToClose());
+
       Promise<String> a = Async.function(testActivities::activity);
       Promise<Integer> a1 = Async.function(testActivities::activity1, 1);
       Promise<String> a2 = Async.function(testActivities::activity2, "1", 2);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityWithCompletionClientTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityWithCompletionClientTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Async;
+import io.temporal.workflow.Promise;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivities;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivitiesImpl;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AsyncActivityWithCompletionClientTest {
+  private static final CompletionClientActivitiesImpl completionClientActivitiesImpl =
+      new CompletionClientActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestAsyncActivityWorkflowImpl.class)
+          .setActivityImplementations(completionClientActivitiesImpl)
+          .build();
+
+  @After
+  public void tearDown() throws Exception {
+    completionClientActivitiesImpl.close();
+  }
+
+  @Test
+  public void testAsyncActivity() {
+    completionClientActivitiesImpl.completionClient =
+        testWorkflowRule.getWorkflowClient().newActivityCompletionClient();
+    TestWorkflow1 client = testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = client.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("workflow", result);
+    Assert.assertEquals("activity1", completionClientActivitiesImpl.invocations.get(0));
+  }
+
+  public static class TestAsyncActivityWorkflowImpl implements TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+
+      CompletionClientActivities completionClientActivities =
+          Workflow.newActivityStub(
+              CompletionClientActivities.class,
+              SDKTestOptions.newActivityOptions20sScheduleToClose());
+
+      Promise<String> a1 = Async.function(completionClientActivities::activity1, "1");
+      assertEquals("1", a1.get());
+      return "workflow";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncUsingActivityStubUntypedActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncUsingActivityStubUntypedActivityTest.java
@@ -32,21 +32,19 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AsyncUntyped2ActivityTest {
+public class AsyncUsingActivityStubUntypedActivityTest {
 
   private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(TestAsyncUtypedActivity2WorkflowImpl.class)
+          .setWorkflowTypes(TestAsyncUsingActivityStubUntypedActivityWorkflowImpl.class)
           .setActivityImplementations(activitiesImpl)
           .build();
 
   @Test
-  public void testAsyncUntyped2Activity() {
-    activitiesImpl.completionClient =
-        testWorkflowRule.getWorkflowClient().newActivityCompletionClient();
+  public void usingActivityStub() {
     TestWorkflow1 client = testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
     String result = client.execute(testWorkflowRule.getTaskQueue());
     Assert.assertEquals("workflow", result);
@@ -59,7 +57,8 @@ public class AsyncUntyped2ActivityTest {
     Assert.assertEquals("123456", activitiesImpl.procResult.get(6));
   }
 
-  public static class TestAsyncUtypedActivity2WorkflowImpl implements TestWorkflow1 {
+  public static class TestAsyncUsingActivityStubUntypedActivityWorkflowImpl
+      implements TestWorkflow1 {
 
     @Override
     public String execute(String taskQueue) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncUsingAsyncUntypedActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncUsingAsyncUntypedActivityTest.java
@@ -33,21 +33,19 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AsyncUntypedActivityTest {
+public class AsyncUsingAsyncUntypedActivityTest {
 
   private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(TestAsyncUtypedActivityWorkflowImpl.class)
+          .setWorkflowTypes(TestAsyncUsingAsyncUntypedActivityWorkflowImpl.class)
           .setActivityImplementations(activitiesImpl)
           .build();
 
   @Test
-  public void testAsyncUntypedActivity() {
-    activitiesImpl.completionClient =
-        testWorkflowRule.getWorkflowClient().newActivityCompletionClient();
+  public void usingAsync() {
     TestWorkflow1 client = testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
     String result = client.execute(testWorkflowRule.getTaskQueue());
     Assert.assertEquals("workflow", result);
@@ -55,10 +53,9 @@ public class AsyncUntypedActivityTest {
     Assert.assertEquals("1", activitiesImpl.procResult.get(1));
     Assert.assertEquals("12", activitiesImpl.procResult.get(2));
     Assert.assertEquals("123", activitiesImpl.procResult.get(3));
-    Assert.assertEquals("1234", activitiesImpl.procResult.get(4));
   }
 
-  public static class TestAsyncUtypedActivityWorkflowImpl implements TestWorkflow1 {
+  public static class TestAsyncUsingAsyncUntypedActivityWorkflowImpl implements TestWorkflow1 {
 
     @Override
     public String execute(String taskQueue) {
@@ -75,13 +72,10 @@ public class AsyncUntypedActivityTest {
           Async.function(testActivities::<String>execute, "Activity2", String.class, "1", 2);
       Promise<String> a3 =
           Async.function(testActivities::<String>execute, "Activity3", String.class, "1", 2, 3);
-      Promise<String> a4 =
-          Async.function(testActivities::<String>execute, "Activity4", String.class, "1", 2, 3, 4);
       assertEquals("activity", a.get());
       assertEquals("1", a1.get());
       assertEquals("12", a2.get());
       assertEquals("123", a3.get());
-      assertEquals("1234", a4.get());
 
       Async.procedure(testActivities::<Void>execute, "Proc", Void.class).get();
       Async.procedure(testActivities::<Void>execute, "Proc1", Void.class, "1").get();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/TryCancelActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/TryCancelActivityTest.java
@@ -28,17 +28,19 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
-import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
-import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivities;
+import io.temporal.workflow.shared.TestActivities.CompletionClientActivitiesImpl;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class TryCancelActivityTest {
 
-  private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
+  private static final CompletionClientActivitiesImpl activitiesImpl =
+      new CompletionClientActivitiesImpl();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -47,8 +49,15 @@ public class TryCancelActivityTest {
           .setActivityImplementations(activitiesImpl)
           .build();
 
+  @AfterClass
+  public static void afterClass() throws Exception {
+    activitiesImpl.close();
+  }
+
   @Test
   public void testTryCancelActivity() {
+    activitiesImpl.setCompletionClient(
+        testWorkflowRule.getWorkflowClient().newActivityCompletionClient());
     TestWorkflow1 client = testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
     WorkflowClient.start(client::execute, testWorkflowRule.getTaskQueue());
     testWorkflowRule
@@ -73,9 +82,9 @@ public class TryCancelActivityTest {
 
     @Override
     public String execute(String taskQueue) {
-      VariousTestActivities testActivities =
+      CompletionClientActivities testActivities =
           Workflow.newActivityStub(
-              VariousTestActivities.class,
+              CompletionClientActivities.class,
               ActivityOptions.newBuilder(SDKTestOptions.newActivityOptionsForTaskQueue(taskQueue))
                   .setHeartbeatTimeout(Duration.ofSeconds(1))
                   .setCancellationType(ActivityCancellationType.TRY_CANCEL)

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
+import com.google.common.base.Preconditions;
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.activity.ActivityInfo;
@@ -34,6 +35,7 @@ import io.temporal.client.ActivityNotExistsException;
 import io.temporal.common.MethodRetry;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
+import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -92,8 +94,6 @@ public class TestActivities {
 
     String sleepActivity(long milliseconds, int input);
 
-    String activityWithDelay(long milliseconds, boolean heartbeatMoreThanOnce);
-
     String activity();
 
     @ActivityMethod(name = "customActivity1")
@@ -135,6 +135,13 @@ public class TestActivities {
     void throwIOAnnotated();
 
     List<UUID> activityUUIDList(List<UUID> arg);
+  }
+
+  @ActivityInterface
+  public interface CompletionClientActivities {
+    String activityWithDelay(long milliseconds, boolean heartbeatMoreThanOnce);
+
+    String activity1(String a1);
   }
 
   /** IMPLEMENTATIONS * */
@@ -189,19 +196,7 @@ public class TestActivities {
     public final List<String> procResult = Collections.synchronizedList(new ArrayList<>());
     final AtomicInteger heartbeatCounter = new AtomicInteger();
     public final AtomicInteger applicationFailureCounter = new AtomicInteger();
-    private final ThreadPoolExecutor executor =
-        new ThreadPoolExecutor(0, 100, 1, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
-    public ActivityCompletionClient completionClient;
     int lastAttempt;
-
-    public void setCompletionClient(ActivityCompletionClient completionClient) {
-      this.completionClient = completionClient;
-    }
-
-    public void close() throws InterruptedException {
-      executor.shutdownNow();
-      executor.awaitTermination(1, TimeUnit.MINUTES);
-    }
 
     public void assertInvocations(String... expected) {
       assertEquals(Arrays.asList(expected), invocations);
@@ -217,39 +212,6 @@ public class TestActivities {
       }
       invocations.add("sleepActivity");
       return "sleepActivity" + input;
-    }
-
-    @Override
-    public String activityWithDelay(long delay, boolean heartbeatMoreThanOnce) {
-      ActivityExecutionContext ctx = Activity.getExecutionContext();
-      byte[] taskToken = ctx.getInfo().getTaskToken();
-      executor.execute(
-          () -> {
-            invocations.add("activityWithDelay");
-            long start = System.currentTimeMillis();
-            try {
-              int count = 0;
-              while (System.currentTimeMillis() - start < delay) {
-                if (heartbeatMoreThanOnce || count == 0) {
-                  completionClient.heartbeat(taskToken, "heartbeatValue");
-                }
-                count++;
-                Thread.sleep(100);
-              }
-              completionClient.complete(taskToken, "activity");
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-            } catch (ActivityNotExistsException | ActivityCanceledException e) {
-              try {
-                Thread.sleep(500);
-              } catch (InterruptedException interruptedException) {
-                Thread.currentThread().interrupt();
-              }
-              completionClient.reportCancellation(taskToken, null);
-            }
-          });
-      ctx.doNotCompleteOnReturn();
-      return "ignored";
     }
 
     @Override
@@ -278,28 +240,14 @@ public class TestActivities {
 
     @Override
     public String activity4(String a1, int a2, int a3, int a4) {
-      byte[] taskToken = Activity.getExecutionContext().getInfo().getTaskToken();
-      executor.execute(
-          () -> {
-            invocations.add("activity4");
-            completionClient.complete(taskToken, a1 + a2 + a3 + a4);
-          });
-      Activity.getExecutionContext().doNotCompleteOnReturn();
-      return "ignored";
+      invocations.add("activity4");
+      return a1 + a2 + a3 + a4;
     }
 
     @Override
     public String activity5(String a1, int a2, int a3, int a4, int a5) {
-      ActivityInfo activityInfo = Activity.getExecutionContext().getInfo();
-      String workflowId = activityInfo.getWorkflowId();
-      String id = activityInfo.getActivityId();
-      executor.execute(
-          () -> {
-            invocations.add("activity5");
-            completionClient.complete(workflowId, Optional.empty(), id, a1 + a2 + a3 + a4 + a5);
-          });
-      Activity.getExecutionContext().doNotCompleteOnReturn();
-      return "ignored";
+      invocations.add("activity5");
+      return a1 + a2 + a3 + a4 + a5;
     }
 
     @Override
@@ -415,6 +363,74 @@ public class TestActivities {
 
     public int getLastAttempt() {
       return lastAttempt;
+    }
+  }
+
+  public static class CompletionClientActivitiesImpl
+      implements CompletionClientActivities, Closeable {
+    public final List<String> invocations = Collections.synchronizedList(new ArrayList<>());
+    private final ThreadPoolExecutor executor =
+        new ThreadPoolExecutor(0, 100, 1, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    public ActivityCompletionClient completionClient;
+
+    public void setCompletionClient(ActivityCompletionClient completionClient) {
+      this.completionClient = completionClient;
+    }
+
+    public void assertInvocations(String... expected) {
+      assertEquals(Arrays.asList(expected), invocations);
+    }
+
+    @Override
+    public String activity1(String a1) {
+      Preconditions.checkNotNull(completionClient, "completionClient");
+      byte[] taskToken = Activity.getExecutionContext().getInfo().getTaskToken();
+      executor.execute(
+          () -> {
+            invocations.add("activity1");
+            completionClient.complete(taskToken, a1);
+          });
+      Activity.getExecutionContext().doNotCompleteOnReturn();
+      return "ignored";
+    }
+
+    @Override
+    public String activityWithDelay(long delay, boolean heartbeatMoreThanOnce) {
+      Preconditions.checkNotNull(completionClient, "completionClient");
+      ActivityExecutionContext ctx = Activity.getExecutionContext();
+      byte[] taskToken = ctx.getInfo().getTaskToken();
+      executor.execute(
+          () -> {
+            invocations.add("activityWithDelay");
+            long start = System.currentTimeMillis();
+            try {
+              int count = 0;
+              while (System.currentTimeMillis() - start < delay) {
+                if (heartbeatMoreThanOnce || count == 0) {
+                  completionClient.heartbeat(taskToken, "heartbeatValue");
+                }
+                count++;
+                Thread.sleep(100);
+              }
+              completionClient.complete(taskToken, "activity");
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } catch (ActivityNotExistsException | ActivityCanceledException e) {
+              try {
+                Thread.sleep(500);
+              } catch (InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+              }
+              completionClient.reportCancellation(taskToken, null);
+            }
+          });
+      ctx.doNotCompleteOnReturn();
+      return "ignored";
+    }
+
+    @Override
+    public void close() throws IOException {
+      executor.shutdownNow();
     }
   }
 }


### PR DESCRIPTION
## What was changed

Activities using completionClient and a thread pool for delayed execution were moved into a separate activities class `CompletionClientActivities` to optimize resource management in tests.
Add clean shutdown for this new activity instance in tests that use it.
Add guards checking that this new `CompletionClientActivities` is correctly initialized by tests code to prevent NullPointer flaky errors.

Closes #756