### PR TITLE
Remove deprecated name.remal.check-updates plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.9' apply false
     id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'name.remal.check-updates' version '1.5.0' apply false
     id 'com.palantir.git-version' version '0.12.3' apply false
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }

--- a/gradle/dependencyManagement.gradle
+++ b/gradle/dependencyManagement.gradle
@@ -1,11 +1,6 @@
-// Run 'gradle checkUpdates' to find out which dependencies have newer versions
-subprojects {
-    apply plugin: "name.remal.check-updates"
-}
-
 subprojects {
     configurations.all {
-        //comes through grpc-api:gauava
+        //comes through grpc-api:guava
         exclude group: 'org.checkerframework', module: 'checker-qual'
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
     }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -469,7 +469,7 @@ public class WorkflowServiceStubsOptions {
      * <p><b>For example, let's consider you've called WorkflowClient#start, and this timeout is set
      * to 1s, while {@link RpcRetryOptions.Builder#setExpiration(Duration)} is set to 5s, and the
      * server is responding slowly. The first two RPC calls may time out and be retried, but if the
-     * third one completes in <1s, the overall call will successfully resolve.
+     * third one completes in &lt;1s, the overall call will successfully resolve.
      */
     public Builder setRpcTimeout(Duration timeout) {
       this.rpcTimeout = Objects.requireNonNull(timeout);


### PR DESCRIPTION
Remove deprecated name.remal.check-updates plugin
We use Dependabot for updates
Closes #321