### PR TITLE
Refactor a local/regular activities difference out from POJOActivityTaskHandler

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/Activity.java
@@ -19,7 +19,7 @@
 
 package io.temporal.activity;
 
-import io.temporal.internal.sync.ActivityInternal;
+import io.temporal.internal.activity.ActivityInternal;
 import io.temporal.internal.sync.WorkflowInternal;
 
 /**

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
@@ -95,13 +95,17 @@ public interface ActivityExecutionContext {
    */
   void doNotCompleteOnReturn();
 
+  /**
+   * @return true if {@link #doNotCompleteOnReturn()} was called and supported by the activity type,
+   *     false otherwise
+   */
   boolean isDoNotCompleteOnReturn();
 
   /**
-   * Returns true if {@link #useLocalManualCompletion()} method has been called on this context. If
-   * this flag is set to true, {@link io.temporal.internal.worker.ActivityWorker} would not release
-   * concurrency semaphore and delegate release function to the manual Activity client returned by
-   * {@link #useLocalManualCompletion()}
+   * @return true if {@link #useLocalManualCompletion()} method has been called on this context. If
+   *     this flag is set to true, {@link io.temporal.internal.worker.ActivityWorker} would not
+   *     release concurrency semaphore and delegate release function to the manual Activity client
+   *     returned by {@link #useLocalManualCompletion()}
    */
   boolean isUseLocalManualCompletion();
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactory.java
@@ -21,7 +21,6 @@ package io.temporal.internal.activity;
 
 import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
