### PR TITLE
Improve diagnostic message of workflow state machines when validation of command-event pair fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ ext {
     grpcVersion = '1.41.0'
     guavaVersion = '[10.0,)!!31.0.1-jre'
     jsonPathVersion = '2.6.0'
+    mockitoVersion = '4.0.0'
 }
 
 apply from: "$rootDir/gradle/versioning.gradle"

--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
     testImplementation group: 'io.jaegertracing', name: 'jaeger-client', version: '1.6.0'
 }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation project(':temporal-testing-junit4')
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.0.0'
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 task registerNamespace(type: JavaExec) {

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     testImplementation project(':temporal-testing')
     testImplementation "ch.qos.logback:logback-classic:${logbackVersion}"
-    testImplementation "org.mockito:mockito-core:3.12.4"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "junit:junit:4.13.2"
 }
 


### PR DESCRIPTION
## What was changed
Diagnostic message if command-event pair fails validation now contains more details about the error

## Why?
The current exception often doesn't have enough information for effective debugging