### PR TITLE
Workflow input defaults should be strings

### DIFF
--- a/.github/workflows/native-testserver-images.yml
+++ b/.github/workflows/native-testserver-images.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
         description: 'Overwrite existing release artifacts'
         required: false
-        default: no
+        default: 'false'
 
 jobs:
   build:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This value needs to be a string and yaml treats `no` as a boolean. Turns out the `type: boolean` on input parameters is just a hint for how to render the user interface and not an indication of an actual type system.

## Why?
<!-- Tell your future self why have you made these changes -->
yaml

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Running this workflow via `gh workflow run` _without_ specifying the `clobber` parameter fails. This fixes the failure.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
