### PR TITLE
Fix for WorkerOptions Builder using maxConcurrentActivityExecutionSize for local activities in partial build()

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -285,7 +285,7 @@ public final class WorkerOptions {
           maxWorkerActivitiesPerSecond,
           maxConcurrentActivityExecutionSize,
           maxConcurrentWorkflowTaskExecutionSize,
-          maxConcurrentActivityExecutionSize,
+          maxConcurrentLocalActivityExecutionSize,
           maxTaskQueueActivitiesPerSecond,
           maxConcurrentWorkflowTaskPollers,
           maxConcurrentActivityTaskPollers,

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerOptionsTest.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class WorkerOptionsTest {
+  @Test
+  public void build() {
+    WorkerOptions.Builder builder =
+        WorkerOptions.newBuilder()
+            .setMaxConcurrentActivityExecutionSize(10)
+            .setMaxConcurrentLocalActivityExecutionSize(11);
+
+    verifyBuild(builder.build());
+    verifyBuild(builder.validateAndBuildWithDefaults());
+  }
+
+  private void verifyBuild(WorkerOptions options) {
+    assertEquals(10, options.getMaxConcurrentActivityExecutionSize());
+    assertEquals(11, options.getMaxConcurrentLocalActivityExecutionSize());
+  }
+}


### PR DESCRIPTION
## What was changed

WorkerOptions Builder now uses the correct value to initialize maxConcurrentLocalActivityExecutionSize inside the partial `build()` method.
Note: `validateAndBuildWithDefaults` worked correctly and is not affected by this change.

Closes #1080