### PR TITLE
Evictions are not logged as errors in opentracing anymore

### DIFF
--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/StandardTagNames.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/StandardTagNames.java
@@ -28,4 +28,6 @@ public class StandardTagNames {
    * @deprecated use {@link io.opentracing.tag.Tags#ERROR}
    */
   @Deprecated public static final String FAILED = "failed";
+
+  public static final String EVICTED = "evicted";
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -168,6 +168,10 @@ public class SpanFactory {
     toSpan.log(System.currentTimeMillis(), logPayload);
   }
 
+  public void logEviction(Span toSpan) {
+    toSpan.setTag(StandardTagNames.EVICTED, true);
+  }
+
   private Tracer.SpanBuilder createSpan(
       SpanCreationContext context,
       Tracer tracer,

--- a/temporal-opentracing/src/test/java/io/temporal/worker/WorkflowEvictionTest.java
+++ b/temporal-opentracing/src/test/java/io/temporal/worker/WorkflowEvictionTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.temporal.client.*;
+import io.temporal.opentracing.*;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.List;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowEvictionTest {
+  private static final MockTracer mockTracer =
+      new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
+
+  private final OpenTracingOptions OT_OPTIONS =
+      OpenTracingOptions.newBuilder().setTracer(mockTracer).build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder()
+                  .setInterceptors(new OpenTracingClientInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new OpenTracingWorkerInterceptor(OT_OPTIONS))
+                  .validateAndBuildWithDefaults())
+          .setWorkflowTypes(SleepingWorkflowImpl.class)
+          .build();
+
+  @After
+  public void tearDown() {
+    mockTracer.reset();
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String workflow(String input);
+  }
+
+  public static class SleepingWorkflowImpl implements TestWorkflow {
+
+    @Override
+    public String workflow(String input) {
+      Workflow.sleep(1000);
+      return "ok";
+    }
+  }
+
+  @Test
+  public void workflowEvicted() {
+    WorkflowClient client = testWorkflowRule.getWorkflowClient();
+    SignalWithStartTest.TestWorkflow workflow =
+        client.newWorkflowStub(
+            SignalWithStartTest.TestWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+
+    Span span = mockTracer.buildSpan("ClientFunction").start();
+
+    try (Scope scope = mockTracer.scopeManager().activate(span)) {
+      WorkflowClient.start(workflow::workflow, "input");
+    } finally {
+      span.finish();
+    }
+
+    SDKTestWorkflowRule.waitForOKQuery(WorkflowStub.fromTyped(workflow));
+
+    testWorkflowRule.getTestEnvironment().getWorkerFactory().getCache().invalidateAll();
+
+    OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
+
+    MockSpan clientSpan = spansHelper.getSpanByOperationName("ClientFunction");
+
+    MockSpan workflowStartSpan = spansHelper.getByParentSpan(clientSpan).get(0);
+    assertEquals(clientSpan.context().spanId(), workflowStartSpan.parentId());
+    assertEquals("StartWorkflow:TestWorkflow", workflowStartSpan.operationName());
+
+    List<MockSpan> workflowRunSpans = spansHelper.getByParentSpan(workflowStartSpan);
+    assertEquals(1, workflowRunSpans.size());
+
+    MockSpan workflowRunSpan = workflowRunSpans.get(0);
+    assertEquals(workflowStartSpan.context().spanId(), workflowRunSpan.parentId());
+    assertEquals("RunWorkflow:TestWorkflow", workflowRunSpan.operationName());
+    assertEquals(true, workflowRunSpan.tags().get(StandardTagNames.EVICTED));
+    assertNull(workflowRunSpan.tags().get(Tags.ERROR.getKey()));
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DestroyWorkflowThreadError.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DestroyWorkflowThreadError.java
@@ -23,11 +23,11 @@ package io.temporal.internal.sync;
  * Used to interrupt deterministic thread execution. Assumption is that none of the code that thread
  * executes catches it.
  */
-final class DestroyWorkflowThreadError extends Error {
+public final class DestroyWorkflowThreadError extends Error {
 
-  public DestroyWorkflowThreadError() {}
+  DestroyWorkflowThreadError() {}
 
-  public DestroyWorkflowThreadError(String message) {
+  DestroyWorkflowThreadError(String message) {
     super(message);
   }
 }


### PR DESCRIPTION
Workflow evictions are not logged as errors in opentracing spans anymore.

Closes #1162