### PR TITLE
Test Server times out workflow task in case of workflow task failure after the second attempt

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -261,7 +261,7 @@ class StateMachines {
 
     long scheduledEventId = NO_EVENT_ID;
 
-    int attempt = 1;
+    int attempt = 0;
 
     /** Query requests received during workflow task processing (after start) */
     final Map<String, TestWorkflowMutableStateImpl.ConsistentQuery> queryBuffer = new HashMap<>();
@@ -278,7 +278,7 @@ class StateMachines {
       startedEventId = NO_EVENT_ID;
       workflowTask = null;
       scheduledEventId = NO_EVENT_ID;
-      attempt = 1;
+      attempt = 0;
     }
 
     @Override
@@ -1107,7 +1107,7 @@ class StateMachines {
         WorkflowTaskScheduledEventAttributes.newBuilder()
             .setStartToCloseTimeout(request.getWorkflowTaskTimeout())
             .setTaskQueue(request.getTaskQueue())
-            .setAttempt(data.attempt)
+            .setAttempt(++data.attempt)
             .build();
     HistoryEvent event =
         HistoryEvent.newBuilder()
@@ -1166,7 +1166,7 @@ class StateMachines {
             : stickyAttributes.getWorkerTaskQueue().getName();
     workflowTaskResponse.setWorkflowExecution(ctx.getExecution());
     workflowTaskResponse.setWorkflowType(request.getWorkflowType());
-    workflowTaskResponse.setAttempt(data.attempt);
+    workflowTaskResponse.setAttempt(++data.attempt);
     TaskQueueId taskQueueId = new TaskQueueId(ctx.getNamespace(), taskQueue);
     WorkflowTask workflowTask = new WorkflowTask(taskQueueId, workflowTaskResponse);
     ctx.setWorkflowTask(workflowTask);
@@ -1298,7 +1298,6 @@ class StateMachines {
           }
           if (!queryOnly) {
             data.startedEventId = startedEventId;
-            data.attempt++;
           }
         });
   }

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/RepeatedWorkflowTaskFailuresTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/RepeatedWorkflowTaskFailuresTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testserver.functional;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.testserver.functional.common.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Server should discard repeated workflow task failures and let the workflow task to time out See
+ * https://github.com/temporalio/temporal/pull/2548
+ */
+public class RepeatedWorkflowTaskFailuresTest {
+
+  private static int retryCount;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflow.class).build();
+
+  @Test
+  public void repeatedFailure() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowTaskTimeout(Duration.ofSeconds(1))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+
+    TestWorkflows.PrimitiveWorkflow workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class, options);
+    workflowStub.execute();
+    WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
+
+    Assert.assertEquals(
+        "Out of three failed retries only the first one should be FAILED, other 2 should be dropped, allowed to time out and not being recorded at all",
+        1,
+        testWorkflowRule
+            .getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .size());
+  }
+
+  public static class TestWorkflow implements TestWorkflows.PrimitiveWorkflow {
+
+    @Override
+    public void execute() {
+      if (++retryCount < 4) {
+        throw new RuntimeException("simulated workflow task failure");
+      }
+    }
+  }
+}

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
@@ -17,13 +17,15 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.testserver.functional.timeskipping;
+package io.temporal.testserver.functional.common;
 
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 
-@WorkflowInterface
-public interface TestWorkflow {
-  @WorkflowMethod
-  void execute();
+public class TestWorkflows {
+  @WorkflowInterface
+  public interface PrimitiveWorkflow {
+    @WorkflowMethod
+    void execute();
+  }
 }

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/timeskipping/TimeSkippingFromAnActivityTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/timeskipping/TimeSkippingFromAnActivityTest.java
@@ -26,6 +26,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testserver.TestServer;
+import io.temporal.testserver.functional.common.TestWorkflows;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
 import io.temporal.workflow.Async;
@@ -47,7 +48,7 @@ public class TimeSkippingFromAnActivityTest {
     }
   }
 
-  public static class TestWorkflowImpl implements TestWorkflow {
+  public static class TestWorkflowImpl implements TestWorkflows.PrimitiveWorkflow {
     @Override
     public void execute() {
       SleepingActivity activity =
@@ -95,7 +96,8 @@ public class TimeSkippingFromAnActivityTest {
   public void testAbandonActivity() {
     WorkflowClient.newInstance(workflowServiceStubs)
         .newWorkflowStub(
-            TestWorkflow.class, SDKTestOptions.newWorkflowOptionsWithTimeouts(TASK_QUEUE))
+            TestWorkflows.PrimitiveWorkflow.class,
+            SDKTestOptions.newWorkflowOptionsWithTimeouts(TASK_QUEUE))
         .execute();
     // time skipping is locked here. Workflow is done, but the activity is not
   }


### PR DESCRIPTION



## What was changed
To match the new behavior of the real server, Test Server now times out a workflow task if the workflow task failed and the attempt is >=2.

## Why?
See https://github.com/temporalio/temporal/pull/2548

## How it was tested
New unit test verifying the behavior across the test and real server.
