### PR TITLE
Fix handling of version marker if it's the last command event of WFT

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -235,7 +235,14 @@ public final class WorkflowStateMachines {
       // That's why peek is used instead of poll.
       CancellableCommand command = commands.peek();
       if (command == null) {
-        throw new IllegalStateException("No command scheduled that corresponds to " + event);
+        if (handleVersionMarker(event)) {
+          // this event is a version marker for removed getVersion call.
+          // Handle the version marker as unmatched and return even if there is no commands to match
+          // it against
+          return;
+        } else {
+          throw new IllegalStateException("No command scheduled that corresponds to " + event);
+        }
       }
 
       if (command.isCanceled()) {
@@ -263,7 +270,7 @@ public final class WorkflowStateMachines {
         case NON_MATCHING_EVENT:
           if (handleVersionMarker(event)) {
             // this event is a version marker for removed getVersion call.
-            // Return without consuming the command
+            // Handle the version marker as unmatched and return without consuming the command
             return;
           } else {
             throw new IllegalStateException(

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
@@ -221,8 +221,8 @@ class TestHistoryBuilder {
     while (true) {
       if (!history.hasNext()) {
         if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
-          // we didn't reach replayToIndex for replays before the end of the history, return "full
-          // replay"
+          // we didn't reach replayToIndex for replays before the end of the history,
+          // return "full replay"
           return new HistoryInfo(started, Integer.MAX_VALUE);
         }
         if (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_STARTED) {
@@ -232,7 +232,7 @@ class TestHistoryBuilder {
         }
         if (started != event.getEventId()) {
           throw new IllegalArgumentException(
-              "The last event in the history is not WorkflowTaskStarted");
+              "The last event in the history is not WorkflowTaskStarted and not one of Workflow Execution Closing events");
         }
         throw new IllegalStateException("unreachable");
       }


### PR DESCRIPTION
## What was changed
When there are version markers at the end of WFT command events without corresponding commands, we handle them as non-matching version markers

## Why?
Now if there is no commands in the queue, handling of an event throws an exception. This is right for most types of events, but not for version markers that should support removal. This bug manifests only when version marker for the removed getVersion call is at the end of command events, which is a rare occurrence (WFT rarely ends right after a version call).

How was this tested:
State machines unit test

Closes #706 
