### PR TITLE
Fix workflow thread name strategy to append a clear marker of truncation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -19,6 +19,7 @@
 
 package io.temporal.internal.sync;
 
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.failure.CanceledFailure;
@@ -42,6 +43,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,7 +169,7 @@ class WorkflowThreadImpl implements WorkflowThread {
   WorkflowThreadImpl(
       ExecutorService threadPool,
       DeterministicRunnerImpl runner,
-      String name,
+      @Nonnull String name,
       int priority,
       boolean detached,
       CancellationScopeImpl parentCancellationScope,
@@ -175,15 +177,12 @@ class WorkflowThreadImpl implements WorkflowThread {
       WorkflowExecutorCache cache,
       List<ContextPropagator> contextPropagators,
       Map<String, Object> propagatedContexts) {
+    Preconditions.checkNotNull(name, "Thread name shouldn't be null");
     this.threadPool = threadPool;
     this.runner = runner;
     this.context = new WorkflowThreadContext(runner.getLock());
     this.cache = cache;
     this.priority = priority;
-    if (name == null) {
-      name = "workflow-" + super.hashCode();
-    }
-
     this.task =
         new RunnableWrapper(
             context,

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/workflow/ExecutionInfoStrategy.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/workflow/ExecutionInfoStrategy.java
@@ -24,14 +24,21 @@ import io.temporal.api.common.v1.WorkflowExecution;
 public class ExecutionInfoStrategy implements WorkflowMethodThreadNameStrategy {
   public static final ExecutionInfoStrategy INSTANCE = new ExecutionInfoStrategy();
   private static final int WORKFLOW_ID_TRIM_LENGTH = 50;
+  private static final String TRIM_MARKER = "...";
 
   private ExecutionInfoStrategy() {}
 
   @Override
   public String createThreadName(WorkflowExecution workflowExecution) {
     String workflowId = workflowExecution.getWorkflowId();
+
     String trimmedWorkflowId =
-        workflowId.substring(0, Math.min(WORKFLOW_ID_TRIM_LENGTH, workflowId.length()) - 1);
+        workflowId.length() > WORKFLOW_ID_TRIM_LENGTH
+            ?
+            // add a ' at the end to explicitly show that the id was trimmed
+            workflowId.substring(0, WORKFLOW_ID_TRIM_LENGTH) + TRIM_MARKER
+            : workflowId;
+
     return WORKFLOW_MAIN_THREAD_PREFIX
         + "-"
         + trimmedWorkflowId


### PR DESCRIPTION
Now if we truncate workflowId before we append it to the workflow thread name, we truncate it and it may be unclear and misleading in some cases. Add a clear marker at the end of workflowId if we indeed truncate.