### PR TITLE
Fix NullPointer in RetryOptions#merge

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "9042:9042"
 
   temporal:
-    image: temporaliotest/auto-setup:13fef8a745eff25ccedb04e2e3cd5c33d4c8abdd
+    image: temporaliotest/auto-setup
     logging:
       driver: none
     ports:

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/OptionsUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/OptionsUtils.java
@@ -22,6 +22,7 @@ package io.temporal.internal.common;
 import com.google.common.base.Defaults;
 import com.google.protobuf.ByteString;
 import java.time.Duration;
+import java.util.Objects;
 
 public final class OptionsUtils {
 
@@ -50,20 +51,15 @@ public final class OptionsUtils {
     return value;
   }
 
-  /** Merges value from annotation and option. Option value takes precedence. */
-  public static <G> G merge(G annotation, G options, Class<G> type) {
+  public static <G> G merge(G value, G overrideValueIfNotDefault, Class<G> type) {
     G defaultValue = Defaults.defaultValue(type);
-    if (defaultValue == null) {
-      if (options != null) {
-        return options;
-      }
-    } else if (!defaultValue.equals(options)) {
-      return options;
+    if (!Objects.equals(defaultValue, overrideValueIfNotDefault)) {
+      return overrideValueIfNotDefault;
     }
     if (type.equals(String.class)) {
-      return ((String) annotation).isEmpty() ? null : annotation;
+      return ((String) value).isEmpty() ? null : value;
     }
-    return annotation;
+    return value;
   }
 
   /**
@@ -75,6 +71,13 @@ public final class OptionsUtils {
       return o;
     }
     return aSeconds == 0 ? null : Duration.ofSeconds(aSeconds);
+  }
+
+  public static String[] merge(String[] fromAnnotation, String[] fromOptions) {
+    if (fromOptions != null) {
+      return fromOptions;
+    }
+    return fromAnnotation;
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/common/RetryOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/RetryOptionsTest.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.common;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class RetryOptionsTest {
+
+  @Test
+  public void mergePrefersTheParameter() {
+    RetryOptions o1 =
+        RetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofSeconds(1))
+            .validateBuildWithDefaults();
+    RetryOptions o2 =
+        RetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofSeconds(2))
+            .validateBuildWithDefaults();
+
+    assertEquals(Duration.ofSeconds(2), o1.merge(o2).getInitialInterval());
+  }
+}


### PR DESCRIPTION
## What was changed
`RetryOptions` are reworked to use shared `OptionsUtils` for its implementation that avoids a NullPointer for non-primitive classes.
Also, `RetryOptions#Builder` interface was relaxed to accept values that manifest defaults.

Closes #832