### PR TITLE
Include more enums transformation into history json transformation

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/WorkflowExecutionHistoryTest.java
@@ -32,7 +32,6 @@ import java.nio.file.Files;
 import org.junit.Test;
 
 public class WorkflowExecutionHistoryTest {
-
   /**
    * "simpleHistory1_withAddedNewRandomField.json" in comparison with "simpleHistory1.json" contains
    * a new field that is not in the proto schema. Proto allows backwards compatible addition of new
@@ -41,7 +40,6 @@ public class WorkflowExecutionHistoryTest {
    */
   @Test
   public void addingANewFieldToHistoryJsonShouldProduceTheSameResult() throws IOException {
-
     WorkflowExecutionHistory originalHistory =
         WorkflowHistoryLoader.readHistoryFromResource("simpleHistory1.json");
     WorkflowExecutionHistory historyWithAnAddedNewField =
@@ -52,11 +50,18 @@ public class WorkflowExecutionHistoryTest {
   }
 
   @Test
-  public void deserializeAndSerializeBack() throws IOException {
-    final String HISTORY_RESOURCE_NAME = "simpleHistory1.json";
+  public void deserializeAndSerializeBackSimpleHistory() throws IOException {
+    deserializeAndSerializeBack("simpleHistory1.json");
+  }
 
+  @Test
+  public void deserializeAndSerializeBackComplexHistory() throws IOException {
+    deserializeAndSerializeBack("complexHistory1.json");
+  }
+
+  public void deserializeAndSerializeBack(String resourceName) throws IOException {
     ClassLoader classLoader = WorkflowExecutionUtils.class.getClassLoader();
-    URL resource = classLoader.getResource(HISTORY_RESOURCE_NAME);
+    URL resource = classLoader.getResource(resourceName);
     String historyUrl = resource.getFile();
     File historyFile = new File(historyUrl);
     String originalSerializedJsonHistory;
@@ -64,8 +69,7 @@ public class WorkflowExecutionHistoryTest {
       originalSerializedJsonHistory = CharStreams.toString(reader);
     }
 
-    WorkflowExecutionHistory history =
-        WorkflowHistoryLoader.readHistoryFromResource(HISTORY_RESOURCE_NAME);
+    WorkflowExecutionHistory history = WorkflowHistoryLoader.readHistoryFromResource(resourceName);
 
     String serializedHistory = history.toJson(true);
     assertEquals(originalSerializedJsonHistory, serializedHistory);

--- a/temporal-sdk/src/test/resources/complexHistory1.json
+++ b/temporal-sdk/src/test/resources/complexHistory1.json
@@ -1,0 +1,264 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowExecutionStarted",
+      "version": "-24",
+      "taskId": "1051760",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "TestWorkflow1"
+        },
+        "taskQueue": {
+          "name": "WorkflowTest-testChildWorkflowRetry-c5c598cd-05d6-4790-b43e-ebf149aee65b",
+          "kind": "Normal"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+              },
+              "data": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5LWM1YzU5OGNkLTA1ZDYtNDc5MC1iNDNlLWViZjE0OWFlZTY1YiI\u003d"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "20s",
+        "workflowTaskTimeout": "2s",
+        "originalExecutionRunId": "9a44eb45-aedc-4183-9ed2-63b4e2a799f2",
+        "identity": "unknown-mac",
+        "firstExecutionRunId": "9a44eb45-aedc-4183-9ed2-63b4e2a799f2"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1051761",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "WorkflowTest-testChildWorkflowRetry-c5c598cd-05d6-4790-b43e-ebf149aee65b"
+        },
+        "startToCloseTimeout": "2s"
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1051766",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "unknown-mac",
+        "requestId": "d1dc69e3-94f9-43e0-ac43-8c6db84b35a6"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1051769",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "unknown-mac"
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "StartChildWorkflowExecutionInitiated",
+      "version": "-24",
+      "taskId": "1051770",
+      "startChildWorkflowExecutionInitiatedEventAttributes": {
+        "workflowId": "ea4b69ed-f9cf-379f-8e16-b101c4aa288c",
+        "workflowType": {
+          "name": "ITestChild"
+        },
+        "taskQueue": {
+          "name": "WorkflowTest-testChildWorkflowRetry-c5c598cd-05d6-4790-b43e-ebf149aee65b"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+              },
+              "data": "IldvcmtmbG93VGVzdC10ZXN0Q2hpbGRXb3JrZmxvd1JldHJ5LWM1YzU5OGNkLTA1ZDYtNDc5MC1iNDNlLWViZjE0OWFlZTY1YiI\u003d"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+              },
+              "data": "MA\u003d\u003d"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "500s",
+        "workflowTaskTimeout": "2s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "1s",
+          "maximumAttempts": 3
+        }
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "ChildWorkflowExecutionStarted",
+      "version": "-24",
+      "taskId": "1051773",
+      "childWorkflowExecutionStartedEventAttributes": {
+        "initiatedEventId": "5",
+        "workflowExecution": {
+          "workflowId": "ea4b69ed-f9cf-379f-8e16-b101c4aa288c",
+          "runId": "978856c7-c962-431f-ad20-4f0f281c457d"
+        },
+        "workflowType": {
+          "name": "ITestChild"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1051775",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "unknown-mac:065bf5af-6b61-4767-be7d-2e4f12da4da4"
+        },
+        "startToCloseTimeout": "2s"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1051779",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "065bf5af-6b61-4767-be7d-2e4f12da4da4",
+        "requestId": "6594d9dc-a686-4ffa-b352-f8934037c4d2"
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2020-07-14T15:05:35Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1051782",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "unknown-mac"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2020-07-14T15:05:37Z",
+      "eventType": "ChildWorkflowExecutionFailed",
+      "version": "-24",
+      "taskId": "1051784",
+      "childWorkflowExecutionFailedEventAttributes": {
+        "failure": {
+          "message": "simulated failure",
+          "source": "JavaSDK",
+          "stackTrace": "io.temporal.workflow.WorkflowTest$AngryChild.execute(WorkflowTest.java:3392)\nsun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\nsun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\nsun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\njava.lang.reflect.Method.invoke(Method.java:498)\nio.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:283)\nio.temporal.common.interceptors.WorkflowInboundCallsInterceptorBase.execute(WorkflowInboundCallsInterceptorBase.java:37)\nio.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:247)\nio.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:52)\nio.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:121)\nio.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:104)\nio.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:105)\njava.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)\njava.util.concurrent.FutureTask.run(FutureTask.java:266)\njava.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\njava.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\njava.lang.Thread.run(Thread.java:748)\n",
+          "applicationFailureInfo": {
+            "type": "java.lang.UnsupportedOperationException"
+          }
+        },
+        "workflowExecution": {
+          "workflowId": "ea4b69ed-f9cf-379f-8e16-b101c4aa288c",
+          "runId": "7fd59b3e-6eae-4a4d-944b-49cde9f2187e"
+        },
+        "workflowType": {
+          "name": "ITestChild"
+        },
+        "initiatedEventId": "5",
+        "startedEventId": "6"
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2020-07-14T15:05:37Z",
+      "eventType": "WorkflowTaskScheduled",
+      "version": "-24",
+      "taskId": "1051786",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "unknown-mac:065bf5af-6b61-4767-be7d-2e4f12da4da4"
+        },
+        "startToCloseTimeout": "2s"
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2020-07-14T15:05:37Z",
+      "eventType": "WorkflowTaskStarted",
+      "version": "-24",
+      "taskId": "1051790",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "065bf5af-6b61-4767-be7d-2e4f12da4da4",
+        "requestId": "45fab3b0-4fe6-4b0d-9e7d-53855b0bea85"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2020-07-14T15:05:37Z",
+      "eventType": "WorkflowTaskCompleted",
+      "version": "-24",
+      "taskId": "1051793",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "unknown-mac"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2020-07-14T15:05:37Z",
+      "eventType": "WorkflowExecutionFailed",
+      "version": "-24",
+      "taskId": "1051794",
+      "workflowExecutionFailedEventAttributes": {
+        "failure": {
+          "source": "JavaSDK",
+          "stackTrace": "java.lang.Thread.getStackTrace(Thread.java:1559)\nio.temporal.internal.sync.ChildWorkflowStubImpl.execute(ChildWorkflowStubImpl.java:85)\nio.temporal.internal.sync.ChildWorkflowInvocationHandler.invoke(ChildWorkflowInvocationHandler.java:75)\ncom.sun.proxy.$Proxy49.execute(Unknown Source)\nio.temporal.workflow.WorkflowTest$TestChildWorkflowRetryWorkflow.execute(WorkflowTest.java:3355)\nsun.reflect.GeneratedMethodAccessor9.invoke(Unknown Source)\nsun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\njava.lang.reflect.Method.invoke(Method.java:498)\nio.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:283)\nio.temporal.common.interceptors.WorkflowInboundCallsInterceptorBase.execute(WorkflowInboundCallsInterceptorBase.java:37)\nio.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:247)\nio.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:52)\nio.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:121)\nio.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:104)\nio.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:105)\njava.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)\njava.util.concurrent.FutureTask.run(FutureTask.java:266)\njava.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\njava.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\njava.lang.Thread.run(Thread.java:748)\n",
+          "cause": {
+            "message": "simulated failure",
+            "source": "JavaSDK",
+            "stackTrace": "io.temporal.workflow.WorkflowTest$AngryChild.execute(WorkflowTest.java:3392)\nsun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\nsun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\nsun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\njava.lang.reflect.Method.invoke(Method.java:498)\nio.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:283)\nio.temporal.common.interceptors.WorkflowInboundCallsInterceptorBase.execute(WorkflowInboundCallsInterceptorBase.java:37)\nio.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:247)\nio.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:52)\nio.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:121)\nio.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:104)\nio.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:105)\njava.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)\njava.util.concurrent.FutureTask.run(FutureTask.java:266)\njava.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\njava.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\njava.lang.Thread.run(Thread.java:748)\n",
+            "applicationFailureInfo": {
+              "type": "java.lang.UnsupportedOperationException"
+            }
+          },
+          "childWorkflowExecutionFailureInfo": {
+            "workflowExecution": {
+              "workflowId": "ea4b69ed-f9cf-379f-8e16-b101c4aa288c",
+              "runId": "7fd59b3e-6eae-4a4d-944b-49cde9f2187e"
+            },
+            "workflowType": {
+              "name": "ITestChild"
+            },
+            "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+          }
+        },
+        "workflowTaskCompletedEventId": "13"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What was changed

WorkflowExecutionHistory implementation is updated to convert some more rarely used history enums in a way compliant with tctl history format

How was this tested:
Unit test from a complex workflow using child workflows and verifying that deserialization-serialization cycle by JavaSDK preserves the same history