### PR TITLE
Allow OpenTracing interceptor to ignore certain exceptions

### DIFF
--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
@@ -119,7 +119,8 @@ public class OpenTracingOptions {
      *     regardless, in order to provide a complete picture of the execution outcome. The "error"
      *     tag on the span will be set according to the value returned by this Predicate. By
      *     default, all exceptions will be considered errors.
-     * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-and-log-errors">
+     * @see <a
+     *     href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-and-log-errors">
      *     OpenTracing Documentation</a> regarding error spans and logging exceptions.
      * @return this
      */

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
@@ -114,9 +114,13 @@ public class OpenTracingOptions {
     }
 
     /**
-     * @param isErrorPredicate indicates whether an exception should or should not be considered an
-     *     error for the purpose of the OpenTracing span. By default, all exceptions are considered
-     *     errors.
+     * @param isErrorPredicate indicates whether the received exception should cause the OpenTracing
+     *     span to finish in an error state or not. All exceptions will be logged to the span
+     *     regardless, in order to provide a complete picture of the execution outcome. The "error"
+     *     tag on the span will be set according to the value returned by this Predicate. By
+     *     default, all exceptions will be considered errors.
+     * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-and-log-errors">
+     *     OpenTracing Documentation</a> regarding error spans and logging exceptions.
      * @return this
      */
     public Builder setIsErrorPredicate(@Nonnull Predicate<Throwable> isErrorPredicate) {

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingOptions.java
@@ -29,7 +29,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class OpenTracingOptions {
-
   private static final OpenTracingOptions DEFAULT_INSTANCE =
       OpenTracingOptions.newBuilder().build();
 
@@ -47,9 +46,7 @@ public class OpenTracingOptions {
       SpanBuilderProvider spanBuilderProvider,
       OpenTracingSpanContextCodec spanContextCodec,
       Predicate<Throwable> isErrorPredicate) {
-    if (tracer == null) {
-      throw new IllegalArgumentException("tracer shouldn't be null");
-    }
+    if (tracer == null) throw new IllegalArgumentException("tracer shouldn't be null");
     this.tracer = tracer;
     this.spanBuilderProvider = spanBuilderProvider;
     this.spanContextCodec = spanContextCodec;
@@ -81,7 +78,6 @@ public class OpenTracingOptions {
   }
 
   public static final class Builder {
-
     private Tracer tracer;
     private SpanBuilderProvider spanBuilderProvider = ActionTypeAndNameSpanBuilderProvider.INSTANCE;
     private OpenTracingSpanContextCodec spanContextCodec =

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -31,6 +31,7 @@ import io.temporal.opentracing.OpenTracingOptions;
 
 public class OpenTracingActivityInboundCallsInterceptor
     extends ActivityInboundCallsInterceptorBase {
+
   private final OpenTracingOptions options;
   private final SpanFactory spanFactory;
   private final Tracer tracer;
@@ -77,7 +78,9 @@ public class OpenTracingActivityInboundCallsInterceptor
     try (Scope scope = tracer.scopeManager().activate(activityRunSpan)) {
       return super.execute(input);
     } catch (Throwable t) {
-      spanFactory.logFail(activityRunSpan, t);
+      if (options.getIsErrorPredicate().test(t)) {
+        spanFactory.logFail(activityRunSpan, t);
+      }
       throw t;
     } finally {
       activityRunSpan.finish();

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -77,9 +77,7 @@ public class OpenTracingActivityInboundCallsInterceptor
     try (Scope scope = tracer.scopeManager().activate(activityRunSpan)) {
       return super.execute(input);
     } catch (Throwable t) {
-      if (options.getIsErrorPredicate().test(t)) {
-        spanFactory.logFail(activityRunSpan, t);
-      }
+      spanFactory.logFail(activityRunSpan, t);
       throw t;
     } finally {
       activityRunSpan.finish();

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -31,7 +31,6 @@ import io.temporal.opentracing.OpenTracingOptions;
 
 public class OpenTracingActivityInboundCallsInterceptor
     extends ActivityInboundCallsInterceptorBase {
-
   private final OpenTracingOptions options;
   private final SpanFactory spanFactory;
   private final Tracer tracer;

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -148,7 +148,7 @@ public class SpanFactory {
   @SuppressWarnings("deprecation")
   public void logFail(Span toSpan, Throwable failReason) {
     toSpan.setTag(StandardTagNames.FAILED, true);
-    toSpan.setTag(Tags.ERROR, true);
+    toSpan.setTag(Tags.ERROR, options.getIsErrorPredicate().test(failReason));
 
     Map<String, Object> logPayload =
         new HashMap<String, Object>() {

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/ExceptionIgnoredTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/ExceptionIgnoredTest.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.opentracing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.serviceclient.CheckedExceptionWrapper;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExceptionIgnoredTest {
+
+  private final MockTracer mockTracer =
+      new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
+
+  private final OpenTracingOptions OT_OPTIONS =
+      OpenTracingOptions.newBuilder()
+          .setTracer(mockTracer)
+          .setIsErrorPredicate(
+              ex -> {
+                if (ex instanceof CheckedExceptionWrapper && ex.getCause() instanceof IOException) {
+                  return false;
+                }
+                return true;
+              })
+          .build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder()
+                  .setInterceptors(new OpenTracingClientInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new OpenTracingWorkerInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkflowTypes(WorkflowImpl.class)
+          .setActivityImplementations(new FailingActivityImpl())
+          .build();
+
+  @After
+  public void tearDown() {
+    mockTracer.reset();
+  }
+
+  @ActivityInterface
+  public interface TestActivity {
+
+    @ActivityMethod
+    String activity(String input);
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+
+    @WorkflowMethod
+    String workflow(String input);
+  }
+
+  private static final AtomicInteger failureCounter = new AtomicInteger(2);
+
+  public static class FailingActivityImpl implements TestActivity {
+
+    @Override
+    public String activity(String input) {
+      int counter = failureCounter.getAndDecrement();
+      if (counter > 1) {
+        throw ApplicationFailure.newFailure("fail", "fail");
+      } else if (counter > 0) {
+        throw Activity.wrap(new IOException());
+      } else {
+        return "bar";
+      }
+    }
+  }
+
+  public static class WorkflowImpl implements TestWorkflow {
+
+    private final TestActivity activity =
+        Workflow.newActivityStub(
+            TestActivity.class,
+            ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofMinutes(1))
+                .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(3).build())
+                .validateAndBuildWithDefaults());
+
+    @Override
+    public String workflow(String input) {
+      return activity.activity(input);
+    }
+  }
+
+  @Test
+  public void testActivityFailureSpanStructure() {
+    MockSpan span = mockTracer.buildSpan("ClientFunction").start();
+
+    WorkflowClient client = testWorkflowRule.getWorkflowClient();
+    try (Scope scope = mockTracer.scopeManager().activate(span)) {
+      TestWorkflow workflow =
+          client.newWorkflowStub(
+              TestWorkflow.class,
+              WorkflowOptions.newBuilder()
+                  .setTaskQueue(testWorkflowRule.getTaskQueue())
+                  .validateBuildWithDefaults());
+      assertEquals("bar", workflow.workflow("input"));
+    } finally {
+      span.finish();
+    }
+
+    OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
+
+    MockSpan clientSpan = spansHelper.getSpanByOperationName("ClientFunction");
+
+    MockSpan workflowStartSpan = spansHelper.getByParentSpan(clientSpan).get(0);
+    assertEquals(clientSpan.context().spanId(), workflowStartSpan.parentId());
+    assertEquals("StartWorkflow:TestWorkflow", workflowStartSpan.operationName());
+
+    MockSpan workflowRunSpan = spansHelper.getByParentSpan(workflowStartSpan).get(0);
+    assertEquals(workflowStartSpan.context().spanId(), workflowRunSpan.parentId());
+    assertEquals("RunWorkflow:TestWorkflow", workflowRunSpan.operationName());
+
+    MockSpan activityStartSpan = spansHelper.getByParentSpan(workflowRunSpan).get(0);
+    assertEquals(workflowRunSpan.context().spanId(), activityStartSpan.parentId());
+    assertEquals("StartActivity:Activity", activityStartSpan.operationName());
+
+    List<MockSpan> activityRunSpans = spansHelper.getByParentSpan(activityStartSpan);
+
+    MockSpan failedActivityRunSpan = activityRunSpans.get(0);
+    assertEquals(activityStartSpan.context().spanId(), failedActivityRunSpan.parentId());
+    assertEquals("RunActivity:Activity", failedActivityRunSpan.operationName());
+    assertEquals(true, failedActivityRunSpan.tags().get(Tags.ERROR.getKey()));
+
+    MockSpan failureIgnoredActivityRunSpan = activityRunSpans.get(1);
+    assertEquals(activityStartSpan.context().spanId(), failureIgnoredActivityRunSpan.parentId());
+    assertEquals("RunActivity:Activity", failureIgnoredActivityRunSpan.operationName());
+    assertNull(failureIgnoredActivityRunSpan.tags().get(Tags.ERROR.getKey()));
+
+    MockSpan successfulActivityRunSpan = activityRunSpans.get(2);
+    assertEquals(activityStartSpan.context().spanId(), successfulActivityRunSpan.parentId());
+    assertEquals("RunActivity:Activity", successfulActivityRunSpan.operationName());
+  }
+}

--- a/temporal-opentracing/src/test/java/io/temporal/opentracing/ExceptionIgnoredTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/opentracing/ExceptionIgnoredTest.java
@@ -20,7 +20,6 @@
 package io.temporal.opentracing;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import io.opentracing.Scope;
 import io.opentracing.mock.MockSpan;
@@ -177,7 +176,7 @@ public class ExceptionIgnoredTest {
     MockSpan failureIgnoredActivityRunSpan = activityRunSpans.get(1);
     assertEquals(activityStartSpan.context().spanId(), failureIgnoredActivityRunSpan.parentId());
     assertEquals("RunActivity:Activity", failureIgnoredActivityRunSpan.operationName());
-    assertNull(failureIgnoredActivityRunSpan.tags().get(Tags.ERROR.getKey()));
+    assertEquals(false, failureIgnoredActivityRunSpan.tags().get(Tags.ERROR.getKey()));
 
     MockSpan successfulActivityRunSpan = activityRunSpans.get(2);
     assertEquals(activityStartSpan.context().spanId(), successfulActivityRunSpan.parentId());


### PR DESCRIPTION
## What was changed
Adds a Predicate as a new option on the OpenTracingOptions, which controls whether or not the tested exception should be considered an error for the purposes of the span. If the predicate returns false, the exception will not be attached to the span; otherwise it will. By default, the predicate simply returns true.

## Why?
Specifically, the use case that I'm solving is this: for Activities which have to periodically poll an external service, the general best practice is to throw an exception if the polled service isn't ready to respond yet (a request isn't finished for instance). In this case, the normal retry logic will kick in and periodically try again. There are surely other instances where one might throw an exception in order to repeat an Activity without it being considered abnormal.
However, when this happens, the OpenTracing integration will attach it to the Activity span as an error, even though it's healthy, expected behavior; the exception is more of an implementation detail. In this case, the workflow has an artificially inflated error rate and your Quality team starts asking you why your workflow is failing so much.

## Checklist
<!--- add/delete as needed --->

1. Closes #1012 

2. How was this tested:
New unit test created which throws two exceptions from an activity and tests that only one was logged.

3. Any docs updates needed?
Javadoc is updated, not sure if anything else is necessary.
