### PR TITLE
Synchronize activity metric names with Core and GoSDK, old names are deprecated

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/POJOActivityTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/POJOActivityTaskHandler.java
@@ -315,12 +315,15 @@ public final class POJOActivityTaskHandler implements ActivityTaskHandler {
     return mapToActivityFailure(e, info.getActivityId(), metricsScope, local);
   }
 
+  @SuppressWarnings("deprecation")
   private ActivityTaskHandler.Result mapToActivityFailure(
       Throwable exception, String activityId, Scope metricsScope, boolean isLocalActivity) {
     if (exception instanceof ActivityCanceledException) {
       if (isLocalActivity) {
+        metricsScope.counter(MetricsType.LOCAL_ACTIVITY_EXEC_CANCELLED_COUNTER).inc(1);
         metricsScope.counter(MetricsType.LOCAL_ACTIVITY_CANCELED_COUNTER).inc(1);
       } else {
+        metricsScope.counter(MetricsType.ACTIVITY_EXEC_CANCELLED_COUNTER).inc(1);
         metricsScope.counter(MetricsType.ACTIVITY_CANCELED_COUNTER).inc(1);
       }
       String stackTrace = FailureConverter.serializeStackTrace(exception);
@@ -334,6 +337,7 @@ public final class POJOActivityTaskHandler implements ActivityTaskHandler {
         metricsScope.tagged(
             ImmutableMap.of(MetricsTag.EXCEPTION, exception.getClass().getSimpleName()));
     if (isLocalActivity) {
+      ms.counter(MetricsType.LOCAL_ACTIVITY_EXEC_FAILED_COUNTER).inc(1);
       ms.counter(MetricsType.LOCAL_ACTIVITY_FAILED_COUNTER).inc(1);
     } else {
       ms.counter(MetricsType.ACTIVITY_EXEC_FAILED_COUNTER).inc(1);

--- a/temporal-sdk/src/main/java/io/temporal/internal/metrics/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/metrics/MetricsType.java
@@ -62,18 +62,34 @@ public class MetricsType {
       TEMPORAL_METRICS_PREFIX + "activity_schedule_to_start_latency";
   public static final String ACTIVITY_EXEC_FAILED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "activity_execution_failed";
+  public static final String ACTIVITY_EXEC_CANCELLED_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "activity_execution_cancelled";
+  /** @deprecated use {@link #ACTIVITY_EXEC_CANCELLED_COUNTER} */
+  @Deprecated
   public static final String ACTIVITY_CANCELED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "activity_canceled";
+
   public static final String ACTIVITY_EXEC_LATENCY =
       TEMPORAL_METRICS_PREFIX + "activity_execution_latency";
   public static final String ACTIVITY_SUCCEED_E2E_LATENCY =
       TEMPORAL_METRICS_PREFIX + "activity_succeed_endtoend_latency";
   public static final String LOCAL_ACTIVITY_TOTAL_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_total";
+
+  public static final String LOCAL_ACTIVITY_EXEC_CANCELLED_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "local_activity_execution_cancelled";
+  /** @deprecated use {@link #LOCAL_ACTIVITY_EXEC_CANCELLED_COUNTER} */
+  @Deprecated
   public static final String LOCAL_ACTIVITY_CANCELED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_canceled";
+
+  public static final String LOCAL_ACTIVITY_EXEC_FAILED_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "local_activity_execution_failed";
+  /** @deprecated use {@link #LOCAL_ACTIVITY_EXEC_FAILED_COUNTER} */
+  @Deprecated
   public static final String LOCAL_ACTIVITY_FAILED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_failed";
+
   public static final String LOCAL_ACTIVITY_EXECUTION_LATENCY =
       TEMPORAL_METRICS_PREFIX + "local_activity_execution_latency";
   public static final String LOCAL_ACTIVITY_SUCCEED_E2E_LATENCY =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -19,9 +19,7 @@
 
 package io.temporal.workflow;
 
-import static io.temporal.internal.metrics.MetricsType.ACTIVITY_EXEC_FAILED_COUNTER;
-import static io.temporal.internal.metrics.MetricsType.CORRUPTED_SIGNALS_COUNTER;
-import static io.temporal.internal.metrics.MetricsType.LOCAL_ACTIVITY_FAILED_COUNTER;
+import static io.temporal.internal.metrics.MetricsType.*;
 import static io.temporal.serviceclient.MetricsType.TEMPORAL_LONG_REQUEST;
 import static io.temporal.serviceclient.MetricsType.TEMPORAL_REQUEST;
 import static io.temporal.serviceclient.MetricsType.TEMPORAL_REQUEST_FAILURE;
@@ -338,7 +336,7 @@ public class MetricsTest {
           }
         };
     reporter.assertCounter(ACTIVITY_EXEC_FAILED_COUNTER, tags, 2);
-    reporter.assertCounter(LOCAL_ACTIVITY_FAILED_COUNTER, tags, 3);
+    reporter.assertCounter(LOCAL_ACTIVITY_EXEC_FAILED_COUNTER, tags, 3);
   }
 
   @Test


### PR DESCRIPTION
Some activity metric names are brought in sync with GoSDK and Core.
temporal_local_activity_failed, temporal_local_activity_canceled, temporal_activity_canceled are deprecated