### PR TITLE
Swallow "Subchannel shutdown" gRPC errors during worker shutdown

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/GrpcUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/GrpcUtils.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.common;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+public class GrpcUtils {
+  /** @return true if {@code ex} is a gRPC exception about a channel shutdown */
+  public static boolean isChannelShutdownException(StatusRuntimeException ex) {
+    String description = ex.getStatus().getDescription();
+    return (Status.Code.UNAVAILABLE.equals(ex.getStatus().getCode())
+        && description != null
+        && (description.startsWith("Channel shutdown")
+            || description.startsWith("Subchannel shutdown")));
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
@@ -23,8 +23,6 @@ import static io.temporal.serviceclient.MetricsTag.METRICS_TAGS_CALL_OPTIONS_KEY
 
 import com.google.protobuf.DoubleValue;
 import com.uber.m3.tally.Scope;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.taskqueue.v1.TaskQueueMetadata;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueRequest;
@@ -111,12 +109,6 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
                   response.getStartedTime(), response.getCurrentAttemptScheduledTime()));
       isSuccessful = true;
       return new ActivityTask(response, pollSemaphore::release);
-    } catch (StatusRuntimeException e) {
-      if (e.getStatus().getCode() == Status.Code.UNAVAILABLE
-          && e.getMessage().startsWith("UNAVAILABLE: Channel shutdown")) {
-        return null;
-      }
-      throw e;
     } finally {
       if (!isSuccessful) pollSemaphore.release();
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -22,8 +22,6 @@ package io.temporal.internal.worker;
 import static io.temporal.serviceclient.MetricsTag.METRICS_TAGS_CALL_OPTIONS_KEY;
 
 import com.uber.m3.tally.Scope;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
@@ -75,19 +73,11 @@ final class WorkflowPollTask implements Poller.PollTask<PollWorkflowTaskQueueRes
       log.trace("poll request begin: " + pollRequest);
     }
     PollWorkflowTaskQueueResponse result;
-    try {
-      result =
-          service
-              .blockingStub()
-              .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-              .pollWorkflowTaskQueue(pollRequest);
-    } catch (StatusRuntimeException e) {
-      if (e.getStatus().getCode() == Status.Code.UNAVAILABLE
-          && e.getMessage().startsWith("UNAVAILABLE: Channel shutdown")) {
-        return null;
-      }
-      throw e;
-    }
+    result =
+        service
+            .blockingStub()
+            .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
+            .pollWorkflowTaskQueue(pollRequest);
     if (log.isTraceEnabled()) {
       log.trace(
           "poll request returned workflow task: workflowType="


### PR DESCRIPTION
Now workers during shutdown may throw 

```io.grpc.StatusRuntimeException io.grpc.StatusRuntimeException: UNAVAILABLE: Subchannel shutdown invoked```

This PR improves handling of gRPC exceptions during shutdown