### PR TITLE
Allow more control in state machines test framework over replayTo, executeTo indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Temporal Java SDK  [![Build status](https://badge.buildkite.com/182afcb377dc16cf9d41b263620446719de2d96d6cd9d43882.svg?branch=master)](https://buildkite.com/temporal/sdk-java)
+# Temporal Java SDK  [![Build status](https://badge.buildkite.com/182afcb377dc16cf9d41b263620446719de2d96d6cd9d43882.svg?branch=master)](https://buildkite.com/temporal/java-sdk)
 
 [Temporal](https://github.com/temporalio/temporal) is a Workflow as Code platform used to build and operate
 resilient applications using developer friendly primitives, instead of constantly fighting your infrastructure.

--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "8126:8126"
 
   temporal:
-    image: temporaliotest/auto-setup:latest
+    image: temporaliotest/auto-setup:13fef8a745eff25ccedb04e2e3cd5c33d4c8abdd
     logging:
       driver: none
     ports:

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
@@ -190,8 +190,8 @@ public final class ActivityOptions {
      * In case of an activity's scope cancellation the corresponding activity stub call fails with a
      * {@link CanceledFailure}.
      *
-     * @param cancellationType Defines the activity's stub cancellation mode. The default
-     *     value is {@link ActivityCancellationType#TRY_CANCEL}
+     * @param cancellationType Defines the activity's stub cancellation mode. The default value is
+     *     {@link ActivityCancellationType#TRY_CANCEL}
      * @see ActivityCancellationType
      */
     public Builder setCancellationType(ActivityCancellationType cancellationType) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -274,26 +274,27 @@ public class WorkflowExecutionUtils {
     }
   }
 
-  /** Is this an event that was created to mirror a command? */
+  /** Command event is an event that is created to mirror a command issued by a workflow task */
   public static boolean isCommandEvent(HistoryEvent event) {
     EventType eventType = event.getEventType();
-    boolean result =
-        ((event != null)
-            && (eventType == EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
-                || eventType == EventType.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED
-                || eventType == EventType.EVENT_TYPE_TIMER_STARTED
-                || eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
-                || eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED
-                || eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED
-                || eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW
-                || eventType == EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED
-                || eventType == EventType.EVENT_TYPE_TIMER_CANCELED
-                || eventType
-                    == EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED
-                || eventType == EventType.EVENT_TYPE_MARKER_RECORDED
-                || eventType == EventType.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED
-                || eventType == EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES));
-    return result;
+    switch (eventType) {
+      case EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+      case EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:
+      case EVENT_TYPE_TIMER_STARTED:
+      case EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+      case EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
+      case EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
+      case EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
+      case EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:
+      case EVENT_TYPE_TIMER_CANCELED:
+      case EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED:
+      case EVENT_TYPE_MARKER_RECORDED:
+      case EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED:
+      case EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES:
+        return true;
+      default:
+        return false;
+    }
   }
 
   /** Returns event that corresponds to a command. */

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -159,9 +159,9 @@ public class LocalActivityStateMachineTest {
                     .putDetails(MARKER_ACTIVITY_ID_KEY, converter.toPayloads("id1").get())
                     .build())
             .add(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED);
-    assertEquals(new TestHistoryBuilder.HistoryInfo(0, 3), h.getHistoryInfo(1));
-    assertEquals(new TestHistoryBuilder.HistoryInfo(3, 8), h.getHistoryInfo(2));
-    assertEquals(new TestHistoryBuilder.HistoryInfo(3, 8), h.getHistoryInfo());
+    assertEquals(new TestHistoryBuilder.HistoryInfo(0, 3), h.getHistoryInfo(0));
+    assertEquals(new TestHistoryBuilder.HistoryInfo(3, 8), h.getHistoryInfo(1));
+    assertEquals(new TestHistoryBuilder.HistoryInfo(8, Integer.MAX_VALUE), h.getHistoryInfo());
 
     TestListener listener = new TestListener();
     stateMachines = newStateMachines(listener);
@@ -315,8 +315,8 @@ public class LocalActivityStateMachineTest {
             .addWorkflowTaskTimedOut()
             .addWorkflowTaskScheduled()
             .addWorkflowTaskStarted();
-    assertEquals(new TestHistoryBuilder.HistoryInfo(0, 3), h.getHistoryInfo(1));
-    assertEquals(new TestHistoryBuilder.HistoryInfo(3, 6), h.getHistoryInfo(2));
+    assertEquals(new TestHistoryBuilder.HistoryInfo(0, 3), h.getHistoryInfo(0));
+    assertEquals(new TestHistoryBuilder.HistoryInfo(3, 6), h.getHistoryInfo(1));
     assertEquals(new TestHistoryBuilder.HistoryInfo(6, 12), h.getHistoryInfo());
 
     TestListener listener = new TestListener();

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
@@ -245,8 +245,13 @@ public class VersionStateMachineTest {
 
     TestEntityManagerListenerBase listener = new TestListener();
     stateMachines = newStateMachines(listener);
+
     try {
-      h.handleWorkflowTaskTakeCommands(stateMachines);
+      // TODO if you try to replace this replay to 0, execute to 1 with a full replay
+      // h.handleWorkflowTaskTakeCommands(stateMachines, Integer.MAX_VALUE)
+      // this test will fail. It's an actual bug in state machine that will be addressed in
+      // https://github.com/temporalio/sdk-java/pull/805
+      h.handleWorkflowTaskTakeCommands(stateMachines, 0, Integer.MAX_VALUE);
       fail("failure expected");
     } catch (Throwable e) {
       assertTrue(
@@ -884,7 +889,11 @@ public class VersionStateMachineTest {
       TestListener listener = new TestListener();
       stateMachines = newStateMachines(listener);
       try {
-        h.handleWorkflowTaskTakeCommands(stateMachines);
+        // TODO if you try to replace this replay to 1, execute to MAX_VALUE with a full replay
+        // h.handleWorkflowTaskTakeCommands(stateMachines, Integer.MAX_VALUE)
+        // this test will fail. It's an actual bug in state machine that will be addressed in
+        // https://github.com/temporalio/sdk-java/pull/805
+        h.handleWorkflowTaskTakeCommands(stateMachines, 1, Integer.MAX_VALUE);
         fail("failure expected");
       } catch (InternalWorkflowTaskException e) {
         assertTrue(e.getCause().getMessage().startsWith("Version is already set"));


### PR DESCRIPTION
This PR is a cherry-pick from #805 that allows keeping the main changeset manageable and clean.

This adds flexibility in the state machine test framework over how replay is performed.
Before this PR "full replay" actually didn't perform a full replay. It was replaying till toIndex and executing the last task instead of replaying. This didn't allow some permutations of states to be tested.
This PR allows for the testing framework to specify `replayTo`, `executeTo` indexes independently, and also it fixes the implementation of "full replay".

Issue #648