### PR TITLE
Expose WorkflowInfo.getCronSchedule

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -261,7 +261,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
   /** Updates or inserts search attributes used to index workflows. */
   void upsertSearchAttributes(SearchAttributes searchAttributes);
 
-  /** @return workflow retry attempt */
+  /** @return workflow retry attempt. default is 1 */
   int getAttempt();
 
   /** @return workflow cron schedule */

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -261,5 +261,9 @@ public interface ReplayWorkflowContext extends ReplayAware {
   /** Updates or inserts search attributes used to index workflows. */
   void upsertSearchAttributes(SearchAttributes searchAttributes);
 
+  /** @return workflow retry attempt */
   int getAttempt();
+
+  /** @return workflow cron schedule */
+  String getCronSchedule();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -341,4 +341,9 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
   public int getAttempt() {
     return workflowContext.getAttempt();
   }
+
+  @Override
+  public String getCronSchedule() {
+    return workflowContext.getCronSchedule();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowContext.java
@@ -192,4 +192,8 @@ final class WorkflowContext {
     }
     this.searchAttributes.putAllIndexedFields(searchAttributes.getIndexedFieldsMap());
   }
+
+  public String getCronSchedule() {
+    return startedAttributes.getCronSchedule();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
@@ -104,4 +104,9 @@ final class WorkflowInfoImpl implements WorkflowInfo {
   public int getAttempt() {
     return context.getAttempt();
   }
+
+  @Override
+  public String getCronSchedule() {
+    return context.getCronSchedule();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -54,4 +54,6 @@ public interface WorkflowInfo {
   Optional<String> getParentRunId();
 
   int getAttempt();
+
+  String getCronSchedule();
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static io.temporal.testing.internal.SDKTestOptions.newWorkflowOptionsWithTimeouts;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class GetCronScheduleFromWorkflowInfoTest {
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestGetCronScheduleWorkflowsFuncImpl.class)
+          .build();
+
+  @Test
+  public void testGetCronScheduleFromWorkflowInfo() {
+
+    WorkflowStub workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(
+                "TestGetCronScheduleWorkflowsFunc",
+                newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+                    .toBuilder()
+                    .setCronSchedule("0 */6 * * *")
+                    .build());
+    testWorkflowRule.registerDelayedCallback(Duration.ofDays(1), workflowStub::cancel);
+    workflowStub.start(testName.getMethodName());
+
+    // make sure that the cron workflow was cancelled
+    try {
+      workflowStub.getResult(String.class);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+
+    // make sure we have the completion results available
+    Map<Integer, String> lastCompletionResults =
+        TestGetCronScheduleWorkflowsFuncImpl.lastCompletionResults.get(testName.getMethodName());
+    assertNotNull(lastCompletionResults);
+    assertTrue(lastCompletionResults.size() > 0);
+    // get the very last run completion result and make sure its the cron
+    assertEquals("0 */6 * * *", lastCompletionResults.get(lastCompletionResults.size()));
+  }
+
+  @WorkflowInterface
+  public interface TestGetCronScheduleWorkflowsFunc {
+    @WorkflowMethod
+    String func(String testName);
+  }
+
+  public static class TestGetCronScheduleWorkflowsFuncImpl
+      implements TestGetCronScheduleWorkflowsFunc {
+
+    public static final Map<String, Map<Integer, String>> lastCompletionResults =
+        new ConcurrentHashMap<>();
+    public static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
+
+    @Override
+    public String func(String testName) {
+      int count = retryCount.computeIfAbsent(testName, k -> new AtomicInteger()).incrementAndGet();
+      lastCompletionResults
+          .computeIfAbsent(testName, k -> new HashMap<>())
+          .put(count, Workflow.getLastCompletionResult(String.class));
+
+      return Workflow.getInfo().getCronSchedule();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -49,6 +50,7 @@ public class GetCronScheduleFromWorkflowInfoTest {
 
   @Test
   public void testGetCronScheduleFromWorkflowInfo() throws InterruptedException {
+    Assume.assumeFalse("skipping for docker tests", testWorkflowRule.isUseExternalService());
 
     WorkflowStub workflowStub =
         testWorkflowRule
@@ -61,9 +63,6 @@ public class GetCronScheduleFromWorkflowInfoTest {
                     .build());
     testWorkflowRule.registerDelayedCallback(Duration.ofDays(1), workflowStub::cancel);
     workflowStub.start(testName.getMethodName());
-
-    // Wait for workflow to start (workaround until issue #856 is fixed)
-    Thread.sleep(1000);
 
     // make sure that the cron workflow was cancelled
     try {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
@@ -48,7 +48,7 @@ public class GetCronScheduleFromWorkflowInfoTest {
           .build();
 
   @Test
-  public void testGetCronScheduleFromWorkflowInfo() {
+  public void testGetCronScheduleFromWorkflowInfo() throws InterruptedException {
 
     WorkflowStub workflowStub =
         testWorkflowRule
@@ -57,10 +57,13 @@ public class GetCronScheduleFromWorkflowInfoTest {
                 "TestGetCronScheduleWorkflowsFunc",
                 newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
                     .toBuilder()
-                    .setCronSchedule("0 */6 * * *")
+                    .setCronSchedule("0 0 * * *")
                     .build());
     testWorkflowRule.registerDelayedCallback(Duration.ofDays(1), workflowStub::cancel);
     workflowStub.start(testName.getMethodName());
+
+    // Wait for workflow to start (workaround until issue #856 is fixed)
+    Thread.sleep(1000);
 
     // make sure that the cron workflow was cancelled
     try {
@@ -76,7 +79,7 @@ public class GetCronScheduleFromWorkflowInfoTest {
     assertNotNull(lastCompletionResults);
     assertTrue(lastCompletionResults.size() > 0);
     // get the very last run completion result and make sure its the cron
-    assertEquals("0 */6 * * *", lastCompletionResults.get(lastCompletionResults.size()));
+    assertEquals("0 0 * * *", lastCompletionResults.get(lastCompletionResults.size()));
   }
 
   @WorkflowInterface

--- a/temporal-test-server/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -270,5 +270,10 @@ public class DummySyncWorkflowContext {
     public int getAttempt() {
       return 1;
     }
+
+    @Override
+    public String getCronSchedule() {
+      return "dummy-cron-schedule";
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

exposes WorkflowInfo.getCronSchedule so can get the defined cron schedule inside workflow code