### PR TITLE
Expose ActivityInfo#getCurrentAttemptScheduledTimestamp

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -55,9 +55,16 @@ public interface ActivityInfo {
   /**
    * Time when the Activity Execution was initially scheduled by the Workflow Execution.
    *
-   * @return Timestamp in milliseconds.
+   * @return Timestamp in milliseconds (UNIX Epoch time)
    */
   long getScheduledTimestamp();
+
+  /**
+   * Time when the Activity Task (current attempt) was scheduled by the Temporal Server.
+   *
+   * @return Timestamp in milliseconds (UNIX Epoch time)
+   */
+  long getCurrentAttemptScheduledTimestamp();
 
   /** @return the Schedule-To-Close Timeout setting as a Duration. */
   Duration getScheduleToCloseTimeout();

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
@@ -73,6 +73,11 @@ final class ActivityInfoImpl implements ActivityInfoInternal {
 
   @Override
   public long getScheduledTimestamp() {
+    return Timestamps.toMillis(response.getScheduledTime());
+  }
+
+  @Override
+  public long getCurrentAttemptScheduledTimestamp() {
     return Timestamps.toMillis(response.getCurrentAttemptScheduledTime());
   }
 


### PR DESCRIPTION
Expose ActivityInfo#getCurrentAttemptScheduledTimestamp in addition to the activity execution scheduled timestamp on the ActivityInfo.

## Why
Can be useful for user metrics