### PR TITLE
Identity for pending activity comes from pollRequest in TestService

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/DescribeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DescribeTest.java
@@ -142,15 +142,12 @@ public class DescribeTest {
             .setActivityId(actual.getActivityId())
             .setActivityType(ActivityType.newBuilder().setName("TestDescribeActivity").build())
             .setState(PendingActivityState.PENDING_ACTIVITY_STATE_STARTED)
-            // TODO: Uncomment when the server is fixed. We should always expect to see an identity
-            //  here because any activity that has been picked up by the worker is pending until it
-            //  is completed/cancelled/terminated.
-            //            .setLastWorkerIdentity(
-            //                testWorkflowRule
-            //                    .getTestEnvironment()
-            //                    .getWorkflowClient()
-            //                    .getOptions()
-            //                    .getIdentity())
+            .setLastWorkerIdentity(
+                testWorkflowRule
+                    .getTestEnvironment()
+                    .getWorkflowClient()
+                    .getOptions()
+                    .getIdentity())
             .setAttempt(1)
             .setMaximumAttempts(2)
             // times should be present, but we can't know what the expected value is if this test is

--- a/temporal-sdk/src/test/java/io/temporal/workflow/IdentityInPendingActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/IdentityInPendingActivityTest.java
@@ -20,6 +20,7 @@
 package io.temporal.workflow;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
@@ -44,7 +45,8 @@ public class IdentityInPendingActivityTest {
           .build();
 
   @Test
-  public void testActivityHeartbeatHasIdentity() throws InterruptedException {
+  public void testPendingActivityHasIdentity() throws InterruptedException {
+    assumeFalse(testWorkflowRule.isUseExternalService());
     NoArgsWorkflow workflow = testWorkflowRule.newWorkflowStub(NoArgsWorkflow.class);
     WorkflowExecution execution = WorkflowClient.start(workflow::execute);
     DescribeWorkflowExecutionResponse response =
@@ -52,7 +54,6 @@ public class IdentityInPendingActivityTest {
     // Call describeWorkflowExecution until we see pending activities.
     // We see a pending activity without an identity first before the worker picks it up.
     while (response.getPendingActivitiesCount() == 0) {
-      // System.out.println(response.getPendingActivitiesList());
       Thread.sleep(50);
       response =
           testWorkflowRule

--- a/temporal-sdk/src/test/java/io/temporal/workflow/IdentityInPendingActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/IdentityInPendingActivityTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
+import io.temporal.client.WorkflowClient;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities.NoArgsActivity;
+import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class IdentityInPendingActivityTest {
+
+  private final NoArgsActivity activityImpl = new ActivityImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(WorkflowImpl.class)
+          .setActivityImplementations(activityImpl)
+          .build();
+
+  @Test
+  public void testActivityHeartbeatHasIdentity() throws InterruptedException {
+    NoArgsWorkflow workflow = testWorkflowRule.newWorkflowStub(NoArgsWorkflow.class);
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+    DescribeWorkflowExecutionResponse response =
+        DescribeWorkflowExecutionResponse.getDefaultInstance();
+    // Call describeWorkflowExecution until we see pending activities.
+    // We see a pending activity without an identity first before the worker picks it up.
+    while (response.getPendingActivitiesCount() == 0) {
+      // System.out.println(response.getPendingActivitiesList());
+      Thread.sleep(50);
+      response =
+          testWorkflowRule
+              .getWorkflowClient()
+              .getWorkflowServiceStubs()
+              .blockingStub()
+              .describeWorkflowExecution(
+                  DescribeWorkflowExecutionRequest.newBuilder()
+                      .setNamespace(
+                          testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                      .setExecution(execution)
+                      .build());
+      if (response.getPendingActivitiesCount() > 0) {
+        assertEquals(
+            "Pending activity identity is not as expected",
+            testWorkflowRule.getTestEnvironment().getWorkflowClient().getOptions().getIdentity(),
+            response.getPendingActivities(0).getLastWorkerIdentity());
+      }
+    }
+  }
+
+  public static class WorkflowImpl implements NoArgsWorkflow {
+
+    private final NoArgsActivity activities =
+        Workflow.newActivityStub(
+            NoArgsActivity.class, SDKTestOptions.newActivityOptions20sScheduleToClose());
+
+    @Override
+    public void execute() {
+      activities.execute();
+    }
+  }
+
+  public static class ActivityImpl implements NoArgsActivity {
+    @Override
+    public void execute() {
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -727,22 +727,27 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   }
 
   private void processScheduleActivityTask(
-      RequestContext ctx, ScheduleActivityTaskCommandAttributes a, long workflowTaskCompletedId) {
-    a = validateScheduleActivityTask(a);
-    String activityId = a.getActivityId();
+      RequestContext ctx,
+      ScheduleActivityTaskCommandAttributes attributes,
+      long workflowTaskCompletedId) {
+    attributes = validateScheduleActivityTask(attributes);
+    String activityId = attributes.getActivityId();
     Long activityScheduledEventId = activityById.get(activityId);
     if (activityScheduledEventId != null) {
       throw Status.FAILED_PRECONDITION
           .withDescription("Already open activity with " + activityId)
           .asRuntimeException();
     }
-    StateMachine<ActivityTaskData> activity = newActivityStateMachine(store, this.startRequest);
+    StateMachine<ActivityTaskData> activityStateMachine =
+        newActivityStateMachine(store, this.startRequest);
     long activityScheduleId = ctx.getNextEventId();
-    activities.put(activityScheduleId, activity);
+    activities.put(activityScheduleId, activityStateMachine);
     activityById.put(activityId, activityScheduleId);
-    activity.action(StateMachines.Action.INITIATE, ctx, a, workflowTaskCompletedId);
-    ActivityTaskScheduledEventAttributes scheduledEvent = activity.getData().scheduledEvent;
-    int attempt = activity.getData().getAttempt();
+    activityStateMachine.action(
+        StateMachines.Action.INITIATE, ctx, attributes, workflowTaskCompletedId);
+    ActivityTaskScheduledEventAttributes scheduledEvent =
+        activityStateMachine.getData().scheduledEvent;
+    int attempt = activityStateMachine.getData().getAttempt();
     ctx.addTimer(
         ProtobufTimeUtils.toJavaDuration(scheduledEvent.getScheduleToCloseTimeout()),
         () ->
@@ -1524,14 +1529,15 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     update(
         ctx -> {
           String activityId = task.getActivityId();
-          StateMachine<ActivityTaskData> activity = getActivityById(activityId);
-          activity.action(StateMachines.Action.START, ctx, pollRequest, 0);
-          ActivityTaskData data = activity.getData();
+          StateMachine<ActivityTaskData> activityStateMachine = getActivityById(activityId);
+          activityStateMachine.action(StateMachines.Action.START, ctx, pollRequest, 0);
+          ActivityTaskData data = activityStateMachine.getData();
+          data.identity = pollRequest.getIdentity();
           Duration startToCloseTimeout =
               ProtobufTimeUtils.toJavaDuration(data.scheduledEvent.getStartToCloseTimeout());
           Duration heartbeatTimeout =
               ProtobufTimeUtils.toJavaDuration(data.scheduledEvent.getHeartbeatTimeout());
-          long scheduledEventId = activity.getData().scheduledEventId;
+          long scheduledEventId = activityStateMachine.getData().scheduledEventId;
           if (startToCloseTimeout.compareTo(Duration.ZERO) > 0) {
             int attempt = data.getAttempt();
             ctx.addTimer(
@@ -1542,7 +1548,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
                 "Activity StartToCloseTimeout");
           }
           updateHeartbeatTimer(
-              ctx, scheduledEventId, activity, startToCloseTimeout, heartbeatTimeout);
+              ctx, scheduledEventId, activityStateMachine, startToCloseTimeout, heartbeatTimeout);
         });
   }
 


### PR DESCRIPTION
## What was changed
Added test that demonstrates that identity is missing from pending activities.

## Why?
identity is missing from pending activities -- probably server issue

## Checklist
1. Closes #766 