-import io.temporal.internal.sync.ActivityInfoInternal;
 
 public interface ActivityExecutionContextFactory {
   ActivityExecutionContext createContext(ActivityInfoInternal info, Scope metricsScope);

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactoryImpl.java
@@ -22,7 +22,6 @@ package io.temporal.internal.activity;
 import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.common.converter.DataConverter;
-import io.temporal.internal.sync.ActivityInfoInternal;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.time.Duration;
 import java.util.Objects;

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.internal.sync;
+package io.temporal.internal.activity;
 
 import com.google.protobuf.util.Timestamps;
 import io.temporal.api.common.v1.Header;

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoInternal.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.internal.sync;
+package io.temporal.internal.activity;
 
 import io.temporal.activity.ActivityInfo;
 import io.temporal.api.common.v1.Header;
@@ -30,7 +30,7 @@ import java.util.Optional;
  * activity is handling that should be available for Temporal SDK, but shouldn't be available or
  * exposed to Activity implementation code.
  */
-public interface ActivityInfoInternal extends ActivityInfo {
+interface ActivityInfoInternal extends ActivityInfo {
   /**
    * @return function shat should be triggered after activity completion with any outcome (success,
    *     failure, cancelling)

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInternal.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.internal.sync;
+package io.temporal.internal.activity;
 
 import io.temporal.activity.ActivityExecutionContext;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/CurrentActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/CurrentActivityExecutionContext.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.internal.sync;
+package io.temporal.internal.activity;
 
 import io.temporal.activity.ActivityExecutionContext;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContext.java
@@ -23,7 +23,7 @@ import io.temporal.client.ActivityCompletionException;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
-public interface HeartbeatContext {
+interface HeartbeatContext {
 
   /** @see io.temporal.activity.ActivityExecutionContext#heartbeat(Object) */
   <V> void heartbeat(V details) throws ActivityCompletionException;

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContextImpl.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class HeartbeatContextImpl implements HeartbeatContext {
+class HeartbeatContextImpl implements HeartbeatContext {
   private static final Logger log = LoggerFactory.getLogger(HeartbeatContextImpl.class);
   private static final long HEARTBEAT_RETRY_WAIT_MILLIS = 1000;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextFactoryImpl.java
@@ -21,7 +21,6 @@ package io.temporal.internal.activity;
 
 import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
-import io.temporal.internal.sync.ActivityInfoInternal;
 
 public class LocalActivityExecutionContextFactoryImpl implements ActivityExecutionContextFactory {
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextImpl.java
@@ -69,14 +69,12 @@ class LocalActivityExecutionContextImpl implements ActivityExecutionContext {
 
   @Override
   public boolean isDoNotCompleteOnReturn() {
-    throw new UnsupportedOperationException(
-        "isDoNotCompleteOnReturn is not supported for local activities");
+    return false;
   }
 
   @Override
   public boolean isUseLocalManualCompletion() {
-    throw new UnsupportedOperationException(
-        "isUseLocalManualCompletion is not supported for local activities");
+    return false;
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncActivityWorker.java
@@ -22,7 +22,7 @@ package io.temporal.internal.sync;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.internal.activity.ActivityExecutionContextFactory;
 import io.temporal.internal.activity.ActivityExecutionContextFactoryImpl;
-import io.temporal.internal.activity.LocalActivityExecutionContextFactoryImpl;
+import io.temporal.internal.activity.POJOActivityTaskHandler;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.worker.*;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -76,15 +76,12 @@ public class SyncActivityWorker implements SuspendableWorker {
             options.getDefaultHeartbeatThrottleInterval(),
             options.getDataConverter(),
             heartbeatExecutor);
-    ActivityExecutionContextFactory laActivityExecutionContextFactory =
-        new LocalActivityExecutionContextFactoryImpl();
     this.taskHandler =
         new POJOActivityTaskHandler(
             namespace,
             options.getDataConverter(),
             workerInterceptors,
-            activityExecutionContextFactory,
-            laActivityExecutionContextFactory);
+            activityExecutionContextFactory);
     this.worker =
         new ActivityWorker(
             service, namespace, taskQueue, taskQueueActivitiesPerSecond, options, taskHandler);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
@@ -25,8 +25,6 @@ public class WorkerThreadsNameHelper {
   private static final String ACTIVITY_POLL_THREAD_NAME_PREFIX = "Activity Poller taskQueue=";
   public static final String SHUTDOWN_MANAGER_THREAD_NAME_PREFIX = "TemporalShutdownManager";
   public static final String ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX = "TemporalActivityHeartbeat-";
-  public static final String LOCAL_ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX =
-      "TemporalLocalActivityHeartbeat-";
 
   public static String getLocalActivityPollerThreadPrefix(String namespace, String taskQueue) {
     return LOCAL_ACTIVITY_POLL_THREAD_NAME_PREFIX
@@ -48,9 +46,5 @@ public class WorkerThreadsNameHelper {
 
   public static String getActivityHeartbeatThreadPrefix(String namespace, String taskQueue) {
     return ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX + namespace + "-" + taskQueue;
-  }
-
-  public static String getLocalActivityHeartbeatThreadPrefix(String namespace, String taskQueue) {
-    return LOCAL_ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX + namespace + "-" + taskQueue;
   }
 }

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -48,7 +48,7 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.FailureConverter;
 import io.temporal.internal.activity.ActivityExecutionContextFactory;
 import io.temporal.internal.activity.ActivityExecutionContextFactoryImpl;
-import io.temporal.internal.activity.LocalActivityExecutionContextFactoryImpl;
+import io.temporal.internal.activity.POJOActivityTaskHandler;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.sync.*;
 import io.temporal.internal.worker.ActivityTask;
@@ -138,15 +138,12 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
             WorkerOptions.getDefaultInstance().getDefaultHeartbeatThrottleInterval(),
             testEnvironmentOptions.getWorkflowClientOptions().getDataConverter(),
             heartbeatExecutor);
-    ActivityExecutionContextFactory laActivityExecutionContextFactory =
-        new LocalActivityExecutionContextFactoryImpl();
     activityTaskHandler =
         new POJOActivityTaskHandler(
             testEnvironmentOptions.getWorkflowClientOptions().getNamespace(),
             testEnvironmentOptions.getWorkflowClientOptions().getDataConverter(),
             testEnvironmentOptions.getWorkerFactoryOptions().getWorkerInterceptors(),
-            activityExecutionContextFactory,
-            laActivityExecutionContextFactory);
+            activityExecutionContextFactory);
   }
 
   private class HeartbeatInterceptingService extends WorkflowServiceGrpc.WorkflowServiceImplBase {


### PR DESCRIPTION
## What was changed

Code duplication between `POJOActivityImplementation` and `POJOLocalActivityImplementation` is cleaned up by unifying the code base and moving the difference out as a `ActivityExecutionContextFactory executionContextFactory`.
Abstracted `executionContextFactory` is reused in `DynamicActivityImplementation` to correctly supporting local mode.

## Why?
`POJOActivityTaskHandler` before contained a large code duplicate in `POJOActivityImplementation` and `POJOLocalActivityImplementation` classes implemented a difference between local and regular activities. This also led to the fact that `DynamicActivityImplementation` was not handling local/regular mode correctly because there was only one version.

Closes #948