### PR TITLE
Improve buildkite pipelines structure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,22 +3,35 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "./gradlew --no-daemon check"
+    command: "./gradlew --no-daemon test"
     timeout_in_minutes: 15
     plugins:
-      - docker-compose#v3.0.0:
+      - docker-compose#v3.8.0:
           run: unit-test-test-service
           config: docker/buildkite/docker-compose.yaml
-  - label: ":java: Unit test with docker service"
+
+  - label: ":docker: Unit test with docker service"
     agents:
       queue: "default"
       docker: "*"
     command: "./gradlew --no-daemon test"
     timeout_in_minutes: 15
     plugins:
-      - docker-compose#v3.0.0:
+      - docker-compose#v3.8.0:
           run: unit-test-docker
           config: docker/buildkite/docker-compose.yaml
+
+  - label: ":copyright: Copyright and code format"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "/bin/sh -c 'docker/buildkite/copyright-and-code-format.sh'"
+    timeout_in_minutes: 15
+    plugins:
+      - docker-compose#v3.8.0:
+          run: unit-test-test-service
+          config: docker/buildkite/docker-compose.yaml
+
   - label: ":alien: Fossa scan"
     agents:
       queue: "default"
@@ -26,7 +39,7 @@ steps:
     command: "fossa init --include-all --no-ansi; fossa analyze --no-ansi -b $${BUILDKITE_BRANCH:-$$(git branch --show-current)}; fossa test --timeout 1800 --no-ansi"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v3.0.0:
+      - docker-compose#v3.8.0:
           run: fossa
           config: docker/buildkite/docker-compose.yaml
 

--- a/docker/buildkite/copyright-and-code-format.sh
+++ b/docker/buildkite/copyright-and-code-format.sh
@@ -2,7 +2,7 @@
 set -eou pipefail
 set -x
 
-./gradlew --no-daemon test
+./gradlew --no-daemon check -x test
 
 if [ ! -z "$(git status --porcelain)" ]; then 
 	echo 'Some files were improperly formatted. Please run build locally and check in all changes.'

--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -8,16 +8,6 @@ services:
     ports:
       - "9042:9042"
 
-  statsd:
-    image: hopsoft/graphite-statsd
-    logging:
-      driver: none
-    ports:
-      - "8080:80"
-      - "2003:2003"
-      - "8125:8125"
-      - "8126:8126"
-
   temporal:
     image: temporaliotest/auto-setup:13fef8a745eff25ccedb04e2e3cd5c33d4c8abdd
     logging:
@@ -33,17 +23,14 @@ services:
       - "6939:6939"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
-      - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cassandra
-      - statsd
 
   unit-test-docker:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command: /bin/sh -c "docker/buildkite/run-tests.sh"
     environment:
       - "USER=unittest"
       - "TEMPORAL_SERVICE_ADDRESS=temporal:7233"
@@ -57,7 +44,6 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command: /bin/sh -c "docker/buildkite/run-tests.sh"
     environment:
       - "USER=unittest"
       - "USE_DOCKER_SERVICE=false"
@@ -74,4 +60,3 @@ services:
       - FOSSA_API_KEY
     volumes:
       - "../../:/temporal-java-client"
-


### PR DESCRIPTION
- Remove no longer needed statsd image
- Add a separate step that checks (and fails if needed) license headers and code formatting