### PR TITLE
Expose AuthorizationGrpcMetadataProvider constructor

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/authorization/AuthorizationGrpcMetadataProvider.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/authorization/AuthorizationGrpcMetadataProvider.java
@@ -28,7 +28,7 @@ public class AuthorizationGrpcMetadataProvider implements GrpcMetadataProvider {
 
   private final AuthorizationTokenSupplier authorizationTokenSupplier;
 
-  protected AuthorizationGrpcMetadataProvider(
+  public AuthorizationGrpcMetadataProvider(
       AuthorizationTokenSupplier authorizationTokenSupplier) {
     this.authorizationTokenSupplier = authorizationTokenSupplier;
   }


### PR DESCRIPTION
## What was changed
The constructor of `AuthorizationGrpcMetadataProvider` is made public so users can instantiate it. 

Closes #762