### PR TITLE
Upgrade protobuf-java-util for CVE-2021-22569

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 ext {
     logbackVersion = '1.2.10'
     grpcVersion = '[1.34.0,)!!1.43.2'
-    protoVersion = '[3.10.0,)!!3.19.1'
+    protoVersion = '[3.10.0,)!!3.19.2'
     guavaVersion = '[10.0,)!!31.0.1-jre'
     jsonPathVersion = '2.6.0'
     mockitoVersion = '4.2.0'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated com.google.protobuf:protobuf-java-util version to 3.19.2 as there is CVE in current pinned version.


## Why?
This is causing  Could not resolve com.google.protobuf:protobuf-java-util:3.19.1 in code which uses google-cloud libraries latest version with fix for CVE

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Yes. Standard gradle build unit tests.

3. Any docs updates needed?
New release needed.