### PR TITLE
Updates temporal-sdk dep in temporal-kotlin

### DIFF
--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -25,7 +25,7 @@ compileTestKotlin {
 dependencies {
     implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
 
-    implementation project(':temporal-sdk')
+    api project(':temporal-sdk')
 
     implementation "org.jetbrains.kotlin:kotlin-reflect"
 


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changes the dependency in temporal-kotlin on temporal-sdk to be `api` instead of `implementation`


## Why?
To prevent needing to define both dependencies explicitly as a user.
