### PR TITLE
Add port callback URL for test server

### DIFF
--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -39,6 +39,9 @@ graal {
   // Signal handling so that ^C actually stops the process
   option "--install-exit-handlers"
 
+  // Enable calling back an HTTP URL with the listening port
+  option "--enable-url-protocols=http"
+
   // If we're on linux, static link everything but libc. Otherwise link
   // everything dynamically (note the '-' rather than '+' in fromt of
   // StaticExecutable)

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -197,7 +197,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
    */
   public static TestWorkflowService createServerOnly(int port) {
     TestWorkflowService result = new TestWorkflowService(true, port);
-    log.info("Server started, listening on " + port);
+    log.info("Server started, listening on " + result.getPort());
     return result;
   }
 
@@ -216,6 +216,10 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public int getPort() {
+    return outOfProcessServer.getPort();
   }
 
   @Override


### PR DESCRIPTION
To avoid port conflicts, I've added a way for the test server executable to accept a URL as a second argument, it can use this URL to report which port it is bound to (assuming the requested bind port is 0 in which case an unused port is assigned).