### PR TITLE
Fix Search in Javadocs

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -39,6 +39,8 @@ subprojects {
         if (JavaVersion.current().isJava9Compatible()) {
             options.addBooleanOption('html5', true)
         }
+        //https://stackoverflow.com/questions/53732632/gradle-javadoc-search-redirects-to-undefined-url
+        options.addBooleanOption('-no-module-directories', true)
     }
 
     // add a collection to track failedTests


### PR DESCRIPTION
Related to:
https://stackoverflow.com/questions/53732632/gradle-javadoc-search-redirects-to-undefined-url