### PR TITLE
Introduce GH actions for native-image builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,25 @@
+# sdk-java Github Workflows
+
+## Native Testserver Images (native-testserver-images.yml)
+
+This is a [manually triggered](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) workflow that uses the gradle build files already present in the sdk-java repository to build native executables for Windows, MacOS, and Linux. Currently only the amd64 architecture is supported. We plan to add macOS/aarch64 native builds when builders for that platform become available.  This workflow takes two parameters:
+1. `release` - a git tag in the form of a 'v' character followed by a semantic version, e.g. v1.2.3. The presence of this parameter instructs the workflow to upload generated artifacts to the github release identified by that version. By default the value is blank and thus the binaries are built but not attached to any release. If the release specified does not exist this workflow will _not_ create it but rather will fail.
+2. `clobber` - a boolean indicating whether or not the release artifact upload should overwrite any existing artifacts attached to the specified release with the same artifact name. If the `release` parameter is blank, this parameter is not used.
+
+### Testing
+
+To test execution of this workflow, first create your own fork of the temporalio/sdk-java repository. In your fork, edit the native-testserver-images.yml (and related files, as necessary) in a branch and push the branch to Github. The Github "Actions" tab in the web UI affords the ability to invoke the workflow on master or on any other branch (you probably want to specify the branch that contains your updates) and pass the parameters described above. If you want to test out the release artifact upload, first create a release (draft release is ok) _of your forked repository_ and specify that release tag in the `release` parameter of the workflow invocation.
+
+Workflows can also be invoked from the `gh` cli. To invoke this workflow and watch its progress
+
+```.sh
+$ gh workflow run \
+  --ref $GITHUB_BRANCH \
+  --field clobber=true \
+  --field release=v0.0.1 \
+  --repo $GITHUB_USER/sdk-java \
+  native-testserver-images.yml \
+$ gh run list --workflow=native-testserver-images.yml --repo $GITHUB_USER/sdk-java
+$ # Note ID of your workflow run in the output of the command above
+$ gh run watch --repo $GITHUB_USER/sdk-java <ID>
+```

