### PR TITLE
Exposes getWorkflowExecutionHistory on TestWorkflowEnvironment

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -33,7 +33,10 @@ import io.temporal.common.converter.DataConverterException;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/** Contains workflow execution ids and the history */
+/**
+ * Provides a wrapper with convenience methods over raw protobuf {@link History} object representing
+ * workflow history
+ */
 public final class WorkflowExecutionHistory {
   private static final Gson GSON_PRETTY_PRINTER = new GsonBuilder().setPrettyPrinting().create();
   // we stay on using the old API that uses a JsonParser instance instead of static methods
@@ -122,6 +125,10 @@ public final class WorkflowExecutionHistory {
   public HistoryEvent getLastEvent() {
     int eventsCount = history.getEventsCount();
     return eventsCount > 0 ? history.getEvents(eventsCount - 1) : null;
+  }
+
+  public History getHistory() {
+    return history;
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
@@ -66,10 +66,7 @@ public class AsyncActivityRetryTest {
     }
     Assert.assertEquals(activitiesImpl.toString(), 3, activitiesImpl.invocations.size());
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    testWorkflowRule.regenerateHistoryForReplay(
-        testWorkflowRule.getTestEnvironment().getWorkflowService(),
-        execution,
-        "testAsyncActivityRetryHistory");
+    testWorkflowRule.regenerateHistoryForReplay(execution, "testAsyncActivityRetryHistory");
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
@@ -20,7 +20,6 @@
 package io.temporal.workflow.childWorkflowTests;
 
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
-import static io.temporal.testing.internal.SDKTestWorkflowRule.regenerateHistoryForReplay;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
@@ -116,10 +115,7 @@ public class ChildWorkflowRetryTest {
     assertEquals("TestWorkflow1", lastStartedWorkflowType.get());
     assertEquals(3, angryChildActivity.getInvocationCount());
     WorkflowExecution execution = WorkflowStub.fromTyped(client).getExecution();
-    regenerateHistoryForReplay(
-        testWorkflowRule.getTestEnvironment().getWorkflowService(),
-        execution,
-        "testChildWorkflowRetryHistory");
+    testWorkflowRule.regenerateHistoryForReplay(execution, "testChildWorkflowRetryHistory");
   }
 
   /**

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -19,7 +19,9 @@
 
 package io.temporal.testing;
 
+import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowClient;
+import io.temporal.internal.common.WorkflowExecutionHistory;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
@@ -159,6 +161,12 @@ public interface TestWorkflowEnvironment {
    * @return the diagnostic data about the internal service state.
    */
   String getDiagnostics();
+
+  /**
+   * @param execution identifies the workflowId and runId (optionally) to reach the history for
+   * @return history of the execution
+   */
+  WorkflowExecutionHistory getWorkflowExecutionHistory(WorkflowExecution execution);
 
   /** Calls {@link #shutdownNow()} and {@link #awaitTermination(long, TimeUnit)}. */
   void close();

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -21,12 +21,14 @@ package io.temporal.testing;
 
 import com.google.common.collect.ObjectArrays;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.client.ActivityCompletionClient;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
+import io.temporal.internal.common.WorkflowExecutionHistory;
 import io.temporal.internal.sync.WorkflowClientInternal;
 import io.temporal.internal.testservice.TestWorkflowService;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -139,6 +141,17 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     StringBuilder result = new StringBuilder();
     service.getDiagnostics(result);
     return result.toString();
+  }
+
+  @Override
+  public WorkflowExecutionHistory getWorkflowExecutionHistory(WorkflowExecution execution) {
+    GetWorkflowExecutionHistoryRequest request =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace(getNamespace())
+            .setExecution(execution)
+            .build();
+    return new WorkflowExecutionHistory(
+        workflowServiceStubs.blockingStub().getWorkflowExecutionHistory(request).getHistory());
   }
 
   @Override

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -21,7 +21,6 @@ package io.temporal.testing;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.history.v1.History;
-import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
@@ -29,6 +28,7 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.internal.common.DebugModeUtils;
+import io.temporal.internal.common.WorkflowExecutionHistory;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerOptions;
@@ -346,14 +346,19 @@ public class TestWorkflowRule implements TestRule {
     return null;
   }
 
-  /** @return name of the task queue that test worker is polling. */
+  /** @return workflow execution history */
+  public History getHistory(WorkflowExecution execution) {
+    return testEnvironment.getWorkflowExecutionHistory(execution).getHistory();
+  }
+
+  /**
+   * @return name of the task queue that test worker is polling.
+   * @deprecated use {@link #getHistory}, this method will be reworked to return {@link
+   *     WorkflowExecutionHistory} in the upcoming releases
+   */
+  @Deprecated
   public History getWorkflowExecutionHistory(WorkflowExecution execution) {
-    GetWorkflowExecutionHistoryRequest request =
-        GetWorkflowExecutionHistoryRequest.newBuilder()
-            .setNamespace(namespace)
-            .setExecution(execution)
-            .build();
-    return this.blockingStub().getWorkflowExecutionHistory(request).getHistory();
+    return testEnvironment.getWorkflowExecutionHistory(execution).getHistory();
   }
 
   /**


### PR DESCRIPTION
## What was changed

`getWorkflowExecutionHistory` implementation was moved from JUnit4 Test Rule into TestWorkflowEnvironment to expose it to users not using JUnit 4 or not using our Test Rule.