### PR TITLE
Fix test service state machines to handle situation when activity get cancelled from SCHEDULED state before being picked up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Temporal Java SDK  [![Build status](https://badge.buildkite.com/663f6d1be81be6700c28c242b35905f20b68c4fda7b2c7c4e3.svg)](https://buildkite.com/temporal/java-sdk-public)
+# Temporal Java SDK  [![Build status](https://badge.buildkite.com/663f6d1be81be6700c28c242b35905f20b68c4fda7b2c7c4e3.svg?branch=master)](https://buildkite.com/temporal/java-sdk-public)
 
 [Temporal](https://github.com/temporalio/temporal) is a Workflow as Code platform used to build and operate
 resilient applications using developer friendly primitives, instead of constantly fighting your infrastructure.

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/CancellingScheduledActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/CancellingScheduledActivityTest.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests.cancellation;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * This test covers a situation when an activity is scheduled on a server side, but is not picked up
+ * by a worker and getting cancelled by the workflow. Activity State Machine goes through
+ *
+ * <p>CREATED -> SCHEDULE_COMMAND_CREATED -> SCHEDULED_EVENT_RECORDED -> <br>
+ * -> SCHEDULED_ACTIVITY_CANCEL_COMMAND_CREATED -> SCHEDULED_ACTIVITY_CANCEL_EVENT_RECORDED ->
+ * CANCELLED
+ */
+public class CancellingScheduledActivityTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestCancellationWorkflow.class)
+          // We don't register activity implementations because we don't want the activity to
+          // actually being picked up in this test
+          .build();
+
+  @Test
+  public void testActivityCancellationBeforeActivityIsPickedUp() {
+    TestWorkflow workflow = testWorkflowRule.newWorkflowStub(TestWorkflow.class);
+    WorkflowStub.fromTyped(workflow).start("input");
+    workflow.signal();
+    assertEquals("result", WorkflowStub.fromTyped(workflow).getResult(String.class));
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String execute(String arg);
+
+    @SignalMethod
+    void signal();
+  }
+
+  @ActivityInterface
+  public interface Activity {
+    String activity(String input);
+  }
+
+  public static class TestCancellationWorkflow implements TestWorkflow {
+
+    private boolean signaled = false;
+
+    private final Activity activity =
+        Workflow.newActivityStub(
+            Activity.class,
+            ActivityOptions.newBuilder()
+                .setScheduleToCloseTimeout(Duration.ofSeconds(1000))
+                .build());
+
+    @Override
+    public String execute(String input) {
+      CancellationScope cancellationScope =
+          Workflow.newCancellationScope(() -> Async.procedure(() -> activity.activity(input)));
+
+      cancellationScope.run();
+
+      // to force WFT finish
+      Workflow.await(() -> signaled);
+
+      cancellationScope.cancel();
+      return "result";
+    }
+
+    @Override
+    public void signal() {
+      this.signaled = true;
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1625,19 +1625,20 @@ class StateMachines {
 
   private static void reportActivityTaskCancellation(
       RequestContext ctx, ActivityTaskData data, Object request, long notUsed) {
-    Optional<Payloads> details;
+    Payloads details = null;
     if (request instanceof RespondActivityTaskCanceledRequest) {
       {
         RespondActivityTaskCanceledRequest cr = (RespondActivityTaskCanceledRequest) request;
-        details = cr.hasDetails() ? Optional.of(cr.getDetails()) : Optional.empty();
+
+        details = cr.hasDetails() ? cr.getDetails() : null;
       }
     } else if (request instanceof RespondActivityTaskCanceledByIdRequest) {
       {
         RespondActivityTaskCanceledByIdRequest cr =
             (RespondActivityTaskCanceledByIdRequest) request;
-        details = cr.hasDetails() ? Optional.of(cr.getDetails()) : Optional.empty();
+        details = cr.hasDetails() ? cr.getDetails() : null;
       }
-    } else {
+    } else if (request != null) {
       throw Status.INTERNAL
           .withDescription("Unexpected request type: " + request)
           .asRuntimeException();
@@ -1646,8 +1647,8 @@ class StateMachines {
         ActivityTaskCanceledEventAttributes.newBuilder()
             .setScheduledEventId(data.scheduledEventId)
             .setStartedEventId(data.startedEventId);
-    if (details.isPresent()) {
-      a.setDetails(details.get());
+    if (details != null) {
+      a.setDetails(details);
     }
     HistoryEvent event =
         HistoryEvent.newBuilder()

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -712,6 +712,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     State beforeState = activity.getState();
     activity.action(StateMachines.Action.REQUEST_CANCELLATION, ctx, a, workflowTaskCompletedId);
     if (beforeState == StateMachines.State.INITIATED) {
+      // request is null here, because it's caused not by a separate cancel request, but by a
+      // command
       activity.action(StateMachines.Action.CANCEL, ctx, null, 0);
       activities.remove(scheduledEventId);
       ctx.setNeedWorkflowTask(true);


### PR DESCRIPTION
Add a test covering a situation when activity is getting to be canceled when it's just scheduled, but not picked up yet.
Fixing a bug in test service state machines to handle this situation correctly without throwing an exception.