### PR TITLE
Set Fossa to run non-blocking in buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,7 @@ steps:
       queue: "default"
       docker: "*"
     command: "fossa init --include-all --no-ansi; fossa analyze --no-ansi -b $${BUILDKITE_BRANCH:-$$(git branch --show-current)}; fossa test --timeout 1800 --no-ansi"
+    branches: "master"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v3.8.0:


### PR DESCRIPTION
## What was changed
Updated buildkite config to run Fossa non-blocking (only on merge to master)

## Why?
Fossa has too many false positives to run in blocking mode