### PR TITLE
Unify worker pollers options naming between GoSDK and JavaSDK

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -147,7 +147,7 @@ public final class Worker implements Suspendable {
         .setPollerOptions(
             PollerOptions.newBuilder()
                 .setMaximumPollRatePerSecond(options.getMaxWorkerActivitiesPerSecond())
-                .setPollThreadCount(options.getActivityPollThreadCount())
+                .setPollThreadCount(options.getMaxConcurrentActivityTaskPollers())
                 .build())
         .setTaskExecutorThreadPoolSize(options.getMaxConcurrentActivityExecutionSize())
         .setMetricsScope(metricsScope)
@@ -166,7 +166,7 @@ public final class Worker implements Suspendable {
     return toSingleWorkerOptions(factoryOptions, options, clientOptions, contextPropagators)
         .setPollerOptions(
             PollerOptions.newBuilder()
-                .setPollThreadCount(options.getWorkflowPollThreadCount())
+                .setPollThreadCount(options.getMaxConcurrentWorkflowTaskPollers())
                 .build())
         .setTaskExecutorThreadPoolSize(options.getMaxConcurrentWorkflowTaskExecutionSize())
         .setDefaultDeadlockDetectionTimeout(options.getDefaultDeadlockDetectionTimeout())

--- a/temporal-sdk/src/main/java/io/temporal/workflow/package-info.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/package-info.java
@@ -353,8 +353,9 @@
  *         <li>Use {@link io.temporal.workflow.WorkflowQueue} instead of {@link
  *             java.util.concurrent.BlockingQueue}.
  *       </ul>
- *   <li>Use Workflow.getVersion when making any changes to the Workflow code. Without this, any
- *       deployment of updated Workflow code might break already running Workflows.
+ *   <li>Use {@link io.temporal.workflow.Workflow#getVersion(java.lang.String, int, int)} when
+ *       making any changes to the Workflow code. Without this, any deployment of updated Workflow
+ *       code might break already running Workflows.
  *   <li>Don’t access configuration APIs directly from a workflow because changes in the
  *       configuration might affect a workflow execution path. Pass it as an argument to a workflow
  *       function or use an activity to load it.

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerIsNotGettingStartedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerIsNotGettingStartedTest.java
@@ -61,8 +61,8 @@ public class WorkerIsNotGettingStartedTest {
         env.newWorker(
             TASK_QUEUE,
             WorkerOptions.newBuilder()
-                .setWorkflowPollThreadCount(WORKFLOW_POLL_COUNT)
-                .setActivityPollThreadCount(ACTIVITY_POLL_COUNT)
+                .setMaxConcurrentWorkflowTaskPollers(WORKFLOW_POLL_COUNT)
+                .setMaxConcurrentActivityTaskPollers(ACTIVITY_POLL_COUNT)
                 .setLocalActivityWorkerOnly(true)
                 .build());
     // Need to register something for workers to start

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerThreadCountTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerThreadCountTest.java
@@ -60,8 +60,8 @@ public class WorkerPollerThreadCountTest {
         env.newWorker(
             "tl1",
             WorkerOptions.newBuilder()
-                .setWorkflowPollThreadCount(WORKFLOW_POLL_COUNT)
-                .setActivityPollThreadCount(ACTIVITY_POLL_COUNT)
+                .setMaxConcurrentWorkflowTaskPollers(WORKFLOW_POLL_COUNT)
+                .setMaxConcurrentActivityTaskPollers(ACTIVITY_POLL_COUNT)
                 .build());
     // Need to register something for workers to start
     worker.registerActivitiesImplementations(new ActivityImpl());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LocalAsyncCompletionWorkflowTest.java
@@ -43,7 +43,7 @@ public class LocalAsyncCompletionWorkflowTest {
           .setWorkerOptions(
               WorkerOptions.newBuilder()
                   .setMaxConcurrentActivityExecutionSize(MAX_CONCURRENT_ACTIVITIES)
-                  .setActivityPollThreadCount(5)
+                  .setMaxConcurrentActivityTaskPollers(5)
                   .build())
           .setWorkflowTypes(TestWorkflowImpl.class)
           .setActivityImplementations(new AsyncActivityWithManualCompletion())

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityPollerPrefetchingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityPollerPrefetchingTest.java
@@ -46,7 +46,7 @@ public class ActivityPollerPrefetchingTest {
           .setWorkerOptions(
               WorkerOptions.newBuilder()
                   .setMaxConcurrentActivityExecutionSize(1)
-                  .setActivityPollThreadCount(5)
+                  .setMaxConcurrentActivityTaskPollers(5)
                   .build())
           .setWorkflowTypes(TestWorkflowImpl.class)
           .setActivityImplementations(new SleepyMultiplier())


### PR DESCRIPTION
Synchronization of similar option names helps to keep guides and docs less cluttered with references between different SDKs.