### PR TITLE
Add support for UpsertSearchAttributes to describe in the test service

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/DescribeWorkflowAsserter.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/DescribeWorkflowAsserter.java
@@ -177,4 +177,12 @@ public class DescribeWorkflowAsserter {
         "child workflow count should match", expected, actual.getPendingChildrenCount());
     return this;
   }
+
+  public DescribeWorkflowAsserter assertSearchAttributes(Map<String, Object> expected) {
+    Assert.assertEquals(
+        "search attributes should match",
+        expected,
+        toSimpleMap(actual.getWorkflowExecutionInfo().getSearchAttributes().getIndexedFieldsMap()));
+    return this;
+  }
 }


### PR DESCRIPTION
## What was changed
This makes the implementation of DescribeWorkflowExecution in the test service aware of calls to Workflow.upsertSearchAttributes.

## Why?
The test service's describe method had a bug that impacted any workflow that upserted search attributes.

## Checklist
1. Closes (nothing)

2. How was this tested:
```
cd temporal-sdk
# using TestWorkflowService
USE_DOCKER_SERVICE=false ../gradlew test --tests io.temporal.workflow.DescribeTest
# using docker-compose to make sure we match the real service's behavior
USE_DOCKER_SERVICE=true ../gradlew test --tests io.temporal.workflow.DescribeTest
```

3. Any docs updates needed?
None.