### PR TITLE
Disable grpc idleTimer as a temporary solution to race condition in gRPC-java

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -10,8 +10,6 @@ services:
 
   temporal:
     image: temporaliotest/auto-setup
-    logging:
-      driver: none
     ports:
       - "7233:7233"
       - "7234:7234"


### PR DESCRIPTION
## What was changed
Disable grpc idleTimer as a temporary solution to race condition in gRPC-java
Improve connection management related documentation on WorkflowServiceStubsOptions
It's a remedy for issue #863 unit gRPC-java bug is fixed or Temporal removes the code manually triggering `ManagedChannel#enterIdle`. 


## Why
See Issue #863 for details. Now we can get a broken worker because of a race condition in gRPC-java.