### PR TITLE
Memory/resource leak improvements in TestWorkflowService

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -155,6 +155,11 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       stubs.shutdown();
       channel.shutdown();
     }
+
+    public void awaitTermination(long halfTheTimeout, TimeUnit unit) throws InterruptedException {
+      stubs.awaitTermination(halfTheTimeout, unit);
+      channel.awaitTermination(halfTheTimeout, unit);
+    }
   }
 
   public WorkflowServiceStubs newClientStub() {
@@ -264,7 +269,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     if (inProcessServer != null) {
       log.info("Shutting down in-process GRPC server");
       inProcessServer.shutdown();
-      client.channel.shutdown();
+      client.close();
     }
 
     forkJoinPool.shutdown();
@@ -273,13 +278,12 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       forkJoinPool.awaitTermination(1, TimeUnit.SECONDS);
 
       if (outOfProcessServer != null) {
-        outOfProcessServer.shutdown();
         outOfProcessServer.awaitTermination(1, TimeUnit.SECONDS);
       }
 
       if (inProcessServer != null) {
         inProcessServer.awaitTermination(1, TimeUnit.SECONDS);
-        client.channel.awaitTermination(1, TimeUnit.SECONDS);
+        client.awaitTermination(1, TimeUnit.SECONDS);
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
## What was changed
This makes minor improvements to resource cleanup on close()

1. If TestWorkflowService gets instantiated with an in-process gRPC server, shut it down during close()
2. Wait for the forkJoinPool to terminate during close()
3. Add a 'no gRPC service at all' mode. This is secretly prep for resetting state via a long-lived API, which will make the test service more usable to other languages.

## Why?
This is a prereq for the external gRPC API that resets the test service state. This API will make it easier to isolate tests when one uses the test service from other languages.

## Checklist
1. Closes [none]

2. How was this tested:
Existing units pass

3. Any docs updates needed?
No.