### PR TITLE
Improve Poller's shutdown log message with a poll task class

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -242,7 +242,7 @@ public final class Poller<T> implements SuspendableWorker {
           // Resubmit itself back to pollExecutor
           pollExecutor.execute(this);
         } else {
-          log.info("poll loop is terminated: {}", this);
+          log.info("poll loop is terminated: {}", Poller.this.pollTask.getClass().getSimpleName());
         }
       }
     }


### PR DESCRIPTION
Replace cryptic unhelpful anonymous class name with an actual class of the polling task in `Poller` shutdown log.