### PR TITLE
Adds workflow id and run id into workflows method names

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -56,7 +56,6 @@ class DeterministicRunnerImpl implements DeterministicRunner {
   private static final int WORKFLOW_THREAD_PRIORITY = 20000000;
 
   static final String WORKFLOW_ROOT_THREAD_NAME = "workflow-root";
-  static final String WORKFLOW_MAIN_THREAD_NAME = "workflow-method";
 
   private static final Logger log = LoggerFactory.getLogger(DeterministicRunnerImpl.class);
   private static final ThreadLocal<WorkflowThread> currentThreadThreadLocal = new ThreadLocal<>();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -27,6 +27,7 @@ import io.temporal.internal.logging.LoggerTag;
 import io.temporal.internal.metrics.MetricsType;
 import io.temporal.internal.replay.ReplayWorkflowContext;
 import io.temporal.internal.replay.WorkflowExecutorCache;
+import io.temporal.internal.worker.workflow.WorkflowMethodThreadNameStrategy;
 import io.temporal.workflow.Functions;
 import io.temporal.workflow.Promise;
 import java.io.PrintWriter;
@@ -398,7 +399,7 @@ class WorkflowThreadImpl implements WorkflowThread {
     if (DeterministicRunnerImpl.WORKFLOW_ROOT_THREAD_NAME.equals(getName())) {
       // TODO revisit this number
       omitBottom = 11;
-    } else if (DeterministicRunnerImpl.WORKFLOW_MAIN_THREAD_NAME.equals(getName())) {
+    } else if (getName().startsWith(WorkflowMethodThreadNameStrategy.WORKFLOW_MAIN_THREAD_PREFIX)) {
       // TODO revisit this number
       omitBottom = 11;
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/workflow/ExecutionInfoStrategy.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/workflow/ExecutionInfoStrategy.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.worker.workflow;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+
+public class ExecutionInfoStrategy implements WorkflowMethodThreadNameStrategy {
+  public static final ExecutionInfoStrategy INSTANCE = new ExecutionInfoStrategy();
+  private static final int WORKFLOW_ID_TRIM_LENGTH = 50;
+
+  private ExecutionInfoStrategy() {}
+
+  @Override
+  public String createThreadName(WorkflowExecution workflowExecution) {
+    String workflowId = workflowExecution.getWorkflowId();
+    String trimmedWorkflowId =
+        workflowId.substring(0, Math.min(WORKFLOW_ID_TRIM_LENGTH, workflowId.length()) - 1);
+    return WORKFLOW_MAIN_THREAD_PREFIX
+        + "-"
+        + trimmedWorkflowId
+        + "-"
+        + workflowExecution.getRunId();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/workflow/WorkflowMethodThreadNameStrategy.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/workflow/WorkflowMethodThreadNameStrategy.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.worker.workflow;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+
+public interface WorkflowMethodThreadNameStrategy {
+  String WORKFLOW_MAIN_THREAD_PREFIX = "workflow-method";
+
+  String createThreadName(WorkflowExecution workflowExecution);
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
@@ -99,7 +99,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
 
     WorkflowRunTaskHandler workflowRunTaskHandler =
         cache.getOrCreate(workflowTask1, metricsScope, () -> createFakeExecutor(workflowTask1));
-    cache.addToCache(workflowTask1.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
+    cache.addToCache(workflowTask1.getWorkflowExecution(), workflowRunTaskHandler);
 
     PollWorkflowTaskQueueResponse workflowTask2 =
         HistoryUtils.generateWorkflowTaskWithPartialHistoryFromExistingTask(
@@ -142,7 +142,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
 
       WorkflowRunTaskHandler workflowRunTaskHandler =
           cache.getOrCreate(workflowTask, scope, () -> createFakeExecutor(workflowTask));
-      cache.addToCache(workflowTask.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
+      cache.addToCache(workflowTask.getWorkflowExecution(), workflowRunTaskHandler);
 
       // Act
       PollWorkflowTaskQueueResponse workflowTask2 =
@@ -213,14 +213,14 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
     // Act
     WorkflowRunTaskHandler workflowRunTaskHandler =
         cache.getOrCreate(workflowTask1, scope, () -> createFakeExecutor(workflowTask1));
-    cache.addToCache(workflowTask1.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
+    cache.addToCache(workflowTask1.getWorkflowExecution(), workflowRunTaskHandler);
     workflowRunTaskHandler =
         cache.getOrCreate(workflowTask2, scope, () -> createFakeExecutor(workflowTask2));
-    cache.addToCache(workflowTask2.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
+    cache.addToCache(workflowTask2.getWorkflowExecution(), workflowRunTaskHandler);
     workflowRunTaskHandler =
         cache.getOrCreate(workflowTask3, scope, () -> createFakeExecutor(workflowTask3));
     WorkflowExecution execution = workflowTask3.getWorkflowExecution();
-    cache.addToCache(execution.getRunId(), workflowRunTaskHandler);
+    cache.addToCache(execution, workflowRunTaskHandler);
 
     assertEquals(3, cache.size());
 
@@ -245,7 +245,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
     WorkflowRunTaskHandler workflowRunTaskHandler =
         cache.getOrCreate(workflowTask1, metricsScope, () -> createFakeExecutor(workflowTask1));
     WorkflowExecution execution = workflowTask1.getWorkflowExecution();
-    cache.addToCache(execution.getRunId(), workflowRunTaskHandler);
+    cache.addToCache(execution, workflowRunTaskHandler);
 
     assertEquals(1, cache.size());
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -689,7 +689,7 @@ public class DeterministicRunnerTest {
     PollWorkflowTaskQueueResponse response = HistoryUtils.generateWorkflowTaskWithInitialHistory();
 
     cache.getOrCreate(response, new com.uber.m3.tally.NoopScope(), () -> workflowRunTaskHandler);
-    cache.addToCache(response.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
+    cache.addToCache(response.getWorkflowExecution(), workflowRunTaskHandler);
     d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals(2, threadPool.getActiveCount());
     assertEquals(1, cache.size());
@@ -751,7 +751,7 @@ public class DeterministicRunnerTest {
     PollWorkflowTaskQueueResponse response = HistoryUtils.generateWorkflowTaskWithInitialHistory();
 
     cache.getOrCreate(response, new com.uber.m3.tally.NoopScope(), () -> workflowRunTaskHandler);
-    cache.addToCache(response.getWorkflowExecution().getRunId(), workflowRunTaskHandler);
+    cache.addToCache(response.getWorkflowExecution(), workflowRunTaskHandler);
     d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
     assertEquals(2, threadPool.getActiveCount());
     assertEquals(1, cache.size());

--- a/temporal-testing-junit4/src/main/java/io/temporal/testing/TracingWorkerInterceptor.java
+++ b/temporal-testing-junit4/src/main/java/io/temporal/testing/TracingWorkerInterceptor.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.common.interceptors.*;
+import io.temporal.internal.worker.workflow.WorkflowMethodThreadNameStrategy;
 import io.temporal.workflow.Functions;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;
@@ -108,7 +109,12 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
       @Override
       public Object newWorkflowMethodThread(Runnable runnable, String name) {
         if (!Workflow.isReplaying()) {
-          trace.add("newThread " + name);
+          if (name.startsWith(WorkflowMethodThreadNameStrategy.WORKFLOW_MAIN_THREAD_PREFIX)) {
+            // strip the IDs we add to identify WF thread method
+            trace.add("newThread " + WorkflowMethodThreadNameStrategy.WORKFLOW_MAIN_THREAD_PREFIX);
+          } else {
+            trace.add("newThread " + name);
+          }
         }
         return next.newWorkflowMethodThread(runnable, name);
       }


### PR DESCRIPTION
Adds workflow id and run id into workflows method names
Added logging to trace WorkflowExecutionCache state

This needs to investigate a user report of workflow thread pool getting filled with open workflows which are yielding, but not getting evicted.
Also having workflowId and runId in the workflow thread names can benefit all users who need to look into thread dumps.