### PR TITLE
Fix WorkflowExecutionHistory problem with deserializing history jsons from the new server versions

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -47,7 +47,7 @@ public final class WorkflowExecutionHistory {
   public static WorkflowExecutionHistory fromJson(String serialized) {
     String protoJson = HistoryJsonUtils.historyFormatJsonToProtoJson(serialized);
 
-    JsonFormat.Parser parser = JsonFormat.parser();
+    JsonFormat.Parser parser = JsonFormat.parser().ignoringUnknownFields();
     History.Builder historyBuilder = History.newBuilder();
     try {
       parser.merge(protoJson, historyBuilder);

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.common;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Test;
+
+public class WorkflowExecutionHistoryTest {
+
+  /**
+   * "simpleHistory1_withAddedNewRandomField.json" in comparison with "simpleHistory1.json" contains
+   * a new field that is not in the proto schema. Proto allows backwards compatible addition of new
+   * fields. This tests verifies that history jsons are also backwards compatible, so an addition of
+   * a new unknown field doesn't fail the deserialization.
+   */
+  @Test
+  public void addingANewFieldToHistoryJsonShouldProduceTheSameResult() throws IOException {
+
+    WorkflowExecutionHistory originalHistory =
+        WorkflowExecutionUtils.readHistoryFromResource("simpleHistory1.json");
+    WorkflowExecutionHistory historyWithAnAddedNewField =
+        WorkflowExecutionUtils.readHistoryFromResource(
+            "simpleHistory1_withAddedNewRandomField.json");
+
+    assertEquals(originalHistory.getLastEvent(), historyWithAnAddedNewField.getLastEvent());
+  }
+}

--- a/temporal-sdk/src/test/resources/simpleHistory1.json
+++ b/temporal-sdk/src/test/resources/simpleHistory1.json
@@ -1,0 +1,26 @@
+{
+  "events": [{
+    "eventId": "1",
+    "eventTime": "2020-07-30T00:30:03.082421843Z",
+    "eventType": "WorkflowExecutionStarted",
+    "version": "-24",
+    "taskId": "5242897",
+    "workflowExecutionStartedEventAttributes": {
+      "workflowType": {
+        "name": "SomeName"
+      },
+      "taskQueue": {
+        "name": "SomeQueueName",
+        "kind": "Normal"
+      },
+      "input": null,
+      "workflowExecutionTimeout": "300s",
+      "workflowTaskTimeout": "60s",
+      "originalExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+      "identity":"",
+      "firstExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+      "attempt": 1,
+      "firstWorkflowTaskBackoff": "0s"
+    }
+  }]
+}

--- a/temporal-sdk/src/test/resources/simpleHistory1_withAddedNewRandomField.json
+++ b/temporal-sdk/src/test/resources/simpleHistory1_withAddedNewRandomField.json
@@ -1,0 +1,28 @@
+{
+  "events": [{
+    "eventId": "1",
+    "eventTime": "2020-07-30T00:30:03.082421843Z",
+    "eventType": "WorkflowExecutionStarted",
+    "version": "-24",
+    "taskId": "5242897",
+    "someNewFieldThatIsAbsentFromTheCurrentProtoSchema": "100500",
+    "workflowExecutionStartedEventAttributes": {
+      "someNewFieldThatIsAbsentFromTheCurrentProtoSchema": "100500",
+      "workflowType": {
+        "name": "SomeName"
+      },
+      "taskQueue": {
+        "name": "SomeQueueName",
+        "kind": "Normal"
+      },
+      "input": null,
+      "workflowExecutionTimeout": "300s",
+      "workflowTaskTimeout": "60s",
+      "originalExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+      "identity":"",
+      "firstExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+      "attempt": 1,
+      "firstWorkflowTaskBackoff": "0s"
+    }
+  }]
+}


### PR DESCRIPTION
## What was changed
Now `WorkflowExecutionHistory` supports histories with unknown fields, because such changes are supposed to be backwards compatible and non-breaking in protobuf schemas.

Closes #836
