### PR TITLE
Fix the type of an exception from the test service

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -471,10 +471,10 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       GetWorkflowExecutionHistoryRequest getRequest,
       StreamObserver<GetWorkflowExecutionHistoryResponse> responseObserver) {
     ExecutionId executionId = new ExecutionId(getRequest.getNamespace(), getRequest.getExecution());
-    TestWorkflowMutableState mutableState = getMutableState(executionId);
     forkJoinPool.execute(
         () -> {
           try {
+            TestWorkflowMutableState mutableState = getMutableState(executionId);
             Deadline deadline = getLongPollDeadline();
             responseObserver.onNext(
                 store.getWorkflowExecutionHistory(

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testing;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class TestWorkflowEnvironmentTest {
+
+  @Rule
+  public TestWatcher watchman =
+      new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+          if (testEnv != null) {
+            System.err.println(testEnv.getDiagnostics());
+            testEnv.close();
+          }
+        }
+      };
+
+  private TestWorkflowEnvironment testEnv;
+
+  @Before
+  public void setUp() {
+    testEnv = TestWorkflowEnvironment.newInstance();
+    testEnv.start();
+  }
+
+  @After
+  public void tearDown() {
+    testEnv.close();
+  }
+
+  @Test
+  public void testGetExecutionHistoryWhenWorkflowNotFound() {
+    Status status =
+        Assert.assertThrows(
+                StatusRuntimeException.class,
+                () -> {
+                  GetWorkflowExecutionHistoryRequest request =
+                      GetWorkflowExecutionHistoryRequest.newBuilder()
+                          .setExecution(
+                              WorkflowExecution.newBuilder()
+                                  .setWorkflowId("does not exist")
+                                  .build())
+                          .build();
+                  testEnv.getWorkflowService().blockingStub().getWorkflowExecutionHistory(request);
+                })
+            .getStatus();
+
+    Assert.assertEquals(Status.Code.NOT_FOUND, status.getCode());
+  }
+}


### PR DESCRIPTION
## What was changed
This changes a GRPC::Unknown to a GRPC::NotFound, which makes the test service match the behavior of the real thing.

## Why?
The test service should behave similarly to the real thing =)

## Checklist
1. Closes (none)

2. How was this tested:
There's a new unit test that fails without the change.

3. Any docs updates needed?
No.