### PR TITLE
Fix thread leak in legacy query path

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/QueryResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/QueryResult.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.replay;
+
+import io.temporal.api.common.v1.Payloads;
+import java.util.Optional;
+
+public class QueryResult {
+  private final Optional<Payloads> responsePayloads;
+  private final boolean workflowMethodCompleted;
+
+  public QueryResult(Optional<Payloads> responsePayloads, boolean workflowMethodCompleted) {
+    this.responsePayloads = responsePayloads;
+    this.workflowMethodCompleted = workflowMethodCompleted;
+  }
+
+  public Optional<Payloads> getResponsePayloads() {
+    return responsePayloads;
+  }
+
+  public boolean isWorkflowMethodCompleted() {
+    return workflowMethodCompleted;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -53,7 +53,6 @@ import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
@@ -238,14 +237,13 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
   }
 
   @Override
-  public Optional<Payloads> handleQueryWorkflowTask(
+  public QueryResult handleQueryWorkflowTask(
       PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowQuery query) {
     lock.lock();
     try {
-      AtomicReference<Optional<Payloads>> result = new AtomicReference<>();
       handleWorkflowTaskImpl(workflowTask);
-      result.set(replayWorkflowExecutor.query(query));
-      return result.get();
+      Optional<Payloads> resultPayloads = replayWorkflowExecutor.query(query);
+      return new QueryResult(resultPayloads, replayWorkflowExecutor.isCompleted());
     } finally {
       lock.unlock();
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
@@ -19,10 +19,8 @@
 
 package io.temporal.internal.replay;
 
-import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.query.v1.WorkflowQuery;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
-import java.util.Optional;
 
 /**
  * Task handler that encapsulates a cached workflow and can handle multiple calls to
@@ -41,7 +39,7 @@ public interface WorkflowRunTaskHandler {
    */
   WorkflowTaskResult handleWorkflowTask(PollWorkflowTaskQueueResponseOrBuilder workflowTask);
 
-  Optional<Payloads> handleQueryWorkflowTask(
+  QueryResult handleQueryWorkflowTask(
       PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowQuery query);
 
   void close();

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/QueryReplayHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/QueryReplayHelper.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+import com.google.protobuf.ByteString;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.common.v1.WorkflowType;
+import io.temporal.api.history.v1.History;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
+import io.temporal.api.query.v1.WorkflowQuery;
+import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
+import io.temporal.internal.common.WorkflowExecutionHistory;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Encapsulates a special query implementation for replaying workflow histories to support {@link
+ * io.temporal.worker.Worker#replayWorkflowExecution}
+ *
+ * <p>The implementation in this class doesn't execute under runId lock used in the main code path
+ * of Worker, so it shouldn't be using the workflow cache either.
+ */
+public class QueryReplayHelper {
+  private final WorkflowTaskHandler handler;
+
+  /**
+   * @param nonStickyHandler it's important for this handler to be non-sticky. Otherwise, we will be
+   *     working with workflow cache without obtaining a runId lock.
+   */
+  public QueryReplayHelper(WorkflowTaskHandler nonStickyHandler) {
+    this.handler = nonStickyHandler;
+  }
+
+  public Optional<Payloads> queryWorkflowExecution(
+      String jsonSerializedHistory, String queryType, Optional<Payloads> args) throws Exception {
+    WorkflowExecutionHistory history = WorkflowExecutionHistory.fromJson(jsonSerializedHistory);
+    return queryWorkflowExecution(queryType, args, history, ByteString.EMPTY);
+  }
+
+  public Optional<Payloads> queryWorkflowExecution(
+      WorkflowExecutionHistory history, String queryType, Optional<Payloads> args)
+      throws Exception {
+    return queryWorkflowExecution(queryType, args, history, ByteString.EMPTY);
+  }
+
+  private Optional<Payloads> queryWorkflowExecution(
+      String queryType,
+      Optional<Payloads> args,
+      WorkflowExecutionHistory history,
+      ByteString nextPageToken)
+      throws Exception {
+    WorkflowQuery.Builder query = WorkflowQuery.newBuilder().setQueryType(queryType);
+    args.ifPresent(query::setQueryArgs);
+    PollWorkflowTaskQueueResponse.Builder task =
+        PollWorkflowTaskQueueResponse.newBuilder()
+            .setWorkflowExecution(history.getWorkflowExecution())
+            .setStartedEventId(Long.MAX_VALUE)
+            .setPreviousStartedEventId(Long.MAX_VALUE)
+            .setNextPageToken(nextPageToken)
+            .setQuery(query);
+    List<HistoryEvent> events = history.getEvents();
+    HistoryEvent startedEvent = events.get(0);
+    if (!startedEvent.hasWorkflowExecutionStartedEventAttributes()) {
+      throw new IllegalStateException(
+          "First event of the history is not WorkflowExecutionStarted: " + startedEvent);
+    }
+    WorkflowExecutionStartedEventAttributes started =
+        startedEvent.getWorkflowExecutionStartedEventAttributes();
+    WorkflowType workflowType = started.getWorkflowType();
+    task.setWorkflowType(workflowType);
+    task.setHistory(History.newBuilder().addAllEvents(events));
+    WorkflowTaskHandler.Result result = handler.handleWorkflowTask(task.build());
+    if (result.getQueryCompleted() != null) {
+      RespondQueryTaskCompletedRequest r = result.getQueryCompleted();
+      if (!r.getErrorMessage().isEmpty()) {
+        throw new RuntimeException(
+            "query failure for "
+                + history.getWorkflowExecution()
+                + ", queryType="
+                + queryType
+                + ", args="
+                + args
+                + ", error="
+                + r.getErrorMessage());
+      }
+      if (r.hasQueryResult()) {
+        return Optional.of(r.getQueryResult());
+      } else {
+        return Optional.empty();
+      }
+    }
+    throw new RuntimeException("Query returned wrong response: " + result);
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -28,7 +28,6 @@ import com.uber.m3.tally.RootScopeBuilder;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.StatsReporter;
 import com.uber.m3.util.ImmutableMap;
-import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.query.v1.WorkflowQuery;
@@ -38,10 +37,7 @@ import io.temporal.common.RetryOptions;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.metrics.MetricsType;
-import io.temporal.internal.replay.ReplayWorkflowContext;
-import io.temporal.internal.replay.WorkflowExecutorCache;
-import io.temporal.internal.replay.WorkflowRunTaskHandler;
-import io.temporal.internal.replay.WorkflowTaskResult;
+import io.temporal.internal.replay.*;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.HistoryUtils;
 import io.temporal.workflow.Async;
@@ -795,9 +791,9 @@ public class DeterministicRunnerTest {
     }
 
     @Override
-    public Optional<Payloads> handleQueryWorkflowTask(
+    public QueryResult handleQueryWorkflowTask(
         PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowQuery query) {
-      return Optional.empty();
+      return new QueryResult(Optional.empty(), true);
     }
 
     @Override


### PR DESCRIPTION
Fix thread leak in legacy query path
Refactor replay functionality into a separate class to keep clear from the main code path and worker code

Closes #880