### PR TITLE
Use correct JsonPath config on history serialization

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryJsonUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryJsonUtils.java
@@ -44,7 +44,7 @@ class HistoryJsonUtils {
       Configuration.builder().options(Option.SUPPRESS_EXCEPTIONS).build();
 
   public static String protoJsonToHistoryFormatJson(String protoJson) {
-    DocumentContext parsed = JsonPath.parse(protoJson);
+    DocumentContext parsed = JsonPath.parse(protoJson, JSON_PATH_CONFIGURATION);
     parsed.map(
         EVENT_TYPE_PATH,
         (currentValue, configuration) ->

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
@@ -19,10 +19,16 @@
 
 package io.temporal.internal.common;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.io.CharStreams;
 import io.temporal.testing.WorkflowHistoryLoader;
+import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.file.Files;
 import org.junit.Test;
 
 public class WorkflowExecutionHistoryTest {
@@ -43,5 +49,25 @@ public class WorkflowExecutionHistoryTest {
             "simpleHistory1_withAddedNewRandomField.json");
 
     assertEquals(originalHistory.getLastEvent(), historyWithAnAddedNewField.getLastEvent());
+  }
+
+  @Test
+  public void deserializeAndSerializeBack() throws IOException {
+    final String HISTORY_RESOURCE_NAME = "simpleHistory1.json";
+
+    ClassLoader classLoader = WorkflowExecutionUtils.class.getClassLoader();
+    URL resource = classLoader.getResource(HISTORY_RESOURCE_NAME);
+    String historyUrl = resource.getFile();
+    File historyFile = new File(historyUrl);
+    String originalSerializedJsonHistory;
+    try (Reader reader = Files.newBufferedReader(historyFile.toPath(), UTF_8)) {
+      originalSerializedJsonHistory = CharStreams.toString(reader);
+    }
+
+    WorkflowExecutionHistory history =
+        WorkflowHistoryLoader.readHistoryFromResource(HISTORY_RESOURCE_NAME);
+
+    String serializedHistory = history.toJson(true);
+    assertEquals(originalSerializedJsonHistory, serializedHistory);
   }
 }

--- a/temporal-sdk/src/test/resources/simpleHistory1.json
+++ b/temporal-sdk/src/test/resources/simpleHistory1.json
@@ -1,26 +1,26 @@
 {
-  "events": [{
-    "eventId": "1",
-    "eventTime": "2020-07-30T00:30:03.082421843Z",
-    "eventType": "WorkflowExecutionStarted",
-    "version": "-24",
-    "taskId": "5242897",
-    "workflowExecutionStartedEventAttributes": {
-      "workflowType": {
-        "name": "SomeName"
-      },
-      "taskQueue": {
-        "name": "SomeQueueName",
-        "kind": "Normal"
-      },
-      "input": null,
-      "workflowExecutionTimeout": "300s",
-      "workflowTaskTimeout": "60s",
-      "originalExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
-      "identity":"",
-      "firstExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
-      "attempt": 1,
-      "firstWorkflowTaskBackoff": "0s"
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2020-07-30T00:30:03.082421843Z",
+      "eventType": "WorkflowExecutionStarted",
+      "version": "-24",
+      "taskId": "5242897",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "SomeName"
+        },
+        "taskQueue": {
+          "name": "SomeQueueName",
+          "kind": "Normal"
+        },
+        "workflowExecutionTimeout": "300s",
+        "workflowTaskTimeout": "60s",
+        "originalExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+        "firstExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s"
+      }
     }
-  }]
+  ]
 }

--- a/temporal-sdk/src/test/resources/simpleHistory1_withAddedNewRandomField.json
+++ b/temporal-sdk/src/test/resources/simpleHistory1_withAddedNewRandomField.json
@@ -1,28 +1,28 @@
 {
-  "events": [{
-    "eventId": "1",
-    "eventTime": "2020-07-30T00:30:03.082421843Z",
-    "eventType": "WorkflowExecutionStarted",
-    "version": "-24",
-    "taskId": "5242897",
-    "someNewFieldThatIsAbsentFromTheCurrentProtoSchema": "100500",
-    "workflowExecutionStartedEventAttributes": {
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2020-07-30T00:30:03.082421843Z",
+      "eventType": "WorkflowExecutionStarted",
+      "version": "-24",
+      "taskId": "5242897",
       "someNewFieldThatIsAbsentFromTheCurrentProtoSchema": "100500",
-      "workflowType": {
-        "name": "SomeName"
-      },
-      "taskQueue": {
-        "name": "SomeQueueName",
-        "kind": "Normal"
-      },
-      "input": null,
-      "workflowExecutionTimeout": "300s",
-      "workflowTaskTimeout": "60s",
-      "originalExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
-      "identity":"",
-      "firstExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
-      "attempt": 1,
-      "firstWorkflowTaskBackoff": "0s"
+      "workflowExecutionStartedEventAttributes": {
+        "someNewFieldThatIsAbsentFromTheCurrentProtoSchema": "100500",
+        "workflowType": {
+          "name": "SomeName"
+        },
+        "taskQueue": {
+          "name": "SomeQueueName",
+          "kind": "Normal"
+        },
+        "workflowExecutionTimeout": "300s",
+        "workflowTaskTimeout": "60s",
+        "originalExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+        "firstExecutionRunId": "1fd5d4c8-1590-4a0a-8027-535e8729de8e",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s"
+      }
     }
-  }]
+  ]
 }


### PR DESCRIPTION
## What was changed

Use the same JSON_PATH_CONFIGURATION during history serialization as we use during deserialization. It allows ignoring exceptions caused by the absence of the path intended for conversion in the source Json.

## Why?
JsonPath upgrade performed in #1020 brought an incompatible change that requires specifying of JsonPath config to achieve an old behavior of JsonPath (ignoring an absence of a path intended for transformation). This config was originally applied in #1020 only history deserialization and left serialization broken in some cases.

### How was this tested:
Added a unit test for bidirectional transformation to make sure the history serialization/deserialization works in both directions and preserves the result.