### PR TITLE
Fix rpcRetryOptions not being set in WorkflowServiceStubsOptions

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -200,6 +200,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcLongPollTimeout = builder.rpcLongPollTimeout;
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
+    this.rpcRetryOptions = builder.rpcRetryOptions;
     this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
     this.grpcReconnectFrequency = builder.grpcReconnectFrequency;
     if (builder.headers != null) {


### PR DESCRIPTION
It wasn't being set in the private constructor `WorkflowServiceStubsOptions(Builder builder, boolean ignore)`.
It also seems like the parameter `ignore` isn't being used?

There also doesn't seem to be any existing tests for this class / builder...

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
