### PR TITLE
Dependency Update

### DIFF
--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api project(':temporal-sdk')
     api group: 'io.opentracing', name: 'opentracing-api', version: "$opentracingVersion"
 
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0-jre'
     implementation group: 'io.opentracing', name: 'opentracing-util', version: "$opentracingVersion"
 
     testImplementation project(":temporal-testing")

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.8'
     api group: 'io.micrometer', name: 'micrometer-core', version: '1.7.4'
 
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.5'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.5'

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    api 'io.grpc:grpc-protobuf:1.40.1'
-    api 'io.grpc:grpc-stub:1.40.1'
-    api 'io.grpc:grpc-core:1.40.1'
-    api 'io.grpc:grpc-netty-shaded:1.40.1'
-    api 'io.grpc:grpc-services:1.40.1'
+    api 'io.grpc:grpc-protobuf:1.41.0'
+    api 'io.grpc:grpc-stub:1.41.0'
+    api 'io.grpc:grpc-core:1.41.0'
+    api 'io.grpc:grpc-netty-shaded:1.41.0'
+    api 'io.grpc:grpc-services:1.41.0'
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.18.0'
     api group: 'com.uber.m3', name: 'tally-core', version: '0.6.1'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
@@ -49,7 +49,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.40.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.41.0'
         }
     }
     generateProtoTasks {

--- a/temporal-testing-junit5/build.gradle
+++ b/temporal-testing-junit5/build.gradle
@@ -3,7 +3,7 @@ description = '''Temporal Workflow Java SDK testing, JUnit 5.x integration'''
 dependencies {
     api project(':temporal-testing')
 
-    api platform('org.junit:junit-bom:5.8.0')
+    api platform('org.junit:junit-bom:5.8.1')
     api group: 'org.junit.jupiter', name: 'junit-jupiter-api'
 
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -7,7 +7,7 @@ description = '''Temporal Workflow Java SDK testing'''
 dependencies {
     api project(':temporal-sdk')
 
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0-jre'
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'


### PR DESCRIPTION
> Task :temporal-kotlin:checkDependencyUpdates
New dependency version: org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable: 1.5.30 -> 1.5.31
New dependency version: org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin: 1.5.30 -> 1.5.31

> Task :temporal-opentracing:checkDependencyUpdates
New dependency version: com.google.guava:guava: 30.1.1-jre -> 31.0-jre

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.google.guava:guava: 30.1.1-jre -> 31.0-jre

> Task :temporal-serviceclient:checkDependencyUpdates
New dependency version: com.uber.m3:tally-core: 0.6.1 -> 0.11.1
New dependency version: io.grpc:grpc-core: 1.40.1 -> 1.41.0
New dependency version: io.grpc:grpc-netty-shaded: 1.40.1 -> 1.41.0
New dependency version: io.grpc:grpc-protobuf: 1.40.1 -> 1.41.0
New dependency version: io.grpc:grpc-services: 1.40.1 -> 1.41.0
New dependency version: io.grpc:grpc-stub: 1.40.1 -> 1.41.0
New dependency version: io.grpc:protoc-gen-grpc-java: 1.40.1 -> 1.41.0

> Task :temporal-testing:checkDependencyUpdates
New dependency version: com.google.guava:guava: 30.1.1-jre -> 31.0-jre

> Task :temporal-testing-junit5:checkDependencyUpdates
New dependency version: org.junit:junit-bom: 5.8.0 -> 5.8.1
New dependency version: org.junit.jupiter:junit-jupiter-api: 5.8.0 -> 5.8.1