### PR TITLE
Added a method that makes sure the even loop is triggered only once

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/TerminatedWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/TerminatedWorkflowTest.java
@@ -56,7 +56,7 @@ public class TerminatedWorkflowTest {
     WorkflowOptions options =
         SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
             .toBuilder()
-            .setWorkflowRunTimeout(Duration.ofSeconds(1))
+            .setWorkflowRunTimeout(Duration.ofMillis(200))
             .build();
     TestTraceWorkflow workflow =
         testWorkflowRule.getWorkflowClient().newWorkflowStub(TestTraceWorkflow.class, options);


### PR DESCRIPTION
## What was changed
Added a method that makes sure the even loop is triggered only once -- in handleStarted method.

## Why?
The query handlers weren't getting initialized after the workflow timed out, because during workflow replay in WorkflowTaskStateMachine#handleStarted() the start event was no longer the last event in the history -- the timeout event was. This prevented queries from working. 

1. Closes #391 and #630 

2. How was this tested:
Modified unit test