--- a/.github/workflows/native-images.yml
+++ b/.github/workflows/native-images.yml
@@ -1,0 +1,115 @@
+name: Build Native Images
+defaults:
+  run:
+    shell: bash
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        type: string
+        description: 'Release version (e.g. v1.2.3); omit to skip attaching artifacts to a release'
+        required: false
+      release_repo:
+        type: string
+        description: 'The repository hosting the github release; used only if the release version parameter is set'
+        required: false
+        default: temporalio/sdk-java
+      clobber:
+        type: boolean
+        description: 'Overwrite existing release artifacts'
+        required: false
+        default: no
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        include:
+          - dist: ubuntu-latest
+            os_family: linux
+            arch: amd64
+          - dist: macos-latest
+            os_family: macOS
+            arch: amd64
+          - dist: windows-latest
+            os_family: windows
+            arch: amd64
+    runs-on: ${{ matrix.dist }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        
+      - name: Build Native Image
+        run: ./gradlew :temporal-test-server:build
+      
+      # path ends in a wildcard because on windows the file ends in '.exe'
+      # path excludes *.txt because native-image also writes a build manifest txt file
+      - name: Upload executable to workflow
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os_family }}_${{ matrix.arch }}
+          path: |
+            temporal-test-server/build/graal/temporal-test-server*
+            !temporal-test-server/build/graal/*.txt
+          if-no-files-found: error
+          retention-days: 1
+          
+  attach_to_release:
+    name: Attach to release
+    needs: build
+    if: github.event.inputs.release
+    runs-on: ubuntu-latest
+    steps:
+    
+      # when no artifact is specified, all artifacts are downloaded and expanded into CWD
+      - name: Fetch executables
+        uses: actions/download-artifact@v2
+        
+      # example: linux_amd64/ -> temporal-test-server_1.2.3_linux_amd64
+      # the name of the directory created becomes the basename of the archive (*.tar.gz or *.zip) and 
+      # the root directory of the contents of the archive.
+      - name: Rename dirs
+        run: |
+          shopt -s nullglob
+          version="$(sed 's/v//'<<<'${{ github.event.inputs.release }}')"
+          for dir in *; do
+            mv "$dir" "temporal-test-server_$version_$dir"
+          done        
+      
+      - name: Upload tars (linux, macOS)
+        run: |
+          shopt -s nullglob
+          for dir in *{linux,macOS}*; do
+            tar cvzf "$dir.tar.gz" "$dir"
+            clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
+            gh release upload $clobberflag --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} "$dir.tar.gz"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Upload zip (windows)
+        run: |
+          shopt -s nullglob
+          for dir in *windows*; do
+            zip -r "$dir.zip" "$dir"
+            clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
+            gh release upload $clobberflag --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} "$dir.zip"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+        
+  
+

--- a/.github/workflows/native-images.yml
+++ b/.github/workflows/native-images.yml
@@ -83,21 +83,21 @@ jobs:
       - name: Rename dirs
         run: |
           version="$(sed 's/v//'<<<'${{ github.event.inputs.release }}')"
-          for dir in *; do mv "$dir" "temporal-test-server_$version_$dir"; done        
+          for dir in *; do mv "$dir" "temporal-test-server_${version}_${dir}"; done        
       
       - name: Tar (linux, macOS)
-        run: for dir in *{linux,macOS}*; do tar cvzf "$dir.tar.gz" "$dir"; done
+        run: for dir in *{linux,macOS}*; do tar cvzf "${dir}.tar.gz" "$dir"; done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Zip (windows)
-        run: for dir in *windows*; do zip -r "$dir.zip" "$dir"; done
+        run: for dir in *windows*; do zip -r "${dir}.zip" "$dir"; done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Upload
         run: |
             clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
-            gh release upload $clobberflag --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} *.zip *.tar.gz
+            gh release upload ${clobberflag} --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} *.zip *.tar.gz
 
 

--- a/.github/workflows/native-images.yml
+++ b/.github/workflows/native-images.yml
@@ -1,7 +1,7 @@
 name: Build Native Images
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail -O nullglob {0}
 on:
   workflow_dispatch:
     inputs:
@@ -82,34 +82,22 @@ jobs:
       # the root directory of the contents of the archive.
       - name: Rename dirs
         run: |
-          shopt -s nullglob
           version="$(sed 's/v//'<<<'${{ github.event.inputs.release }}')"
-          for dir in *; do
-            mv "$dir" "temporal-test-server_$version_$dir"
-          done        
+          for dir in *; do mv "$dir" "temporal-test-server_$version_$dir"; done        
       
-      - name: Upload tars (linux, macOS)
-        run: |
-          shopt -s nullglob
-          for dir in *{linux,macOS}*; do
-            tar cvzf "$dir.tar.gz" "$dir"
-            clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
-            gh release upload $clobberflag --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} "$dir.tar.gz"
-          done
+      - name: Tar (linux, macOS)
+        run: for dir in *{linux,macOS}*; do tar cvzf "$dir.tar.gz" "$dir"; done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-      - name: Upload zip (windows)
-        run: |
-          shopt -s nullglob
-          for dir in *windows*; do
-            zip -r "$dir.zip" "$dir"
-            clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
-            gh release upload $clobberflag --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} "$dir.zip"
-          done
+      - name: Zip (windows)
+        run: for dir in *windows*; do zip -r "$dir.zip" "$dir"; done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-        
-  
+      - name: Upload
+        run: |
+            clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
+            gh release upload $clobberflag --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} *.zip *.tar.gz
+
 

--- a/.github/workflows/native-testserver-images.yml
+++ b/.github/workflows/native-testserver-images.yml
@@ -82,17 +82,15 @@ jobs:
       
       - name: Tar (linux, macOS)
         run: for dir in *{linux,macOS}*; do tar cvzf "${dir}.tar.gz" "$dir"; done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Zip (windows)
         run: for dir in *windows*; do zip -r "${dir}.zip" "$dir"; done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Upload
         run: |
             clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
             gh release upload ${clobberflag} --repo ${{ github.repository }} ${{ github.event.inputs.release }} *.zip *.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 

--- a/.github/workflows/native-testserver-images.yml
+++ b/.github/workflows/native-testserver-images.yml
@@ -1,4 +1,4 @@
-name: Build Native Images
+name: Build Native Testserver Images
 defaults:
   run:
     shell: bash -euo pipefail -O nullglob {0}

--- a/.github/workflows/native-testserver-images.yml
+++ b/.github/workflows/native-testserver-images.yml
@@ -9,11 +9,6 @@ on:
         type: string
         description: 'Release version (e.g. v1.2.3); omit to skip attaching artifacts to a release'
         required: false
-      release_repo:
-        type: string
-        description: 'The repository hosting the github release; used only if the release version parameter is set'
-        required: false
-        default: temporalio/sdk-java
       clobber:
         type: boolean
         description: 'Overwrite existing release artifacts'
@@ -98,6 +93,6 @@ jobs:
       - name: Upload
         run: |
             clobberflag="$([[ ${{ github.event.inputs.clobber }} = true ]] && echo "--clobber" || echo '')"
-            gh release upload ${clobberflag} --repo ${{ github.event.inputs.release_repo }} ${{ github.event.inputs.release }} *.zip *.tar.gz
+            gh release upload ${clobberflag} --repo ${{ github.repository }} ${{ github.event.inputs.release }} *.zip *.tar.gz
 
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
A GH action that will build the test server native image on linux/amd64,
macOS/amd64, and windows/amd64. Build outputs are stored with the
workflow execution for 1 day and optionally attached to a user-supplied
GH release.

Missing from this work is a matrix build entry for macOS/aarch64 as
we don't have build machines for that platform yet.

The tgz and zip files that are ultimately released are modeled on
https://github.com/cli/cli/releases/tag/v2.4.0

## Why?
<!-- Tell your future self why have you made these changes -->
Cross-platform native builds of the test server

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
