### PR TITLE
Added local whitesource config files

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,7 @@
+{
+  "settingsInheritedFrom": "temporalio/whitesource-config@main", 
+  "scanSettings": {
+    "configMode": "EXTERNAL",
+    "configExternalURL": "https://github.com/temporalio/sdk-java/blob/master/whitesource.config"
+  }
+}

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,1 @@
+gradle.ignoredConfigurations=.*test.*


### PR DESCRIPTION
## What was changed
Added a local .whitesource and whitesource.config files, to exclude Gradle test scopes.

## Why?
Test scopes are:
1. Not expected to be in the classpath at runtime
2. Not included into dependencies descriptor of the jar publishing into maven central repos
3. Not used for compilation of the sources that end up in the target jar.
