### PR TITLE
Beautify the output of prettyPrint for history to make test histories much easier to read

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ ext {
     logbackVersion = '1.2.6'
     grpcVersion = '1.41.0'
     guavaVersion = '31.0.1-jre'
+    jsonPathVersion = '2.6.0'
 }
 
 apply from: "$rootDir/gradle/versioning.gradle"

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     // which shouldn't be needed for any production usage of temporal-sdk.
     // It's useful only for unit tests and debugging.
     // For these use-cases Temporal users can add this dep in the classpath temporary or permanently themselves.
-    compileOnly group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0'
-    testImplementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0'
+    compileOnly "com.jayway.jsonpath:json-path:$jsonPathVersion"
+    testImplementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
 
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientHelper.java
@@ -24,6 +24,7 @@ import static io.temporal.serviceclient.MetricsTag.METRICS_TAGS_CALL_OPTIONS_KEY
 import com.google.protobuf.ByteString;
 import com.uber.m3.tally.Scope;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
@@ -31,7 +32,7 @@ import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.client.WorkflowClient;
-import io.temporal.internal.common.WorkflowExecutionUtils;
+import io.temporal.internal.common.WorkflowExecutionHistory;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.util.Iterator;
 
@@ -65,7 +66,8 @@ public final class WorkflowClientHelper {
       boolean showWorkflowTasks,
       Scope metricsScope) {
     Iterator<HistoryEvent> events = getHistory(service, namespace, workflowExecution, metricsScope);
-    return WorkflowExecutionUtils.prettyPrintHistory(events, showWorkflowTasks);
+    History history = History.newBuilder().addAllEvents(() -> events).build();
+    return new WorkflowExecutionHistory(history).toProtoText(showWorkflowTasks);
   }
 
   public static Iterator<HistoryEvent> getHistory(

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryProtoTextUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryProtoTextUtils.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.common;
+
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.TextFormat;
+import io.temporal.api.history.v1.History;
+import io.temporal.api.history.v1.HistoryEvent;
+
+/** Converts history protos into human readable format */
+public class HistoryProtoTextUtils {
+
+  public static String toProtoText(History history, boolean showWorkflowTasks) {
+    TextFormat.Printer printer = TextFormat.printer();
+    StringBuilder result = new StringBuilder();
+    for (HistoryEvent event : history.getEventsList()) {
+      if (!showWorkflowTasks
+          && event.getEventType().name().startsWith("EVENT_TYPE_WORKFLOW_TASK")) {
+        continue;
+      }
+      printEvent(printer, result, event);
+      result.append("\n");
+    }
+
+    return result.toString();
+  }
+
+  private static void printEvent(
+      TextFormat.Printer printer, StringBuilder result, HistoryEvent event) {
+    event
+        .getAllFields()
+        .forEach(
+            (d, v) -> {
+              if (d.getName().endsWith("_attributes")) {
+                result.append(d.getName()).append(" { \n");
+                String printedAttributes = printEventAttributes(printer, (MessageOrBuilder) v);
+                for (String attributeField : printedAttributes.split("\\n")) {
+                  result.append("  ").append(attributeField).append('\n');
+                }
+                result.append("}");
+              } else {
+                result.append(printer.shortDebugString(d, v));
+              }
+              result.append("\n");
+            });
+  }
+
+  private static String printEventAttributes(
+      TextFormat.Printer printer, MessageOrBuilder attributesValue) {
+    StringBuilder result = new StringBuilder();
+    attributesValue
+        .getAllFields()
+        .forEach(
+            (d, v) -> {
+              if (d.getName().equals("input") || d.getName().equals("result")) {
+                result.append(printer.printFieldToString(d, v));
+              } else {
+                result.append(printer.shortDebugString(d, v));
+                result.append("\n");
+              }
+            });
+    if (result.length() > 0 && result.charAt(result.length() - 1) == '\n') {
+      // delete trailing \n
+      result.deleteCharAt(result.length() - 1);
+    }
+
+    return result.toString();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -19,6 +19,10 @@
 
 package io.temporal.internal.common;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -30,6 +34,8 @@ import java.util.List;
 
 /** Contains workflow execution ids and the history */
 public final class WorkflowExecutionHistory {
+  private static final Gson PRETTY_PRINTER = new GsonBuilder().setPrettyPrinting().create();
+
   private final History history;
 
   public WorkflowExecutionHistory(History history) {
@@ -67,14 +73,32 @@ public final class WorkflowExecutionHistory {
     }
   }
 
-  public String toJson() {
+  /** @return full json that can be used for replay and which is compatible with tctl */
+  public String toJson(boolean prettyPrint) {
     JsonFormat.Printer printer = JsonFormat.printer();
     try {
       String protoJson = printer.print(history);
-      return HistoryJsonUtils.protoJsonToHistoryFormatJson(protoJson);
+      String historyFormatJson = HistoryJsonUtils.protoJsonToHistoryFormatJson(protoJson);
+
+      if (prettyPrint) {
+        JsonElement je = JsonParser.parseString(historyFormatJson);
+        return PRETTY_PRINTER.toJson(je);
+      } else {
+        return historyFormatJson;
+      }
     } catch (InvalidProtocolBufferException e) {
       throw new DataConverterException(e);
     }
+  }
+
+  /**
+   * Returns workflow instance history in a human readable format.
+   *
+   * @param showWorkflowTasks when set to false workflow task events (command events) are not
+   *     included
+   */
+  public String toProtoText(boolean showWorkflowTasks) {
+    return HistoryProtoTextUtils.toProtoText(history, showWorkflowTasks);
   }
 
   public WorkflowExecution getWorkflowExecution() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -34,7 +34,6 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.enums.v1.RetryState;
 import io.temporal.api.enums.v1.TimeoutType;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
-import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.HistoryEventOrBuilder;
 import io.temporal.api.history.v1.WorkflowExecutionCanceledEventAttributes;
@@ -53,7 +52,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -235,30 +233,6 @@ public class WorkflowExecutionUtils {
       default:
         throw new IllegalArgumentException("Not a close event: " + event);
     }
-  }
-
-  /**
-   * Returns workflow instance history in a human readable format.
-   *
-   * @param showWorkflowTasks when set to false workflow task events (command events) are not
-   *     included
-   * @param history Workflow instance history
-   */
-  public static String prettyPrintHistory(History history, boolean showWorkflowTasks) {
-    return prettyPrintHistory(history.getEventsList().iterator(), showWorkflowTasks);
-  }
-
-  public static String prettyPrintHistory(
-      Iterator<HistoryEvent> events, boolean showWorkflowTasks) {
-    StringBuilder result = new StringBuilder();
-    while (events.hasNext()) {
-      HistoryEvent event = events.next();
-      if (!showWorkflowTasks && event.getEventType().toString().startsWith("WorkflowTask")) {
-        continue;
-      }
-      result.append(prettyPrintObject(event));
-    }
-    return result.toString();
   }
 
   public static String prettyPrintCommands(Iterable<Command> commands) {

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -341,7 +341,7 @@ public class SDKTestWorkflowRule implements TestRule {
       GetWorkflowExecutionHistoryResponse response =
           service.blockingStub().getWorkflowExecutionHistory(request);
       WorkflowExecutionHistory history = new WorkflowExecutionHistory(response.getHistory());
-      String json = history.toJson();
+      String json = history.toJson(true);
       String projectPath = System.getProperty("user.dir");
       String resourceFile = projectPath + "/src/test/resources/" + fileName + ".json";
       File file = new File(resourceFile);

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation "io.grpc:grpc-core:$grpcVersion"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
+    implementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -39,6 +39,7 @@ import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.failure.ApplicationFailure;
+import io.temporal.internal.common.WorkflowExecutionHistory;
 import io.temporal.internal.common.WorkflowExecutionUtils;
 import io.temporal.internal.testservice.RequestContext.Timer;
 import io.temporal.workflow.Functions;
@@ -491,10 +492,11 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       {
         for (Entry<ExecutionId, HistoryStore> entry : this.histories.entrySet()) {
           result.append(entry.getKey());
-          result.append("\n");
+          result.append("\n\n");
           result.append(
-              WorkflowExecutionUtils.prettyPrintHistory(
-                  entry.getValue().getEventsLocked().iterator(), true));
+              new WorkflowExecutionHistory(
+                      History.newBuilder().addAllEvents(entry.getValue().getEventsLocked()).build())
+                  .toProtoText(true));
           result.append("\n");
         }
       }


### PR DESCRIPTION
The current version of prettyPrint is very verbose and hard to navigate. This change makes test history print much more manageable.