### PR TITLE
Use ReplayAwareScope to don't double report completion on replays, fix STICKY_CACHE_THREAD_FORCED_EVICTION double reporting

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -130,8 +130,7 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
             options,
             metricsScope);
 
-    replayWorkflowExecutor =
-        new ReplayWorkflowExecutor(workflow, metricsScope, workflowStateMachines, context);
+    replayWorkflowExecutor = new ReplayWorkflowExecutor(workflow, workflowStateMachines, context);
 
     localActivityCompletionSink = historyEvent -> localActivityCompletionQueue.add(historyEvent);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -249,12 +249,8 @@ class WorkflowThreadImpl implements WorkflowThread {
         taskFuture = threadPool.submit(task);
         return;
       } catch (RejectedExecutionException e) {
-        getWorkflowContext()
-            .getMetricsScope()
-            .counter(MetricsType.STICKY_CACHE_THREAD_FORCED_EVICTION)
-            .inc(1);
         if (cache != null) {
-          SyncWorkflowContext workflowContext = this.runner.getWorkflowContext();
+          SyncWorkflowContext workflowContext = getWorkflowContext();
           ReplayWorkflowContext context = workflowContext.getContext();
           boolean evicted =
               cache.evictAnyNotInProcessing(


### PR DESCRIPTION
## What was changed
Use ReplayAwareScope for metric reporting to address #759
Remove duplicate STICKY_CACHE_THREAD_FORCED_EVICTION reporting to address #201

Closes #759 
Closes #201