### PR TITLE
Provide configuration hooks extending usage of standard SDK configuration functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,11 @@ plugins {
 ext {
     logbackVersion = '1.2.10'
     grpcVersion = '[1.34.0,)!!1.43.2'
-    protoVersion = '[3.10.0,)!!3.19.2'
+    protoVersion = '[3.10.0,)!!3.19.3'
     guavaVersion = '[10.0,)!!31.0.1-jre'
     jsonPathVersion = '2.6.0'
     mockitoVersion = '4.2.0'
-    micrometerVersion = '[1.0.0,)!!1.8.1'
+    micrometerVersion = '[1.0.0,)!!1.8.2'
     jacksonVersion = '[2.9.0,)!!2.13.1'
     tallyVersion = '[0.4.0,)!!0.11.1'
     gsonVersion = '[2.0,)!!2.8.9'

--- a/temporal-opentracing/build.gradle
+++ b/temporal-opentracing/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation group: 'io.opentracing', name: 'opentracing-mock', version: "$opentracingVersion"
-    testImplementation group: 'io.jaegertracing', name: 'jaeger-client', version: '1.7.0'
+    testImplementation group: 'io.jaegertracing', name: 'jaeger-client', version: '1.8.0'
 
     testRuntimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
 }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "io.grpc:grpc-core:$grpcVersion"
     implementation "io.grpc:grpc-services:$grpcVersion"
 
-    api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.33'
     if (!JavaVersion.current().isJava8()) {
         implementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
@@ -51,7 +51,7 @@ protobuf {
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
     // with the oldest supported versions of protoc and grpc artifacts.
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.10.0'
+        artifact = 'com.google.protobuf:protoc:3.10.1'
     }
     plugins {
         grpc {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -148,6 +148,10 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       // https://github.com/grpc/grpc-java/issues/8714#issuecomment-974389414
       builder.idleTimeout(31, TimeUnit.DAYS);
 
+      if (options.getChannelInitializer() != null) {
+        options.getChannelInitializer().initChannel(builder);
+      }
+
       this.channel = builder.build();
       // Currently, it is impossible to modify backoff policy on NettyChannelBuilder.
       // For this reason we reset connection backoff every few seconds in order to limit maximum


### PR DESCRIPTION
## What was changed

Added
- WorkflowServiceStubsOptions#channelInitializer mimicking Netty's addChannelInitializer 
- SimpleSslContextBuilder#configure() mimicking GrpcSslContexts

that provide a more flexible approach to configuration.

## Why?
Previously users were able to either use basic config functionality of WorkflowServiceStubsOptions OR a fully custom channel. This works fine until users need to tweak or change some exotic parameter of the gRPC channel. To do that they have to fall back to a fully custom channel and stop using the whole Temporal built-in configuration.

Now users can use the full standard Temporal configuration and tune some parameters of the channel right before it gets built using a listener.