### PR TITLE
Add trivial describeNamespace test server implementation

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -314,7 +314,7 @@ public class MetricsTest {
       serviceStubs.blockingStub().describeNamespace(DescribeNamespaceRequest.newBuilder().build());
       fail("failure expected");
     } catch (StatusRuntimeException e) {
-      assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
+      assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
     }
 
     // Wait for reporter
@@ -328,7 +328,7 @@ public class MetricsTest {
           }
         };
     reporter.assertCounter(TEMPORAL_REQUEST, tags, 1);
-    tags.put(MetricsTag.STATUS_CODE, "UNIMPLEMENTED");
+    tags.put(MetricsTag.STATUS_CODE, "INVALID_ARGUMENT");
     reporter.assertCounter(TEMPORAL_REQUEST_FAILURE, tags, 1);
   }
 

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/DescribeNamespaceTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/DescribeNamespaceTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.testserver.functional;
+
+import static org.junit.Assert.*;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.temporal.api.enums.v1.NamespaceState;
+import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
+import io.temporal.api.workflowservice.v1.DescribeNamespaceResponse;
+import io.temporal.internal.docker.RegisterTestNamespace;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DescribeNamespaceTest {
+  @Rule public SDKTestWorkflowRule testWorkflowRule = SDKTestWorkflowRule.newBuilder().build();
+
+  @Test
+  public void testDescribeNamespace() {
+    DescribeNamespaceResponse describeNamespaceResponse =
+        testWorkflowRule
+            .getWorkflowServiceStubs()
+            .blockingStub()
+            .describeNamespace(
+                DescribeNamespaceRequest.newBuilder()
+                    .setNamespace(RegisterTestNamespace.NAMESPACE)
+                    .build());
+    assertEquals(
+        NamespaceState.NAMESPACE_STATE_REGISTERED,
+        describeNamespaceResponse.getNamespaceInfo().getState());
+    assertEquals(
+        RegisterTestNamespace.NAMESPACE, describeNamespaceResponse.getNamespaceInfo().getName());
+    assertTrue(describeNamespaceResponse.getNamespaceInfo().getId().length() > 0);
+  }
+
+  @Test
+  public void noNamespaceSet() {
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                testWorkflowRule
+                    .getWorkflowServiceStubs()
+                    .blockingStub()
+                    .describeNamespace(DescribeNamespaceRequest.newBuilder().build()));
+    assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+    assertEquals("Namespace not set on request.", ex.getStatus().getDescription());
+  }
+}

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/DescribeWorkflowExecutionTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/DescribeWorkflowExecutionTest.java
@@ -57,7 +57,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DescribeTest {
+public class DescribeWorkflowExecutionTest {
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =


### PR DESCRIPTION
Add trivial describeNamespace test server implementation.
This implementation returns a trivial REGISTERED response about any namespace describe request. The test server currently doesn't need a namespace to be registered.

Closes #1158