### PR TITLE
Fix POJOActivityImplMetadata not being able to handle activity impl that uses inheritance

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOActivityImplMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOActivityImplMetadata.java
@@ -20,6 +20,7 @@
 package io.temporal.common.metadata;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.common.MethodRetry;
 import java.lang.reflect.Method;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Metadata of an activity implementation object.
@@ -47,6 +49,7 @@ import java.util.Map;
 public final class POJOActivityImplMetadata {
 
   private final List<POJOActivityInterfaceMetadata> activityInterfaces;
+  private final List<POJOActivityMethodMetadata> activityMethods;
 
   /** Creates POJOActivityImplMetadata for an activity implementation class. */
   public static POJOActivityImplMetadata newInstance(Class<?> implementationClass) {
@@ -75,11 +78,11 @@ public final class POJOActivityImplMetadata {
                 + "\" This annotation can be used only on the interface method it implements.");
       }
     }
-    Class<?>[] interfaces = implClass.getInterfaces();
+    Set<Class<?>> interfaces =
+        (Set<Class<?>>) TypeToken.of(implClass).getTypes().interfaces().rawTypes();
     List<POJOActivityInterfaceMetadata> activityInterfaces = new ArrayList<>();
     Map<String, POJOActivityMethodMetadata> byName = new HashMap<>();
-    for (int i = 0; i < interfaces.length; i++) {
-      Class<?> anInterface = interfaces[i];
+    for (Class<?> anInterface : interfaces) {
       POJOActivityInterfaceMetadata interfaceMetadata =
           POJOActivityInterfaceMetadata.newImplementationInterface(anInterface);
       activityInterfaces.add(interfaceMetadata);
@@ -109,10 +112,16 @@ public final class POJOActivityImplMetadata {
               + implClass.getName());
     }
     this.activityInterfaces = ImmutableList.copyOf(activityInterfaces);
+    this.activityMethods = ImmutableList.copyOf(byName.values());
   }
 
   /** Activity interfaces implemented by the object. */
   public List<POJOActivityInterfaceMetadata> getActivityInterfaces() {
     return activityInterfaces;
+  }
+
+  /** Activity methods implemented by the object */
+  public List<POJOActivityMethodMetadata> getActivityMethods() {
+    return activityMethods;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java
@@ -39,7 +39,6 @@ import io.temporal.common.interceptors.ActivityInboundCallsInterceptor;
 import io.temporal.common.interceptors.Header;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.common.metadata.POJOActivityImplMetadata;
-import io.temporal.common.metadata.POJOActivityInterfaceMetadata;
 import io.temporal.common.metadata.POJOActivityMethodMetadata;
 import io.temporal.failure.FailureConverter;
 import io.temporal.failure.SimulatedTimeoutFailure;
@@ -110,18 +109,15 @@ public final class POJOActivityTaskHandler implements ActivityTaskHandler {
     }
     Class<?> cls = activity.getClass();
     POJOActivityImplMetadata activityImplMetadata = POJOActivityImplMetadata.newInstance(cls);
-    for (POJOActivityInterfaceMetadata activityInterface :
-        activityImplMetadata.getActivityInterfaces()) {
-      for (POJOActivityMethodMetadata activityMetadata : activityInterface.getMethodsMetadata()) {
-        String typeName = activityMetadata.getActivityTypeName();
-        if (activities.containsKey(typeName)) {
-          throw new IllegalArgumentException(
-              "\"" + typeName + "\" activity type is already registered with the worker");
-        }
-        Method method = activityMetadata.getMethod();
-        ActivityTaskExecutor implementation = newTaskExecutor.apply(method, activity);
-        activities.put(typeName, implementation);
+    for (POJOActivityMethodMetadata activityMetadata : activityImplMetadata.getActivityMethods()) {
+      String typeName = activityMetadata.getActivityTypeName();
+      if (activities.containsKey(typeName)) {
+        throw new IllegalArgumentException(
+            "\"" + typeName + "\" activity type is already registered with the worker");
       }
+      Method method = activityMetadata.getMethod();
+      ActivityTaskExecutor implementation = newTaskExecutor.apply(method, activity);
+      activities.put(typeName, implementation);
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
@@ -354,6 +354,34 @@ public class ActivityTestingTest {
     }
   }
 
+  public abstract class BaseE implements E {
+    protected final List<String> invocations = new ArrayList<>();
+
+    @Override
+    public void a() {
+      doA();
+    }
+
+    @Override
+    public void d() {
+      invocations.add("d");
+    }
+
+    @Override
+    public void e() {
+      invocations.add("e");
+    }
+
+    abstract void doA();
+  }
+
+  public class EImplBaseExtended extends BaseE {
+    @Override
+    void doA() {
+      invocations.add("a");
+    }
+  }
+
   @Test
   public void testInvokingActivityByBaseInterface1() {
     BImpl bImpl = new BImpl();
@@ -426,6 +454,26 @@ public class ActivityTestingTest {
   @Test
   public void testInvokingActivityByBaseInterface2() {
     EImpl eImpl = new EImpl();
+    testEnvironment.registerActivitiesImplementations(eImpl);
+    E e = testEnvironment.newActivityStub(E.class);
+    e.a();
+    e.d();
+    e.e();
+    D d = testEnvironment.newActivityStub(D.class);
+    d.a();
+    d.d();
+    List<String> expectedE = new ArrayList<>();
+    expectedE.add("a");
+    expectedE.add("d");
+    expectedE.add("e");
+    expectedE.add("a");
+    expectedE.add("d");
+    assertEquals(expectedE, eImpl.invocations);
+  }
+
+  @Test
+  public void testInvokingInheritedActivityByBaseInterfaces() {
+    EImplBaseExtended eImpl = new EImplBaseExtended();
     testEnvironment.registerActivitiesImplementations(eImpl);
     E e = testEnvironment.newActivityStub(E.class);
     e.a();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
`POJOActivityImplMetadata` now uses guava to find all activity interfaces for a given activity impl class. Inspiration - https://stackoverflow.com/questions/6616055/get-all-derived-interfaces-of-a-class

## Why?
https://github.com/temporalio/sdk-java/issues/929

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/929

2. How was this tested?
Added a test. All existing tests pass.
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? 
I don't think this needs any doc updates.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
