### PR TITLE
Remove Error throwing from DeterministicRunner#executeInWorkflowThread is case if execution is closed

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -434,7 +434,9 @@ class DeterministicRunnerImpl implements DeterministicRunner {
   public void executeInWorkflowThread(String name, Runnable runnable) {
     lock.lock();
     try {
-      checkClosed();
+      // if the execution is closed, we will just add the callbacks, but we will never create
+      // threads for them,
+      // so they will be effectively ignored
       toExecuteInWorkflowThread.add(new NamedRunnable(name, runnable));
     } finally {
       lock.unlock();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/ActivityCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/ActivityCancellationTest.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.cancellationTests;
+
+import static org.junit.Assert.*;
+
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.*;
+import io.temporal.failure.*;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.*;
+
+public class ActivityCancellationTest {
+  private static final AtomicBoolean timeSkipping = new AtomicBoolean();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestCancellationWorkflow.class)
+          .setActivityImplementations(new TestCancellationActivityImpl())
+          .build();
+
+  @Test
+  public void testActivityCancellation() {
+    timeSkipping.set(!testWorkflowRule.isUseExternalService());
+    TestWorkflow1 workflow = testWorkflowRule.newWorkflowStub(TestWorkflow1.class);
+    try {
+      WorkflowClient.start(workflow::execute, "input1");
+      WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
+      // While activity is running time skipping is disabled.
+      // So sleep for 1 second after it is scheduled.
+      testWorkflowRule.sleep(Duration.ofSeconds((timeSkipping.get() ? 3600 : 0) + 1));
+      untyped.cancel();
+      untyped.getResult(String.class);
+      fail("unreacheable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+  }
+
+  @ActivityInterface
+  public interface TestCancellationActivity {
+    String activity1(String input);
+  }
+
+  private static class TestCancellationActivityImpl implements TestCancellationActivity {
+
+    @Override
+    public String activity1(String input) {
+      long start = System.currentTimeMillis();
+      while (true) {
+        Activity.getExecutionContext().heartbeat(System.currentTimeMillis() - start);
+        try {
+          Thread.sleep(50);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+
+  public static class TestCancellationWorkflow implements TestWorkflow1 {
+
+    private final TestCancellationActivity activity =
+        Workflow.newActivityStub(
+            TestCancellationActivity.class,
+            ActivityOptions.newBuilder()
+                .setScheduleToCloseTimeout(Duration.ofSeconds(1000))
+                .setHeartbeatTimeout(Duration.ofSeconds(1))
+                .build());
+
+    @Override
+    public String execute(String input) {
+      if (timeSkipping.get()) {
+        Workflow.sleep(Duration.ofHours(1)); // test time skipping
+      }
+      return activity.activity1(input);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitCancellationTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.cancellationTests;
+
+import static org.junit.Assert.*;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.History;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowAwaitCancellationTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(AwaitingWorkflow.class).build();
+
+  @Test
+  public void awaitCancellation() {
+    TestWorkflows.TestWorkflow1 workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflow1.class);
+    WorkflowExecution execution = null;
+    try {
+      execution = WorkflowClient.start(workflow::execute, "input1");
+      WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
+      untyped.cancel();
+      untyped.getResult(String.class);
+      fail("unreacheable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+      History history = testWorkflowRule.getHistory(execution);
+
+      HistoryEvent lastEvent = history.getEvents(history.getEventsCount() - 1);
+      assertEquals(
+          "WorkflowExecutionCancelled event is expected",
+          EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+          lastEvent.getEventType());
+    }
+  }
+
+  public static class AwaitingWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String input) {
+      Workflow.await(() -> false);
+      return "success";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitWithDurationCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitWithDurationCancellationTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.cancellationTests;
+
+import static org.junit.Assert.*;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.History;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowAwaitWithDurationCancellationTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(AwaitingWorkflow.class).build();
+
+  @Test
+  public void awaitWithDurationCancellation() {
+    TestWorkflows.TestWorkflow1 workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflow1.class);
+    WorkflowExecution execution = null;
+    try {
+      execution = WorkflowClient.start(workflow::execute, "input1");
+      WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
+      untyped.cancel();
+      untyped.getResult(String.class);
+      fail("unreacheable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+      History history = testWorkflowRule.getHistory(execution);
+
+      HistoryEvent lastEvent = history.getEvents(history.getEventsCount() - 1);
+      assertEquals(
+          "WorkflowExecutionCancelled event is expected",
+          EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+          lastEvent.getEventType());
+
+      HistoryEvent oneBeforeLastEvent = history.getEvents(history.getEventsCount() - 2);
+      assertEquals(
+          "TimerCancelled event is expected because we should cancel the timer created for timed conditional wait",
+          EventType.EVENT_TYPE_TIMER_CANCELED,
+          oneBeforeLastEvent.getEventType());
+    }
+  }
+
+  public static class AwaitingWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String input) {
+      Workflow.await(Duration.ofHours(1), () -> false);
+      return "success";
+    }
+  }
+}


### PR DESCRIPTION
## What was changed
`checkClosed` was removed from `DeterministicRunner#executeInWorkflowThread` method that register callbacks to call in workflow thread.

## Why?
1. It allows state machines to trigger their callbacks and finish processing without getting an Error during `prepareCommands` when the workflow execution is closed.
2. It's safe, this method just adds into a collection of runnables and doesn't really create WorkflowThread instances yet and doesn't trigger an actual callback directly.

### How was this tested
Unit tests that test workflow cancelation with `Workflow.await()`

Closes #816
