### PR TITLE
Avoid spurious error notification from prep-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,19 +35,22 @@ jobs:
         
       - name: Check for existing release
         id: check_release
-        run: gh release view --repo '${{ github.repository }}' '${{ github.event.inputs.tag }}'
-        continue-on-error: true
+        run: |
+          echo "::echo::on"
+          gh release view --repo '${{ github.repository }}' '${{ github.event.inputs.tag }}' \
+            && echo "::set-output name=already_exists::true" \
+            || echo "::set-output name=already_exists::false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Checkout repo
-        if: steps.check_release.outcome != 'success'
+        if: steps.check_release.outputs.already_exists == 'false'
         uses: actions/checkout@v2
         with:
           ref: '${{ github.event.inputs.ref }}'
         
       - name: Create release
-        if: steps.check_release.outcome != 'success'
+        if: steps.check_release.outputs.already_exists == 'false'
         run: >
           gh release create
           '${{ github.event.inputs.tag }}'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This change uses step outputs rather than step outcomes to determine
whether or not a release already exists.

## Why?
<!-- Tell your future self why have you made these changes -->
The Github web ui sees the (intentional) failure of the check_release
step and generates a Big Red X warning on associated workflow runs. This
occurs even though we're indicating that an error for this step is
ok/expected via the `continue-on-error` tag. The error indication is
troubling because (a) nothing went wrong and (b) someoneone unfamiliar
with the details of the workflow might think that there's a problem.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
