### PR TITLE
Changed to hour step function so that passing of the test doesn't depend on the number of days in the month

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
@@ -59,11 +59,10 @@ public class WorkflowWithCronScheduleTest {
                     .toBuilder()
                     .setWorkflowRunTimeout(Duration.ofHours(1))
                     // Slash is used to describe increments of n here so this cron executes every
-                    // 1st and 28th of the month. We picked 27 here, so that this test doesn't fail
-                    // around the month of Feb :)
-                    .setCronSchedule("0 5 */27 * *")
+                    // 6th hour.
+                    .setCronSchedule("0 */6 * * *")
                     .build());
-    testWorkflowRule.registerDelayedCallback(Duration.ofDays(60), client::cancel);
+    testWorkflowRule.registerDelayedCallback(Duration.ofDays(1), client::cancel);
     client.start(testName.getMethodName());
 
     try {


### PR DESCRIPTION
## What was changed
Changed to hour step function so that passing of the test doesn't depend on the number of days in the month

## Why?
Test fails on certain days

1. Closes #847 

2. How was this tested:
unit test
