### PR TITLE
Shutdown of WorkflowFactory now invalidates the workflow cache

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ExecutorThreadFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ExecutorThreadFactory.java
@@ -22,14 +22,13 @@ package io.temporal.internal.worker;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class ExecutorThreadFactory implements ThreadFactory {
+public class ExecutorThreadFactory implements ThreadFactory {
+  private final String threadPrefix;
 
   private final Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
   private final AtomicInteger threadIndex = new AtomicInteger();
 
-  private final String threadPrefix;
-
-  ExecutorThreadFactory(String threadPrefix, Thread.UncaughtExceptionHandler eh) {
+  public ExecutorThreadFactory(String threadPrefix, Thread.UncaughtExceptionHandler eh) {
     this.threadPrefix = threadPrefix;
     this.uncaughtExceptionHandler = eh;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopSuspendableWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopSuspendableWorker.java
@@ -19,6 +19,7 @@
 
 package io.temporal.internal.worker;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -41,13 +42,9 @@ class NoopSuspendableWorker implements SuspendableWorker {
   }
 
   @Override
-  public void shutdown() {
+  public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
     shutdown.set(true);
-  }
-
-  @Override
-  public void shutdownNow() {
-    shutdown.set(true);
+    return CompletableFuture.completedFuture(null);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollWorkflowTaskDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollWorkflowTaskDispatcher.java
@@ -30,6 +30,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.workflow.Functions;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -106,13 +107,9 @@ public final class PollWorkflowTaskDispatcher
   }
 
   @Override
-  public void shutdown() {
+  public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
     shutdown.set(true);
-  }
-
-  @Override
-  public void shutdownNow() {
-    shutdown.set(true);
+    return CompletableFuture.completedFuture(null);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ShutdownManager.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ShutdownManager.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.concurrent.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ShutdownManager implements Closeable {
+  private static final Logger log = LoggerFactory.getLogger(ShutdownManager.class);
+
+  private final ScheduledExecutorService scheduledExecutorService =
+      Executors.newSingleThreadScheduledExecutor(
+          new ExecutorThreadFactory(
+              WorkerThreadsNameHelper.SHUTDOWN_MANAGER_THREAD_NAME_PREFIX, null));
+
+  private static final int CHECK_PERIOD_MS = 250;
+
+  /** executorToShutdown.shutdownNow() -> timed wait for a graceful termination */
+  public CompletableFuture<Void> shutdownExecutorNow(
+      ExecutorService executorToShutdown, String executorName, Duration timeout) {
+    executorToShutdown.shutdownNow();
+    return limitedWait(executorToShutdown, executorName, timeout);
+  }
+
+  /** executorToShutdown.shutdownNow() -> unlimited wait for termination */
+  public CompletableFuture<Void> shutdownExecutorNowUntimed(
+      ExecutorService executorToShutdown, String executorName) {
+    executorToShutdown.shutdownNow();
+    return untimedWait(executorToShutdown, executorName);
+  }
+
+  /**
+   * executorToShutdown.shutdown() -> timed wait for graceful termination ->
+   * executorToShutdown.shutdownNow()
+   */
+  public CompletableFuture<Void> shutdownExecutor(
+      ExecutorService executorToShutdown, String executorName, Duration timeout) {
+    executorToShutdown.shutdown();
+
+    return limitedWait(executorToShutdown, executorName, timeout);
+  }
+
+  /** executorToShutdown.shutdown() -> unlimited wait for graceful termination */
+  public CompletableFuture<Void> shutdownExecutorUntimed(
+      ExecutorService executorToShutdown, String executorName) {
+    executorToShutdown.shutdown();
+    return untimedWait(executorToShutdown, executorName);
+  }
+
+  /**
+   * Wait for {@code executorToShutdown} to terminate. Only completes the returned CompletableFuture
+   * when the executor is terminated.
+   */
+  private CompletableFuture<Void> untimedWait(
+      ExecutorService executorToShutdown, String executorName) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    scheduledExecutorService.submit(
+        new ReportingDelayShutdown(executorToShutdown, executorName, future));
+    return future;
+  }
+
+  /**
+   * Wait for {@code executorToShutdown} to terminate for a defined interval, shutdownNow after
+   * that. Always completes the returned CompletableFuture on termination of the executor or on a
+   * timeout, whatever happens earlier.
+   */
+  private CompletableFuture<Void> limitedWait(
+      ExecutorService executorToShutdown, String executorName, Duration timeout) {
+    int attempts = (int) Math.ceil((double) timeout.toMillis() / CHECK_PERIOD_MS);
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    scheduledExecutorService.submit(
+        new LimitedWaitShutdown(executorToShutdown, attempts, executorName, future));
+    return future;
+  }
+
+  @Override
+  public void close() {
+    scheduledExecutorService.shutdownNow();
+  }
+
+  private class LimitedWaitShutdown implements Runnable {
+    private final ExecutorService executorToShutdown;
+    private final CompletableFuture<Void> promise;
+    private final int maxAttempts;
+    private final String executorName;
+    private int attempt;
+
+    public LimitedWaitShutdown(
+        ExecutorService executorToShutdown,
+        int maxAttempts,
+        String executorName,
+        CompletableFuture<Void> promise) {
+      this.executorToShutdown = executorToShutdown;
+      this.promise = promise;
+      this.maxAttempts = maxAttempts;
+      this.executorName = executorName;
+    }
+
+    @Override
+    public void run() {
+      if (executorToShutdown.isTerminated()) {
+        promise.complete(null);
+        return;
+      }
+      attempt++;
+      if (attempt > maxAttempts) {
+        log.warn(
+            "Wait for a graceful shutdown of {} timed out, fallback to shutdownNow()",
+            executorName);
+        executorToShutdown.shutdownNow();
+        // we don't want to complicate shutdown with dealing of exceptions and errors of all sorts,
+        // so just log and complete the promise
+        promise.complete(null);
+        return;
+      }
+      scheduledExecutorService.schedule(this, CHECK_PERIOD_MS, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private class ReportingDelayShutdown implements Runnable {
+    private static final int BLOCKED_REPORTING_THRESHOLD = 60;
+    private static final int BLOCKED_REPORTING_PERIOD = 20;
+
+    private final ExecutorService executorToShutdown;
+    private final CompletableFuture<Void> promise;
+    private final String executorName;
+    private int attempt;
+
+    public ReportingDelayShutdown(
+        ExecutorService executorToShutdown, String executorName, CompletableFuture<Void> promise) {
+      this.executorToShutdown = executorToShutdown;
+      this.promise = promise;
+      this.executorName = executorName;
+    }
+
+    @Override
+    public void run() {
+      if (executorToShutdown.isTerminated()) {
+        if (attempt > BLOCKED_REPORTING_THRESHOLD) {
+          // log warn only if we already logged a shutdown being delayed
+          log.warn("{} successfully terminated", executorName);
+        }
+        promise.complete(null);
+        return;
+      }
+      attempt++;
+      // log a problem after BLOCKED_REPORTING_THRESHOLD attempts only
+      if (attempt >= BLOCKED_REPORTING_THRESHOLD) {
+        // and repeat every BLOCKED_REPORTING_PERIOD attempts
+        if (((float) (attempt - BLOCKED_REPORTING_THRESHOLD) % BLOCKED_REPORTING_PERIOD) < 0.001) {
+          log.warn(
+              "Graceful shutdown of {} is blocked by one of the long currently processing tasks",
+              executorName);
+        }
+      }
+      scheduledExecutorService.schedule(this, CHECK_PERIOD_MS, TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Shutdownable.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Shutdownable.java
@@ -19,7 +19,10 @@
 
 package io.temporal.internal.worker;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 public interface Shutdownable {
 
@@ -27,9 +30,18 @@ public interface Shutdownable {
 
   boolean isTerminated();
 
-  void shutdown();
-
-  void shutdownNow();
+  /**
+   * @param shutdownManager provides toolset to get a Future for a shutdown of instances that have
+   *     both non-blocking and not returning a Future on a completion shutdown methods (like {@link
+   *     ExecutorService#shutdown()})
+   * @param interruptTasks if the threads processing user code (like workflows, workflow tasks or
+   *     activities) should be interrupted, or we want to wait for their full graceful completion
+   * @return CompletableFuture which should be completed when awaiting downstream dependencies can
+   *     proceed with their own shutdown. Should never be completed exceptionally {@link
+   *     CompletableFuture#exceptionally(Function)} as downstream dependencies have no use of this
+   *     information (they need to perform a shutdown anyway), and it complicates the shutdown flow.
+   */
+  CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks);
 
   void awaitTermination(long timeout, TimeUnit unit);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+public class WorkerThreadsNameHelper {
+  private static final String LOCAL_ACTIVITY_POLL_THREAD_NAME_PREFIX =
+      "Local Activity Poller taskQueue=";
+  private static final String ACTIVITY_POLL_THREAD_NAME_PREFIX = "Activity Poller taskQueue=";
+  public static final String SHUTDOWN_MANAGER_THREAD_NAME_PREFIX = "TemporalShutdownManager";
+  public static final String ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX = "TemporalActivityHeartbeat-";
+  public static final String LOCAL_ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX =
+      "TemporalLocalActivityHeartbeat-";
+
+  public static String getLocalActivityPollerThreadPrefix(String namespace, String taskQueue) {
+    return LOCAL_ACTIVITY_POLL_THREAD_NAME_PREFIX
+        + "\""
+        + taskQueue
+        + "\", namespace=\""
+        + namespace
+        + "\"";
+  }
+
+  public static String getActivityPollerThreadPrefix(String namespace, String taskQueue) {
+    return ACTIVITY_POLL_THREAD_NAME_PREFIX
+        + "\""
+        + taskQueue
+        + "\", namespace=\""
+        + namespace
+        + "\"";
+  }
+
+  public static String getActivityHeartbeatThreadPrefix(String namespace, String taskQueue) {
+    return ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX + namespace + "-" + taskQueue;
+  }
+
+  public static String getLocalActivityHeartbeatThreadPrefix(String namespace, String taskQueue) {
+    return LOCAL_ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX + namespace + "-" + taskQueue;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -37,6 +37,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.workflow.Functions;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -139,19 +140,11 @@ public final class WorkflowWorker
   }
 
   @Override
-  public void shutdown() {
+  public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
     if (poller == null) {
-      return;
+      return CompletableFuture.completedFuture(null);
     }
-    poller.shutdown();
-  }
-
-  @Override
-  public void shutdownNow() {
-    if (poller == null) {
-      return;
-    }
-    poller.shutdownNow();
+    return poller.shutdown(shutdownManager, interruptTasks);
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownHeartBeatingActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownHeartBeatingActivityTest.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.worker;
+package io.temporal.worker.shutdown;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -33,6 +33,7 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactory;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestActivities.NoArgsReturnsStringActivity;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowReturnString;

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownInvalidatesWorkflowCacheTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownInvalidatesWorkflowCacheTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.worker.shutdown;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.testUtils.Signal;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactory;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests that {@link WorkerFactory} invalidates the workflow cache and destroys the workflow threads
+ * during shutdown.
+ */
+public class CleanWorkerShutdownInvalidatesWorkflowCacheTest {
+  private static final Signal STARTED = new Signal();
+  private static final Signal WORKFLOW_THREAD_DESTROYED = new Signal();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowImpl.class).build();
+
+  @Before
+  public void setUp() throws Exception {
+    STARTED.clearSignal();
+    WORKFLOW_THREAD_DESTROYED.clearSignal();
+  }
+
+  @Test
+  public void testShutdownHeartBeatingActivity() throws InterruptedException {
+    TestWorkflows.NoArgsWorkflow workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.NoArgsWorkflow.class);
+    WorkflowClient.start(workflow::execute);
+    STARTED.waitForSignal();
+    testWorkflowRule.getTestEnvironment().shutdown();
+    WORKFLOW_THREAD_DESTROYED.waitForSignal();
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.NoArgsWorkflow {
+
+    private final boolean forWait = false;
+
+    @Override
+    public void execute() {
+      try {
+        STARTED.signal();
+        Workflow.await(() -> forWait);
+      } catch (Error e) {
+        // never ever catch Errors in production code
+        if ("DestroyWorkflowThreadError".equals(e.getClass().getSimpleName())) {
+          WORKFLOW_THREAD_DESTROYED.signal();
+        }
+        throw e;
+      }
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownTest.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.worker;
+package io.temporal.worker.shutdown;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -135,7 +135,7 @@ public class CleanWorkerShutdownTest {
         shutdownNowLatch.countDown();
       }
       try {
-        Thread.sleep(1000);
+        Thread.sleep(3000);
       } catch (InterruptedException e) {
         // We ignore the interrupted exception here to let the activity complete and return the
         // result. Otherwise, the result is not reported:

--- a/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyFailWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyFailWorkflowTest.java
@@ -20,6 +20,7 @@
 package io.temporal.workflow.determinism;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
@@ -62,14 +63,14 @@ public class NonDeterministicWorkflowPolicyFailWorkflowTest {
             .build();
     TestWorkflowStringArg workflowStub =
         testWorkflowRule.getWorkflowClient().newWorkflowStub(TestWorkflowStringArg.class, options);
-    try {
-      workflowStub.execute(testWorkflowRule.getTaskQueue());
-      Assert.fail("unreachable");
-    } catch (WorkflowFailedException e) {
-      // expected to fail on non-deterministic error
-      Assert.assertTrue(e.getCause() instanceof ApplicationFailure);
-      assertEquals(
-          NonDeterministicException.class.getName(), ((ApplicationFailure) e.getCause()).getType());
-    }
+    WorkflowFailedException e =
+        assertThrows(
+            WorkflowFailedException.class,
+            () -> {
+              workflowStub.execute(testWorkflowRule.getTaskQueue());
+            });
+    Assert.assertTrue(e.getCause() instanceof ApplicationFailure);
+    assertEquals(
+        NonDeterministicException.class.getName(), ((ApplicationFailure) e.getCause()).getType());
   }
 }


### PR DESCRIPTION
## What was changed
A shutdown of WorkflowFactory now invalidates the workflow cache.
Full rework and polishing of a graceful worker shutdown to be actually graceful.
`ShutdownManager` is introduced to be able to represent shutdown as a sequence of `CompletableFuture` steps.

## How it was tested
`CleanWorkerShutdownInvalidatesWorkflowCacheTest` - Test verifying that an awaiting workflow gets `DestroyWorkflowThreadError` during shutdown.

Closes #914