### PR TITLE
Improve PotentialDeadlockException message with timestamps

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -222,7 +222,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
           dump.append(t.getStackTrace());
         }
       }
-      e.setStackDump(dump.toString());
+      e.setStackDump(dump.toString(), System.currentTimeMillis());
       throw e;
     } finally {
       inRunUntilAllBlocked = false;

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -97,8 +97,8 @@ public class WorkerFactoryOptions {
     }
 
     /**
-     * Timeout for a workflow task routed to the the host that caches a workflow object. Once it
-     * times out then it can be picked up by any worker.
+     * Timeout for a workflow task routed to the "sticky worker" - host that has the workflow
+     * instance cached in memory. Once it times out, then it can be picked up by any worker.
      *
      * <p>Default value is 10 seconds.
      */

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -932,8 +932,10 @@ public final class Workflow {
    *     changeId are guaranteed to return the same version number. Use this to perform multiple
    *     coordinated changes that should be enabled together.
    * @param minSupported min version supported for the change
-   * @param maxSupported max version supported for the change
-   * @return version
+   * @param maxSupported max version supported for the change, this version is used as the current
+   *     one during the original execution.
+   * @return {@code maxSupported} when is originally executed. Original version recorded in the
+   *     history on replays.
    */
   public static int getVersion(String changeId, int minSupported, int maxSupported) {
     return WorkflowInternal.getVersion(changeId, minSupported, maxSupported);


### PR DESCRIPTION
- Potential Deadlock detection firing time
- The time when SDK was able to obtain a stacktrace of a potentially deadlocked thread
- A timestamp when a thread dump of other threads was taken 
could be different because of JVM safepoints. To make it more clear to the investigator, timestamps are now included in the Potential Deadlock message.