### PR TITLE
Upgrade gson dep to the last version and switch on using a version range

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ ext {
     micrometerVersion = '[1.0.0,)!!1.7.5'
     jacksonVersion = '[2.9.0,)!!2.13.0'
     tallyVersion = '[0.4.0,)!!0.11.1'
+    gsonVersion = '[2.0,)!!2.8.9'
 }
 
 apply from: "$rootDir/gradle/versioning.gradle"

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
 
     api project(':temporal-serviceclient')
-    api group: 'com.google.code.gson', name: 'gson', version: '2.8.8'
+    api "com.google.code.gson:gson:$gsonVersion"
     api "io.micrometer:micrometer-core:$micrometerVersion"
 
     implementation ("com.google.guava:guava:$guavaVersion") {

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -35,7 +35,11 @@ import javax.annotation.Nullable;
 
 /** Contains workflow execution ids and the history */
 public final class WorkflowExecutionHistory {
-  private static final Gson PRETTY_PRINTER = new GsonBuilder().setPrettyPrinting().create();
+  private static final Gson GSON_PRETTY_PRINTER = new GsonBuilder().setPrettyPrinting().create();
+  // we stay on using the old API that uses a JsonParser instance instead of static methods
+  // to give users a larger range of supported version
+  @SuppressWarnings("deprecation")
+  private static final JsonParser GSON_PARSER = new JsonParser();
 
   private final History history;
 
@@ -82,8 +86,9 @@ public final class WorkflowExecutionHistory {
       String historyFormatJson = HistoryJsonUtils.protoJsonToHistoryFormatJson(protoJson);
 
       if (prettyPrint) {
-        JsonElement je = JsonParser.parseString(historyFormatJson);
-        return PRETTY_PRINTER.toJson(je);
+        @SuppressWarnings("deprecation")
+        JsonElement je = GSON_PARSER.parse(historyFormatJson);
+        return GSON_PRETTY_PRINTER.toJson(je);
       } else {
         return historyFormatJson;
       }


### PR DESCRIPTION
Upgrade gson dep to the last version and switch to using a version range.
Rework `WorkflowExecutionHistory` onto using deprecated APIs but that support a much larger range of versions.