### PR TITLE
Fix bug where TLS certificate streams are read twice

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SimpleSslContextBuilder.java
@@ -107,7 +107,6 @@ public class SimpleSslContextBuilder {
                     : useInsecureTrustManager
                         ? InsecureTrustManagerFactory.INSTANCE.getTrustManagers()[0]
                         : getDefaultTrustManager())
-            .keyManager(keyCertChain, key, keyPassword)
             .applicationProtocolConfig(DEFAULT_APPLICATION_PROTOCOL_CONFIG);
 
     switch (pkcs) {


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Fix bug where TLS certificate streams are read twice, Causing java.lang.IllegalArgumentException: Input stream not contain valid certificates.

