### PR TITLE
Add metadata.messageType to protobuf payloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To generate licence headers execute
 
 ## Commit Messages
 
-Overcommit adds some requirements to your commit messages. At Uber, we follow the
+Overcommit adds some requirements to your commit messages. We follow the
 [Chris Beams](http://chris.beams.io/posts/git-commit/) guide to writing git
 commit messages. Read it, follow it, learn it, love it.
 

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/AbstractProtobufPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/AbstractProtobufPayloadConverter.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.common.converter;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.MessageOrBuilder;
+import io.temporal.api.common.v1.Payload;
+import java.lang.reflect.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractProtobufPayloadConverter {
+  protected static final Logger log =
+      LoggerFactory.getLogger(AbstractProtobufPayloadConverter.class);
+
+  private final boolean excludeProtobufMessageTypes;
+
+  protected AbstractProtobufPayloadConverter() {
+    this.excludeProtobufMessageTypes = false;
+  }
+
+  protected AbstractProtobufPayloadConverter(boolean excludeProtobufMessageTypes) {
+    this.excludeProtobufMessageTypes = excludeProtobufMessageTypes;
+  }
+
+  protected void addMessageType(Payload.Builder builder, Object value) {
+    if (this.excludeProtobufMessageTypes) {
+      return;
+    }
+    String messageTypeName = ((MessageOrBuilder) value).getDescriptorForType().getFullName();
+    builder.putMetadata(
+        EncodingKeys.METADATA_MESSAGE_TYPE_KEY, ByteString.copyFrom(messageTypeName, UTF_8));
+  }
+
+  protected void checkMessageType(Payload payload, Class valueClass) throws DataConverterException {
+    ByteString messageTypeBytes =
+        payload.getMetadataMap().get(EncodingKeys.METADATA_MESSAGE_TYPE_KEY);
+    if (messageTypeBytes != null) {
+      try {
+        String messageType = messageTypeBytes.toString(UTF_8);
+        Method getDescriptor = valueClass.getMethod("getDescriptor");
+        String valueMessageType =
+            ((Descriptors.Descriptor) getDescriptor.invoke(null)).getFullName();
+        if (!messageType.equals(valueMessageType) && log.isWarnEnabled()) {
+          log.warn(
+              "Encoded protobuf message type \""
+                  + messageType
+                  + "\" does not match valueClass `"
+                  + valueClass.getName()
+                  + "`, which has message type \""
+                  + valueMessageType
+                  + '"');
+        }
+      } catch (Exception e) {
+        throw new DataConverterException(e);
+      }
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
@@ -40,26 +40,23 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class DefaultDataConverter implements DataConverter {
 
+  // Order is important as the first converter that can convert the payload is used. Needs to match
+  // the other SDKs. Go SDK:
+  // https://github.com/temporalio/sdk-go/blob/5e5645f0c550dcf717c095ae32c76a7087d2e985/converter/default_data_converter.go#L28
+  private static final PayloadConverter[] DEFAULT_PAYLOAD_CONVERTERS = {
+    new NullPayloadConverter(),
+    new ByteArrayPayloadConverter(),
+    new ProtobufJsonPayloadConverter(),
+    new ProtobufPayloadConverter(),
+    new JacksonJsonPayloadConverter()
+  };
+
   private static final AtomicReference<DataConverter> defaultDataConverterInstance =
       new AtomicReference<>(newDefaultInstance());
 
   private final Map<String, PayloadConverter> converterMap = new ConcurrentHashMap<>();
 
   private final List<PayloadConverter> converters = new ArrayList<>();
-
-  // Order is important as the first converter that can convert the payload is used. Needs to match
-  // the other SDKs. Go SDK:
-  // https://github.com/temporalio/sdk-go/blob/5e5645f0c550dcf717c095ae32c76a7087d2e985/converter/default_data_converter.go#L28
-  private static final PayloadConverter[] getDefaultPayloadConverters(
-      boolean excludeProtobufMessageTypes) {
-    return new PayloadConverter[] {
-      new NullPayloadConverter(),
-      new ByteArrayPayloadConverter(),
-      new ProtobufJsonPayloadConverter(excludeProtobufMessageTypes),
-      new ProtobufPayloadConverter(excludeProtobufMessageTypes),
-      new JacksonJsonPayloadConverter()
-    };
-  }
 
   static DataConverter getDefaultInstance() {
     return defaultDataConverterInstance.get();
@@ -80,11 +77,7 @@ public class DefaultDataConverter implements DataConverter {
    * payload converters.
    */
   public static DefaultDataConverter newDefaultInstance() {
-    return new DefaultDataConverter(getDefaultPayloadConverters(false));
-  }
-
-  public static DefaultDataConverter newDefaultInstance(boolean excludeProtobufMessageTypes) {
-    return new DefaultDataConverter(getDefaultPayloadConverters(excludeProtobufMessageTypes));
+    return new DefaultDataConverter(DEFAULT_PAYLOAD_CONVERTERS);
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
@@ -40,20 +40,26 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class DefaultDataConverter implements DataConverter {
 
-  // Order is important as the first converter that can convert the payload is used
-  private static final PayloadConverter[] DEFAULT_PAYLOAD_CONVERTERS = {
-    new NullPayloadConverter(),
-    new ByteArrayPayloadConverter(),
-    new ProtobufJsonPayloadConverter(),
-    new JacksonJsonPayloadConverter()
-  };
-
   private static final AtomicReference<DataConverter> defaultDataConverterInstance =
       new AtomicReference<>(newDefaultInstance());
 
   private final Map<String, PayloadConverter> converterMap = new ConcurrentHashMap<>();
 
   private final List<PayloadConverter> converters = new ArrayList<>();
+
+  // Order is important as the first converter that can convert the payload is used. Needs to match
+  // the other SDKs. Go SDK:
+  // https://github.com/temporalio/sdk-go/blob/5e5645f0c550dcf717c095ae32c76a7087d2e985/converter/default_data_converter.go#L28
+  private static final PayloadConverter[] getDefaultPayloadConverters(
+      boolean excludeProtobufMessageTypes) {
+    return new PayloadConverter[] {
+      new NullPayloadConverter(),
+      new ByteArrayPayloadConverter(),
+      new ProtobufJsonPayloadConverter(excludeProtobufMessageTypes),
+      new ProtobufPayloadConverter(excludeProtobufMessageTypes),
+      new JacksonJsonPayloadConverter()
+    };
+  }
 
   static DataConverter getDefaultInstance() {
     return defaultDataConverterInstance.get();
@@ -74,7 +80,11 @@ public class DefaultDataConverter implements DataConverter {
    * payload converters.
    */
   public static DefaultDataConverter newDefaultInstance() {
-    return new DefaultDataConverter(DEFAULT_PAYLOAD_CONVERTERS);
+    return new DefaultDataConverter(getDefaultPayloadConverters(false));
+  }
+
+  public static DefaultDataConverter newDefaultInstance(boolean excludeProtobufMessageTypes) {
+    return new DefaultDataConverter(getDefaultPayloadConverters(excludeProtobufMessageTypes));
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/EncodingKeys.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/EncodingKeys.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 
 public class EncodingKeys {
   public static final String METADATA_ENCODING_KEY = "encoding";
+  public static final String METADATA_MESSAGE_TYPE_KEY = "messageType";
 
   static final String METADATA_ENCODING_NULL_NAME = "binary/null";
   static final ByteString METADATA_ENCODING_NULL =

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
@@ -32,17 +32,30 @@ import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.Optional;
 
-public final class ProtobufJsonPayloadConverter implements PayloadConverter {
+public final class ProtobufJsonPayloadConverter extends AbstractProtobufPayloadConverter
+    implements PayloadConverter {
 
   private final JsonFormat.Printer printer;
   private final JsonFormat.Parser parser;
 
   public ProtobufJsonPayloadConverter() {
-    printer = JsonFormat.printer();
-    parser = JsonFormat.parser().ignoringUnknownFields();
+    this(JsonFormat.printer(), JsonFormat.parser().ignoringUnknownFields(), false);
+  }
+
+  public ProtobufJsonPayloadConverter(boolean excludeProtobufMessageTypes) {
+    this(
+        JsonFormat.printer(),
+        JsonFormat.parser().ignoringUnknownFields(),
+        excludeProtobufMessageTypes);
   }
 
   public ProtobufJsonPayloadConverter(JsonFormat.Printer printer, JsonFormat.Parser parser) {
+    this(printer, parser, false);
+  }
+
+  public ProtobufJsonPayloadConverter(
+      JsonFormat.Printer printer, JsonFormat.Parser parser, boolean excludeProtobufMessageTypes) {
+    super(excludeProtobufMessageTypes);
     this.printer = Objects.requireNonNull(printer);
     this.parser = Objects.requireNonNull(parser);
   }
@@ -59,17 +72,14 @@ public final class ProtobufJsonPayloadConverter implements PayloadConverter {
     }
 
     try {
-      String messageTypeName = ((MessageOrBuilder) value).getDescriptorForType().getFullName();
       String data = printer.print((MessageOrBuilder) value);
-      return Optional.of(
+      Payload.Builder builder =
           Payload.newBuilder()
               .putMetadata(
                   EncodingKeys.METADATA_ENCODING_KEY, EncodingKeys.METADATA_ENCODING_PROTOBUF_JSON)
-              .putMetadata(
-                  EncodingKeys.METADATA_MESSAGE_TYPE_KEY,
-                  ByteString.copyFrom(messageTypeName, UTF_8))
-              .setData(ByteString.copyFrom(data, UTF_8))
-              .build());
+              .setData(ByteString.copyFrom(data, UTF_8));
+      super.addMessageType(builder, value);
+      return Optional.of(builder.build());
     } catch (InvalidProtocolBufferException e) {
       throw new DataConverterException(e);
     }
@@ -83,6 +93,7 @@ public final class ProtobufJsonPayloadConverter implements PayloadConverter {
     if (!MessageOrBuilder.class.isAssignableFrom(valueClass)) {
       throw new IllegalArgumentException("Not a protobuf. valueClass=" + valueClass.getName());
     }
+    super.checkMessageType(content, valueClass);
     try {
       Method toBuilder = valueClass.getMethod("newBuilder");
       Message.Builder builder = (Message.Builder) toBuilder.invoke(null);

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
@@ -59,11 +59,15 @@ public final class ProtobufJsonPayloadConverter implements PayloadConverter {
     }
 
     try {
+      String messageTypeName = ((MessageOrBuilder) value).getDescriptorForType().getFullName();
       String data = printer.print((MessageOrBuilder) value);
       return Optional.of(
           Payload.newBuilder()
               .putMetadata(
                   EncodingKeys.METADATA_ENCODING_KEY, EncodingKeys.METADATA_ENCODING_PROTOBUF_JSON)
+              .putMetadata(
+                  EncodingKeys.METADATA_MESSAGE_TYPE_KEY,
+                  ByteString.copyFrom(messageTypeName, UTF_8))
               .setData(ByteString.copyFrom(data, UTF_8))
               .build());
     } catch (InvalidProtocolBufferException e) {

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufJsonPayloadConverter.java
@@ -93,13 +93,13 @@ public final class ProtobufJsonPayloadConverter extends AbstractProtobufPayloadC
     if (!MessageOrBuilder.class.isAssignableFrom(valueClass)) {
       throw new IllegalArgumentException("Not a protobuf. valueClass=" + valueClass.getName());
     }
-    super.checkMessageType(content, valueClass);
     try {
       Method toBuilder = valueClass.getMethod("newBuilder");
       Message.Builder builder = (Message.Builder) toBuilder.invoke(null);
       parser.merge(data.toString(UTF_8), builder);
-
-      return (T) builder.build();
+      Message instance = builder.build();
+      super.checkMessageType(content, instance);
+      return (T) instance;
     } catch (Exception e) {
       throw new DataConverterException(e);
     }

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufPayloadConverter.java
@@ -19,7 +19,11 @@
 
 package io.temporal.common.converter;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageLite;
+import com.google.protobuf.MessageOrBuilder;
 import io.temporal.api.common.v1.Payload;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -39,10 +43,14 @@ public final class ProtobufPayloadConverter implements PayloadConverter {
       return Optional.empty();
     }
     try {
+      String messageTypeName = ((MessageOrBuilder) value).getDescriptorForType().getFullName();
       return Optional.of(
           Payload.newBuilder()
               .putMetadata(
                   EncodingKeys.METADATA_ENCODING_KEY, EncodingKeys.METADATA_ENCODING_PROTOBUF)
+              .putMetadata(
+                  EncodingKeys.METADATA_MESSAGE_TYPE_KEY,
+                  ByteString.copyFrom(messageTypeName, UTF_8))
               .setData(((MessageLite) value).toByteString())
               .build());
     } catch (Exception e) {

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufPayloadConverter.java
@@ -19,18 +19,23 @@
 
 package io.temporal.common.converter;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageLite;
-import com.google.protobuf.MessageOrBuilder;
 import io.temporal.api.common.v1.Payload;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
-public final class ProtobufPayloadConverter implements PayloadConverter {
+public final class ProtobufPayloadConverter extends AbstractProtobufPayloadConverter
+    implements PayloadConverter {
+
+  public ProtobufPayloadConverter() {
+    super();
+  }
+
+  public ProtobufPayloadConverter(boolean excludeProtobufMessageTypes) {
+    super(excludeProtobufMessageTypes);
+  }
 
   @Override
   public String getEncodingType() {
@@ -43,16 +48,13 @@ public final class ProtobufPayloadConverter implements PayloadConverter {
       return Optional.empty();
     }
     try {
-      String messageTypeName = ((MessageOrBuilder) value).getDescriptorForType().getFullName();
-      return Optional.of(
+      Payload.Builder builder =
           Payload.newBuilder()
               .putMetadata(
                   EncodingKeys.METADATA_ENCODING_KEY, EncodingKeys.METADATA_ENCODING_PROTOBUF)
-              .putMetadata(
-                  EncodingKeys.METADATA_MESSAGE_TYPE_KEY,
-                  ByteString.copyFrom(messageTypeName, UTF_8))
-              .setData(((MessageLite) value).toByteString())
-              .build());
+              .setData(((MessageLite) value).toByteString());
+      super.addMessageType(builder, value);
+      return Optional.of(builder.build());
     } catch (Exception e) {
       throw new DataConverterException(e);
     }
@@ -65,6 +67,7 @@ public final class ProtobufPayloadConverter implements PayloadConverter {
     if (!MessageLite.class.isAssignableFrom(valueClass)) {
       throw new IllegalArgumentException("Not a protobuf. valueClass=" + valueClass.getName());
     }
+    super.checkMessageType(content, valueClass);
     try {
       Method parseFrom = valueClass.getMethod("parseFrom", ByteBuffer.class);
       return (T) parseFrom.invoke(null, content.getData().asReadOnlyByteBuffer());

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/ProtobufPayloadConverter.java
@@ -67,10 +67,11 @@ public final class ProtobufPayloadConverter extends AbstractProtobufPayloadConve
     if (!MessageLite.class.isAssignableFrom(valueClass)) {
       throw new IllegalArgumentException("Not a protobuf. valueClass=" + valueClass.getName());
     }
-    super.checkMessageType(content, valueClass);
     try {
       Method parseFrom = valueClass.getMethod("parseFrom", ByteBuffer.class);
-      return (T) parseFrom.invoke(null, content.getData().asReadOnlyByteBuffer());
+      Object instance = parseFrom.invoke(null, content.getData().asReadOnlyByteBuffer());
+      super.checkMessageType(content, instance);
+      return (T) instance;
     } catch (Exception e) {
       throw new DataConverterException(e);
     }

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/ProtoPayloadConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/ProtoPayloadConverterTest.java
@@ -123,7 +123,7 @@ public class ProtoPayloadConverterTest {
 
   @Test
   public void testProtoMessageTypeExclusion() {
-    DataConverter converter = DefaultDataConverter.newDefaultInstance(true);
+    DataConverter converter = new DefaultDataConverter(new ProtobufPayloadConverter(true));
     WorkflowExecution execution =
         WorkflowExecution.newBuilder()
             .setWorkflowId(UUID.randomUUID().toString())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

In `ProtobufPayloadConverter` and `ProtobufJSONPayloadConverter`, I added a second `metadata` attribute, `mesageType`, with the full proto message name:

```
metadata: 
  encoding: binary("json/protobuf"),
  messageType: binary("foo.bar.MyMessage")
data: ...
```

## Why?
<!-- Tell your future self why have you made these changes -->

1. Support decoding protobuf payloads in languages that don't have the ability to get the types of a given function's parameters at runtime (see TS SDK [PR](https://github.com/temporalio/sdk-typescript/pull/430) and [design doc](https://github.com/lorensr/sdk-node/blob/binary/protobuf/docs/protobuf-libraries.md)).
2. Support decoding binary protobuf payloads in the UI (https://github.com/temporalio/ui-server/issues/79).

## Checklist
<!--- add/delete as needed --->


2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added `ProtoPayloadConverterTest.testProtoMessageType()` to check that an execution payload has the correct `messageType`.