### PR TITLE
Fix signalWithStart integration with tracing

### DIFF
--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanCreationContext.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanCreationContext.java
@@ -19,6 +19,8 @@
 
 package io.temporal.opentracing;
 
+import javax.annotation.Nullable;
+
 /**
  * Used when creating an OpenTracing span and provides contextual information used for naming and
  * tagging OT spans.
@@ -64,7 +66,7 @@ public class SpanCreationContext {
     return workflowId;
   }
 
-  public String getRunId() {
+  public @Nullable String getRunId() {
     return runId;
   }
 

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
@@ -19,6 +19,7 @@
 
 package io.temporal.opentracing.internal;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.opentracing.Tracer;
 import io.temporal.opentracing.SpanBuilderProvider;
@@ -69,8 +70,10 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
    * @return The map of tags for the span
    */
   protected Map<String, String> getSpanTags(SpanCreationContext context) {
-    switch (context.getSpanOperationType()) {
+    SpanOperationType operationType = context.getSpanOperationType();
+    switch (operationType) {
       case START_WORKFLOW:
+      case SIGNAL_WITH_START_WORKFLOW:
         return ImmutableMap.of(StandardTagNames.WORKFLOW_ID, context.getWorkflowId());
       case START_CHILD_WORKFLOW:
         return ImmutableMap.of(
@@ -80,7 +83,9 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
       case RUN_WORKFLOW:
       case START_ACTIVITY:
       case RUN_ACTIVITY:
-      case SIGNAL_WITH_START_WORKFLOW:
+        String runId = context.getRunId();
+        Preconditions.checkNotNull(
+            runId, "runId is expected to be not null for span operation type %s", operationType);
         return ImmutableMap.of(
             StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.RUN_ID, context.getRunId());

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/SignalWithStartTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/SignalWithStartTest.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing;
+
+import static org.junit.Assert.*;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.temporal.client.*;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.List;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SignalWithStartTest {
+
+  private static final MockTracer mockTracer =
+      new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
+
+  private final OpenTracingOptions OT_OPTIONS =
+      OpenTracingOptions.newBuilder().setTracer(mockTracer).build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder()
+                  .setInterceptors(new OpenTracingClientInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new OpenTracingWorkerInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkflowTypes(WorkflowImpl.class)
+          .build();
+
+  @After
+  public void tearDown() {
+    mockTracer.reset();
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String workflow(String input);
+
+    @SignalMethod
+    void signal(String signal);
+  }
+
+  public static class WorkflowImpl implements TestWorkflow {
+
+    private String signal;
+
+    @Override
+    public String workflow(String input) {
+      return signal;
+    }
+
+    @Override
+    public void signal(String signal) {
+      this.signal = signal;
+    }
+  }
+
+  @Test
+  public void signalWithStart() {
+    WorkflowClient client = testWorkflowRule.getWorkflowClient();
+    TestWorkflow workflow =
+        client.newWorkflowStub(
+            TestWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+
+    Span span = mockTracer.buildSpan("ClientFunction").start();
+
+    try (Scope scope = mockTracer.scopeManager().activate(span)) {
+      BatchRequest batchRequest = client.newSignalWithStartRequest();
+      batchRequest.add(workflow::workflow, "input");
+      batchRequest.add(workflow::signal, "signal");
+      client.signalWithStart(batchRequest);
+    } finally {
+      span.finish();
+    }
+
+    // wait for the workflow completion
+    WorkflowStub.fromTyped(workflow).getResult(String.class);
+
+    OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
+
+    MockSpan clientSpan = spansHelper.getSpanByOperationName("ClientFunction");
+
+    MockSpan workflowStartSpan = spansHelper.getByParentSpan(clientSpan).get(0);
+    assertEquals(clientSpan.context().spanId(), workflowStartSpan.parentId());
+    assertEquals("SignalWithStartWorkflow:TestWorkflow", workflowStartSpan.operationName());
+
+    List<MockSpan> workflowRunSpans = spansHelper.getByParentSpan(workflowStartSpan);
+    assertEquals(1, workflowRunSpans.size());
+
+    MockSpan workflowRunSpan = workflowRunSpans.get(0);
+    assertEquals(workflowStartSpan.context().spanId(), workflowRunSpan.parentId());
+    assertEquals("RunWorkflow:TestWorkflow", workflowRunSpan.operationName());
+  }
+}

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/SpanContextPropagationTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/SpanContextPropagationTest.java
@@ -127,7 +127,7 @@ public class SpanContextPropagationTest {
    */
   @Test
   public void testBaggageItemPropagation() {
-    Span span = mockTracer.buildSpan("clientFunction").start();
+    Span span = mockTracer.buildSpan("ClientFunction").start();
 
     WorkflowClient client = testWorkflowRule.getWorkflowClient();
     try (Scope scope = mockTracer.scopeManager().activate(span)) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/external/GenericWorkflowClientExternalImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/external/GenericWorkflowClientExternalImpl.java
@@ -150,6 +150,10 @@ public final class GenericWorkflowClientExternalImpl implements GenericWorkflowC
       request.setRetryPolicy(startParameters.getRetryPolicy());
     }
 
+    if (startParameters.hasHeader()) {
+      request.setHeader(startParameters.getHeader());
+    }
+
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(2)
             .put(MetricsTag.WORKFLOW_TYPE, request.getWorkflowType().getName())


### PR DESCRIPTION
## What was changed
Fix `signalWithStart` integration with tracing
Pass a supplied header during `signalWithStart` client call
Issue #912