### PR TITLE
Polish WorkflowThreadContext thread status switching

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -359,10 +359,6 @@ class WorkflowThreadImpl implements WorkflowThread {
       throw new Error("Cannot call destroy on itself: " + thread.getName());
     }
     context.destroy();
-    if (!context.isDone()) {
-      throw new RuntimeException(
-          "Couldn't destroy the thread. " + "The blocked thread stack trace: " + getStackTrace());
-    }
     if (taskFuture == null) {
       return getCompletedFuture();
     }


### PR DESCRIPTION
WorkflowThreadContext has some code paths that are hard to comprehend, especially with premature switching to DONE and unswitching from it that should never happen. 
This PR polishes the statuses behavior and also simplifies destroy thread logic removing the need to implement it two ways - through a flag check and through a "coroutine" invocation simplifying and unifying threads destruction.