### PR TITLE
Exclude synthetic and static methods from Activity Interface Hierarchy

### DIFF
--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation project(':temporal-testing')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
 }
 

--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOActivityInterfaceMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOActivityInterfaceMetadata.java
@@ -23,13 +23,7 @@ import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Metadata of an activity interface.
@@ -97,13 +91,6 @@ public final class POJOActivityInterfaceMetadata {
     return result;
   }
 
-  private static void validateModifierAccess(Class<?> current) {
-    if (!Modifier.isPublic(current.getModifiers())) {
-      throw new IllegalArgumentException(
-          "Interface with @ActivityInterface annotation must be public: " + current);
-    }
-  }
-
   static POJOActivityInterfaceMetadata newImplementationInterface(Class<?> anInterface) {
     return new POJOActivityInterfaceMetadata(anInterface);
   }
@@ -115,6 +102,7 @@ public final class POJOActivityInterfaceMetadata {
     this.interfaceClass = anInterface;
     Map<EqualsByMethodName, POJOActivityMethodMetadata> dedupeMap = new HashMap<>();
     getActivityInterfaceMethods(anInterface, dedupeMap);
+    dedupeMap.forEach((k, v) -> methods.put(k.getMethod(), v));
   }
 
   /** Java interface {@code Class} that backs this activity interface. */
@@ -134,61 +122,96 @@ public final class POJOActivityInterfaceMetadata {
     return result;
   }
 
