### PR TITLE
Refactor and cleanup "exception to failure" conversion code

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
@@ -178,6 +178,22 @@ public class FailureConverter {
     }
   }
 
+  /**
+   * This method is needed when we need to serialize an exception having a {@link
+   * io.temporal.failure.TemporalFailure} instance in the chain with {@code details} field and no
+   * data converter attached explicitly during creation.
+   */
+  public static Failure exceptionToFailure(Throwable e, DataConverter dataConverter) {
+    Throwable ex = e;
+    while (ex != null) {
+      if (ex instanceof TemporalFailure) {
+        ((TemporalFailure) ex).setDataConverter(dataConverter);
+      }
+      ex = ex.getCause();
+    }
+    return FailureConverter.exceptionToFailure(e);
+  }
+
   public static Failure exceptionToFailure(Throwable e) {
     if (e instanceof CheckedExceptionWrapper) {
       return exceptionToFailure(e.getCause());

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflow.java
@@ -20,9 +20,9 @@
 package io.temporal.internal.replay;
 
 import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.query.v1.WorkflowQuery;
-import io.temporal.internal.worker.WorkflowExecutionException;
 import io.temporal.worker.WorkflowImplementationOptions;
 import java.util.Optional;
 
@@ -52,14 +52,16 @@ public interface ReplayWorkflow {
   Optional<Payloads> query(WorkflowQuery query);
 
   /**
-   * Convert exception that happened in the framework code to the format that ReplayWorkflow
-   * implementation understands. The framework code is not aware of DataConverter so this is working
-   * around this layering.
+   * Convert exception to the serialized Failure that can be reported to the server.<br>
+   * This method is needed when framework code needs to serialize a {@link
+   * io.temporal.failure.TemporalFailure} instance with details object produced by the application
+   * code.<br>
+   * The framework code is not aware of DataConverter so this is working around this layering.
    *
-   * @param failure Unexpected failure cause
+   * @param exception throwable to convert
    * @return Serialized failure
    */
-  WorkflowExecutionException mapUnexpectedException(Throwable failure);
+  Failure mapExceptionToFailure(Throwable exception);
 
   WorkflowImplementationOptions getWorkflowImplementationOptions();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowExecutor.java
@@ -76,7 +76,7 @@ final class ReplayWorkflowExecutor {
       completed = true;
     } catch (CanceledFailure e) {
       if (!cancelRequested) {
-        failure = workflow.mapUnexpectedException(e);
+        failure = new WorkflowExecutionException(workflow.mapExceptionToFailure(e));
       }
       completed = true;
     }
@@ -146,9 +146,5 @@ final class ReplayWorkflowExecutor {
 
   public void start(HistoryEvent startWorkflowEvent) {
     workflow.start(startWorkflowEvent, context);
-  }
-
-  public WorkflowExecutionException mapUnexpectedException(Throwable exception) {
-    return workflow.mapUnexpectedException(exception);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -29,10 +29,10 @@ import io.temporal.api.query.v1.WorkflowQuery;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.failure.FailureConverter;
 import io.temporal.internal.replay.ReplayWorkflow;
 import io.temporal.internal.replay.ReplayWorkflowContext;
 import io.temporal.internal.replay.WorkflowExecutorCache;
-import io.temporal.internal.worker.WorkflowExecutionException;
 import io.temporal.internal.worker.workflow.ExecutionInfoStrategy;
 import io.temporal.internal.worker.workflow.WorkflowMethodThreadNameStrategy;
 import io.temporal.worker.WorkflowImplementationOptions;
@@ -188,8 +188,7 @@ class SyncWorkflow implements ReplayWorkflow {
   }
 
   @Override
-  public WorkflowExecutionException mapUnexpectedException(Throwable failure) {
-    return POJOWorkflowImplementationFactory.mapToWorkflowExecutionException(
-        failure, dataConverter);
+  public Failure mapExceptionToFailure(Throwable failure) {
+    return FailureConverter.exceptionToFailure(failure, dataConverter);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
@@ -35,12 +35,12 @@ import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.query.v1.WorkflowQuery;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.worker.SingleWorkerOptions;
-import io.temporal.internal.worker.WorkflowExecutionException;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.HistoryUtils;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
@@ -308,7 +308,7 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
           }
 
           @Override
-          public WorkflowExecutionException mapUnexpectedException(Throwable failure) {
+          public Failure mapExceptionToFailure(Throwable exception) {
             return null;
           }
 


### PR DESCRIPTION
It's a purely refactoring and cleanup PR that improves the code structure, decreases copy-pasted similar code, adds or refreshes the javadocs.
It's the first of the PRs focused on simplifying the error handling logic. 
Code in this area right now is quite convoluted and spread across several classes, it's safer to make smaller changes that are easier to verify.