### PR TITLE
Fix for Worker#isSuspended not returning the correct state

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -50,7 +50,7 @@ import javax.annotation.Nonnull;
 import org.slf4j.MDC;
 
 public final class ActivityWorker implements SuspendableWorker {
-  private SuspendableWorker poller = new NoopSuspendableWorker();
+  @Nonnull private SuspendableWorker poller = new NoopSuspendableWorker();
   private final ActivityTaskHandler handler;
   private final WorkflowServiceStubs service;
   private final String namespace;

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -45,7 +45,7 @@ import javax.annotation.Nonnull;
 
 public final class LocalActivityWorker implements SuspendableWorker {
 
-  private SuspendableWorker poller = new NoopSuspendableWorker();
+  @Nonnull private SuspendableWorker poller = new NoopSuspendableWorker();
   private final ActivityTaskHandler handler;
   private final String namespace;
   private final String taskQueue;
@@ -100,35 +100,22 @@ public final class LocalActivityWorker implements SuspendableWorker {
 
   @Override
   public boolean isStarted() {
-    if (poller == null) {
-      return false;
-    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isTerminated();
   }
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
-    if (poller != null) {
-      return poller.shutdown(shutdownManager, interruptTasks);
-    } else {
-      return CompletableFuture.completedFuture(null);
-    }
+    return poller.shutdown(shutdownManager, interruptTasks);
   }
 
   @Override
@@ -138,25 +125,16 @@ public final class LocalActivityWorker implements SuspendableWorker {
 
   @Override
   public void suspendPolling() {
-    if (poller == null) {
-      return;
-    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
-    if (poller == null) {
-      return;
-    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isSuspended();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopSuspendableWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopSuspendableWorker.java
@@ -68,6 +68,6 @@ class NoopSuspendableWorker implements SuspendableWorker {
 
   @Override
   public boolean isSuspended() {
-    return false;
+    return true;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -62,7 +62,7 @@ public final class WorkflowWorker
   private final PollerOptions pollerOptions;
   private final Scope workerMetricsScope;
 
-  private SuspendableWorker poller = new NoopSuspendableWorker();
+  @Nonnull private SuspendableWorker poller = new NoopSuspendableWorker();
   private PollTaskExecutor<PollWorkflowTaskQueueResponse> pollTaskExecutor;
 
   public WorkflowWorker(
@@ -115,66 +115,41 @@ public final class WorkflowWorker
 
   @Override
   public boolean isStarted() {
-    if (poller == null) {
-      return false;
-    }
     return poller.isStarted();
   }
 
   @Override
   public boolean isShutdown() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
-    if (poller == null) {
-      return true;
-    }
     return poller.isTerminated();
   }
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
-    if (poller == null) {
-      return CompletableFuture.completedFuture(null);
-    }
     return poller.shutdown(shutdownManager, interruptTasks);
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    if (poller == null || !poller.isStarted()) {
-      return;
-    }
-
     poller.awaitTermination(timeout, unit);
   }
 
   @Override
   public void suspendPolling() {
-    if (poller == null) {
-      return;
-    }
     poller.suspendPolling();
   }
 
   @Override
   public void resumePolling() {
-    if (poller == null) {
-      return;
-    }
     poller.resumePolling();
   }
 
   @Override
   public boolean isSuspended() {
-    if (poller == null) {
-      return false;
-    }
     return poller.isSuspended();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -419,11 +419,7 @@ public final class Worker implements Suspendable {
 
   @Override
   public boolean isSuspended() {
-    boolean isSuspended = workflowWorker.isSuspended();
-    if (activityWorker != null) {
-      isSuspended = isSuspended && activityWorker.isSuspended();
-    }
-    return isSuspended;
+    return workflowWorker.isSuspended() && (activityWorker == null || activityWorker.isSuspended());
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerSuspendTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerSuspendTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkerSuspendTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowImpl.class).build();
+
+  @Test
+  public void testSuspendResume() {
+    Worker worker = testWorkflowRule.getWorker();
+    assertFalse(worker.isSuspended());
+    worker.suspendPolling();
+    assertTrue(worker.isSuspended());
+    worker.resumePolling();
+    assertFalse(worker.isSuspended());
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflow1 {
+    @Override
+    public String execute(String now) {
+      return "";
+    }
+  }
+}


### PR DESCRIPTION
## What was changed

`Worker#isSuspended` now behaves correctly.
NoopSuspendableWorker#isSuspended now returns true.

## Why

NoopSuspendableWorker#isSuspended returned false which messed with the `Worker#isSuspended` final result.
Now it always returns true which is technically correct.

Closes #1114