### PR TITLE
Add worker_task_slots_available metric and worker_type tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.9' apply false
     id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'com.palantir.git-version' version '0.12.3' apply false
+    id 'com.palantir.git-version' version '0.13.0' apply false
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
@@ -115,7 +115,7 @@ public class SyncWorkflowWorker
 
     workflowWorker =
         new WorkflowWorker(
-            service, namespace, taskQueue, singleWorkerOptions, taskHandler, stickyTaskQueueName);
+            service, namespace, taskQueue, stickyTaskQueueName, singleWorkerOptions, taskHandler);
 
     // Exists to support Worker#replayWorkflowExecution functionality.
     // This handler has to be non-sticky to avoid evicting actual executions from the cache

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
@@ -34,6 +34,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import java.util.Objects;
 import java.util.concurrent.Semaphore;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,27 +44,26 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
   private final WorkflowServiceStubs service;
   private final String namespace;
   private final String taskQueue;
-  private final Scope metricsScope;
   private final String identity;
   private final double activitiesPerSecond;
   private final Semaphore pollSemaphore;
+  private final Scope metricsScope;
 
   public ActivityPollTask(
-      WorkflowServiceStubs service,
-      String namespace,
-      String taskQueue,
-      Scope metricsScope,
-      String identity,
+      @Nonnull WorkflowServiceStubs service,
+      @Nonnull String namespace,
+      @Nonnull String taskQueue,
+      @Nonnull String identity,
       double activitiesPerSecond,
-      int workerTaskSlots) {
-
+      int workerTaskSlots,
+      @Nonnull Scope metricsScope) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
-    this.metricsScope = Objects.requireNonNull(metricsScope);
     this.identity = Objects.requireNonNull(identity);
     this.activitiesPerSecond = activitiesPerSecond;
     this.pollSemaphore = new Semaphore(workerTaskSlots);
+    this.metricsScope = Objects.requireNonNull(metricsScope);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -31,6 +31,8 @@ import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,23 +42,23 @@ final class WorkflowPollTask implements Poller.PollTask<PollWorkflowTaskQueueRes
   private final WorkflowServiceStubs service;
   private final String namespace;
   private final String taskQueue;
-  private final Scope metricsScope;
   private final String identity;
   private final String binaryChecksum;
+  private final Scope metricsScope;
 
   WorkflowPollTask(
-      WorkflowServiceStubs service,
-      String namespace,
-      String taskQueue,
-      Scope metricsScope,
-      String identity,
-      String binaryChecksum) {
+      @Nonnull WorkflowServiceStubs service,
+      @Nonnull String namespace,
+      @Nonnull String taskQueue,
+      @Nonnull String identity,
+      @Nullable String binaryChecksum,
+      @Nonnull Scope metricsScope) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
-    this.metricsScope = Objects.requireNonNull(metricsScope);
     this.identity = Objects.requireNonNull(identity);
     this.binaryChecksum = binaryChecksum;
+    this.metricsScope = Objects.requireNonNull(metricsScope);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTaskFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTaskFactory.java
@@ -53,6 +53,6 @@ public class WorkflowPollTaskFactory
   @Override
   public Poller.PollTask<PollWorkflowTaskQueueResponse> get() {
     return new WorkflowPollTask(
-        service, namespace, taskQueue, metricScope, identity, binaryChecksum);
+        service, namespace, taskQueue, identity, binaryChecksum, metricScope);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -68,10 +68,6 @@ public class MetricsType {
   public static final String WORKFLOW_TASK_HEARTBEAT_COUNTER =
       TEMPORAL_METRICS_PREFIX + "workflow_task_heartbeat";
 
-  // gauge
-  public static final String WORKFLOW_TASK_ACTIVE_EXECUTOR_THREAD_COUNT =
-      TEMPORAL_METRICS_PREFIX + "workflow_task_active_executor_thread_count";
-
   //
   // Activity
   //
@@ -93,10 +89,6 @@ public class MetricsType {
   @Deprecated
   public static final String ACTIVITY_CANCELED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "activity_canceled";
-
-  // gauge
-  public static final String ACTIVITY_ACTIVE_EXECUTOR_THREAD_COUNT =
-      TEMPORAL_METRICS_PREFIX + "activity_active_executor_thread_count";
 
   //
   // Local Activity
@@ -123,13 +115,12 @@ public class MetricsType {
   public static final String LOCAL_ACTIVITY_FAILED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_failed";
 
-  // gauge
-  public static final String LOCAL_ACTIVITY_ACTIVE_EXECUTOR_THREAD_COUNT =
-      TEMPORAL_METRICS_PREFIX + "local_activity_active_executor_thread_count";
-
   // Worker internals, tagged with worker_type
   public static final String WORKER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "worker_start";
   public static final String POLLER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "poller_start";
+  // gauge
+  public static final String WORKER_TASK_SLOTS_AVAILABLE =
+      TEMPORAL_METRICS_PREFIX + "worker_task_slots_available";
 
   //
   // Worker Factory

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerMetricsTag.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerMetricsTag.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import io.temporal.serviceclient.MetricsTag;
+
+public class WorkerMetricsTag {
+  public enum WorkerType implements MetricsTag.TagValue {
+    WORKFLOW_WORKER("WorkflowWorker"),
+    ACTIVITY_WORKER("ActivityWorker"),
+    LOCAL_ACTIVITY_WORKER("LocalActivityWorker");
+
+    WorkerType(String value) {
+      this.value = value;
+    }
+
+    private final String value;
+
+    @Override
+    public String getTag() {
+      return MetricsTag.WORKER_TYPE;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -22,6 +22,7 @@ package io.temporal.serviceclient;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
 import io.grpc.CallOptions;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -36,6 +37,7 @@ public class MetricsTag {
   public static final String STATUS_CODE = "status_code";
   public static final String EXCEPTION = "exception";
   public static final String OPERATION_NAME = "operation";
+  public static final String WORKER_TYPE = "worker_type";
 
   /** Used to pass metrics scope to the interceptor */
   public static final CallOptions.Key<Scope> METRICS_TAGS_CALL_OPTIONS_KEY =
@@ -49,6 +51,12 @@ public class MetricsTag {
 
   private static final ConcurrentMap<String, Map<String, String>> tagsByNamespace =
       new ConcurrentHashMap<>();
+
+  public interface TagValue {
+    String getTag();
+
+    String getValue();
+  }
 
   /** Returns a set of default metric tags for a given namespace. */
   public static Map<String, String> defaultTags(String namespace) {
@@ -66,6 +74,15 @@ public class MetricsTag {
         .put(STATUS_CODE, DEFAULT_VALUE)
         .put(EXCEPTION, DEFAULT_VALUE)
         .put(WORKFLOW_TYPE, DEFAULT_VALUE)
+        .put(WORKER_TYPE, DEFAULT_VALUE)
         .build();
+  }
+
+  public static Scope tagged(Scope scope, String tagName, String tagValue) {
+    return scope.tagged(Collections.singletonMap(tagName, tagValue));
+  }
+
+  public static Scope tagged(Scope scope, TagValue tagValue) {
+    return tagged(scope, tagValue.getTag(), tagValue.getValue());
   }
 }


### PR DESCRIPTION
Add worker_task_slots_available metric providing information about the count of available executor threads and worker_type tag for worker-level metrics.

Closes #986