### PR TITLE
Reimplemented WorkflowRunLockManager to fix design flaw with an unsafe unlock

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowRunLockManagerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowRunLockManagerTest.java
@@ -19,15 +19,9 @@
 
 package io.temporal.internal.worker;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.locks.Lock;
+import java.util.concurrent.*;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,8 +54,13 @@ public class WorkflowRunLockManagerTest {
   }
 
   private String processTask(String runId, int taskId) {
-    Lock runLock = runLockManager.getLockForLocking(runId);
-    runLock.lock();
+    try {
+      log.info("trying to get a lock runId " + runId + " taskId " + taskId);
+      boolean locked = runLockManager.tryLock(runId, 10, TimeUnit.SECONDS);
+      assertTrue(locked);
+    } catch (InterruptedException e) {
+      fail("unexpected");
+    }
 
     log.info("Got lock runId " + runId + " taskId " + taskId);
     try {


### PR DESCRIPTION
## What was changed

WorkflowRunLockManager was reimplemented in a safe way. Now unlock for a runId can be called only from a thread that acquired the lock.

## Why?
See #1146. The current API and implementation of WorkflowRunLockManager may lead to a lock for a runId being released by a thread that is not eligible for that.

Closes #1146