### PR TITLE
Cancel pollers when client disconnects

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TaskQueue.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TaskQueue.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.testservice;
+
+import com.google.common.base.Preconditions;
+import java.util.LinkedList;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.annotation.Nonnull;
+
+/**
+ * A specialized unbounded queue that requires blocking poll operations to happen through a Future
+ * so that they can be cancelled (i.e. cancelling the future breaks out of the poll via a
+ * j.u.c.CancellationException).
+ *
+ * @param <E>
+ */
+class TaskQueue<E> {
+  private final LinkedList<E> backlog = new LinkedList<>();
+  private final LinkedList<PollFuture> waiters = new LinkedList<>();
+
+  /**
+   * Adds the provided element to the tail of this queue.
+   *
+   * @param element the value to add
+   */
+  synchronized void add(E element) {
+    for (PollFuture future = waiters.poll(); future != null; future = waiters.pop()) {
+      if (future.set(element)) {
+        return;
+      }
+    }
+    backlog.push(element);
+  }
+
+  /**
+   * Creates a new j.u.c.Future whose get() method will eventually return a value from the head of
+   * this queue. Note that failing to call get() on the returned Future can result in missed queue
+   * updates.
+   *
+   * @return a Future providing one-shot access to the head of this queue.
+   */
+  synchronized Future<E> poll() {
+    final PollFuture future = new PollFuture();
+    E element;
+    synchronized (this) {
+      if (backlog.isEmpty()) {
+        waiters.push(future);
+        return future;
+      }
+      element = backlog.pop();
+    }
+    future.set(element);
+    return future;
+  }
+
+  /**
+   * A Future implementation specifically for consuming from the enclosing TaskQueue type. The get
+   * method on this class blocks until a value is available from the queue but unlike
+   * BlockingQueue#take, a blocked consumer can be "interrupted" without the use of thread
+   * interruption by calling #cancel() on this Future.
+   */
+  private class PollFuture implements Future<E> {
+    boolean cancelled = false;
+    E value;
+
+    private synchronized boolean set(E element) {
+      Preconditions.checkState(value == null);
+      if (cancelled) {
+        return false;
+      }
+      value = element;
+      notifyAll();
+      return true;
+    }
+
+    @Override
+    public boolean cancel(boolean ignored) {
+      synchronized (TaskQueue.this) {
+        TaskQueue.this.waiters.remove(this);
+      }
+      synchronized (this) {
+        if (value != null) {
+          return false;
+        }
+        cancelled = true;
+        notifyAll();
+        return true;
+      }
+    }
+
+    @Override
+    public synchronized boolean isCancelled() {
+      return cancelled;
+    }
+
+    @Override
+    public synchronized boolean isDone() {
+      return value != null;
+    }
+
+    @Override
+    public synchronized E get() throws InterruptedException, ExecutionException {
+      while (value == null && !cancelled) {
+        this.wait();
+      }
+      if (cancelled) {
+        throw new CancellationException();
+      }
+      return value;
+    }
+
+    @Override
+    public synchronized E get(long timeout, @Nonnull TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      while (value == null && !cancelled) {
+        unit.timedWait(this, timeout);
+      }
+      if (cancelled) {
+        throw new CancellationException();
+      }
+      return value;
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Future;
 
 interface TestWorkflowStore {
 
@@ -144,13 +145,13 @@ interface TestWorkflowStore {
 
   void registerDelayedCallback(Duration delay, Runnable r);
 
-  /** @return empty if deadline expired */
-  Optional<PollWorkflowTaskQueueResponse.Builder> pollWorkflowTaskQueue(
-      PollWorkflowTaskQueueRequest pollRequest, Deadline deadline);
+  /** @return empty if this store is closed or thread interrupted */
+  Future<PollWorkflowTaskQueueResponse.Builder> pollWorkflowTaskQueue(
+      PollWorkflowTaskQueueRequest pollRequest);
 
-  /** @return empty if deadline expired */
-  Optional<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
-      PollActivityTaskQueueRequest pollRequest, Deadline deadline);
+  /** @return empty if this store is closed or thread interrupted */
+  Future<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
+      PollActivityTaskQueueRequest pollRequest);
 
   void sendQueryTask(
       ExecutionId executionId, TaskQueueId taskQueue, PollWorkflowTaskQueueResponse.Builder task);

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -52,8 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -64,14 +63,13 @@ import org.slf4j.LoggerFactory;
 
 class TestWorkflowStoreImpl implements TestWorkflowStore {
 
-  private static final int TASK_QUEUE_POLLER_TIMEOUT = 500;
   private static final Logger log = LoggerFactory.getLogger(TestWorkflowStoreImpl.class);
 
   private final Lock lock = new ReentrantLock();
   private final Map<ExecutionId, HistoryStore> histories = new HashMap<>();
-  private final Map<TaskQueueId, BlockingQueue<PollActivityTaskQueueResponse.Builder>>
+  private final Map<TaskQueueId, TaskQueue<PollActivityTaskQueueResponse.Builder>>
       activityTaskQueues = new HashMap<>();
-  private final Map<TaskQueueId, BlockingQueue<PollWorkflowTaskQueueResponse.Builder>>
+  private final Map<TaskQueueId, TaskQueue<PollWorkflowTaskQueueResponse.Builder>>
       workflowTaskQueues = new HashMap<>();
   private final SelfAdvancingTimer timerService;
   private LockHandle emptyHistoryLockHandle;
@@ -239,7 +237,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       if (id.getTaskQueueName().isEmpty() || id.getNamespace().isEmpty()) {
         throw Status.INTERNAL.withDescription("Invalid TaskQueueId: " + id).asRuntimeException();
       }
-      BlockingQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
+      TaskQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
           getWorkflowTaskQueueQueue(id);
       workflowTaskQueue.add(workflowTask.getTask());
     }
@@ -247,7 +245,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     List<ActivityTask> activityTasks = ctx.getActivityTasks();
     if (activityTasks != null) {
       for (ActivityTask activityTask : activityTasks) {
-        BlockingQueue<PollActivityTaskQueueResponse.Builder> activityTaskQueue =
+        TaskQueue<PollActivityTaskQueueResponse.Builder> activityTaskQueue =
             getActivityTaskQueueQueue(activityTask.getTaskQueueId());
         activityTaskQueue.add(activityTask.getTask());
       }
@@ -292,32 +290,30 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     timerService.schedule(delay, r, "registerDelayedCallback");
   }
 
-  private BlockingQueue<PollActivityTaskQueueResponse.Builder> getActivityTaskQueueQueue(
+  private TaskQueue<PollActivityTaskQueueResponse.Builder> getActivityTaskQueueQueue(
       TaskQueueId taskQueueId) {
     lock.lock();
     try {
-      {
-        BlockingQueue<PollActivityTaskQueueResponse.Builder> activityTaskQueue =
-            activityTaskQueues.get(taskQueueId);
-        if (activityTaskQueue == null) {
-          activityTaskQueue = new LinkedBlockingQueue<>();
-          activityTaskQueues.put(taskQueueId, activityTaskQueue);
-        }
-        return activityTaskQueue;
+      TaskQueue<PollActivityTaskQueueResponse.Builder> activityTaskQueue =
+          activityTaskQueues.get(taskQueueId);
+      if (activityTaskQueue == null) {
+        activityTaskQueue = new TaskQueue<>();
+        activityTaskQueues.put(taskQueueId, activityTaskQueue);
       }
+      return activityTaskQueue;
     } finally {
       lock.unlock();
     }
   }
 
-  private BlockingQueue<PollWorkflowTaskQueueResponse.Builder> getWorkflowTaskQueueQueue(
+  private TaskQueue<PollWorkflowTaskQueueResponse.Builder> getWorkflowTaskQueueQueue(
       TaskQueueId taskQueueId) {
     lock.lock();
     try {
-      BlockingQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
+      TaskQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
           workflowTaskQueues.get(taskQueueId);
       if (workflowTaskQueue == null) {
-        workflowTaskQueue = new LinkedBlockingQueue<>();
+        workflowTaskQueue = new TaskQueue<>();
         workflowTaskQueues.put(taskQueueId, workflowTaskQueue);
       }
       return workflowTaskQueue;
@@ -327,58 +323,19 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   }
 
   @Override
-  public Optional<PollWorkflowTaskQueueResponse.Builder> pollWorkflowTaskQueue(
-      PollWorkflowTaskQueueRequest pollRequest, Deadline deadline) {
-    TaskQueueId taskQueueId =
+  public Future<PollWorkflowTaskQueueResponse.Builder> pollWorkflowTaskQueue(
+      PollWorkflowTaskQueueRequest pollRequest) {
+    final TaskQueueId taskQueueId =
         new TaskQueueId(pollRequest.getNamespace(), pollRequest.getTaskQueue().getName());
-    BlockingQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
-        getWorkflowTaskQueueQueue(taskQueueId);
-    if (log.isTraceEnabled()) {
-      log.trace(
-          "Poll request on workflow task queue about to block waiting for a task on "
-              + taskQueueId);
-    }
-    PollWorkflowTaskQueueResponse.Builder result = null;
-    try {
-      if (deadline == null) {
-        result = workflowTaskQueue.take();
-      } else {
-        // Listen on the task queue for short periods, and keep checking if we are being shutdown in
-        // between. Long poll doesn't work well here because thread interrupted status gets lost and
-        // poller keeps hanging on an empty queue, resulting in test timing out.
-        while (result == null && !isShuttingDown && !deadline.isExpired()) {
-          result = workflowTaskQueue.poll(TASK_QUEUE_POLLER_TIMEOUT, TimeUnit.MILLISECONDS);
-        }
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-    return Optional.ofNullable(result);
+    return getWorkflowTaskQueueQueue(taskQueueId).poll();
   }
 
   @Override
-  public Optional<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
-      PollActivityTaskQueueRequest pollRequest, Deadline deadline) {
-    TaskQueueId taskQueueId =
+  public Future<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
+      PollActivityTaskQueueRequest pollRequest) {
+    final TaskQueueId taskQueueId =
         new TaskQueueId(pollRequest.getNamespace(), pollRequest.getTaskQueue().getName());
-    BlockingQueue<PollActivityTaskQueueResponse.Builder> activityTaskQueue =
-        getActivityTaskQueueQueue(taskQueueId);
-    PollActivityTaskQueueResponse.Builder result = null;
-    try {
-      if (deadline == null) {
-        result = activityTaskQueue.take();
-      } else {
-        // Listen on the task queue for short periods, and keep checking if we are being shutdown in
-        // between. Long poll doesn't work well here because thread interrupted status gets lost and
-        // poller keeps hanging on an empty queue, resulting in test timing out.
-        while (result == null && !isShuttingDown && !deadline.isExpired()) {
-          result = activityTaskQueue.poll(TASK_QUEUE_POLLER_TIMEOUT, TimeUnit.MILLISECONDS);
-        }
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-    return Optional.ofNullable(result);
+    return getActivityTaskQueueQueue(taskQueueId).poll();
   }
 
   @Override
@@ -421,7 +378,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     } finally {
       lock.unlock();
     }
-    BlockingQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
+    TaskQueue<PollWorkflowTaskQueueResponse.Builder> workflowTaskQueue =
         getWorkflowTaskQueueQueue(taskQueue);
     workflowTaskQueue.add(task);
   }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Connects gRPC context cancellation up to the threads performing
long-polls on task queues so that when a client exits/dies and the
attendant connections go away, the polling threads are broken out of
their blocking polls.

## Why?
<!-- Tell your future self why have you made these changes -->
To reuse a test server process across multiple test cases without having 
to wait for the 60s long-poll timeout.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
