### PR TITLE
Add a trivial query test

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/WaitingWorkflowQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/WaitingWorkflowQueryTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.queryTests;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testUtils.Signal;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WaitingWorkflowQueryTest {
+
+  private static final Signal QUERY_READY = new Signal();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestLocalActivityAndQueryWorkflow.class)
+          .build();
+
+  @Test
+  public void query() throws ExecutionException, InterruptedException {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofMinutes(30))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflowWithQuery workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflowWithQuery.class, options);
+    WorkflowClient.start(workflowStub::execute);
+
+    QUERY_READY.waitForSignal();
+    assertEquals("started", workflowStub.query());
+  }
+
+  public static final class TestLocalActivityAndQueryWorkflow
+      implements TestWorkflows.TestWorkflowWithQuery {
+
+    private String queryResult = "";
+
+    @Override
+    public String execute() {
+      queryResult = "started";
+      QUERY_READY.signal();
+      Workflow.sleep(30_000);
+      return "done";
+    }
+
+    @Override
+    public String query() {
+      return queryResult.toString();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
@@ -163,6 +163,15 @@ public class TestWorkflows {
     void mySignal(String value);
   }
 
+  @WorkflowInterface
+  public interface TestWorkflowWithQuery {
+    @WorkflowMethod()
+    String execute();
+
+    @QueryMethod()
+    String query();
+  }
+
   /** IMPLEMENTATIONS * */
   public static class TestChild implements ITestChild {
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -780,7 +780,7 @@ public class WorkflowServiceStubsOptions {
   /**
    * If the {@link WorkflowServiceStubsOptions} is configured with a {@code target} instead of
    * externally created {@code channel}, this listener is called as a last step of channel creation
-   * giving an oportunity to provide some additional configuration to the channel.
+   * giving an opportunity to provide some additional configuration to the channel.
    */
   public interface ChannelInitializer {
     void initChannel(ManagedChannelBuilder<?> managedChannelBuilder);


### PR DESCRIPTION
## Why?
Provide the simplest query test that may be used as a starting point to allow easy investigation/reproduction of query-related issues.
There are some existing tests that use queries, but they use them as a tool instead of being focused on them.