### PR TITLE
Expose methods for loading history from files as WorkflowExecutionHistoryLoader

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -19,9 +19,6 @@
 
 package io.temporal.internal.common;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import com.google.common.io.CharStreams;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.protobuf.MessageOrBuilder;
@@ -48,10 +45,6 @@ import io.temporal.common.converter.EncodedValues;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.TerminatedFailure;
 import io.temporal.failure.TimeoutFailure;
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -335,21 +328,6 @@ public class WorkflowExecutionUtils {
         return EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES;
     }
     throw new IllegalArgumentException("Unknown commandType");
-  }
-
-  public static WorkflowExecutionHistory readHistoryFromResource(String resourceFileName)
-      throws IOException {
-    ClassLoader classLoader = WorkflowExecutionUtils.class.getClassLoader();
-    String historyUrl = classLoader.getResource(resourceFileName).getFile();
-    File historyFile = new File(historyUrl);
-    return readHistory(historyFile);
-  }
-
-  public static WorkflowExecutionHistory readHistory(File historyFile) throws IOException {
-    try (Reader reader = Files.newBufferedReader(historyFile.toPath(), UTF_8)) {
-      String jsonHistory = CharStreams.toString(reader);
-      return WorkflowExecutionHistory.fromJson(jsonHistory);
-    }
   }
 
   public static boolean isFullHistory(PollWorkflowTaskQueueResponseOrBuilder workflowTask) {

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -375,14 +375,21 @@ public final class Worker implements Suspendable {
   }
 
   /**
-   * This is an utility method to replay a workflow execution using this particular instance of a
-   * worker. This method is useful to troubleshoot workflows by running them in a debugger. To work
-   * the workflow implementation type must be registered with this worker. There is no need to call
-   * {@link #start()} to be able to call this method.
+   * This is a utility method to replay a workflow execution using this particular instance of a
+   * worker. This method is useful for troubleshooting workflows by running them in a debugger. The
+   * workflow implementation type must be already registered with this worker for this method to
+   * work.
+   *
+   * <p>There is no need to call {@link #start()} to be able to call this method <br>
+   * The worker doesn't have to be registered on the same task queue as the execution in the
+   * history. <br>
+   * This method shouldn't be a part of normal production usage. It's intended for testing and
+   * debugging only.
    *
    * @param history workflow execution history to replay
    * @throws Exception if replay failed for any reason
    */
+  @VisibleForTesting
   public void replayWorkflowExecution(WorkflowExecutionHistory history) throws Exception {
     workflowWorker.queryWorkflowExecution(
         history,

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
@@ -21,6 +21,7 @@ package io.temporal.internal.common;
 
 import static org.junit.Assert.assertEquals;
 
+import io.temporal.testing.WorkflowHistoryLoader;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -36,9 +37,9 @@ public class WorkflowExecutionHistoryTest {
   public void addingANewFieldToHistoryJsonShouldProduceTheSameResult() throws IOException {
 
     WorkflowExecutionHistory originalHistory =
-        WorkflowExecutionUtils.readHistoryFromResource("simpleHistory1.json");
+        WorkflowHistoryLoader.readHistoryFromResource("simpleHistory1.json");
     WorkflowExecutionHistory historyWithAnAddedNewField =
-        WorkflowExecutionUtils.readHistoryFromResource(
+        WorkflowHistoryLoader.readHistoryFromResource(
             "simpleHistory1_withAddedNewRandomField.json");
 
     assertEquals(originalHistory.getLastEvent(), historyWithAnAddedNewField.getLastEvent());

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     junit4Api 'junit:junit:4.13.2'
 
-    junit5Api platform('org.junit:junit-bom:5.8.1')
+    junit5Api platform('org.junit:junit-bom:5.8.2')
     junit5Api 'org.junit.jupiter:junit-jupiter-api'
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter'

--- a/temporal-testing/src/main/java/io/temporal/testing/WorkflowHistoryLoader.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/WorkflowHistoryLoader.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testing;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.CharStreams;
+import io.temporal.common.Experimental;
+import io.temporal.internal.common.WorkflowExecutionHistory;
+import io.temporal.internal.common.WorkflowExecutionUtils;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.file.Files;
+
+/**
+ * Expose methods to read and deserialize workflow execution history from json.<br>
+ * To be used with {@link WorkflowReplayer}
+ *
+ * <p>2021-11-29 Experimental because the user facing interface to history replay functionality is
+ * actively evolving.
+ */
+@Experimental
+public final class WorkflowHistoryLoader {
+  private WorkflowHistoryLoader() {}
+
+  public static WorkflowExecutionHistory readHistoryFromResource(String resourceFileName)
+      throws IOException {
+    ClassLoader classLoader = WorkflowExecutionUtils.class.getClassLoader();
+    URL resource = classLoader.getResource(resourceFileName);
+    Preconditions.checkArgument(resource != null, "File %s can't be found", resourceFileName);
+    String historyUrl = resource.getFile();
+    File historyFile = new File(historyUrl);
+    return readHistory(historyFile);
+  }
+
+  public static WorkflowExecutionHistory readHistory(File historyFile) throws IOException {
+    try (Reader reader = Files.newBufferedReader(historyFile.toPath(), UTF_8)) {
+      String jsonHistory = CharStreams.toString(reader);
+      return WorkflowExecutionHistory.fromJson(jsonHistory);
+    }
+  }
+}


### PR DESCRIPTION
Now the methods to read history from files exist only in internal package and can be used as a part of WorkflowReplayer only.
To provide better flexibility for our users, if they want to use `worker.replayWorkflowExecution` directly, for example, the methods are moved under `WorkflowExecutionHistoryLoader`class available for testing only.