### PR TITLE
Various debugging utils developed during state machine bug investigation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryProtoTextUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryProtoTextUtils.java
@@ -69,7 +69,10 @@ public class HistoryProtoTextUtils {
         .getAllFields()
         .forEach(
             (d, v) -> {
-              if (d.getName().equals("input") || d.getName().equals("result")) {
+              String fieldName = d.getName();
+              if (fieldName.equals("input")
+                  || fieldName.equals("result")
+                  || fieldName.equals("details")) {
                 result.append(printer.printFieldToString(d, v));
               } else {
                 result.append(printer.shortDebugString(d, v));

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/CancellableCommand.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/CancellableCommand.java
@@ -67,7 +67,7 @@ class CancellableCommand {
   public WorkflowStateMachines.HandleEventStatus handleEvent(
       HistoryEvent event, boolean hasNextEvent) {
     if (canceled) {
-      return WorkflowStateMachines.HandleEventStatus.NON_MATCHING_EVENT;
+      return WorkflowStateMachines.HandleEventStatus.COMMAND_CANCELLED;
     }
     return entityStateMachine.handleEvent(event, hasNextEvent);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/EntityStateMachineBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/EntityStateMachineBase.java
@@ -22,21 +22,25 @@ package io.temporal.internal.statemachines;
 import io.temporal.api.enums.v1.CommandType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.workflow.Functions;
+import javax.annotation.Nullable;
 
 class EntityStateMachineBase<State, ExplicitEvent, Data> implements EntityStateMachine {
-
-  private final StateMachine<State, ExplicitEvent, Data> stateMachine;
-
+  protected final StateMachine<State, ExplicitEvent, Data> stateMachine;
   protected final Functions.Proc1<CancellableCommand> commandSink;
 
   protected HistoryEvent currentEvent;
   protected boolean hasNextEvent;
 
+  /**
+   * @param entityName name or id of the entity this state machine represents. For debug purposes
+   *     only. Can be null.
+   */
   public EntityStateMachineBase(
       StateMachineDefinition<State, ExplicitEvent, Data> stateMachineDefinition,
       Functions.Proc1<CancellableCommand> commandSink,
-      Functions.Proc1<StateMachine> stateMachineSink) {
-    this.stateMachine = StateMachine.newInstance(stateMachineDefinition);
+      Functions.Proc1<StateMachine> stateMachineSink,
+      @Nullable String entityName) {
+    this.stateMachine = StateMachine.newInstance(stateMachineDefinition, entityName);
     this.commandSink = commandSink;
     stateMachineSink.apply(this.stateMachine);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/EntityStateMachineInitialCommand.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/EntityStateMachineInitialCommand.java
@@ -22,6 +22,7 @@ package io.temporal.internal.statemachines;
 import io.temporal.api.command.v1.Command;
 import io.temporal.api.enums.v1.CommandType;
 import io.temporal.workflow.Functions;
+import javax.annotation.Nullable;
 
 class EntityStateMachineInitialCommand<State, ExplicitEvent, Data>
     extends EntityStateMachineBase<State, ExplicitEvent, Data> {
@@ -34,7 +35,15 @@ class EntityStateMachineInitialCommand<State, ExplicitEvent, Data>
       StateMachineDefinition<State, ExplicitEvent, Data> stateMachineDefinition,
       Functions.Proc1<CancellableCommand> commandSink,
       Functions.Proc1<StateMachine> stateMachineSink) {
-    super(stateMachineDefinition, commandSink, stateMachineSink);
+    this(stateMachineDefinition, commandSink, stateMachineSink, null);
+  }
+
+  public EntityStateMachineInitialCommand(
+      StateMachineDefinition<State, ExplicitEvent, Data> stateMachineDefinition,
+      Functions.Proc1<CancellableCommand> commandSink,
+      Functions.Proc1<StateMachine> stateMachineSink,
+      @Nullable String entityName) {
+    super(stateMachineDefinition, commandSink, stateMachineSink, entityName);
   }
 
   protected final void addCommand(Command command) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/FixedTransitionAction.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/FixedTransitionAction.java
@@ -37,7 +37,7 @@ class FixedTransitionAction<State, Data> implements TransitionAction<State, Data
 
   @Override
   public String toString() {
-    return "FixedTransitionAction{" + "state=" + state + ", callback=" + action + '}';
+    return "FixedTransitionAction{" + "toState=" + state + "}";
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StateMachineDefinition.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StateMachineDefinition.java
@@ -195,7 +195,7 @@ final class StateMachineDefinition<State, ExplicitEvent, Data> {
     checkFinalState(from);
     add(
         new Transition<>(from, new TransitionEvent<>(eventType)),
-        new DynamicTransitionAction<State, Data>(toStates, action));
+        new DynamicTransitionAction<>(toStates, action));
     validEventTypes.add(eventType);
     return this;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/TimerStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/TimerStateMachine.java
@@ -57,7 +57,7 @@ final class TimerStateMachine
       Functions.Proc1<HistoryEvent> completionCallback,
       Functions.Proc1<CancellableCommand> commandSink,
       Functions.Proc1<StateMachine> stateMachineSink) {
-    super(STATE_MACHINE_DEFINITION, commandSink, stateMachineSink);
+    super(STATE_MACHINE_DEFINITION, commandSink, stateMachineSink, attributes.getTimerId());
     this.startAttributes = attributes;
     this.completionCallback = completionCallback;
     explicitEvent(ExplicitEvent.SCHEDULE);

--- a/temporal-sdk/src/test/resources/logback-test.xml
+++ b/temporal-sdk/src/test/resources/logback-test.xml
@@ -27,6 +27,9 @@
         </encoder>
     </appender>
     <logger name="io.grpc.netty" level="INFO"/>
+
+    <!--    <logger name="io.temporal.internal.statemachines.StateMachine" level="TRACE"/>-->
+
     <!-- Modify root log level to get more info -->
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -92,7 +92,6 @@ public class TestWorkflowRule implements TestRule {
       };
 
   private TestWorkflowRule(Builder builder) {
-
     doNotStart = builder.doNotStart;
     useExternalService = builder.useExternalService;
     namespace = (builder.namespace == null) ? "UnitTest" : builder.namespace;

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -43,6 +43,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.TestWorkflowRule;
 import io.temporal.testing.TracingWorkerInterceptor;
+import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.WorkflowImplementationOptions;
@@ -223,8 +224,16 @@ public class SDKTestWorkflowRule implements TestRule {
     return testWorkflowRule.getTaskQueue();
   }
 
+  public Worker getWorker() {
+    return testWorkflowRule.getWorker();
+  }
+
   public History getHistory(WorkflowExecution execution) {
     return testWorkflowRule.getWorkflowExecutionHistory(execution);
+  }
+
+  public String getHistoryJsonForReplay(WorkflowExecution execution) {
+    return new WorkflowExecutionHistory(getHistory(execution)).toJson(true);
   }
 
   /** Returns list of all events of the given EventType found in the history. */


### PR DESCRIPTION
These changes are taken from the branch related to investigation and fixes of #648 to keep that branch and future PR clean and easy to follow.
This PR includes various helper logging and functions that could be helpful with state machine debugging.
Including:
- improved states transition logging
- included optional entityName into state machines for concise debug prints
- methods helping with getting a workflow history 
- methods helping with replaying workflow history in tests using TestRule