### PR TITLE
Fix "Operation allowed only while eventLoop is running" exception if deadlock is detected

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/DebugModeUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/DebugModeUtils.java
@@ -42,7 +42,12 @@ public class DebugModeUtils {
   }
 
   @VisibleForTesting
-  public static void initializeForTests(EnvironmentVariablesProvider environmentVariableProvider) {
-    TEMPORAL_DEBUG_MODE = readTemporalDebugMode(environmentVariableProvider);
+  public static void override(boolean debugMode) {
+    TEMPORAL_DEBUG_MODE = debugMode;
+  }
+
+  @VisibleForTesting
+  public static void reset() {
+    TEMPORAL_DEBUG_MODE = readTemporalDebugMode(SystemEnvironmentVariablesProvider.INSTANCE);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -50,6 +50,7 @@ import io.temporal.internal.replay.ExecuteActivityParameters;
 import io.temporal.internal.replay.ExecuteLocalActivityParameters;
 import io.temporal.internal.replay.InternalWorkflowTaskException;
 import io.temporal.internal.replay.StartChildWorkflowExecutionParameters;
+import io.temporal.internal.sync.WorkflowThread;
 import io.temporal.internal.worker.ActivityTaskHandler;
 import io.temporal.worker.NonDeterministicException;
 import io.temporal.workflow.ChildWorkflowCancellationType;
@@ -1007,6 +1008,9 @@ public final class WorkflowStateMachines {
    */
   private void checkEventLoopExecuting() {
     if (!eventLoopExecuting) {
+      // this call doesn't yield or await, because the await function returns true,
+      // but it checks if the workflow thread needs to be destroyed
+      WorkflowThread.await("kill workflow thread if destroy requested", () -> true);
       throw new IllegalStateException("Operation allowed only while eventLoop is running");
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/deadlockdetector/DeadlockBeforeActivityCallTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/deadlockdetector/DeadlockBeforeActivityCallTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.deadlockdetector;
+
+import static org.junit.Assert.*;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.internal.common.DebugModeUtils;
+import io.temporal.testUtils.Signal;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeadlockBeforeActivityCallTest {
+  private final WorkflowImplementationOptions workflowImplementationOptions =
+      WorkflowImplementationOptions.newBuilder()
+          .setFailWorkflowExceptionTypes(Throwable.class)
+          .build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              workflowImplementationOptions, TestDeadlockWorkflowWithActivityAfterDeadlock.class)
+          .setActivityImplementations(new TestActivities.TestActivityImpl())
+          .build();
+
+  private static final AtomicReference<Exception> EXCEPTION_CAUGHT_IN_WORKFLOW_CODE =
+      new AtomicReference<>();
+  private static final Signal WORKFLOW_CODE_COMPLETED = new Signal();
+
+  @Before
+  public void setUp() throws Exception {
+    DebugModeUtils.override(false);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    DebugModeUtils.reset();
+  }
+
+  @Test
+  public void testDeadlockDetectedBeforeAnActivityCall() throws InterruptedException {
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    TestWorkflows.NoArgsWorkflow workflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflows.NoArgsWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setWorkflowRunTimeout(Duration.ofSeconds(20))
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .build());
+
+    Throwable failure = assertThrows(WorkflowFailedException.class, workflow::execute);
+    while (failure.getCause() != null) {
+      failure = failure.getCause();
+    }
+    assertTrue(failure.getMessage().contains("Potential deadlock detected"));
+
+    WORKFLOW_CODE_COMPLETED.waitForSignal();
+    assertNull(EXCEPTION_CAUGHT_IN_WORKFLOW_CODE.get());
+  }
+
+  public static class TestDeadlockWorkflowWithActivityAfterDeadlock
+      implements TestWorkflows.NoArgsWorkflow {
+    @Override
+    public void execute() {
+      try {
+        try {
+          Thread.sleep(2000);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw Workflow.wrap(e);
+        }
+        try {
+          TestActivities.NoArgsActivity activity =
+              Workflow.newActivityStub(
+                  TestActivities.NoArgsActivity.class,
+                  SDKTestOptions.newActivityOptions20sScheduleToClose());
+          activity.execute();
+        } catch (Exception e) {
+          EXCEPTION_CAUGHT_IN_WORKFLOW_CODE.set(e);
+        }
+      } finally {
+        WORKFLOW_CODE_COMPLETED.signal();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What was changed
State machines are now checking if the workflow thread destruction has been requested and if it is, the thread gets killed.

## Why?
Before this changes "Operation allowed only while eventLoop is running" is thrown if detection of deadlock is followed by some state machines change by the workflow thread.

## How it was tested
Covered by the new unit test that fails on the current master.

Closes #1066