-  /** @return methods which are not part of an interface annotated with ActivityInterface */
-  private Set<Method> getActivityInterfaceMethods(
+  /**
+   * Returns methods collected from the {@code current} interface that belong to classed NOT
+   * annotated with {@link ActivityInterface} The idea is that such methods should be propagated to
+   * a nearest child annotated with {@link ActivityInterface} if it's present
+   */
+  private static Set<Method> getActivityInterfaceMethods(
       Class<?> current, Map<EqualsByMethodName, POJOActivityMethodMetadata> dedupeMap) {
     ActivityInterface annotation = current.getAnnotation(ActivityInterface.class);
-    if (annotation != null) {
+    final boolean isCurrentAnActivityInterface = annotation != null;
+
+    if (isCurrentAnActivityInterface) {
       validateModifierAccess(current);
     }
 
     // Set to dedupe the same method due to diamond inheritance
     Set<Method> result = new HashSet<>();
     Class<?>[] interfaces = current.getInterfaces();
-    for (int i = 0; i < interfaces.length; i++) {
-      Class<?> anInterface = interfaces[i];
+    for (Class<?> anInterface : interfaces) {
       Set<Method> parentMethods = getActivityInterfaceMethods(anInterface, dedupeMap);
-      for (Method parentMethod : parentMethods) {
-        ActivityMethod activityMethod = parentMethod.getAnnotation(ActivityMethod.class);
-        if (activityMethod == null) {
-          try {
-            current.getDeclaredMethod(parentMethod.getName(), parentMethod.getParameterTypes());
-            // Don't add to result as it is redefined by current.
-            // This allows overriding methods without annotation with annotated methods.
-            continue;
-          } catch (NoSuchMethodException e) {
-          }
-        }
-        result.add(parentMethod);
-      }
+      addParentMethods(parentMethods, current, result);
     }
+
     Method[] declaredMethods = current.getDeclaredMethods();
-    for (int i = 0; i < declaredMethods.length; i++) {
-      Method declaredMethod = declaredMethods[i];
-      result.add(declaredMethod);
+    result.addAll(Arrays.asList(declaredMethods));
+
+    if (isCurrentAnActivityInterface) {
+      result.stream()
+          .filter(POJOActivityInterfaceMetadata::isValidActivityMethod)
+          .map(method -> new POJOActivityMethodMetadata(method, current, annotation))
+          .forEach(
+              methodMetadata ->
+                  POJOActivityInterfaceMetadata.dedupeAndAdd(methodMetadata, dedupeMap));
+
+      // the current interface is an ActivityInterface, so we process the collected methods and
+      // there is nothing to pass down
+      return Collections.emptySet();
+    } else {
+      return result; // Not annotated just pass all the methods to the child
     }
-    if (annotation == null) {
-      return result; // Not annotated just pass all the methods to the parent
+  }
+
+  private static void dedupeAndAdd(
+      POJOActivityMethodMetadata methodMetadata,
+      Map<EqualsByMethodName, POJOActivityMethodMetadata> toDedupeMap) {
+    EqualsByMethodName wrapped = new EqualsByMethodName(methodMetadata.getMethod());
+    POJOActivityMethodMetadata registeredBefore = toDedupeMap.put(wrapped, methodMetadata);
+    if (registeredBefore != null) {
+      throw new IllegalArgumentException(
+          "Duplicated methods (overloads are not allowed in activity interfaces): \""
+              + registeredBefore.getMethod()
+              + " through \""
+              + registeredBefore.getInterfaceType()
+              + "\" and \""
+              + methodMetadata.getMethod()
+              + "\" through \""
+              + methodMetadata.getInterfaceType()
+              + "\"");
     }
-    for (Method method : result) {
-      POJOActivityMethodMetadata methodMetadata =
-          new POJOActivityMethodMetadata(method, current, annotation);
-      EqualsByMethodName wrapped = new EqualsByMethodName(method);
-      POJOActivityMethodMetadata registered = dedupeMap.put(wrapped, methodMetadata);
-      if (registered != null) {
-        throw new IllegalArgumentException(
-            "Duplicated methods (overloads are not allowed in activity interfaces): \""
-                + registered.getMethod()
-                + " through \""
-                + registered.getInterfaceType()
-                + "\" and \""
-                + methodMetadata.getMethod()
-                + "\" through \""
-                + methodMetadata.getInterfaceType()
-                + "\"");
+  }
+
+  private static void addParentMethods(
+      Set<Method> parentMethods, Class<?> currentInterface, Set<Method> toSet) {
+    for (Method parentMethod : parentMethods) {
+      ActivityMethod activityMethod = parentMethod.getAnnotation(ActivityMethod.class);
+      if (activityMethod == null) {
+        try {
+          currentInterface.getDeclaredMethod(
+              parentMethod.getName(), parentMethod.getParameterTypes());
+          // Don't add to result as it is redefined by current.
+          // This allows overriding methods without annotation with annotated methods.
+        } catch (NoSuchMethodException e) {
+          // current interface doesn't have an override for this method - add it from the parent
+          toSet.add(parentMethod);
+        }
+      } else {
+        // parent interface method is explicitly annotated with @ActivityMethod - adding to the
+        // result
+        toSet.add(parentMethod);
       }
-      methods.put(method, methodMetadata);
     }
-    return Collections.emptySet();
+  }
+
+  private static void validateModifierAccess(Class<?> activityInterface) {
+    if (!Modifier.isPublic(activityInterface.getModifiers())) {
+      throw new IllegalArgumentException(
+          "Interface with @ActivityInterface annotation must be public: " + activityInterface);
+    }
+  }
+
+  private static boolean isValidActivityMethod(Method method) {
+    return !method.isSynthetic() && !Modifier.isStatic(method.getModifiers());
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOActivityInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOActivityInterfaceMetadataTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.common.metadata;
+
+import static org.junit.Assert.*;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.common.metadata.testclasses.ActivityInterfaceWithOneNonAnnotatedMethod;
+import java.util.ArrayList;
+import java.util.Collection;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.description.modifier.ModifierContributor;
+import net.bytebuddy.description.modifier.Ownership;
+import net.bytebuddy.description.modifier.SyntheticState;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.implementation.FixedValue;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class POJOActivityInterfaceMetadataTest {
+  @Test
+  public void unannotatedActivityMethod() {
+    POJOActivityInterfaceMetadata metadata =
+        POJOActivityInterfaceMetadata.newInstance(ActivityInterfaceWithOneNonAnnotatedMethod.class);
+    assertEquals(1, metadata.getMethodsMetadata().size());
+    assertTrue(
+        metadata.getMethodsMetadata().stream()
+            .anyMatch(m -> m.getMethod().getName().equals("activityMethod")));
+  }
+
+  @Test
+  @Parameters({
+    "false, true, false, false, false",
+    "true, false, false, false, false",
+    "false, true, true, false, true",
+    "true, false, true, true, false"
+  })
+  public void testSyntheticAndStaticMethods(
+      boolean synthetic,
+      boolean statik,
+      boolean annotated,
+      boolean shouldBeConsideredAnActivityMethod,
+      boolean shouldThrow)
+      throws Throwable {
+    Class<?> interfaice = generateActivityInterfaceWithMethod(synthetic, statik, annotated);
+
+    ThrowingRunnable r =
+        () -> {
+          POJOActivityInterfaceMetadata metadata =
+              POJOActivityInterfaceMetadata.newInstance(interfaice);
+          assertEquals(
+              shouldBeConsideredAnActivityMethod,
+              metadata.getMethodsMetadata().stream()
+                  .anyMatch(m -> m.getMethod().getName().equals("method")));
+        };
+    if (shouldThrow) {
+      assertThrows(IllegalArgumentException.class, r);
+    } else {
+      r.run();
+    }
+  }
+
+  private Class<?> generateActivityInterfaceWithMethod(
+      boolean synthetic, boolean statik, boolean annotated) {
+    DynamicType.Builder<?> builder =
+        new ByteBuddy()
+            .makeInterface(ActivityInterfaceWithOneNonAnnotatedMethod.class)
+            .name("GeneratedActivityInterface")
+            .annotateType(AnnotationDescription.Builder.ofType(ActivityInterface.class).build());
+    Collection<ModifierContributor.ForMethod> modifiers = new ArrayList<>();
+    modifiers.add(Visibility.PUBLIC);
+    if (synthetic) {
+      modifiers.add(SyntheticState.SYNTHETIC);
+    }
+    if (statik) {
+      modifiers.add(Ownership.STATIC);
+    }
+
+    DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<?> methodInitial =
+        builder.defineMethod("method", String.class, modifiers);
+    DynamicType.Builder.MethodDefinition<?> methodDefinition =
+        statik ? methodInitial.intercept(FixedValue.value("hi")) : methodInitial.withoutCode();
+
+    if (annotated) {
+      methodDefinition =
+          methodDefinition.annotateMethod(
+              AnnotationDescription.Builder.ofType(ActivityMethod.class).build());
+    }
+
+    return methodDefinition.make().load(this.getClass().getClassLoader()).getLoaded();
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/testclasses/ActivityInterfaceWithOneNonAnnotatedMethod.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/testclasses/ActivityInterfaceWithOneNonAnnotatedMethod.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.common.metadata.testclasses;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface ActivityInterfaceWithOneNonAnnotatedMethod {
+  boolean activityMethod();
+}


### PR DESCRIPTION
Exclude synthetic and static methods from Activity Interface Hierarchy
Refactor POJOActivityInterfaceMetadata for easier reading

Closes #977