### PR TITLE
Moved NO_COMPLETION counter reporting to handle all cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     // micrometerVersion = '[1.0.0,)!!1.8.3'
     grpcVersion = '1.45.1'
     jacksonVersion = '2.13.1'
-    micrometerVersion = '1.8.4'
+    micrometerVersion = '1.8.5'
 
     protoVersion = '[3.10.0,3.99)!!3.20.0'
     annotationApiVersion = '1.3.2'

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -189,7 +189,6 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
           throw replayWorkflowExecutor.mapUnexpectedException(e);
         }
       }
-      metricsScope.counter(MetricsType.WORKFLOW_TASK_NO_COMPLETION_COUNTER).inc(1);
       throw wrap(e);
     } finally {
       if (!timerStopped) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -244,6 +244,9 @@ public final class WorkflowWorker
             workflowTypeMetricsScope
                 .counter(MetricsType.WORKFLOW_TASK_EXECUTION_FAILURE_COUNTER)
                 .inc(1);
+            workflowTypeMetricsScope
+                .counter(MetricsType.WORKFLOW_TASK_NO_COMPLETION_COUNTER)
+                .inc(1);
             throw e;
           } finally {
             sw.stop();

--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -61,7 +61,12 @@ public class MetricsType {
   /** Workflow task failed, possibly failing workflow or reporting failure to the service. */
   public static final String WORKFLOW_TASK_EXECUTION_FAILURE_COUNTER =
       TEMPORAL_METRICS_PREFIX + "workflow_task_execution_failed";
-  /** Workflow task failed with unhandled exception without replying to the service. */
+  /**
+   * Workflow task failed with unhandled exception without replying to the service.<br>
+   * This typically happens when workflow task fails second time in a row.<br>
+   * SDK drops the task and emulates a time-out instead of keeping reporting the failure.<br>
+   * It's implemented this way to get a sdk controlled backoff behavior.<br>
+   */
   public static final String WORKFLOW_TASK_NO_COMPLETION_COUNTER =
       TEMPORAL_METRICS_PREFIX + "workflow_task_no_completion";
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -31,6 +31,7 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.internal.common.DebugModeUtils;
 import io.temporal.internal.common.WorkflowExecutionHistory;
+import io.temporal.internal.docker.RegisterTestNamespace;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactoryOptions;
@@ -105,7 +106,8 @@ public class TestWorkflowRule implements TestRule {
   private TestWorkflowRule(Builder builder) {
     this.doNotStart = builder.doNotStart;
     this.useExternalService = builder.useExternalService;
-    this.namespace = (builder.namespace == null) ? "UnitTest" : builder.namespace;
+    this.namespace =
+        (builder.namespace == null) ? RegisterTestNamespace.NAMESPACE : builder.namespace;
     this.workflowTypes = (builder.workflowTypes == null) ? new Class[0] : builder.workflowTypes;
     this.activityImplementations =
         (builder.activityImplementations == null) ? new Object[0] : builder.activityImplementations;

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -26,6 +26,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.io.CharSink;
 import com.google.common.io.Files;
+import com.uber.m3.tally.Scope;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.enums.v1.IndexedValueType;
@@ -197,6 +198,11 @@ public class SDKTestWorkflowRule implements TestRule {
 
     public Builder registerSearchAttribute(String name, IndexedValueType type) {
       testWorkflowRuleBuilder.registerSearchAttribute(name, type);
+      return this;
+    }
+
+    public Builder setMetricsScope(Scope scope) {
+      testWorkflowRuleBuilder.setMetricsScope(scope);
       return this;
     }
 


### PR DESCRIPTION
## What was changed
Moved NO_COMPLETION counter reporting to an expected area of code.

## Why?
The current (before this change) location of the metric reporting looks off (it's probably outdated because the logic of when SDK "doesn't report a failure to the server" changed in the past) and doesn't work as expected.

## How was this tested
Provided an assertion for the metric in the unit test.
