### PR TITLE
Tests verifying that getVersion inside a signal handler works correctly

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/interceptors/SignalWorkflowOutboundCallsInterceptor.java
@@ -20,51 +20,20 @@
 package io.temporal.workflow.interceptors;
 
 import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
-import io.temporal.workflow.Functions;
-import io.temporal.workflow.Promise;
-import java.lang.reflect.Type;
-import java.time.Duration;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.UUID;
-import java.util.function.BiPredicate;
+import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptorBase;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
-public class SignalWorkflowOutboundCallsInterceptor implements WorkflowOutboundCallsInterceptor {
-
+public class SignalWorkflowOutboundCallsInterceptor extends WorkflowOutboundCallsInterceptorBase {
   private final Function<Object[], Object[]> overrideArgs;
   private final Function<String, String> overrideSignalName;
-  private final WorkflowOutboundCallsInterceptor next;
 
   public SignalWorkflowOutboundCallsInterceptor(
       Function<Object[], Object[]> overrideArgs,
       Function<String, String> overrideSignalName,
       WorkflowOutboundCallsInterceptor next) {
+    super(next);
     this.overrideArgs = overrideArgs;
     this.overrideSignalName = overrideSignalName;
-    this.next = Objects.requireNonNull(next);
-  }
-
-  @Override
-  public <T> ActivityOutput<T> executeActivity(ActivityInput<T> input) {
-    return next.executeActivity(input);
-  }
-
-  @Override
-  public <R> LocalActivityOutput<R> executeLocalActivity(LocalActivityInput<R> input) {
-    return next.executeLocalActivity(input);
-  }
-
-  @Override
-  public <R> ChildWorkflowOutput<R> executeChildWorkflow(ChildWorkflowInput<R> input) {
-    return next.executeChildWorkflow(input);
-  }
-
-  @Override
-  public Random newRandom() {
-    return next.newRandom();
   }
 
   @Override
@@ -73,100 +42,10 @@ public class SignalWorkflowOutboundCallsInterceptor implements WorkflowOutboundC
     if (args != null && args.length > 0) {
       args = new Object[] {"corrupted signal"};
     }
-    return next.signalExternalWorkflow(
+    return super.signalExternalWorkflow(
         new SignalExternalInput(
             input.getExecution(),
             overrideSignalName.apply(input.getSignalName()),
             overrideArgs.apply(args)));
-  }
-
-  @Override
-  public CancelWorkflowOutput cancelWorkflow(CancelWorkflowInput input) {
-    return next.cancelWorkflow(input);
-  }
-
-  @Override
-  public void sleep(Duration duration) {
-    next.sleep(duration);
-  }
-
-  @Override
-  public boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition) {
-    return next.await(timeout, reason, unblockCondition);
-  }
-
-  @Override
-  public void await(String reason, Supplier<Boolean> unblockCondition) {
-    next.await(reason, unblockCondition);
-  }
-
-  @Override
-  public Promise<Void> newTimer(Duration duration) {
-    return next.newTimer(duration);
-  }
-
-  @Override
-  public <R> R sideEffect(Class<R> resultClass, Type resultType, Functions.Func<R> func) {
-    return next.sideEffect(resultClass, resultType, func);
-  }
-
-  @Override
-  public <R> R mutableSideEffect(
-      String id,
-      Class<R> resultClass,
-      Type resultType,
-      BiPredicate<R, R> updated,
-      Functions.Func<R> func) {
-    return null;
-  }
-
-  @Override
-  public int getVersion(String changeId, int minSupported, int maxSupported) {
-    return next.getVersion(changeId, minSupported, maxSupported);
-  }
-
-  @Override
-  public void continueAsNew(ContinueAsNewInput input) {
-    next.continueAsNew(input);
-  }
-
-  @Override
-  public void registerQuery(RegisterQueryInput input) {
-    next.registerQuery(input);
-  }
-
-  @Override
-  public void registerSignalHandlers(RegisterSignalHandlersInput input) {
-    next.registerSignalHandlers(input);
-  }
-
-  @Override
-  public void registerDynamicSignalHandler(RegisterDynamicSignalHandlerInput input) {
-    next.registerDynamicSignalHandler(input);
-  }
-
-  @Override
-  public void registerDynamicQueryHandler(RegisterDynamicQueryHandlerInput input) {
-    next.registerDynamicQueryHandler(input);
-  }
-
-  @Override
-  public UUID randomUUID() {
-    return next.randomUUID();
-  }
-
-  @Override
-  public void upsertSearchAttributes(Map<String, Object> searchAttributes) {
-    next.upsertSearchAttributes(searchAttributes);
-  }
-
-  @Override
-  public Object newChildThread(Runnable runnable, boolean detached, String name) {
-    return next.newChildThread(runnable, detached, name);
-  }
-
-  @Override
-  public long currentTimeMillis() {
-    return next.currentTimeMillis();
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInSignalOnReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInSignalOnReplayTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import io.temporal.workflow.unsafe.WorkflowUnsafe;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetVersionInSignalOnReplayTest {
+  public static boolean hasReplayedSignal;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestGetVersionInSignal.class)
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  // forcing a replay
+                  .setWorkflowHostLocalTaskQueueScheduleToStartTimeout(Duration.ZERO)
+                  .build())
+          .build();
+
+  @Test
+  public void testGetVersionInSignal() {
+    TestWorkflows.TestSignaledWorkflow workflow =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestSignaledWorkflow.class);
+    WorkflowExecution start = WorkflowClient.start(workflow::execute);
+
+    WorkflowStub workflowStub = WorkflowStub.fromTyped(workflow);
+    SDKTestWorkflowRule.waitForOKQuery(workflowStub);
+    workflow.signal("done");
+    String result = workflowStub.getResult(String.class);
+    assertTrue(hasReplayedSignal);
+    assertEquals("[done]", result);
+  }
+
+  /** The following test covers the scenario where getVersion call is performed inside a signal */
+  public static class TestGetVersionInSignal implements TestWorkflows.TestSignaledWorkflow {
+
+    private final List<String> signalled = new ArrayList<>();
+
+    @Override
+    public String execute() {
+      Workflow.sleep(5_000);
+      return signalled.toString();
+    }
+
+    @Override
+    public void signal(String arg) {
+      hasReplayedSignal = WorkflowUnsafe.isReplaying();
+      Workflow.getVersion("some-id", 1, 2);
+      signalled.add(arg);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInSignalTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInSignalTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetVersionInSignalTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestGetVersionInSignal.class).build();
+
+  @Test
+  public void testGetVersionInSignal() {
+    TestWorkflows.TestSignaledWorkflow workflow =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestSignaledWorkflow.class);
+    WorkflowClient.start(workflow::execute);
+
+    WorkflowStub workflowStub = WorkflowStub.fromTyped(workflow);
+    SDKTestWorkflowRule.waitForOKQuery(workflowStub);
+    workflow.signal("done");
+    String result = workflowStub.getResult(String.class);
+    assertEquals("[done]", result);
+  }
+
+  /** The following test covers the scenario where getVersion call is performed inside a signal */
+  public static class TestGetVersionInSignal implements TestWorkflows.TestSignaledWorkflow {
+
+    private final List<String> signalled = new ArrayList<>();
+
+    @Override
+    public String execute() {
+      Workflow.sleep(5_000);
+      return signalled.toString();
+    }
+
+    @Override
+    public void signal(String arg) {
+      Workflow.getVersion("some-id", 1, 2);
+      signalled.add(arg);
+    }
+  }
+}


### PR DESCRIPTION
Adds a couple of tests verifying that getVersion call can be used inside a signal handler