### PR TITLE
Rearrange WFT handle logging and metrics to accommodate all failure modes

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
@@ -90,7 +90,6 @@ public class SyncWorkflowWorker
             stickyTaskQueueName,
             stickyWorkflowTaskScheduleToStartTimeout,
             service,
-            this::isShutdown,
             laWorker.getLocalActivityTaskPoller());
 
     workflowWorker =
@@ -108,7 +107,6 @@ public class SyncWorkflowWorker
             null,
             stickyWorkflowTaskScheduleToStartTimeout,
             service,
-            this::isShutdown,
             laWorker.getLocalActivityTaskPoller());
 
     queryReplayHelper = new QueryReplayHelper(nonStickyReplayTaskHandler);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowTaskHandler.java
@@ -95,12 +95,13 @@ public interface WorkflowTaskHandler {
   }
 
   /**
-   * Handles a single workflow task. Shouldn't throw any exceptions. A compliant implementation
-   * should return any unexpected errors as RespondWorkflowTaskFailedRequest.
+   * Handles a single workflow task
    *
    * @param workflowTask The workflow task to handle.
    * @return One of the possible workflow task replies: RespondWorkflowTaskCompletedRequest,
    *     RespondQueryTaskCompletedRequest, RespondWorkflowTaskFailedRequest
+   * @throws Exception an original exception or error if the processing should be just abandoned
+   *     without replying to the server
    */
   Result handleWorkflowTask(PollWorkflowTaskQueueResponse workflowTask) throws Exception;
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -74,7 +74,6 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
             null,
             Duration.ofSeconds(5),
             service,
-            () -> false,
             null);
 
     // Act
@@ -100,13 +99,11 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
             "sticky",
             Duration.ofSeconds(5),
             service,
-            () -> false,
             null);
 
     PollWorkflowTaskQueueResponse workflowTask =
         HistoryUtils.generateWorkflowTaskWithInitialHistory();
 
-    // Act
     WorkflowTaskHandler.Result result = taskHandler.handleWorkflowTask(workflowTask);
 
     assertTrue(result.isCompletionCommand());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityRetryOnTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityRetryOnTimeoutTest.java
@@ -45,6 +45,7 @@ public class ActivityRetryOnTimeoutTest {
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestActivityRetryOnTimeout.class)
           .setActivityImplementations(activitiesImpl)
+          .setTestTimeoutSeconds(15)
           .build();
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ParallelLocalActivitiesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ParallelLocalActivitiesTest.java
@@ -46,14 +46,15 @@ public class ParallelLocalActivitiesTest {
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestParallelLocalActivitiesWorkflowImpl.class)
           .setActivityImplementations(activitiesImpl)
+          .setTestTimeoutSeconds(20)
           .build();
 
   @Test
   public void testParallelLocalActivities() {
     WorkflowOptions options =
         WorkflowOptions.newBuilder()
-            .setWorkflowRunTimeout(Duration.ofMinutes(5))
-            .setWorkflowTaskTimeout(Duration.ofSeconds(3))
+            .setWorkflowRunTimeout(Duration.ofMinutes(1))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(5))
             .setTaskQueue(testWorkflowRule.getTaskQueue())
             .build();
 


### PR DESCRIPTION
## What was changed
WFT handling counters gathered in `WorkflowWorker` instead of being spread between `WorkflowWorker` and `WorkflowTaskHandler`
Added logging in case of successful handling o WFT on the worker, but failing to report to the server.
Cleanup usage of tags and Scopes to remove inconsistent and duplicate tagging.  

Closes #900