### PR TITLE
Prevent Windows 2022 being used for native-images

### DIFF
--- a/.github/workflows/native-testserver-images.yml
+++ b/.github/workflows/native-testserver-images.yml
@@ -27,7 +27,7 @@ jobs:
           - dist: macos-latest
             os_family: macOS
             arch: amd64
-          - dist: windows-latest
+          - dist: windows-2019
             os_family: windows
             arch: amd64
     runs-on: ${{ matrix.dist }}


### PR DESCRIPTION
## What was changed
Require windows-2019 for native image builds rather than windows-latest

## Why?
GraalVM doesn't have an SDK for Windows Server 2022 yet so the native
executable build fails if we catch an updated builder. Windows 2022 is
becoming the default for `windows-latest` "real soon now" so pin the
version in use to 2019.

More context at actions/virtual-environments#4856

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
