### PR TITLE
Adapt CheckedExceptionWrapper to Throwables that are not Exceptions and Errors

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/CheckedExceptionWrapperTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/CheckedExceptionWrapperTest.java
@@ -19,6 +19,8 @@
 
 package io.temporal.internal.sync;
 
+import static org.junit.Assert.assertTrue;
+
 import io.temporal.serviceclient.CheckedExceptionWrapper;
 import io.temporal.workflow.Workflow;
 import org.junit.Assert;
@@ -57,4 +59,13 @@ public class CheckedExceptionWrapperTest {
     Throwable eu = CheckedExceptionWrapper.unwrap(e);
     Assert.assertEquals(e, eu);
   }
+
+  @Test
+  public void customThrowable() {
+    RuntimeException wrapped = CheckedExceptionWrapper.wrap(new CustomThrowable());
+    Throwable unwrapped = CheckedExceptionWrapper.unwrap(wrapped);
+    assertTrue(unwrapped instanceof CustomThrowable);
+  }
+
+  private static class CustomThrowable extends Throwable {}
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/failure/WorkflowFailureNonRetryableFlagTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/failure/WorkflowFailureNonRetryableFlagTest.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.workflow;
+package io.temporal.workflow.failure;
 
 import io.temporal.client.WorkflowException;
 import io.temporal.common.RetryOptions;
@@ -45,7 +45,7 @@ public class WorkflowFailureNonRetryableFlagTest {
       SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowNonRetryableFlag.class).build();
 
   @Test
-  public void testWorkflowFailureNonRetryableFlag() {
+  public void nonRetryableFlag() {
     RetryOptions workflowRetryOptions =
         RetryOptions.newBuilder()
             .setInitialInterval(Duration.ofSeconds(1))
@@ -81,11 +81,7 @@ public class WorkflowFailureNonRetryableFlagTest {
 
     @Override
     public String execute(String testName) {
-      AtomicInteger count = retryCount.get(testName);
-      if (count == null) {
-        count = new AtomicInteger();
-        retryCount.put(testName, count);
-      }
+      AtomicInteger count = retryCount.computeIfAbsent(testName, ignore -> new AtomicInteger());
       int c = count.incrementAndGet();
       ApplicationFailure f =
           ApplicationFailure.newFailure("simulated " + c, "foo", "details1", 123);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/failure/WorkflowFailureNonStandardThrowableTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/failure/WorkflowFailureNonStandardThrowableTest.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.failure;
+
+import static org.junit.Assert.*;
+
+import io.temporal.client.WorkflowException;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/** https://github.com/temporalio/sdk-java/issues/744 */
+public class WorkflowFailureNonStandardThrowableTest {
+
+  public static class NonStandardThrowable extends Throwable {}
+
+  private static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(NonStandardThrowable.class)
+                  .build(),
+              TestWorkflowNonStandardThrowable.class)
+          .build();
+
+  @Test
+  public void nonStandardThrowable() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflow1.class,
+                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+
+    try {
+      workflowStub.execute(testName.getMethodName());
+      fail();
+    } catch (WorkflowException e) {
+      assertTrue(e.getCause() instanceof ApplicationFailure);
+      ApplicationFailure applicationFailure = (ApplicationFailure) e.getCause();
+      assertEquals(NonStandardThrowable.class.getName(), applicationFailure.getType());
+    }
+  }
+
+  @Test
+  public void nonStandardThrowableSuccessOnSecondAttempt() {
+    RetryOptions workflowRetryOptions =
+        RetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofMillis(1))
+            .setMaximumAttempts(2)
+            .setBackoffCoefficient(1.0)
+            .build();
+    TestWorkflow1 workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflow1.class,
+                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+                    .toBuilder()
+                    .setRetryOptions(workflowRetryOptions)
+                    .build());
+
+    String result = workflowStub.execute(testName.getMethodName());
+    assertEquals("success", result);
+    assertEquals(
+        "Success is expected on a second run only",
+        2,
+        retryCount.get(testName.getMethodName()).get());
+  }
+
+  public static class TestWorkflowNonStandardThrowable implements TestWorkflow1 {
+
+    @Override
+    public String execute(String testName) {
+      AtomicInteger count = retryCount.computeIfAbsent(testName, ignore -> new AtomicInteger());
+      int c = count.incrementAndGet();
+      if (c <= 1) {
+        rethrow(new NonStandardThrowable());
+        // unreachable
+        return "fail";
+      } else {
+        return "success";
+      }
+    }
+  }
+
+  private static <T extends Throwable> void rethrow(Throwable e) throws T {
+    if (e instanceof RuntimeException) {
+      throw (RuntimeException) e;
+    } else {
+      @SuppressWarnings("unchecked")
+      T toRethrow = (T) e;
+      throw toRethrow;
+    }
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/CheckedExceptionWrapper.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/CheckedExceptionWrapper.java
@@ -53,7 +53,7 @@ public final class CheckedExceptionWrapper extends RuntimeException {
     if (e instanceof RuntimeException) {
       return (RuntimeException) e;
     }
-    return new CheckedExceptionWrapper((Exception) e);
+    return new CheckedExceptionWrapper(e);
   }
 
   /**
@@ -64,7 +64,7 @@ public final class CheckedExceptionWrapper extends RuntimeException {
     return e instanceof CheckedExceptionWrapper ? e.getCause() : e;
   }
 
-  private CheckedExceptionWrapper(Exception e) {
+  private CheckedExceptionWrapper(Throwable e) {
     super(e);
   }
 }


### PR DESCRIPTION
## What was changed
Adapt CheckedExceptionWrapper to Throwables that are not Exceptions and Errors

## Why?
If workflow throws a Throwable that is not an exception or error, we get an internal failure instead of graceful processing.

Closes #744

How was this tested:
Unit tests with a custom throwable