### PR TITLE
setMetricsScope is wired into test rules

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -525,6 +525,18 @@ class ServiceStubsOptions {
      *         .build();
      * }</pre>
      *
+     * <p>Note: Don't mock {@link Scope} in tests! If you need to verify the metrics behavior,
+     * create a real Scope and mock, stub or spy a reporter instance:<br>
+     *
+     * <pre>{@code
+     * StatsReporter reporter = mock(StatsReporter.class);
+     * Scope metricsScope =
+     *     new RootScopeBuilder()
+     *         .reporter(reporter)
+     *         .reportEvery(com.uber.m3.util.Duration.ofMillis(10));
+     * }</pre>
+     *
+     * @param metricsScope the scope to be used for metrics reporting.
      * @return {@code this}
      */
     public T setMetricsScope(Scope metricsScope) {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
@@ -92,6 +92,23 @@ public final class TestEnvironmentOptions {
       return this;
     }
 
+    /**
+     * Sets the scope to be used for metrics reporting. Optional. Default is to not report metrics.
+     *
+     * <p>Note: Don't mock {@link Scope} in tests! If you need to verify the metrics behavior,
+     * create a real Scope and mock, stub or spy a reporter instance:<br>
+     *
+     * <pre>{@code
+     * StatsReporter reporter = mock(StatsReporter.class);
+     * Scope metricsScope =
+     *     new RootScopeBuilder()
+     *         .reporter(reporter)
+     *         .reportEvery(com.uber.m3.util.Duration.ofMillis(10));
+     * }</pre>
+     *
+     * @param metricsScope the scope to be used for metrics reporting.
+     * @return {@code this}
+     */
     public Builder setMetricsScope(Scope metricsScope) {
       this.metricsScope = metricsScope;
       return this;


### PR DESCRIPTION
`setMetricsScope` is wired into test rules
Guidance about Scope mocking for unit tests is provided