### PR TITLE
Add shutdown hook for a clean server exit

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/testserver/TestServer.java
+++ b/temporal-test-server/src/main/java/io/temporal/testserver/TestServer.java
@@ -48,7 +48,8 @@ public class TestServer {
         System.err.println("Unknown flag " + args[1]);
       }
     }
-    createPortBoundServer(port, !enableTimeSkipping);
+    PortBoundTestServer server = createPortBoundServer(port, !enableTimeSkipping);
+    Runtime.getRuntime().addShutdownHook(new Thread(server::close));
   }
 
   /**
@@ -161,7 +162,7 @@ public class TestServer {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
       if (outOfProcessServer != null) {
         log.info("Shutting down port-bind gRPC server");
         outOfProcessServer.shutdown();


### PR DESCRIPTION
Right now the native test server returns code 130 on signing because of the absent shutdown hook.
This PR adds a clean exit on SIGINT.
