### PR TITLE
Add WorkflowImplementationOptions.setLocalActivityOptions (#975)

### DIFF
--- a/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkflowImplementationOptionsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkflowImplementationOptionsExt.kt
@@ -20,6 +20,7 @@
 package io.temporal.worker
 
 import io.temporal.activity.ActivityOptions
+import io.temporal.activity.LocalActivityOptions
 import io.temporal.common.metadata.activityName
 import io.temporal.kotlin.TemporalDsl
 
@@ -69,4 +70,43 @@ inline fun @TemporalDsl WorkflowImplementationOptions.Builder.setDefaultActivity
   defaultActivityOptions: @TemporalDsl ActivityOptions.Builder.() -> Unit
 ) {
   setDefaultActivityOptions(ActivityOptions(defaultActivityOptions))
+}
+
+/**
+ * Set individual Local Activity options per `activityType`.
+ *
+ * The [activityName] method could be used resolve activity method references to activity names:
+ *
+ * ```kotlin
+ * val options = WorkflowImplementationOptions {
+ *   // ...
+ *   setLocalActivityOptions(
+ *     localActivityName(Activity1::method1) to LocalActivityOptions {
+ *       // options for local activity method1
+ *     },
+ *     localActivityName(Activity2::method2) to LocalActivityOptions {
+ *       // options for local activity method2
+ *     },
+ *   )
+ * }
+ * ```
+ *
+ * @param localActivityOptions map from activityType to [LocalActivityOptions]
+ * @see WorkflowImplementationOptions.Builder.setLocalActivityOptions
+ * @see WorkflowImplementationOptions.getLocalActivityOptions
+ */
+fun WorkflowImplementationOptions.Builder.setLocalActivityOptions(
+  vararg localActivityOptions: Pair<String, LocalActivityOptions>
+) {
+  setLocalActivityOptions(localActivityOptions.toMap())
+}
+
+/**
+ * @see WorkflowImplementationOptions.Builder.setDefaultLocalActivityOptions
+ * @see WorkflowImplementationOptions.getDefaultLocalActivityOptions
+ */
+inline fun @TemporalDsl WorkflowImplementationOptions.Builder.setDefaultLocalActivityOptions(
+  defaultLocalActivityOptions: @TemporalDsl LocalActivityOptions.Builder.() -> Unit
+) {
+  setDefaultLocalActivityOptions(LocalActivityOptions(defaultLocalActivityOptions))
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -101,6 +101,8 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
 
   private ActivityOptions defaultActivityOptions = null;
   private Map<String, ActivityOptions> activityOptionsMap = new HashMap<>();
+  private LocalActivityOptions defaultLocalActivityOptions = null;
+  private Map<String, LocalActivityOptions> localActivityOptionsMap = new HashMap<>();
 
   public SyncWorkflowContext(
       ReplayWorkflowContext context,
@@ -128,6 +130,9 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     if (workflowImplementationOptions != null) {
       this.defaultActivityOptions = workflowImplementationOptions.getDefaultActivityOptions();
       this.activityOptionsMap = workflowImplementationOptions.getActivityOptions();
+      this.defaultLocalActivityOptions =
+          workflowImplementationOptions.getDefaultLocalActivityOptions();
+      this.localActivityOptionsMap = workflowImplementationOptions.getLocalActivityOptions();
     }
     // initial values for headInboundInterceptor and headOutboundInterceptor until they initialized
     // with actual interceptors through #initHeadInboundCallsInterceptor and
@@ -176,6 +181,14 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     return activityOptionsMap;
   }
 
+  public LocalActivityOptions getDefaultLocalActivityOptions() {
+    return defaultLocalActivityOptions;
+  }
+
+  public Map<String, LocalActivityOptions> getLocalActivityOptions() {
+    return localActivityOptionsMap;
+  }
+
   public void setDefaultActivityOptions(ActivityOptions defaultActivityOptions) {
     this.defaultActivityOptions =
         (this.defaultActivityOptions == null)
@@ -195,6 +208,29 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     activityMethodOptions.forEach(
         (key, value) ->
             this.activityOptionsMap.merge(
+                key, value, (o1, o2) -> o1.toBuilder().mergeActivityOptions(o2).build()));
+  }
+
+  public void setDefaultLocalActivityOptions(LocalActivityOptions defaultLocalActivityOptions) {
+    this.defaultLocalActivityOptions =
+        (this.defaultLocalActivityOptions == null)
+            ? defaultLocalActivityOptions
+            : this.defaultLocalActivityOptions
+                .toBuilder()
+                .mergeActivityOptions(defaultLocalActivityOptions)
+                .build();
+  }
+
+  public void setLocalActivityOptions(
+      Map<String, LocalActivityOptions> localActivityMethodOptions) {
+    Objects.requireNonNull(localActivityMethodOptions);
+    if (this.localActivityOptionsMap == null) {
+      this.localActivityOptionsMap = new HashMap<>(localActivityMethodOptions);
+      return;
+    }
+    localActivityMethodOptions.forEach(
+        (key, value) ->
+            this.localActivityOptionsMap.merge(
                 key, value, (o1, o2) -> o1.toBuilder().mergeActivityOptions(o2).build()));
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -79,6 +79,16 @@ public final class Workflow {
     WorkflowInternal.setActivityOptions(activityMethodOptions);
   }
 
+  public static void setDefaultLocalActivityOptions(
+      LocalActivityOptions defaultLocalActivityOptions) {
+    WorkflowInternal.setDefaultLocalActivityOptions(defaultLocalActivityOptions);
+  }
+
+  public static void setLocalActivityOptions(
+      Map<String, LocalActivityOptions> localActivityMethodOptions) {
+    WorkflowInternal.setLocalActivityOptions(localActivityMethodOptions);
+  }
+
   /**
    * Creates client stub to activities that implement given interface. `
    *

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityTestOptions.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityTestOptions.java
@@ -45,4 +45,23 @@ public class ActivityTestOptions {
         .setContextPropagators(null)
         .build();
   }
+
+  public static LocalActivityOptions newLocalActivityOptions1() {
+    return LocalActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofDays(1))
+        .setStartToCloseTimeout(Duration.ofSeconds(2))
+        .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
+        .setLocalRetryThreshold(Duration.ofSeconds(1))
+        .setDoNotIncludeArgumentsIntoMarker(true)
+        .build();
+  }
+
+  public static LocalActivityOptions newLocalActivityOptions2() {
+    return LocalActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofDays(3))
+        .setStartToCloseTimeout(Duration.ofSeconds(3))
+        .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(2).build())
+        .setLocalRetryThreshold(Duration.ofSeconds(3))
+        .build();
+  }
 }

--- a/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
@@ -56,6 +56,28 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
         }
       };
 
+  // local activity options
+  private static final LocalActivityOptions localActivityWorkflowOps =
+      ActivityTestOptions.newLocalActivityOptions1();
+  private static final LocalActivityOptions localActivityWorkerOps =
+      ActivityTestOptions.newLocalActivityOptions2();
+  private static final LocalActivityOptions localActivity2Ops =
+      SDKTestOptions.newLocalActivityOptions20sScheduleToClose();
+  private static final Map<String, LocalActivityOptions> localActivity2options =
+      new HashMap<String, LocalActivityOptions>() {
+        {
+          put("LocalActivity2", localActivity2Ops);
+        }
+      };
+  private static final Map<String, LocalActivityOptions> defaultLocalActivity2options =
+      new HashMap<String, LocalActivityOptions>() {
+        {
+          put(
+              "LocalActivity2",
+              LocalActivityOptions.newBuilder().setDoNotIncludeArgumentsIntoMarker(false).build());
+        }
+      };
+
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
@@ -63,9 +85,11 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
               WorkflowImplementationOptions.newBuilder()
                   .setDefaultActivityOptions(workerOps)
                   .setActivityOptions(activity2options)
+                  .setDefaultLocalActivityOptions(localActivityWorkerOps)
+                  .setLocalActivityOptions(localActivity2options)
                   .build(),
               TestSetDefaultActivityOptionsWorkflowImpl.class)
-          .setActivityImplementations(new TestActivityImpl())
+          .setActivityImplementations(new TestActivityImpl(), new LocalActivityTestImpl())
           .build();
 
   @Test
@@ -96,15 +120,49 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
     assertEquals(workflowOps.getStartToCloseTimeout(), activity2Values.get("StartToCloseTimeout"));
   }
 
+  @Test
+  public void testSetLocalActivityWorkflowImplementationOptions() {
+    TestWorkflowReturnMap workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflowReturnMap.class,
+                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+    Map<String, Map<String, Duration>> result = workflowStub.execute();
+
+    // Check that local activity1 has default workerOptions options that were partially overwritten
+    // with workflow.
+    Map<String, Duration> localActivity1Values = result.get("LocalActivity1");
+    assertEquals(
+        localActivityWorkflowOps.getScheduleToCloseTimeout(),
+        localActivity1Values.get("ScheduleToCloseTimeout"));
+    assertEquals(
+        localActivityWorkflowOps.getStartToCloseTimeout(),
+        localActivity1Values.get("StartToCloseTimeout"));
+    // Check that default options for local activity2 were overwritten.
+    Map<String, Duration> localActivity2Values = result.get("LocalActivity2");
+    assertEquals(
+        localActivity2Ops.getScheduleToCloseTimeout(),
+        localActivity2Values.get("ScheduleToCloseTimeout"));
+    assertEquals(
+        localActivityWorkflowOps.getStartToCloseTimeout(),
+        localActivity2Values.get("StartToCloseTimeout"));
+  }
+
   public static class TestSetDefaultActivityOptionsWorkflowImpl implements TestWorkflowReturnMap {
     @Override
     public Map<String, Map<String, Duration>> execute() {
       Workflow.setDefaultActivityOptions(workflowOps);
       Workflow.setActivityOptions(defaultActivity2options);
+      Workflow.setDefaultLocalActivityOptions(localActivityWorkflowOps);
+      Workflow.setLocalActivityOptions(defaultLocalActivity2options);
       Map<String, Map<String, Duration>> result = new HashMap<>();
       TestActivity activities = Workflow.newActivityStub(TestActivity.class);
+      LocalActivityTest localActivities = Workflow.newLocalActivityStub(LocalActivityTest.class);
       result.put("Activity1", activities.activity1());
       result.put("Activity2", activities.activity2());
+      result.put("LocalActivity1", localActivities.localActivity1());
+      result.put("LocalActivity2", localActivities.localActivity2());
       return result;
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
@@ -23,7 +23,6 @@ import io.temporal.common.RetryOptions;
 import io.temporal.testing.TestActivityEnvironment;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +52,7 @@ public class LocalActivityMethodOptionsTest {
   private static final Map<String, LocalActivityOptions> perMethodOptionsMap =
       new HashMap<String, LocalActivityOptions>() {
         {
-          put("Method1", methodOps2);
+          put("LocalActivity1", methodOps2);
         }
       };
   private TestActivityEnvironment testEnv;
@@ -83,61 +82,22 @@ public class LocalActivityMethodOptionsTest {
 
   @Test
   public void testLocalActivityMethodOptions() {
-    testEnv.registerActivitiesImplementations(new ActivityImpl());
-    TestActivity localActivity =
-        testEnv.newLocalActivityStub(TestActivity.class, defaultOps, perMethodOptionsMap);
+    testEnv.registerActivitiesImplementations(new LocalActivityTestImpl());
+    LocalActivityTest localActivity =
+        testEnv.newLocalActivityStub(LocalActivityTest.class, defaultOps, perMethodOptionsMap);
 
     // Check that options for method1 were merged.
-    Map<String, Duration> method1OpsValues = localActivity.method1();
+    Map<String, Duration> method1OpsValues = localActivity.localActivity1();
     Assert.assertEquals(
         defaultOps.getScheduleToCloseTimeout(), method1OpsValues.get("ScheduleToCloseTimeout"));
     Assert.assertEquals(
         methodOps2.getStartToCloseTimeout(), method1OpsValues.get("StartToCloseTimeout"));
 
     // Check that options for method2 were default.
-    Map<String, Duration> method2OpsValues = localActivity.method2();
+    Map<String, Duration> method2OpsValues = localActivity.localActivity2();
     Assert.assertEquals(
         defaultOps.getScheduleToCloseTimeout(), method2OpsValues.get("ScheduleToCloseTimeout"));
     Assert.assertEquals(
         defaultOps.getStartToCloseTimeout(), method2OpsValues.get("StartToCloseTimeout"));
-  }
-
-  @ActivityInterface
-  public interface TestActivity {
-
-    @ActivityMethod
-    Map<String, Duration> method1();
-
-    @ActivityMethod
-    Map<String, Duration> method2();
-  }
-
-  private static class ActivityImpl implements TestActivity {
-
-    @Override
-    public Map<String, Duration> method1() {
-      ActivityInfo info = Activity.getExecutionContext().getInfo();
-      Hashtable<String, Duration> result =
-          new Hashtable<String, Duration>() {
-            {
-              put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-              put("StartToCloseTimeout", info.getStartToCloseTimeout());
-            }
-          };
-      return result;
-    }
-
-    @Override
-    public Map<String, Duration> method2() {
-      ActivityInfo info = Activity.getExecutionContext().getInfo();
-      Hashtable<String, Duration> result =
-          new Hashtable<String, Duration>() {
-            {
-              put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-              put("StartToCloseTimeout", info.getStartToCloseTimeout());
-            }
-          };
-      return result;
-    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.activity;
+
+import java.time.Duration;
+import java.util.Map;
+
+@ActivityInterface
+public interface LocalActivityTest {
+
+  @ActivityMethod
+  Map<String, Duration> localActivity1();
+
+  @ActivityMethod
+  Map<String, Duration> localActivity2();
+}

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTestImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTestImpl.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.activity;
+
+import java.time.Duration;
+import java.util.Hashtable;
+import java.util.Map;
+
+public class LocalActivityTestImpl implements LocalActivityTest {
+
+  @Override
+  public Map<String, Duration> localActivity1() {
+    ActivityInfo info = Activity.getExecutionContext().getInfo();
+    Hashtable<String, Duration> result =
+        new Hashtable<String, Duration>() {
+          {
+            put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
+            put("StartToCloseTimeout", info.getStartToCloseTimeout());
+          }
+        };
+    return result;
+  }
+
+  @Override
+  public Map<String, Duration> localActivity2() {
+    ActivityInfo info = Activity.getExecutionContext().getInfo();
+    Hashtable<String, Duration> result =
+        new Hashtable<String, Duration>() {
+          {
+            put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
+            put("StartToCloseTimeout", info.getStartToCloseTimeout());
+          }
+        };
+    return result;
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
@@ -57,6 +57,12 @@ public class SDKTestOptions {
     return ActivityOptions.newBuilder().setScheduleToCloseTimeout(Duration.ofSeconds(20)).build();
   }
 
+  public static LocalActivityOptions newLocalActivityOptions20sScheduleToClose() {
+    return LocalActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofSeconds(20))
+        .build();
+  }
+
   public static ActivityOptions newActivityOptionsForTaskQueue(String taskQueue) {
     if (DEBUGGER_TIMEOUTS) {
       return ActivityOptions.newBuilder()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added `localActivityOptions` and `defaultLocalActivityOptions` fields and relevant setters/getters to `WorkflowImplementationOptions`, `SyncWorkflowContext`, and `Workflow`, so that in `Workflow.newLocalActivityStub`, any local activity options received from the workflow are merged with options in WorkflowImplementationOptions. 

## Why?
<!-- Tell your future self why have you made these changes -->
Following existing WorkflowImplementationOptions.setActivityOptions, allow user to define local activity options for different types of activities instead of defining them in workflow code. This would be applied to `Workflow.newLocalActivityStub`.

## Checklist
<!--- add/delete as needed --->

1. Closes [Issue #975](https://github.com/temporalio/sdk-java/issues/975)

2. How was this tested:
Duplicated existing tests for merging regular Activity Options for merging Local Activity Options. `DefaultActivityOptionsOnWorkflowNotSetTest.testDefaultLocalActivityOptionsNotSetTest` is disabled for now as discussed with @Spikhalskiy 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Don't see any existing docs on `WorkflowImplementationOptions` on docs.temporal.io
