### PR TITLE
WorkflowExecutionUtils method renaming and a new WFT helper method

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollAsyncHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollAsyncHelper.java
@@ -95,7 +95,7 @@ final class WorkflowClientLongPollAsyncHelper {
                 service, workflowClientHelper, workflowExecution, pageToken, timeout, unit);
           }
           HistoryEvent event = history.getEvents(0);
-          if (!WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event)) {
+          if (!WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
             throw new RuntimeException("Last history event is not completion event: " + event);
           }
           // Workflow called continueAsNew. Start polling the new generation with new runId.

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollHelper.java
@@ -161,7 +161,7 @@ final class WorkflowClientLongPollHelper {
       History history = response.getHistory();
       if (history.getEventsCount() > 0) {
         HistoryEvent event = history.getEvents(0);
-        if (!WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event)) {
+        if (!WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
           throw new RuntimeException("Last history event is not completion event: " + event);
         }
         // Workflow called continueAsNew. Start polling the new execution with new runId.

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -127,7 +127,14 @@ public class WorkflowExecutionUtils {
     }
   }
 
-  public static boolean isWorkflowExecutionCompletedEvent(HistoryEventOrBuilder event) {
+  public static boolean isWorkflowTaskClosedEvent(HistoryEventOrBuilder event) {
+    return ((event != null)
+        && (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+            || event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED
+            || event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT));
+  }
+
+  public static boolean isWorkflowExecutionClosedEvent(HistoryEventOrBuilder event) {
     return ((event != null)
         && (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED
             || event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
@@ -220,7 +220,7 @@ class TestHistoryBuilder {
     int count = 0;
     while (true) {
       if (!history.hasNext()) {
-        if (WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event)) {
+        if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
           // we didn't reach replayToIndex for replays before the end of the history, return "full
           // replay"
           return new HistoryInfo(started, Integer.MAX_VALUE);
@@ -327,7 +327,7 @@ class TestHistoryBuilder {
             : 0;
     while (true) {
       if (!history.hasNext()) {
-        if (WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event)) {
+        if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
           return;
         }
         if (wftStartedEventId != -1 && wftStartedEventId != event.getEventId()) {

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/RequestContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/RequestContext.java
@@ -177,7 +177,7 @@ final class RequestContext {
           .asRuntimeException();
     }
     long eventId = initialEventId + events.size();
-    if (WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event)) {
+    if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
       workflowCompletedAtEventId = eventId;
     } else {
       if (workflowCompletedAtEventId > 0 && workflowCompletedAtEventId < eventId) {

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -2299,7 +2299,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   private static Optional<HistoryEvent> getCompletionEvent(List<HistoryEvent> history) {
     HistoryEvent lastEvent = history.get(history.size() - 1);
 
-    if (WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(lastEvent)) {
+    if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(lastEvent)) {
       return Optional.of(lastEvent);
     } else {
       return Optional.empty();

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -118,7 +118,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
           eBuilder.setEventTime(eventTime);
         }
         history.add(eBuilder.build());
-        completed = completed || WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(eBuilder);
+        completed = completed || WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(eBuilder);
       }
       newEventsCondition.signal();
     }
@@ -400,7 +400,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
             previousStaredEventId = startedEventId;
             startedEventId = event.getEventId();
           }
-        } else if (WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(event)) {
+        } else if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
           previousStaredEventId = startedEventId;
           startedEventId = 0;
           if (iterator.hasNext()) {
@@ -449,7 +449,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
 
                       // They asked for only the close event. There are a variety of ways a workflow
                       // can close.
-                      return WorkflowExecutionUtils.isWorkflowExecutionCompletedEvent(e);
+                      return WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(e);
                     })
                 .collect(Collectors.toList());
         return GetWorkflowExecutionHistoryResponse.newBuilder()


### PR DESCRIPTION
Renaming is proposed by @Sushisource in review to PR #805 to make method names more clear and consistent with other helper methods in this class.
Moved in this separate refactoring PR to keep the main changes in PR #805 clean from the noise.