### PR TITLE
Doc describing building test-server into a native binary using GraalVM native-image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,12 @@ plugins {
 
 ext {
     logbackVersion = '1.2.7'
-    grpcVersion = '[1.34.0,)!!1.41.0'
-    protoVersion = '[3.10.0,)!!3.18.1'
+    grpcVersion = '[1.34.0,)!!1.41.1'
+    protoVersion = '[3.10.0,)!!3.19.1'
     guavaVersion = '[10.0,)!!31.0.1-jre'
     jsonPathVersion = '2.6.0'
     mockitoVersion = '4.1.0'
-    micrometerVersion = '[1.0.0,)!!1.7.5'
+    micrometerVersion = '[1.0.0,)!!1.8.0'
     jacksonVersion = '[2.9.0,)!!2.13.0'
     tallyVersion = '[0.4.0,)!!0.11.1'
     gsonVersion = '[2.0,)!!2.8.9'

--- a/gradle/dependencyManagement.gradle
+++ b/gradle/dependencyManagement.gradle
@@ -2,3 +2,11 @@
 subprojects {
     apply plugin: "name.remal.check-updates"
 }
+
+subprojects {
+    configurations.all {
+        //comes through grpc-api:gauava
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
+    }
+}

--- a/temporal-testing/README.md
+++ b/temporal-testing/README.md
@@ -45,3 +45,24 @@ and `io.temporal.testing.TestActivityExtension` for isolated testing of activiti
 See `io.temporal.testing.TestActivityEnvironment` that provides an easy way for isolated testing of
 activity implementations without needing to provide workflows calling the activities, triggering the workflows
 and bootstrapping a Temporal server or In-memory testing service.
+
+## To build a test service using GraalVM native-image
+
+From the root of the java-sdk repo:
+```
+./gradlew :temporal-testing:copyDependencies
+```
+```
+native-image -jar "./temporal-testing/build/libs/temporal-testing-1.6.0-SNAPSHOT.jar" test-server --class-path "./temporal-testing/build/dependencies/*" \
+--allow-incomplete-classpath --no-fallback
+```
+Additional `native-image` flags to consider:
+1. `--static` to build a fully static binary. _[Not supported](https://developer.apple.com/library/archive/qa/qa1118/_index.html) for MacOS._
+
+### Notes on installing GraalVM
+1. Install [prerequisites](https://www.graalvm.org/reference-manual/native-image/#prerequisites)
+2. Install [sdkman](https://sdkman.io/install)
+3. `sdk install java 21.2.0.r11-grl` GraalVM on JDK 11
+4. `sdk use java 21.2.0.r11-grl`
+5. `gu install native-image`, where `gu` is GraalVM Updater.
+6. After these steps, if sdkman is configured properly, you can switch to GraalVM JDK any time in the shell by using `sdk use java 21.2.0.r11-grl` which will make `native-image` tool also available

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -16,7 +16,7 @@ java {
 dependencies {
     api project(':temporal-sdk')
 
-    implementation "io.grpc:grpc-core:$grpcVersion"
+    implementation("io.grpc:grpc-core:$grpcVersion")
     implementation "com.google.guava:guava:$guavaVersion"
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.6'
     implementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
@@ -28,6 +28,21 @@ dependencies {
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter'
     testRuntimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
+}
+
+application {
+    mainClassName = 'io.temporal.internal.testservice.TestServiceServer'
+}
+
+task copyDependencies(type: Copy) {
+    from configurations.runtimeClasspath
+    into 'build/dependencies'
+}
+
+jar {
+    manifest {
+        attributes("Main-Class": application.mainClassName)
+    }
 }
 
 task testServiceServer(type: CreateStartScripts) {

--- a/temporal-testing/src/main/resources/META-INF/native-image/io.temporal/temporal-testing/native-image.properties
+++ b/temporal-testing/src/main/resources/META-INF/native-image/io.temporal/temporal-testing/native-image.properties
@@ -1,0 +1,26 @@
+#
+#  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+#
+#  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Modifications copyright (C) 2017 Uber Technologies, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+#  use this file except in compliance with the License. A copy of the License is
+#  located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+#  or in the "license" file accompanying this file. This file is distributed on
+#  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+Args = --initialize-at-build-time=org.slf4j.impl.StaticLoggerBinder \
+  --initialize-at-build-time=org.slf4j.LoggerFactory \
+  --initialize-at-run-time=io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLogger \
+  --initialize-at-run-time=io.grpc.netty.shaded.io.netty.internal.tcnative \
+  --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl
+
+


### PR DESCRIPTION
This PR provides some adjustments and documentation about how to use GraalVM native-image tool to build Temporal Java Test Service into a native binary.