### PR TITLE
Upgrade grpc version to 1.42.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "/bin/sh -c 'docker/buildkite/copyright-and-code-format.sh'"
+    command: "docker/buildkite/copyright-and-code-format.sh"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     logbackVersion = '1.2.7'
-    grpcVersion = '[1.34.0,)!!1.41.1'
+    grpcVersion = '[1.34.0,)!!1.42.1'
     protoVersion = '[3.10.0,)!!3.19.1'
     guavaVersion = '[10.0,)!!31.0.1-jre'
     jsonPathVersion = '2.6.0'

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,16 +1,7 @@
-FROM openjdk:8-alpine
-
-# Based on https://github.com/sgerrand/alpine-pkg-glibc
-# Needed to run protoc java plugin
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk
-RUN apk add glibc-2.33-r0.apk
-
-# Install dependencies using apk
-RUN apk update && apk add --virtual wget ca-certificates wget && apk add protobuf
+FROM openjdk:8-slim
 
 # Git is needed in order to update the dls submodule
-RUN apk add --virtual git
+RUN apt-get update && apt-get install -y wget protobuf-compiler git
 
 # Fossa to run license scans
 RUN wget -O- https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sh

--- a/docker/buildkite/copyright-and-code-format.sh
+++ b/docker/buildkite/copyright-and-code-format.sh
@@ -1,6 +1,5 @@
-#!/usr/bin/env sh
-set -eou pipefail
-set -x
+#!/bin/bash
+set -xeou pipefail
 
 ./gradlew --no-daemon check -x test
 

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -2,10 +2,11 @@ description = '''Temporal Workflow Java SDK'''
 
 dependencies {
     implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+    api(platform("io.micrometer:micrometer-bom:$micrometerVersion"))
 
     api project(':temporal-serviceclient')
     api "com.google.code.gson:gson:$gsonVersion"
-    api "io.micrometer:micrometer-core:$micrometerVersion"
+    api "io.micrometer:micrometer-core"
 
     implementation ("com.google.guava:guava:$guavaVersion") {
         exclude group: 'com.google.code.findbugs'


### PR DESCRIPTION
CI docker image has been updated to use the latest jdk8 image
CI scripts have been revisited for a switch from alpine to slim-bullseye Linux baseimage.

Closes #918 