### PR TITLE
Fix continue-as-new wiring, interception, context propagation and OpenTracing integration

### DIFF
--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanOperationType.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanOperationType.java
@@ -24,6 +24,7 @@ public enum SpanOperationType {
   SIGNAL_WITH_START_WORKFLOW("SignalWithStartWorkflow"),
   RUN_WORKFLOW("RunWorkflow"),
   START_CHILD_WORKFLOW("StartChildWorkflow"),
+  START_CONTINUE_AS_NEW_WORKFLOW("StartContinueAsNewWorkflow"),
   START_ACTIVITY("StartActivity"),
   RUN_ACTIVITY("RunActivity");
 

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
@@ -46,7 +46,7 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
   public Tracer.SpanBuilder createSpanBuilder(Tracer tracer, SpanCreationContext context) {
     Tracer.SpanBuilder spanBuilder = tracer.buildSpan(this.getSpanName(context));
 
-    this.getSpanTags(context).forEach(spanBuilder::withTag);
+    getSpanTags(context).forEach(spanBuilder::withTag);
 
     return spanBuilder;
   }
@@ -79,6 +79,10 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
         return ImmutableMap.of(
             StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.PARENT_WORKFLOW_ID, context.getParentWorkflowId(),
+            StandardTagNames.PARENT_RUN_ID, context.getParentRunId());
+      case START_CONTINUE_AS_NEW_WORKFLOW:
+        return ImmutableMap.of(
+            StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.PARENT_RUN_ID, context.getParentRunId());
       case RUN_WORKFLOW:
       case START_ACTIVITY:

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ContextAccessor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ContextAccessor.java
@@ -20,6 +20,7 @@
 package io.temporal.opentracing.internal;
 
 import com.google.common.reflect.TypeToken;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.temporal.api.common.v1.Payload;
@@ -31,6 +32,7 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class ContextAccessor {
   private static final String TRACER_HEADER_KEY = "_tracer-data";
@@ -41,6 +43,13 @@ public class ContextAccessor {
 
   public ContextAccessor(OpenTracingOptions options) {
     this.codec = options.getSpanContextCodec();
+  }
+
+  public Span writeSpanContextToHeader(
+      Supplier<Span> spanSupplier, Header toHeader, Tracer tracer) {
+    Span span = spanSupplier.get();
+    writeSpanContextToHeader(span.context(), toHeader, tracer);
+    return span;
   }
 
   public void writeSpanContextToHeader(SpanContext spanContext, Header header, Tracer tracer) {

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -66,16 +66,32 @@ public class SpanFactory {
   public Tracer.SpanBuilder createChildWorkflowStartSpan(
       Tracer tracer,
       String childWorkflowType,
+      String childWorkflowId,
       long startTimeMs,
-      String workflowId,
       String parentWorkflowId,
       String parentRunId) {
     SpanCreationContext context =
         SpanCreationContext.newBuilder()
             .setSpanOperationType(SpanOperationType.START_CHILD_WORKFLOW)
             .setActionName(childWorkflowType)
-            .setWorkflowId(workflowId)
+            .setWorkflowId(childWorkflowId)
             .setParentWorkflowId(parentWorkflowId)
+            .setParentRunId(parentRunId)
+            .build();
+    return createSpan(context, tracer, startTimeMs, null, References.CHILD_OF);
+  }
+
+  public Tracer.SpanBuilder createContinueAsNewWorkflowStartSpan(
+      Tracer tracer,
+      String continueAsNewWorkflowType,
+      String workflowId,
+      long startTimeMs,
+      String parentRunId) {
+    SpanCreationContext context =
+        SpanCreationContext.newBuilder()
+            .setSpanOperationType(SpanOperationType.START_CONTINUE_AS_NEW_WORKFLOW)
+            .setActionName(continueAsNewWorkflowType)
+            .setWorkflowId(workflowId)
             .setParentRunId(parentRunId)
             .build();
     return createSpan(context, tracer, startTimeMs, null, References.FOLLOWS_FROM);
@@ -125,7 +141,8 @@ public class SpanFactory {
             .setWorkflowId(workflowId)
             .setRunId(runId)
             .build();
-    return createSpan(context, tracer, startTimeMs, activityStartSpanContext, References.CHILD_OF);
+    return createSpan(
+        context, tracer, startTimeMs, activityStartSpanContext, References.FOLLOWS_FROM);
   }
 
   @SuppressWarnings("deprecation")

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/ContinueAsNewTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/ContinueAsNewTest.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ContinueAsNewTest {
+
+  private static final String BAGGAGE_ITEM_KEY = "baggage-item-key";
+
+  private static final MockTracer mockTracer =
+      new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
+
+  private final OpenTracingOptions OT_OPTIONS =
+      OpenTracingOptions.newBuilder().setTracer(mockTracer).build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder()
+                  .setInterceptors(new OpenTracingClientInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new OpenTracingWorkerInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkflowTypes(WorkflowImpl.class)
+          .build();
+
+  @After
+  public void tearDown() {
+    mockTracer.reset();
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String workflow(String input, boolean continueAsNew);
+  }
+
+  public static class WorkflowImpl implements TestWorkflow {
+    @Override
+    public String workflow(String input, boolean continueAsNew) {
+      Span activeSpan = mockTracer.scopeManager().activeSpan();
+
+      MockSpan mockSpan = (MockSpan) activeSpan;
+      assertNotNull(activeSpan);
+      assertNotEquals(0, mockSpan.parentId());
+
+      if (continueAsNew) {
+        Workflow.continueAsNew(input);
+      }
+      return activeSpan.getBaggageItem(BAGGAGE_ITEM_KEY);
+    }
+  }
+
+  /*
+   * We are checking that spans structure looks like this:
+   * ClientFunction
+   *       |
+   *     child
+   *       v
+   * StartWorkflow:TestWorkflow
+   *       |
+   *       ↳ follow>  RunWorkflow:TestWorkflow
+   *                             |
+   *                             ↳ -follow> StartContinueAsNewWorkflow:TestWorkflow  -follow> RunWorkflow:TestWorkflow
+   */
+  @Test
+  public void continueAsNewCorrectSpanStructureAndBaggagePropagation() {
+    Span span = mockTracer.buildSpan("ClientFunction").start();
+
+    WorkflowClient client = testWorkflowRule.getWorkflowClient();
+    try (Scope scope = mockTracer.scopeManager().activate(span)) {
+      Span activeSpan = mockTracer.scopeManager().activeSpan();
+      final String BAGGAGE_ITEM_VALUE = "baggage-item-value";
+      activeSpan.setBaggageItem(BAGGAGE_ITEM_KEY, BAGGAGE_ITEM_VALUE);
+
+      TestWorkflow workflow =
+          client.newWorkflowStub(
+              TestWorkflow.class,
+              WorkflowOptions.newBuilder()
+                  .setTaskQueue(testWorkflowRule.getTaskQueue())
+                  .validateBuildWithDefaults());
+      assertEquals(
+          "Baggage item should be propagated all the way down continue-as-new chain",
+          BAGGAGE_ITEM_VALUE,
+          workflow.workflow("input", true));
+    } finally {
+      span.finish();
+    }
+
+    OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
+
+    MockSpan clientSpan = spansHelper.getSpanByOperationName("ClientFunction");
+
+    MockSpan workflowStartSpan = spansHelper.getByParentSpan(clientSpan).get(0);
+    assertEquals(clientSpan.context().spanId(), workflowStartSpan.parentId());
+    assertEquals("StartWorkflow:TestWorkflow", workflowStartSpan.operationName());
+
+    MockSpan workflowRunSpan = spansHelper.getByParentSpan(workflowStartSpan).get(0);
+    assertEquals(workflowStartSpan.context().spanId(), workflowRunSpan.parentId());
+    assertEquals("RunWorkflow:TestWorkflow", workflowRunSpan.operationName());
+
+    MockSpan continueAsNewStartSpan = spansHelper.getByParentSpan(workflowRunSpan).get(0);
+    assertEquals(workflowRunSpan.context().spanId(), continueAsNewStartSpan.parentId());
+    assertEquals("StartContinueAsNewWorkflow:TestWorkflow", continueAsNewStartSpan.operationName());
+
+    MockSpan continueAsNewRunSpan = spansHelper.getByParentSpan(continueAsNewStartSpan).get(0);
+    assertEquals(continueAsNewStartSpan.context().spanId(), continueAsNewRunSpan.parentId());
+    assertEquals("RunWorkflow:TestWorkflow", continueAsNewRunSpan.operationName());
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityInboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityInboundCallsInterceptor.java
@@ -20,7 +20,9 @@
 package io.temporal.common.interceptors;
 
 import io.temporal.activity.ActivityExecutionContext;
+import io.temporal.common.Experimental;
 
+@Experimental
 public interface ActivityInboundCallsInterceptor {
   final class ActivityInput {
     private final Header header;

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkerInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkerInterceptor.java
@@ -19,11 +19,14 @@
 
 package io.temporal.common.interceptors;
 
+import io.temporal.common.Experimental;
+
 /**
  * Intercepts workflow and activity executions.
  *
  * <p>TODO(maxim): JavaDoc with sample
  */
+@Experimental
 public interface WorkerInterceptor {
   WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next);
 

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowInboundCallsInterceptor.java
@@ -19,12 +19,14 @@
 
 package io.temporal.common.interceptors;
 
+import io.temporal.common.Experimental;
 import javax.annotation.Nullable;
 
 /**
  * Intercepts calls to the workflow execution. Executes under workflow context. So all the
  * restrictions on the workflow code should be obeyed.
  */
+@Experimental
 public interface WorkflowInboundCallsInterceptor {
 
   final class WorkflowInput {

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -22,17 +22,18 @@ package io.temporal.common.interceptors;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.common.Experimental;
 import io.temporal.workflow.*;
 import io.temporal.workflow.Functions.Func;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Can be used to intercept workflow code calls to the Temporal APIs. An instance should be created
@@ -43,6 +44,7 @@ import java.util.function.Supplier;
  * <p>The calls to the interceptor are executed in the context of a workflow and must follow the
  * same rules all the other workflow code follows.
  */
+@Experimental
 public interface WorkflowOutboundCallsInterceptor {
 
   final class ActivityInput<R> {
@@ -300,14 +302,14 @@ public interface WorkflowOutboundCallsInterceptor {
   }
 
   final class ContinueAsNewInput {
-    private final Optional<String> workflowType;
-    private final Optional<ContinueAsNewOptions> options;
+    private final @Nullable String workflowType;
+    private final @Nullable ContinueAsNewOptions options;
     private final Object[] args;
     private final Header header;
 
     public ContinueAsNewInput(
-        Optional<String> workflowType,
-        Optional<ContinueAsNewOptions> options,
+        @Nullable String workflowType,
+        @Nullable ContinueAsNewOptions options,
         Object[] args,
         Header header) {
       this.workflowType = workflowType;
@@ -316,11 +318,19 @@ public interface WorkflowOutboundCallsInterceptor {
       this.header = header;
     }
 
-    public Optional<String> getWorkflowType() {
+    /**
+     * @return workflowType for the continue-as-new workflow run. null if continue-as-new should
+     *     inherit the type of the original workflow run.
+     */
+    public @Nullable String getWorkflowType() {
       return workflowType;
     }
 
-    public Optional<ContinueAsNewOptions> getOptions() {
+    /**
+     * @return options for the continue-as-new workflow run. Can be null, in that case the values
+     *     will be taken from the original workflow run.
+     */
+    public @Nullable ContinueAsNewOptions getOptions() {
       return options;
     }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ContinueAsNewWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ContinueAsNewWorkflowInvocationHandler.java
@@ -26,17 +26,16 @@ import io.temporal.common.metadata.POJOWorkflowInterfaceMetadata;
 import io.temporal.workflow.ContinueAsNewOptions;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 class ContinueAsNewWorkflowInvocationHandler implements InvocationHandler {
-
-  private final ContinueAsNewOptions options;
+  private final @Nullable ContinueAsNewOptions options;
   private final WorkflowOutboundCallsInterceptor outboundCallsInterceptor;
   private final POJOWorkflowInterfaceMetadata workflowMetadata;
 
   ContinueAsNewWorkflowInvocationHandler(
       Class<?> interfaceClass,
-      ContinueAsNewOptions options,
+      @Nullable ContinueAsNewOptions options,
       WorkflowOutboundCallsInterceptor outboundCallsInterceptor) {
     workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(interfaceClass);
     if (!workflowMetadata.getWorkflowMethod().isPresent()) {
@@ -50,8 +49,7 @@ class ContinueAsNewWorkflowInvocationHandler implements InvocationHandler {
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) {
     String workflowType = workflowMetadata.getMethodMetadata(method).getName();
-    WorkflowInternal.continueAsNew(
-        Optional.of(workflowType), Optional.ofNullable(options), args, outboundCallsInterceptor);
+    WorkflowInternal.continueAsNew(workflowType, options, args, outboundCallsInterceptor);
     return getValueOrDefault(null, method.getReturnType());
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -68,6 +68,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -444,7 +445,7 @@ public final class WorkflowInternal {
   }
 
   public static void continueAsNew(
-      Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object[] args) {
+      @Nullable String workflowType, @Nullable ContinueAsNewOptions options, Object[] args) {
     getWorkflowInterceptor()
         .continueAsNew(
             new WorkflowOutboundCallsInterceptor.ContinueAsNewInput(
@@ -452,8 +453,8 @@ public final class WorkflowInternal {
   }
 
   public static void continueAsNew(
-      Optional<String> workflowType,
-      Optional<ContinueAsNewOptions> options,
+      @Nullable String workflowType,
+      @Nullable ContinueAsNewOptions options,
       Object[] args,
       WorkflowOutboundCallsInterceptor outboundCallsInterceptor) {
     outboundCallsInterceptor.continueAsNew(

--- a/temporal-sdk/src/main/java/io/temporal/workflow/ContinueAsNewOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/ContinueAsNewOptions.java
@@ -19,9 +19,16 @@
 
 package io.temporal.workflow;
 
+import io.temporal.common.context.ContextPropagator;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
+/**
+ * This class contain overrides for continueAsNew call. Every field can be null and it means that
+ * the value of the option should be taken from the originating workflow run.
+ */
 public final class ContinueAsNewOptions {
 
   public static Builder newBuilder() {
@@ -49,6 +56,7 @@ public final class ContinueAsNewOptions {
     private Duration workflowTaskTimeout;
     private Map<String, Object> memo;
     private Map<String, Object> searchAttributes;
+    private List<ContextPropagator> contextPropagators;
 
     private Builder() {}
 
@@ -59,6 +67,9 @@ public final class ContinueAsNewOptions {
       this.workflowRunTimeout = options.workflowRunTimeout;
       this.taskQueue = options.taskQueue;
       this.workflowTaskTimeout = options.workflowTaskTimeout;
+      this.memo = options.getMemo();
+      this.searchAttributes = options.getSearchAttributes();
+      this.contextPropagators = options.getContextPropagators();
     }
 
     public Builder setWorkflowRunTimeout(Duration workflowRunTimeout) {
@@ -86,48 +97,65 @@ public final class ContinueAsNewOptions {
       return this;
     }
 
+    public Builder setContextPropagators(List<ContextPropagator> contextPropagators) {
+      this.contextPropagators = contextPropagators;
+      return this;
+    }
+
     public ContinueAsNewOptions build() {
       return new ContinueAsNewOptions(
-          workflowRunTimeout, taskQueue, workflowTaskTimeout, memo, searchAttributes);
+          workflowRunTimeout,
+          taskQueue,
+          workflowTaskTimeout,
+          memo,
+          searchAttributes,
+          contextPropagators);
     }
   }
 
-  private final Duration workflowRunTimeout;
-  private final String taskQueue;
-  private final Duration workflowTaskTimeout;
-  private final Map<String, Object> memo;
-  private final Map<String, Object> searchAttributes;
+  private final @Nullable Duration workflowRunTimeout;
+  private final @Nullable String taskQueue;
+  private final @Nullable Duration workflowTaskTimeout;
+  private final @Nullable Map<String, Object> memo;
+  private final @Nullable Map<String, Object> searchAttributes;
+  private final @Nullable List<ContextPropagator> contextPropagators;
 
   public ContinueAsNewOptions(
-      Duration workflowRunTimeout,
-      String taskQueue,
-      Duration workflowTaskTimeout,
-      Map<String, Object> memo,
-      Map<String, Object> searchAttributes) {
+      @Nullable Duration workflowRunTimeout,
+      @Nullable String taskQueue,
+      @Nullable Duration workflowTaskTimeout,
+      @Nullable Map<String, Object> memo,
+      @Nullable Map<String, Object> searchAttributes,
+      @Nullable List<ContextPropagator> contextPropagators) {
     this.workflowRunTimeout = workflowRunTimeout;
     this.taskQueue = taskQueue;
     this.workflowTaskTimeout = workflowTaskTimeout;
     this.memo = memo;
     this.searchAttributes = searchAttributes;
+    this.contextPropagators = contextPropagators;
   }
 
-  public Duration getWorkflowRunTimeout() {
+  public @Nullable Duration getWorkflowRunTimeout() {
     return workflowRunTimeout;
   }
 
-  public String getTaskQueue() {
+  public @Nullable String getTaskQueue() {
     return taskQueue;
   }
 
-  public Duration getWorkflowTaskTimeout() {
+  public @Nullable Duration getWorkflowTaskTimeout() {
     return workflowTaskTimeout;
   }
 
-  public Map<String, Object> getMemo() {
+  public @Nullable Map<String, Object> getMemo() {
     return memo;
   }
 
-  public Map<String, Object> getSearchAttributes() {
+  public @Nullable Map<String, Object> getSearchAttributes() {
     return searchAttributes;
+  }
+
+  public @Nullable List<ContextPropagator> getContextPropagators() {
+    return contextPropagators;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -40,6 +40,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 
 /**
@@ -597,19 +598,50 @@ public final class Workflow {
    * @see #newContinueAsNewStub(Class)
    */
   public static void continueAsNew(Object... args) {
-    Workflow.continueAsNew(Optional.empty(), Optional.empty(), args);
+    Workflow.continueAsNew(null, args);
+  }
+
+  /**
+   * Continues the current workflow execution as a new run with the same workflowType and overridden
+   * {@code options}.
+   *
+   * @param options option overrides for the next run, can contain null if no overrides are needed
+   * @param args arguments of the next run.
+   * @see #newContinueAsNewStub(Class, ContinueAsNewOptions)
+   */
+  public static void continueAsNew(@Nullable ContinueAsNewOptions options, Object... args) {
+    Workflow.continueAsNew(null, options, args);
   }
 
   /**
    * Continues the current workflow execution as a new run possibly overriding the workflow type and
    * options.
    *
-   * @param options option overrides for the next run.
+   * @param workflowType workflow type override for the next run, can contain null if no override is
+   *     needed
+   * @param options option overrides for the next run, can contain null if no overrides are needed
+   * @param args arguments of the next run.
+   * @see #newContinueAsNewStub(Class)
+   * @deprecated use {@link #continueAsNew(String, ContinueAsNewOptions, Object...)}
+   */
+  @Deprecated
+  public static void continueAsNew(
+      Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object... args) {
+    WorkflowInternal.continueAsNew(workflowType.orElse(null), options.orElse(null), args);
+  }
+
+  /**
+   * Continues the current workflow execution as a new run possibly overriding the workflow type and
+   * options.
+   *
+   * @param workflowType workflow type override for the next run, can be null of no override is
+   *     needed
+   * @param options option overrides for the next run, can be null if no overrides are needed
    * @param args arguments of the next run.
    * @see #newContinueAsNewStub(Class)
    */
   public static void continueAsNew(
-      Optional<String> workflowType, Optional<ContinueAsNewOptions> options, Object... args) {
+      @Nullable String workflowType, @Nullable ContinueAsNewOptions options, Object... args) {
     WorkflowInternal.continueAsNew(workflowType, options, args);
   }
 

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -899,6 +899,9 @@ class StateMachines {
     WorkflowExecutionContinuedAsNewEventAttributes.Builder a =
         WorkflowExecutionContinuedAsNewEventAttributes.newBuilder();
     a.setInput(d.getInput());
+    if (d.hasHeader()) {
+      a.setHeader(d.getHeader());
+    }
     if (Durations.compare(d.getWorkflowRunTimeout(), Durations.ZERO) > 0) {
       a.setWorkflowRunTimeout(d.getWorkflowRunTimeout());
     } else {

--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1000,11 +1000,11 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     if (previousRunStartRequest.hasRetryPolicy()) {
       startRequestBuilder.setRetryPolicy(previousRunStartRequest.getRetryPolicy());
     }
-    if (previousRunStartRequest.hasHeader()) {
-      startRequestBuilder.setHeader(previousRunStartRequest.getHeader());
-    }
     if (a.hasInput()) {
       startRequestBuilder.setInput(a.getInput());
+    }
+    if (a.hasHeader()) {
+      startRequestBuilder.setHeader(a.getHeader());
     }
     StartWorkflowExecutionRequest startRequest = startRequestBuilder.build();
     lock.lock();


### PR DESCRIPTION
## What was changed
Interception of  continue-as-new is fixed,  continue-as-new headers are passed to the server now instead of discarding
Test Service implementation of continue-as-new regarding headers is also fixed and brought in agreement with an actual Temporal server
Context Propagation for continue-as-new is implemented
OpenTracing span propagation for continue-as-new is implemented

How was this tested:
Unit test for OpenTracing span connectivity, propagation, and structure for a workflow containing continue-as-new.

Closes #844