### PR TITLE
Enable IdentityInPendingActivityTest for Dockerized Temporal

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:3.11.9
     logging:
       driver: none
     ports:

--- a/temporal-sdk/src/test/java/io/temporal/workflow/IdentityInPendingActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/IdentityInPendingActivityTest.java
@@ -20,7 +20,6 @@
 package io.temporal.workflow;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
@@ -46,7 +45,6 @@ public class IdentityInPendingActivityTest {
 
   @Test
   public void testPendingActivityHasIdentity() throws InterruptedException {
-    assumeFalse(testWorkflowRule.isUseExternalService());
     NoArgsWorkflow workflow = testWorkflowRule.newWorkflowStub(NoArgsWorkflow.class);
     WorkflowExecution execution = WorkflowClient.start(workflow::execute);
     DescribeWorkflowExecutionResponse response =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryOptionsChangeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryOptionsChangeTest.java
@@ -19,6 +19,9 @@
 
 package io.temporal.workflow.activityTests;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowException;
 import io.temporal.common.RetryOptions;
@@ -55,8 +58,8 @@ public class AsyncActivityRetryOptionsChangeTest {
       workflowStub.execute(testWorkflowRule.getTaskQueue());
       Assert.fail("unreachable");
     } catch (WorkflowException e) {
-      Assert.assertTrue(e.getCause() instanceof ActivityFailure);
-      Assert.assertTrue(e.getCause().getCause() instanceof ApplicationFailure);
+      assertThat(e.getCause(), instanceOf(ActivityFailure.class));
+      assertThat(e.getCause().getCause(), instanceOf(ApplicationFailure.class));
       Assert.assertEquals(
           IOException.class.getName(), ((ApplicationFailure) e.getCause().getCause()).getType());
     }
@@ -72,17 +75,14 @@ public class AsyncActivityRetryOptionsChangeTest {
       ActivityOptions.Builder options =
           ActivityOptions.newBuilder()
               .setTaskQueue(taskQueue)
-              .setHeartbeatTimeout(Duration.ofSeconds(5))
-              .setScheduleToCloseTimeout(Duration.ofSeconds(5))
-              .setScheduleToStartTimeout(Duration.ofSeconds(5))
-              .setStartToCloseTimeout(Duration.ofSeconds(10));
+              .setScheduleToCloseTimeout(Duration.ofSeconds(8));
       if (Workflow.isReplaying()) {
         options.setRetryOptions(
             RetryOptions.newBuilder()
                 .setMaximumInterval(Duration.ofSeconds(1))
                 .setInitialInterval(Duration.ofSeconds(1))
-                .setDoNotRetry(NullPointerException.class.getName())
                 .setMaximumAttempts(3)
+                .setDoNotRetry(NullPointerException.class.getName())
                 .build());
       } else {
         options.setRetryOptions(


### PR DESCRIPTION
## What was changed
Enable IdentityInPendingActivityTest for Dockerized Temporal that was disabled by mistake in #784
Fix flaky AsyncActivityRetryOptionsChangeTest for Dockerized Temporal