### PR TITLE
Use jackson-bom platform dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ ext {
     jsonPathVersion = '2.6.0'
     mockitoVersion = '4.0.0'
     micrometerVersion = '[1.0.0,)!!1.7.5'
+    jacksonVersion = '[2.9.0,)!!2.13.0'
+    tallyVersion = '[0.4.0,)!!0.11.1'
 }
 
 apply from: "$rootDir/gradle/versioning.gradle"

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -21,11 +21,14 @@ compileTestKotlin {
 }
 
 dependencies {
+    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+
     implementation project(':temporal-sdk')
 
     implementation "org.jetbrains.kotlin:kotlin-reflect"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0"
-    implementation ("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0") {
+
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+    implementation ("com.fasterxml.jackson.module:jackson-module-kotlin") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-reflect'
     }
 

--- a/temporal-kotlin/src/main/kotlin/io/temporal/common/converter/KotlinObjectMapperFactory.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/common/converter/KotlinObjectMapperFactory.kt
@@ -34,7 +34,9 @@ class KotlinObjectMapperFactory {
       mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
       mapper.registerModule(JavaTimeModule())
       mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
-      val km = KotlinModule.Builder().build()
+      @Suppress("deprecation")
+      // use deprecated constructor instead of builder to maintain compatibility with old jackson versions
+      val km = KotlinModule()
       mapper.registerModule(km)
       return mapper
     }

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -1,6 +1,8 @@
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
+    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+
     api project(':temporal-serviceclient')
     api group: 'com.google.code.gson', name: 'gson', version: '2.8.8'
     api "io.micrometer:micrometer-core:$micrometerVersion"
@@ -10,8 +12,7 @@ dependencies {
         exclude group: 'com.google.errorprone'
         exclude group: 'com.google.j2objc'
     }
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.0'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.0'
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api "io.grpc:grpc-stub:$grpcVersion" //Part of WorkflowServiceStubs API
     api "io.grpc:grpc-netty-shaded:$grpcVersion" //Part of WorkflowServiceStubs API, specifically SslContext
     api "com.google.protobuf:protobuf-java-util:$protoVersion" //proto request and response objects are a part of this module's API
-    api "com.uber.m3:tally-core:0.11.1"
+    api "com.uber.m3:tally-core:$tallyVersion"
 
     implementation "io.grpc:grpc-core:$grpcVersion"
     implementation "io.grpc:grpc-services:$grpcVersion"


### PR DESCRIPTION
Switch jackson and tally to version ranges
KotlinObjectMapperFactory reworked back to use constructor to be compatible with older Jackson versions.