### PR TITLE
Fix absent workflow statuses in TestService#listOpenWorkflowExecutions

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -73,7 +73,6 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       workflowTaskQueues = new HashMap<>();
   private final SelfAdvancingTimer timerService;
   private LockHandle emptyHistoryLockHandle;
-  private volatile boolean isShuttingDown;
 
   private static class HistoryStore {
 
@@ -480,7 +479,9 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
         if (entry.getValue().isCompleted()) {
           continue;
         }
-        result.add(constructWorkflowExecutionInfo(entry, executionId, null));
+        result.add(
+            constructWorkflowExecutionInfo(
+                entry, executionId, WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING));
       } else {
         if (!entry.getValue().isCompleted()) {
           continue;
@@ -513,7 +514,6 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
 
   @Override
   public void close() {
-    isShuttingDown = true;
     timerService.shutdown();
   }
 }


### PR DESCRIPTION
This PR fixes absent workflow statuses in TestService#listOpenWorkflowExecutions return value

How was this tested:
It's not according to the current strategy [TestSerice and the real dockerized temporal server are used for SDK tests themselves]. It will be covered with SDK test though once we expose listOpenWorkflowExecutions as SDK API call (not just a service client call).

Closes #842