### PR TITLE
Fix HealthCheckTest to run with dockerized buildkite environment

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -408,7 +408,11 @@ public class WorkflowServiceStubsOptions {
       this.keepAlivePermitWithoutStream = options.keepAlivePermitWithoutStream;
     }
 
-    /** Sets gRPC channel to use. Exclusive with target and sslContext. */
+    /**
+     * Sets gRPC channel to use.
+     *
+     * <p>Exclusive with {@link #setTarget(String)} and {@link #setSslContext(SslContext)}.
+     */
     public Builder setChannel(ManagedChannel channel) {
       this.channel = channel;
       return this;
@@ -437,9 +441,9 @@ public class WorkflowServiceStubsOptions {
     /**
      * Sets a target string, which can be either a valid {@link NameResolver}-compliant URI, or an
      * authority string. See {@link ManagedChannelBuilder#forTarget(String)} for more information
-     * about parameter format.
+     * about parameter format. Default is {@link #DEFAULT_LOCAL_DOCKER_TARGET}
      *
-     * <p>Exclusive with channel.
+     * <p>Exclusive with {@link #setChannel(ManagedChannel)}.
      */
     public Builder setTarget(String target) {
       this.target = target;

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
@@ -31,14 +31,23 @@ public class HealthCheckTest {
   private static final boolean useDockerService =
       Boolean.parseBoolean(System.getenv("USE_DOCKER_SERVICE"));
 
+  public static final String temporalServiceAddress = System.getenv("TEMPORAL_SERVICE_ADDRESS");
+
   @Test
   public void testHealthCheck() {
     WorkflowServiceStubs workflowServiceStubs = null;
     if (useDockerService) {
       try {
+        WorkflowServiceStubsOptions stubsOptions = WorkflowServiceStubsOptions.getDefaultInstance();
+        if (temporalServiceAddress != null) {
+          stubsOptions =
+              WorkflowServiceStubsOptions.newBuilder(stubsOptions)
+                  .setTarget(temporalServiceAddress)
+                  .build();
+        }
         // Stub creation triggers health check by default, unless disableHealthCheck flag is set in
         // the WorkflowServiceStubsOptions.
-        workflowServiceStubs = WorkflowServiceStubs.newInstance();
+        workflowServiceStubs = WorkflowServiceStubs.newInstance(stubsOptions);
       } catch (Exception e) {
         Assert.fail("Health check failed");
       } finally {


### PR DESCRIPTION
`HealthCheckTest` assumes that Temporal server is available on default location only (127.0.0.1:7233)
This doesn't work with our buildkite setup where Temporal is available on temporal:7233
This PR uses `TEMPORAL_SERVICE_ADDRESS` env var to get Temporal Server URL in `HealthCheckTest` as it's done in other places.