### PR TITLE
Implement activity_succeed_endtoend_latency and local_activity_succeed_endtoend_latency metrics

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/metrics/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/metrics/MetricsType.java
@@ -66,8 +66,8 @@ public class MetricsType {
       TEMPORAL_METRICS_PREFIX + "activity_canceled";
   public static final String ACTIVITY_EXEC_LATENCY =
       TEMPORAL_METRICS_PREFIX + "activity_execution_latency";
-  public static final String ACTIVITY_E2E_LATENCY =
-      TEMPORAL_METRICS_PREFIX + "activity_endtoend_latency";
+  public static final String ACTIVITY_SUCCEED_E2E_LATENCY =
+      TEMPORAL_METRICS_PREFIX + "activity_succeed_endtoend_latency";
   public static final String LOCAL_ACTIVITY_TOTAL_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_total";
   public static final String LOCAL_ACTIVITY_CANCELED_COUNTER =
@@ -76,6 +76,8 @@ public class MetricsType {
       TEMPORAL_METRICS_PREFIX + "local_activity_failed";
   public static final String LOCAL_ACTIVITY_EXECUTION_LATENCY =
       TEMPORAL_METRICS_PREFIX + "local_activity_execution_latency";
+  public static final String LOCAL_ACTIVITY_SUCCEED_E2E_LATENCY =
+      TEMPORAL_METRICS_PREFIX + "local_activity_succeed_endtoend_latency";
   public static final String CORRUPTED_SIGNALS_COUNTER =
       TEMPORAL_METRICS_PREFIX + "corrupted_signals";
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ExecuteLocalActivityParameters.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ExecuteLocalActivityParameters.java
@@ -23,7 +23,6 @@ import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import java.time.Duration;
 
 public class ExecuteLocalActivityParameters {
-
   private final PollActivityTaskQueueResponse.Builder activityTask;
   private final Duration localRetryThreshold;
   private boolean doNotIncludeArgumentsIntoMarker;

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -234,6 +234,13 @@ public final class LocalActivityWorker implements SuspendableWorker {
         return result;
       }
 
+      if (result.getTaskCompleted() != null) {
+        com.uber.m3.util.Duration e2eDuration =
+            ProtobufTimeUtils.toM3DurationSinceNow(
+                task.params.getActivityTask().getScheduledTime());
+        metricsScope.timer(MetricsType.LOCAL_ACTIVITY_SUCCEED_E2E_LATENCY).record(e2eDuration);
+      }
+
       if (result.getTaskCompleted() != null
           || result.getTaskCanceled() != null
           || !activityTask.hasRetryPolicy()) {


### PR DESCRIPTION
## What was changed

Misleading activity_endtoend_latency is replaced with activity_succeed_endtoend_latency and local_activity_succeed_endtoend_latency which includes a latency between activity schedule to the end of the successful execution.

Closes #799