### PR TITLE
Dependency Update

### DIFF
--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -23,8 +23,8 @@ compileTestKotlin {
 dependencies {
     implementation project(':temporal-sdk')
 
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.5'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.12.5'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.0'
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.0'
 
     testImplementation project(':temporal-testing')
     testImplementation project(':temporal-testing-junit4')

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -7,8 +7,8 @@ dependencies {
 
     implementation "com.google.guava:guava:$guavaVersion"
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.5'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.5'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.5'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.0'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.0'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }


### PR DESCRIPTION
> Task :temporal-kotlin:checkDependencyUpdates
New dependency version: com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.12.5 -> 2.13.0
New dependency version: com.fasterxml.jackson.module:jackson-module-kotlin: 2.12.5 -> 2.13.0
New dependency version: org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable: 1.4.32 -> 1.5.31
New dependency version: org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin: 1.4.32 -> 1.5.31

> Task :temporal-sdk:checkDependencyUpdates
New dependency version: com.fasterxml.jackson.core:jackson-databind: 2.12.5 -> 2.13.0
New dependency version: com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.12.5 -> 2.13.0