### PR TITLE
Improve Promise and io.temporal.workflow javadocs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/workflow/Promise.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Promise.java
@@ -40,8 +40,9 @@ import java.util.concurrent.TimeoutException;
  *   <li>Promise doesn't directly supports cancellation. Use {@link CancellationScope} to cancel and
  *       handle cancellations. The pattern is that a canceled operation completes its Promise with
  *       {@link CanceledFailure} when canceled.
- *   <li>{@link #handle(Functions.Func2)} and similar callback operations do not allow blocking
- *       calls inside functions
+ *   <li>{@link #handle(Functions.Func2)} and similar callback operations should follow all the same
+ *       constraints as other Workflow Code. See "Workflow Implementation Constraints" on {@link
+ *       io.temporal.workflow}.
  * </ul>
  */
 public interface Promise<V> {
@@ -117,7 +118,8 @@ public interface Promise<V> {
    * this Promise when it is ready. #completeExceptionally is propagated directly to the returned
    * Promise skipping the function.
    *
-   * <p>Note that no blocking calls are allowed inside of the function.
+   * <p>Note that all the constraints of Workflow Implementation Code apply to {@code fn}. See
+   * "Workflow Implementation Constraints" on {@link io.temporal.workflow}.
    */
   <U> Promise<U> thenApply(Functions.Func1<? super V, ? extends U> fn);
 
@@ -126,13 +128,17 @@ public interface Promise<V> {
    * this Promise or with an exception when it is completed. If the function throws a {@link
    * RuntimeException} it fails the resulting promise.
    *
-   * <p>Note that no blocking calls are allowed inside of the function.
+   * <p>Note that all the constraints of Workflow Implementation Code apply to {@code fn}. See
+   * "Workflow Implementation Constraints" on {@link io.temporal.workflow}.
    */
   <U> Promise<U> handle(Functions.Func2<? super V, RuntimeException, ? extends U> fn);
 
   /**
    * Returns a new Promise that, when this promise completes normally, is executed with this promise
    * as the argument to the supplied function.
+   *
+   * <p>Note that all the constraints of Workflow Implementation Code apply to {@code fn}. See
+   * "Workflow Implementation Constraints" on {@link io.temporal.workflow}.
    *
    * @param fn the function returning a new Promise
    * @param <U> the type of the returned CompletionStage's result
@@ -144,6 +150,9 @@ public interface Promise<V> {
    * Returns a new Promise that, when this promise completes exceptionally, is executed with this
    * promise's exception as the argument to the supplied function. Otherwise, if this promise
    * completes normally, then the returned promise also completes normally with the same value.
+   *
+   * <p>Note that all the constraints of Workflow Implementation Code apply to {@code fn}. See
+   * "Workflow Implementation Constraints" on {@link io.temporal.workflow}.
    *
    * @param fn the function to use to compute the value of the returned CompletionPromise if this
    *     CompletionPromise completed exceptionally

--- a/temporal-sdk/src/main/java/io/temporal/workflow/package-info.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/package-info.java
@@ -319,32 +319,42 @@
  * <ul>
  *   <li>Do not use any mutable global variables because multiple instances of workflows are
  *       executed in parallel.
- *   <li>Do not call any non-deterministic functions like non seeded random, {@link java.lang.System
- *       .currentTimeMillis()} or {@link java.util.UUID#randomUUID()} directly form the workflow
- *       code. Always do this in activities.
- *   <li>Don’t perform any IO or service calls as they are not usually deterministic. Use activities
- *       for this.
- *   <li>Use methods on {@link io.temporal.workflow.Workflow} as safe deterministic alternatives to
- *       non-deterministic methods. For example, only use {@link
- *       io.temporal.workflow.Workflow#currentTimeMillis()} to get the current time inside a
- *       workflow.
+ *   <li>Do not call any non-deterministic functions, like non-seeded random, directly form the
+ *       workflow code. Always use safe deterministic alternatives provided by Temporal SDK on
+ *       {@link io.temporal.workflow.Workflow} or perform such calls in activities if have to. For
+ *       example:
+ *       <ul>
+ *         <li>Use {@link io.temporal.workflow.Workflow#currentTimeMillis()} instead of {@link
+ *             java.lang.System#currentTimeMillis()} to get the current time inside a workflow
+ *         <li>Use {@link io.temporal.workflow.Workflow#randomUUID()} instead of {@link
+ *             java.util.UUID#randomUUID()}
+ *       </ul>
+ *   <li>Don't perform long blocking operations other than calls that block inside Temporal SDK
+ *       (like Activity invocations or {@link io.temporal.workflow.Workflow} APIs). Use activities
+ *       for this. For example:
+ *       <ul>
+ *         <li>Call {@link io.temporal.workflow.Workflow#sleep(Duration)} instead of {@link
+ *             java.lang.Thread#sleep(long)}.
+ *         <li>Use {@link io.temporal.workflow.Promise} and {@link
+ *             io.temporal.workflow.CompletablePromise} instead of {@link
+ *             java.util.concurrent.Future} and {@link java.util.concurrent.CompletableFuture}.
+ *       </ul>
+ *   <li>Don’t perform any IO or service calls as they are blocking and usually not deterministic.
+ *       Use activities for long running or non-deterministic code.
  *   <li>Do not use native Java {@link java.lang.Thread} or any other multi-threaded classes like
  *       {@link java.util.concurrent.ThreadPoolExecutor}. Use {@link
  *       io.temporal.workflow.Async#function(Functions.Func)} or {@link
  *       io.temporal.workflow.Async#procedure(Functions.Proc)} to execute code asynchronously.
  *   <li>Don't use any synchronization, locks, and other standard Java blocking concurrency-related
  *       classes besides those provided by the Workflow class. There is no need in explicit
- *       synchronization because multi-threaded code inside a workflow is executed one thread at a
- *       time and under a global lock.
- *   <li>Call {@link io.temporal.workflow.Workflow#sleep(Duration)} instead of {@link
- *       java.lang.Thread#sleep(long)}.
- *   <li>Use {@link io.temporal.workflow.Promise} and {@link
- *       io.temporal.workflow.CompletablePromise} instead of {@link java.util.concurrent.Future} and
- *       {@link java.util.concurrent.CompletableFuture}.
- *   <li>Use {@link io.temporal.workflow.WorkflowQueue} instead of {@link
- *       java.util.concurrent.BlockingQueue}.
- *   <li>Don't change workflow code when there are open workflows. The ability to do updates through
- *       visioning is TBD.
+ *       synchronization because multi-threaded code inside a single workflow execution is executed
+ *       one thread at a time and under a global lock. For example:
+ *       <ul>
+ *         <li>Use {@link io.temporal.workflow.WorkflowQueue} instead of {@link
+ *             java.util.concurrent.BlockingQueue}.
+ *       </ul>
+ *   <li>Use Workflow.getVersion when making any changes to the Workflow code. Without this, any
+ *       deployment of updated Workflow code might break already running Workflows.
  *   <li>Don’t access configuration APIs directly from a workflow because changes in the
  *       configuration might affect a workflow execution path. Pass it as an argument to a workflow
  *       function or use an activity to load it.

--- a/temporal-sdk/src/main/java/io/temporal/workflow/package-info.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/package-info.java
@@ -319,9 +319,9 @@
  * <ul>
  *   <li>Do not use any mutable global variables because multiple instances of workflows are
  *       executed in parallel.
- *   <li>Do not call any non-deterministic functions, like non-seeded random, directly form the
- *       workflow code. Always use safe deterministic alternatives provided by Temporal SDK on
- *       {@link io.temporal.workflow.Workflow} or perform such calls in activities if have to. For
+ *   <li>Do not call non-deterministic functions, like non-seeded random, directly from the workflow
+ *       code. Always use safe deterministic alternatives provided by the Temporal SDK on {@link
+ *       io.temporal.workflow.Workflow} or perform such calls in activities when required. For
  *       example:
  *       <ul>
  *         <li>Use {@link io.temporal.workflow.Workflow#currentTimeMillis()} instead of {@link
@@ -329,9 +329,9 @@
  *         <li>Use {@link io.temporal.workflow.Workflow#randomUUID()} instead of {@link
  *             java.util.UUID#randomUUID()}
  *       </ul>
- *   <li>Don't perform long blocking operations other than calls that block inside Temporal SDK
- *       (like Activity invocations or {@link io.temporal.workflow.Workflow} APIs). Use activities
- *       for this. For example:
+ *   <li>Don't perform long (more than a few ms) blocking operations other than Temporal
+ *       SDK-provided operations (like Activity invocations or {@link io.temporal.workflow.Workflow}
+ *       APIs). Use activities for this. For example:
  *       <ul>
  *         <li>Call {@link io.temporal.workflow.Workflow#sleep(Duration)} instead of {@link
  *             java.lang.Thread#sleep(long)}.
@@ -346,7 +346,7 @@
  *       io.temporal.workflow.Async#function(Functions.Func)} or {@link
  *       io.temporal.workflow.Async#procedure(Functions.Proc)} to execute code asynchronously.
  *   <li>Don't use any synchronization, locks, and other standard Java blocking concurrency-related
- *       classes besides those provided by the Workflow class. There is no need in explicit
+ *       classes besides those provided by the Workflow class. There is no need for explicit
  *       synchronization because multi-threaded code inside a single workflow execution is executed
  *       one thread at a time and under a global lock. For example:
  *       <ul>

--- a/temporal-sdk/src/test/java/io/temporal/workflow/PromiseAllowsBlockingTemporalCodeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/PromiseAllowsBlockingTemporalCodeTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests that a call to an activity is allowed in the Promise handler. It's technically is blocking
+ * operation. And blocking operations are disallowed in Workflow code. But because it's one of the
+ * "Temporal SDK" blocking operations, it's allowed.
+ */
+public class PromiseAllowsBlockingTemporalCodeTest {
+  private static final TestActivities.VariousTestActivities activities =
+      new TestActivities.TestActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflow.class)
+          .setActivityImplementations(activities)
+          .build();
+
+  @Test
+  public void testChildWorkflowExecutionPromiseHandler() {
+    WorkflowClient workflowStub = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(20))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflowReturnString client =
+        workflowStub.newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class, options);
+    String result = client.execute();
+    assertEquals("sleepFinished", result);
+  }
+
+  public static class TestWorkflow implements TestWorkflows.TestWorkflowReturnString {
+    @Override
+    public String execute() {
+      TestActivities.VariousTestActivities testActivities =
+          Workflow.newActivityStub(
+              TestActivities.VariousTestActivities.class,
+              SDKTestOptions.newActivityOptionsForTaskQueue(Workflow.getInfo().getTaskQueue()));
+
+      return Async.function(testActivities::sleepActivity, 50L, 0)
+          .thenApply(
+              (ignore) -> {
+                // 3000ms is more than wft timeout of 2s set earlier on WorkflowOptions
+                testActivities.sleepActivity(3000, 0);
+                return "sleepFinished";
+              })
+          .get();
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
@@ -78,7 +78,7 @@ public class SDKTestOptions {
           .setScheduleToCloseTimeout(Duration.ofSeconds(5))
           .setHeartbeatTimeout(Duration.ofSeconds(5))
           .setScheduleToStartTimeout(Duration.ofSeconds(5))
-          .setStartToCloseTimeout(Duration.ofSeconds(10))
+          .setStartToCloseTimeout(Duration.ofSeconds(5))
           .build();
     }
   }


### PR DESCRIPTION
## What was changed
Improve Promise and io.temporal.workflow javadocs.
Add a test for Promise handler calling a sleeping activity.

## Why?
Currently Promise handlers doc states that it can't contain blocking calls, while in reality, this code has all the same limitations as a regular workflow code.