### PR TITLE
Rework PotentialDeadlockException to don't override the original stacktrace

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -213,16 +213,20 @@ class DeterministicRunnerImpl implements DeterministicRunner {
         workflowThreadsToAdd.clear();
       } while (progress && !threads.isEmpty());
     } catch (PotentialDeadlockException e) {
-      StringBuilder dump = new StringBuilder();
+      String triggerThreadStackTrace = "";
+      StringBuilder otherThreadsDump = new StringBuilder();
       for (WorkflowThread t : threads) {
         if (t.getWorkflowThreadContext() != e.getWorkflowThreadContext()) {
-          if (dump.length() > 0) {
-            dump.append("\n");
+          if (otherThreadsDump.length() > 0) {
+            otherThreadsDump.append("\n");
           }
-          dump.append(t.getStackTrace());
+          otherThreadsDump.append(t.getStackTrace());
+        } else {
+          triggerThreadStackTrace = t.getStackTrace();
         }
       }
-      e.setStackDump(dump.toString(), System.currentTimeMillis());
+      e.setStackDump(
+          triggerThreadStackTrace, otherThreadsDump.toString(), System.currentTimeMillis());
       throw e;
     } finally {
       inRunUntilAllBlocked = false;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -262,10 +262,7 @@ public class WorkflowThreadContext {
             && potentialProgressStatesLocked()) {
           long detectionTimestamp = System.currentTimeMillis();
           if (currentThread != null) {
-            StackTraceElement[] stackTrace = currentThread.getStackTrace();
-            long stackTraceTimestamp = System.currentTimeMillis();
-            throw new PotentialDeadlockException(
-                currentThread.getName(), stackTrace, this, detectionTimestamp, stackTraceTimestamp);
+            throw new PotentialDeadlockException(currentThread.getName(), this, detectionTimestamp);
           } else {
             // This should never happen.
             // We clear currentThread only after setting the status to DONE.
@@ -273,12 +270,7 @@ public class WorkflowThreadContext {
             // and acquiring the lock back
             log.warn(
                 "Illegal State: WorkflowThreadContext has no currentThread in {} state", status);
-            throw new PotentialDeadlockException(
-                "UnknownThread",
-                new StackTraceElement[0],
-                this,
-                detectionTimestamp,
-                detectionTimestamp);
+            throw new PotentialDeadlockException("UnknownThread", this, detectionTimestamp);
           }
         }
         if (evaluationFunction != null) {


### PR DESCRIPTION
## What was changed
PotentialDeadlockException now includes the original stack trace from where it was thrown.
A stack trace of the thread that triggered the exception is getting collected in the same place as the thread dump of other workflow threads and it gets populated into the exception message instead of the stack trace.

## Why?
Right now PotentialDeadlockException hides an original stack trace where it was thrown and replaces it with the stack trace of the method that triggered it. While this solution may seem elegant, it's proven to cause confusion in some situations.

This also brings us closer to implementing and fixing #1125 by taking all the workflow threads stacktraces in one place.