### PR TITLE
Fix flaky ActivityThrowingErrorTest

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
@@ -21,6 +21,7 @@ package io.temporal.activity;
 
 import static org.junit.Assert.assertEquals;
 
+import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkflowImplementationOptions;
@@ -70,7 +71,11 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
   @Test
   public void testSetWorkflowImplementationOptions() {
     TestWorkflowReturnMap workflowStub =
-        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflowReturnMap.class);
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflowReturnMap.class,
+                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
     Map<String, Map<String, Duration>> result = workflowStub.execute();
 
     // Check that activity1 has default workerOptions options that were partially overwritten with

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
@@ -19,11 +19,11 @@
 
 package io.temporal.workflow.childWorkflowTests;
 
-import static io.temporal.testing.internal.SDKTestOptions.newWorkflowOptionsWithTimeouts;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
 import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
@@ -53,11 +53,17 @@ public class ChildWorkflowWithCronScheduleTest {
     // Feel free to uncomment the line below and test in local.
     assumeFalse("skipping as test will timeout", SDKTestWorkflowRule.useExternalService);
 
+    WorkflowOptions workflowOptions =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofDays(1))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(5))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+
     WorkflowStub client =
         testWorkflowRule
             .getWorkflowClient()
-            .newUntypedWorkflowStub(
-                "TestWorkflow1", newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+            .newUntypedWorkflowStub("TestWorkflow1", workflowOptions);
     client.start(testName.getMethodName());
     testWorkflowRule.getTestEnvironment().sleep(Duration.ofHours(3));
     client.cancel();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -22,6 +22,7 @@ package io.temporal.workflow.versionTests;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
+import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -56,7 +57,14 @@ public class GetVersionAndTimerTest {
   }
 
   private void testTimedWorkflow(SDKTestWorkflowRule rule) {
-    TimedWorkflow workflowStub = rule.newWorkflowStubTimeoutOptions(TimedWorkflow.class);
+    WorkflowOptions workflowOptions =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofDays(1))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(5))
+            .setTaskQueue(rule.getTaskQueue())
+            .build();
+    TimedWorkflow workflowStub =
+        rule.getWorkflowClient().newWorkflowStub(TimedWorkflow.class, workflowOptions);
 
     Instant startInstant = Instant.ofEpochMilli(rule.getTestEnvironment().currentTimeMillis());
 

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
@@ -46,7 +46,7 @@ public class SDKTestOptions {
           .build();
     } else {
       return WorkflowOptions.newBuilder()
-          .setWorkflowRunTimeout(Duration.ofHours(30))
+          .setWorkflowRunTimeout(Duration.ofSeconds(200))
           .setWorkflowTaskTimeout(Duration.ofSeconds(5))
           .setTaskQueue(taskQueue)
           .build();


### PR DESCRIPTION
`ActivityThrowingErrorTest` flakes in a build with dockerized Temporal with a timeout.
Fix retry options to don't waste time in retries.