### PR TITLE
Remove "Resolved versions" dependencies resolution strategy during Nexus publishing

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -7,15 +7,6 @@ subprojects {
         publications {
             mavenJava(MavenPublication) {
                 from components.java
-                versionMapping {
-                    usage('java-api') {
-                        fromResolutionOf('runtimeClasspath')
-                    }
-                    usage('java-runtime') {
-                        fromResolutionResult()
-                    }
-                }
-
             }
         }
 

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -1,7 +1,7 @@
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+    api(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
     api(platform("io.micrometer:micrometer-bom:$micrometerVersion"))
 
     api project(':temporal-serviceclient')
@@ -13,6 +13,7 @@ dependencies {
         exclude group: 'com.google.errorprone'
         exclude group: 'com.google.j2objc'
     }
+    api "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'


### PR DESCRIPTION
## What was changed

Remove "Resolved versions" dependencies resolution strategy during Nexus publishing
This will switch a resolution to "Declared versions" (default).
See https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:resolved_dependencies

Closes #964