### PR TITLE
Switch to specific versions for dependencies with Platforms to make release Maven compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,22 @@ plugins {
 }
 
 ext {
+    // Platforms.
+    // We have to use specific versions with platforms until Maven 4.0.0 is released
+    // See https://github.com/temporalio/sdk-java/issues/1033
+    //
+    // grpcVersion = '[1.34.0,)!!1.44.0'
+    // jacksonVersion = '[2.9.0,)!!2.13.1'
+    // micrometerVersion = '[1.0.0,)!!1.8.2'
+    grpcVersion = '1.44.0'
+    jacksonVersion = '2.13.1'
+    micrometerVersion = '1.8.2'
+
     logbackVersion = '1.2.10'
-    grpcVersion = '[1.34.0,)!!1.44.0'
     protoVersion = '[3.10.0,)!!3.19.4'
     guavaVersion = '[10.0,)!!31.0.1-jre'
     jsonPathVersion = '2.7.0'
     mockitoVersion = '4.3.1'
-    micrometerVersion = '[1.0.0,)!!1.8.2'
-    jacksonVersion = '[2.9.0,)!!2.13.1'
     tallyVersion = '[0.4.0,)!!0.11.1'
     gsonVersion = '[2.0,)!!2.8.9'
     slf4jVersion = '[1.4.0,)!!1.7.35'

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -7,14 +7,16 @@ apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
 description = '''Temporal Workflow Java SDK'''
 
 dependencies {
-    api "io.grpc:grpc-api:$grpcVersion" //Classes like io.grpc.Metadata are used as a part of our API
-    api "io.grpc:grpc-stub:$grpcVersion" //Part of WorkflowServiceStubs API
-    api "io.grpc:grpc-netty-shaded:$grpcVersion" //Part of WorkflowServiceStubs API, specifically SslContext
+    api(platform("io.grpc:grpc-bom:$grpcVersion"))
+
+    api "io.grpc:grpc-api" //Classes like io.grpc.Metadata are used as a part of our API
+    api "io.grpc:grpc-stub" //Part of WorkflowServiceStubs API
+    api "io.grpc:grpc-netty-shaded" //Part of WorkflowServiceStubs API, specifically SslContext
     api "com.google.protobuf:protobuf-java-util:$protoVersion" //proto request and response objects are a part of this module's API
     api "com.uber.m3:tally-core:$tallyVersion"
 
-    implementation "io.grpc:grpc-core:$grpcVersion"
-    implementation "io.grpc:grpc-services:$grpcVersion"
+    implementation "io.grpc:grpc-core"
+    implementation "io.grpc:grpc-services"
 
     api "org.slf4j:slf4j-api:$slf4jVersion"
     if (!JavaVersion.current().isJava8()) {

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -8,7 +8,7 @@ description = '''Temporal test workflow server'''
 
 dependencies {
     api project(':temporal-sdk')
-    implementation("io.grpc:grpc-core:$grpcVersion")
+    implementation("io.grpc:grpc-core")
     implementation "com.google.guava:guava:$guavaVersion"
     implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.6'
 }


### PR DESCRIPTION
Switch to specific versions for dependencies with Platforms to make release Maven compatible.
This is required as a temporary workaround for a long time Maven bug that should be addressed in Maven 4.0.0 that Is still to be released.

Closes #1033