### PR TITLE
Explicit methods for lazy and eager connecting client, new #healthCheck method on stubs

### DIFF
--- a/temporal-kotlin/src/main/kotlin/io/temporal/serviceclient/WorkflowServiceStubsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/serviceclient/WorkflowServiceStubsExt.kt
@@ -20,13 +20,18 @@
 package io.temporal.serviceclient
 
 import io.temporal.kotlin.TemporalDsl
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaDuration
 
 /**
  * Create gRPC connection stubs using default options.
  *
  * @see WorkflowServiceStubs.newInstance
  */
+@Deprecated("Use LocalWorkflowServiceStubs()", replaceWith = ReplaceWith("LocalWorkflowServiceStubs()"))
 fun WorkflowServiceStubs(): WorkflowServiceStubs {
+  @Suppress("DEPRECATION")
   return WorkflowServiceStubs.newInstance()
 }
 
@@ -35,8 +40,43 @@ fun WorkflowServiceStubs(): WorkflowServiceStubs {
  *
  * @see WorkflowServiceStubs.newInstance
  */
+@Deprecated("Use LazyWorkflowServiceStubs(options) or ConnectedWorkflowServiceStubs(options)")
 inline fun WorkflowServiceStubs(
   options: @TemporalDsl WorkflowServiceStubsOptions.Builder.() -> Unit
 ): WorkflowServiceStubs {
+  @Suppress("DEPRECATION")
   return WorkflowServiceStubs.newInstance(WorkflowServiceStubsOptions(options))
+}
+
+/**
+ * Create WorkflowService gRPC stubs pointed on to the locally running Temporal Server.
+ *
+ * @see WorkflowServiceStubs.newLocalServiceStubs
+ */
+fun LocalWorkflowServiceStubs(): WorkflowServiceStubs {
+  return WorkflowServiceStubs.newLocalServiceStubs()
+}
+
+/**
+ * Create WorkflowService gRPC stubs using provided [options].
+ *
+ * @see WorkflowServiceStubs.newServiceStubs
+ */
+inline fun LazyWorkflowServiceStubs(
+  options: @TemporalDsl WorkflowServiceStubsOptions.Builder.() -> Unit
+): WorkflowServiceStubs {
+  return WorkflowServiceStubs.newServiceStubs(WorkflowServiceStubsOptions(options))
+}
+
+/**
+ * Create WorkflowService gRPC stubs using provided [options].
+ *
+ * @see WorkflowServiceStubs.newConnectedServiceStubs
+ */
+@OptIn(ExperimentalTime::class)
+inline fun ConnectedWorkflowServiceStubs(
+  options: @TemporalDsl WorkflowServiceStubsOptions.Builder.() -> Unit,
+  timeout: Duration
+): WorkflowServiceStubs {
+  return WorkflowServiceStubs.newConnectedServiceStubs(WorkflowServiceStubsOptions(options), timeout.toJavaDuration())
 }

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -216,7 +216,10 @@ public final class WorkerFactory {
     if (state == State.Started) {
       return;
     }
-    state = State.Started;
+
+    // Workers check and require that Temporal Server is available during start to fail-fast in case
+    // of configuration issues.
+    workflowClient.getWorkflowServiceStubs().connect(null);
 
     for (Worker worker : workers.values()) {
       worker.start();
@@ -228,6 +231,8 @@ public final class WorkerFactory {
     if (stickyPoller != null) {
       stickyPoller.start();
     }
+
+    state = State.Started;
   }
 
   /** Was {@link #start()} called. */

--- a/temporal-sdk/src/test/java/io/temporal/testUtils/HistoryUtils.java
+++ b/temporal-sdk/src/test/java/io/temporal/testUtils/HistoryUtils.java
@@ -41,7 +41,7 @@ public class HistoryUtils {
       throws Exception {
     try (TestServer.InProcessTestServer server = TestServer.createServer(true)) {
       WorkflowServiceStubs workflowServiceStubs =
-          WorkflowServiceStubs.newInstance(
+          WorkflowServiceStubs.newServiceStubs(
               WorkflowServiceStubsOptions.newBuilder().setChannel(server.getChannel()).build());
       try {
         return generateWorkflowTaskWithInitialHistory(
@@ -69,7 +69,7 @@ public class HistoryUtils {
       String namespace, String taskqueueName, String workflowType) throws Exception {
     try (TestServer.InProcessTestServer server = TestServer.createServer(true)) {
       WorkflowServiceStubs workflowServiceStubs =
-          WorkflowServiceStubs.newInstance(
+          WorkflowServiceStubs.newServiceStubs(
               WorkflowServiceStubsOptions.newBuilder().setChannel(server.getChannel()).build());
       try {
         PollWorkflowTaskQueueResponse response =

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -173,7 +173,7 @@ public class WorkerStressTests {
           WorkflowClientOptions.newBuilder().setNamespace(NAMESPACE).build();
       if (useDockerService) {
         service =
-            WorkflowServiceStubs.newInstance(
+            WorkflowServiceStubs.newServiceStubs(
                 WorkflowServiceStubsOptions.newBuilder().setTarget(serviceAddress).build());
         WorkflowClient client = WorkflowClient.newInstance(service, clientOptions);
         factory = WorkerFactory.newInstance(client, options);

--- a/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java
@@ -50,7 +50,7 @@ public class WorkerFactoryTests {
   @Before
   public void setUp() {
     service =
-        WorkflowServiceStubs.newInstance(
+        WorkflowServiceStubs.newServiceStubs(
             WorkflowServiceStubsOptions.newBuilder().setTarget(serviceAddress).build());
     WorkflowClient client = WorkflowClient.newInstance(service);
     factory = WorkerFactory.newInstance(client);

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
@@ -27,12 +27,14 @@ import io.grpc.health.v1.HealthGrpc;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.MetadataUtils;
 import io.temporal.internal.retryer.GrpcRetryer;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +94,6 @@ final class ChannelManager {
     interceptedChannel = applyHeadStandardInterceptors(interceptedChannel);
     interceptedChannel =
         ClientInterceptors.intercept(interceptedChannel, additionalHeadInterceptors);
-
     this.interceptedChannel = interceptedChannel;
     this.healthBlockingStub = HealthGrpc.newBlockingStub(interceptedChannel);
   }
@@ -244,22 +245,29 @@ final class ChannelManager {
   }
 
   /**
-   * Waits for a responding service using gRPC standard Health Check:
-   * https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+   * Establish a connection to the server and ensures that the server is reachable. Throws if the
+   * server can't be reached after the specified {@code timeout}.
    *
-   * <p>Please note that this method throws if the Health Check service can't be reached.
-   *
-   * @throws StatusRuntimeException if the service is unavailable.
-   * @return gRPC Health HealthCheckResponse
+   * @param timeout how long to wait for a successful connection with the server. If null,
+   *     rpcTimeout configured for this stub will be used.
+   * @throws StatusRuntimeException if the service is unavailable after {@code timeout}
+   * @throws IllegalStateException if the channel is already shutdown
    */
-  public HealthCheckResponse waitForServer(String healthCheckServiceName) {
+  public void connect(String healthCheckServiceName, @Nullable Duration timeout) {
+    ConnectivityState currentState = rawChannel.getState(false);
+    if (ConnectivityState.READY.equals(currentState)) {
+      return;
+    }
+    if (ConnectivityState.SHUTDOWN.equals(currentState)) {
+      throw new IllegalStateException("Can't connect stubs in SHUTDOWN state");
+    }
+    if (timeout == null) {
+      timeout = options.getRpcTimeout();
+    }
     RpcRetryOptions retryOptions =
-        RpcRetryOptions.newBuilder()
-            .setExpiration(options.getHealthCheckTimeout())
-            .validateBuildWithDefaults();
+        RpcRetryOptions.newBuilder().setExpiration(timeout).validateBuildWithDefaults();
 
-    return GrpcRetryer.retryWithResult(
-        retryOptions, () -> this.checkHealth(healthCheckServiceName));
+    GrpcRetryer.retryWithResult(retryOptions, () -> this.healthCheck(healthCheckServiceName, null));
   }
 
   /**
@@ -269,15 +277,22 @@ final class ChannelManager {
    * <p>Please note that this method throws if the Health Check service can't be reached.
    *
    * @param healthCheckServiceName a target service name for the health check request
+   * @param timeout custom timeout for the healthcheck
    * @throws StatusRuntimeException if the service is unavailable.
-   * @return gRPC Health HealthCheckResponse
+   * @return gRPC Health {@link HealthCheckResponse}
    */
-  public HealthCheckResponse checkHealth(String healthCheckServiceName) {
-    return healthBlockingStub
-        .withDeadline(
-            Deadline.after(
-                options.getHealthCheckAttemptTimeout().toMillis(), TimeUnit.MILLISECONDS))
-        .check(HealthCheckRequest.newBuilder().setService(healthCheckServiceName).build());
+  public HealthCheckResponse healthCheck(
+      String healthCheckServiceName, @Nullable Duration timeout) {
+    HealthGrpc.HealthBlockingStub stub;
+    if (timeout != null) {
+      stub =
+          this.healthBlockingStub.withDeadline(
+              Deadline.after(
+                  options.getHealthCheckAttemptTimeout().toMillis(), TimeUnit.MILLISECONDS));
+    } else {
+      stub = this.healthBlockingStub;
+    }
+    return stub.check(HealthCheckRequest.newBuilder().setService(healthCheckServiceName).build());
   }
 
   public void shutdown() {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/OperatorServiceStubs.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/OperatorServiceStubs.java
@@ -29,18 +29,39 @@ public interface OperatorServiceStubs
     extends ServiceStubs<
         OperatorServiceGrpc.OperatorServiceBlockingStub,
         OperatorServiceGrpc.OperatorServiceFutureStub> {
-  String HEALTH_CHECK_SERVICE_NAME = "temporal.api.workflowservice.v1.WorkflowService";
+  String HEALTH_CHECK_SERVICE_NAME = "temporal.api.operatorservice.v1.OperatorService";
 
   /**
-   * Create gRPC connection stubs using default options. The options default to the connection to
-   * the locally running temporal service.
+   * @deprecated use {@link #newLocalServiceStubs()}
    */
   static OperatorServiceStubs newInstance() {
-    return newInstance(OperatorServiceStubsOptions.getDefaultInstance());
+    return newLocalServiceStubs();
   }
 
-  /** Create gRPC connection stubs using provided options. */
+  /**
+   * @deprecated use {@link #newServiceStubs(OperatorServiceStubsOptions)}
+   */
+  @Deprecated
   static OperatorServiceStubs newInstance(OperatorServiceStubsOptions options) {
+    return newServiceStubs(options);
+  }
+
+  /**
+   * Creates OperatorService gRPC stubs pointed on to the locally running Temporal Server. The
+   * Server should be available on 127.0.0.1:7233
+   */
+  static OperatorServiceStubs newLocalServiceStubs() {
+    return newServiceStubs(OperatorServiceStubsOptions.getDefaultInstance());
+  }
+
+  /**
+   * Creates OperatorService gRPC stubs<br>
+   * This method creates stubs with lazy connectivity, connection is not performed during the
+   * creation time and happens on the first request.
+   *
+   * @param options stub options to use
+   */
+  static OperatorServiceStubs newServiceStubs(OperatorServiceStubsOptions options) {
     enforceNonWorkflowThread();
     return WorkflowThreadMarker.protectFromWorkflowThread(
         new OperatorServiceStubsImpl(options), OperatorServiceStubs.class);

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubs.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubs.java
@@ -20,7 +20,11 @@
 package io.temporal.serviceclient;
 
 import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import io.grpc.health.v1.HealthCheckResponse;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 public interface ServiceStubs<B, F> {
   /**
@@ -57,4 +61,28 @@ public interface ServiceStubs<B, F> {
    * @return false if timed out or the thread was interrupted.
    */
   boolean awaitTermination(long timeout, TimeUnit unit);
+
+  /**
+   * Establishes a connection with Temporal Server. If the Server is not available, retries waits
+   * for {@code timeout} duration.
+   *
+   * @param timeout how long to wait for a successful connection with the server. If null,
+   *     rpcTimeout configured for this stub will be used.
+   * @throws StatusRuntimeException if the server is unavailable after {@code timeout}
+   * @throws IllegalStateException if the channel is already shutdown
+   */
+  void connect(@Nullable Duration timeout);
+
+  /**
+   * Checks service health using gRPC standard Health Check:
+   * https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+   *
+   * <p>{@link ServiceStubsOptions#rpcTimeout} is used as a timeout for this call.
+   *
+   * <p>Please note that this method throws if the service Health Check endpoint can't be reached.
+   *
+   * @throws StatusRuntimeException if the service Health Check endpoint is unavailable.
+   * @return gRPC Health {@link HealthCheckResponse}
+   */
+  HealthCheckResponse healthCheck();
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -579,7 +579,9 @@ class ServiceStubsOptions {
      * Set the time to wait between service responses on each health check.
      *
      * @return {@code this}
+     * @deprecated {@link #rpcTimeout} is now used as an attempt timeout.
      */
+    @Deprecated
     public T setHealthCheckAttemptTimeout(Duration healthCheckAttemptTimeout) {
       this.healthCheckAttemptTimeout = healthCheckAttemptTimeout;
       return self();
@@ -590,7 +592,11 @@ class ServiceStubsOptions {
      * creating new client.
      *
      * @return {@code this}
+     * @deprecated Use more explicit {@link
+     *     WorkflowServiceStubs#newConnectedServiceStubs(WorkflowServiceStubsOptions, Duration)}
+     *     with a timeout parameter instead
      */
+    @Deprecated
     public T setHealthCheckTimeout(Duration healthCheckTimeout) {
       this.healthCheckTimeout = healthCheckTimeout;
       return self();

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubs.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubs.java
@@ -24,6 +24,8 @@ import static io.temporal.internal.WorkflowThreadMarker.enforceNonWorkflowThread
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.internal.WorkflowThreadMarker;
 import io.temporal.internal.testservice.InProcessGRPCServer;
+import java.time.Duration;
+import javax.annotation.Nullable;
 
 /** Initializes and holds gRPC blocking and future stubs. */
 public interface WorkflowServiceStubs
@@ -33,18 +35,93 @@ public interface WorkflowServiceStubs
   String HEALTH_CHECK_SERVICE_NAME = "temporal.api.workflowservice.v1.WorkflowService";
 
   /**
+   * Creates WorkflowService gRPC stubs pointed on to the locally running Temporal Server. The
+   * Server should be available on 127.0.0.1:7233
+   */
+  static WorkflowServiceStubs newLocalServiceStubs() {
+    return newServiceStubs(WorkflowServiceStubsOptions.getDefaultInstance());
+  }
+
+  /**
+   * Creates WorkflowService gRPC stubs.
+   *
+   * <p>This method creates stubs with "lazy" connectivity. The connection is not performed during
+   * the creation time and happens on the first request. <br>
+   * If you wish to perform a connection in an eager manner, call {@link
+   * WorkflowServiceStubs#connect(Duration)} after creation or use {@link
+   * #newConnectedServiceStubs(WorkflowServiceStubsOptions, Duration)} instead of this method.
+   *
+   * <p>Migration Note: This method doesn't respect {@link
+   * WorkflowServiceStubsOptions.Builder#setDisableHealthCheck(boolean)}, {@link
+   * WorkflowServiceStubsOptions.Builder#setHealthCheckAttemptTimeout(Duration)} (boolean)} and
+   * {@link WorkflowServiceStubsOptions.Builder#setHealthCheckTimeout(Duration)} (boolean)}. This
+   * method is equivalent to {@link
+   * WorkflowServiceStubsOptions.Builder#setDisableHealthCheck(boolean)} set.
+   *
+   * @param options stub options to use
+   */
+  static WorkflowServiceStubs newServiceStubs(WorkflowServiceStubsOptions options) {
+    enforceNonWorkflowThread();
+    return WorkflowThreadMarker.protectFromWorkflowThread(
+        new WorkflowServiceStubsImpl(null, options), WorkflowServiceStubs.class);
+  }
+
+  /**
+   * Creates WorkflowService gRPC stubs and ensures connectivity with the server at the moment of
+   * creation.
+   *
+   * <p>See {@link #newServiceStubs(WorkflowServiceStubsOptions)} if you prefer a lazy version of
+   * this method that doesn't perform an eager connection. This method is functionally equivalent to
+   * a sequence of {@link #newServiceStubs(WorkflowServiceStubsOptions)} and {@link
+   * WorkflowServiceStubs#connect(Duration)}
+   *
+   * <p>Migration Note: This method doesn't respect {@link
+   * WorkflowServiceStubsOptions.Builder#setDisableHealthCheck(boolean)}, {@link
+   * WorkflowServiceStubsOptions.Builder#setHealthCheckAttemptTimeout(Duration)} (boolean)} and
+   * {@link WorkflowServiceStubsOptions.Builder#setHealthCheckTimeout(Duration)} (boolean)}. This
+   * method is equivalent to {@link
+   * WorkflowServiceStubsOptions.Builder#setDisableHealthCheck(boolean)} not set.
+   *
+   * @param options stub options to use
+   * @param timeout timeout to use in {@link WorkflowServiceStubs#connect(Duration)} call. If null,
+   *     {@code options.getRpcTimeout()} will be used.
+   */
+  static WorkflowServiceStubs newConnectedServiceStubs(
+      WorkflowServiceStubsOptions options, @Nullable Duration timeout) {
+    WorkflowServiceStubs workflowServiceStubs = newServiceStubs(options);
+    workflowServiceStubs.connect(timeout);
+    return workflowServiceStubs;
+  }
+
+  /**
    * Create gRPC connection stubs using default options. The options default to the connection to
    * the locally running temporal service.
+   *
+   * @deprecated use {@link #newLocalServiceStubs()}.
    */
+  @Deprecated
   static WorkflowServiceStubs newInstance() {
     return newInstance(WorkflowServiceStubsOptions.getDefaultInstance());
   }
 
-  /** Create gRPC connection stubs using provided options. */
+  /**
+   * Create gRPC connection stubs using provided options.
+   *
+   * @deprecated use {@link #newServiceStubs(WorkflowServiceStubsOptions)} or {@link
+   *     #newConnectedServiceStubs(WorkflowServiceStubsOptions, Duration)}. Use {@link
+   *     #newServiceStubs(WorkflowServiceStubsOptions)} to get the same behavior as with set {@link
+   *     WorkflowServiceStubsOptions.Builder#setDisableHealthCheck(boolean)} (preferred). Use {@link
+   *     #newConnectedServiceStubs(WorkflowServiceStubsOptions, Duration)} with {{@link
+   *     WorkflowServiceStubsOptions.Builder#setHealthCheckTimeout(Duration)} as {@code timeout}
+   *     (null if you didn't specify it).
+   */
+  @Deprecated
   static WorkflowServiceStubs newInstance(WorkflowServiceStubsOptions options) {
-    enforceNonWorkflowThread();
-    return WorkflowThreadMarker.protectFromWorkflowThread(
-        new WorkflowServiceStubsImpl(null, options), WorkflowServiceStubs.class);
+    if (options.getDisableHealthCheck()) {
+      return newServiceStubs(options);
+    } else {
+      return newConnectedServiceStubs(options, options.getHealthCheckTimeout());
+    }
   }
 
   /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -21,6 +21,7 @@ package io.temporal.serviceclient;
 
 import com.google.common.base.Preconditions;
 import io.grpc.*;
+import io.grpc.health.v1.HealthCheckResponse;
 import io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions;
 import java.time.Duration;
 import java.util.*;
@@ -82,8 +83,10 @@ public final class WorkflowServiceStubsOptions extends ServiceStubsOptions {
 
   /**
    * @return false when client checks endpoint to make sure that the server is accessible.
-   * @deprecated eager health check inService Stubs will be enforced and required in the next
-   *     release.
+   * @deprecated ServiceStubs don't perform health check on start anymore to allow lazy
+   *     connectivity. Users that prefer old behavior should explicitly call {@link
+   *     ServiceStubs#healthCheck()} on client/stubs start and wait until it returns {@link
+   *     HealthCheckResponse.ServingStatus#SERVING}
    */
   @Deprecated
   public boolean getDisableHealthCheck() {
@@ -115,7 +118,7 @@ public final class WorkflowServiceStubsOptions extends ServiceStubsOptions {
 
   /** Builder is the builder for ClientOptions. */
   public static class Builder extends ServiceStubsOptions.Builder<Builder> {
-    private boolean disableHealthCheck;
+    private boolean disableHealthCheck = true;
     private Duration rpcLongPollTimeout = DEFAULT_POLL_RPC_TIMEOUT;
     private Duration rpcQueryTimeout = DEFAULT_QUERY_RPC_TIMEOUT;
     private RpcRetryOptions rpcRetryOptions = DefaultStubServiceOperationRpcRetryOptions.INSTANCE;
@@ -136,8 +139,9 @@ public final class WorkflowServiceStubsOptions extends ServiceStubsOptions {
      * If false, enables client to make a request to health check endpoint to make sure that the
      * server is accessible.
      *
-     * @deprecated eager health check inService Stubs will be enforced and required in the next
-     *     release.
+     * @deprecated Use more explicit {@link
+     *     WorkflowServiceStubs#newServiceStubs(WorkflowServiceStubsOptions)} that doesn't perform
+     *     an explicit connection and health check.
      */
     @Deprecated
     public Builder setDisableHealthCheck(boolean disableHealthCheck) {

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/HealthCheckTest.java
@@ -47,7 +47,7 @@ public class HealthCheckTest {
         }
         // Stub creation triggers health check by default, unless disableHealthCheck flag is set in
         // the WorkflowServiceStubsOptions.
-        workflowServiceStubs = WorkflowServiceStubs.newInstance(stubsOptions);
+        workflowServiceStubs = WorkflowServiceStubs.newServiceStubs(stubsOptions);
       } catch (Exception e) {
         Assert.fail("Health check failed");
       } finally {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1179,7 +1179,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     if (startInProcessServer) {
       this.inProcessServer = new InProcessGRPCServer(Collections.singletonList(this));
       this.workflowServiceStubs =
-          WorkflowServiceStubs.newInstance(
+          WorkflowServiceStubs.newServiceStubs(
               WorkflowServiceStubsOptions.newBuilder()
                   .setChannel(inProcessServer.getChannel())
                   .build());

--- a/temporal-test-server/src/main/java/io/temporal/serviceclient/TestServiceStubs.java
+++ b/temporal-test-server/src/main/java/io/temporal/serviceclient/TestServiceStubs.java
@@ -29,7 +29,7 @@ public interface TestServiceStubs
         TestServiceGrpc.TestServiceBlockingStub, TestServiceGrpc.TestServiceFutureStub> {
   String HEALTH_CHECK_SERVICE_NAME = "temporal.api.testservice.v1.TestService";
 
-  static TestServiceStubs newInstance(TestServiceStubsOptions options) {
+  static TestServiceStubs newServiceStubs(TestServiceStubsOptions options) {
     enforceNonWorkflowThread();
     return WorkflowThreadMarker.protectFromWorkflowThread(
         new TestServiceStubsImpl(options), TestServiceStubs.class);

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowCachingTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowCachingTest.java
@@ -59,12 +59,12 @@ public class WorkflowCachingTest {
   public void setUp() {
     this.testServer = TestServer.createServer(true);
     this.workflowServiceStubs =
-        WorkflowServiceStubs.newInstance(
+        WorkflowServiceStubs.newServiceStubs(
             WorkflowServiceStubsOptions.newBuilder()
                 .setChannel(testServer.getChannel())
                 .validateAndBuildWithDefaults());
     this.testServiceStubs =
-        TestServiceStubs.newInstance(
+        TestServiceStubs.newServiceStubs(
             TestServiceStubsOptions.newBuilder()
                 .setChannel(testServer.getChannel())
                 .validateAndBuildWithDefaults());

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/timeskipping/TimeSkippingFromAnActivityTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/timeskipping/TimeSkippingFromAnActivityTest.java
@@ -68,10 +68,10 @@ public class TimeSkippingFromAnActivityTest {
   public void setUp() {
     this.server = TestServer.createServer(false, 0);
     this.workflowServiceStubs =
-        WorkflowServiceStubs.newInstance(
+        WorkflowServiceStubs.newServiceStubs(
             WorkflowServiceStubsOptions.newBuilder().setChannel(server.getChannel()).build());
     this.testServiceStubs =
-        TestServiceStubs.newInstance(
+        TestServiceStubs.newServiceStubs(
             TestServiceStubsOptions.newBuilder()
                 .setChannel(workflowServiceStubs.getRawChannel())
                 .validateAndBuildWithDefaults());

--- a/temporal-testing/src/main/java/io/temporal/internal/docker/RegisterTestNamespace.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/docker/RegisterTestNamespace.java
@@ -48,7 +48,7 @@ public class RegisterTestNamespace {
 
     WorkflowServiceStubs service = null;
     try {
-      service = WorkflowServiceStubs.newInstance(options.build());
+      service = WorkflowServiceStubs.newServiceStubs(options.build());
       if (doesNamespaceExist(service)) {
         System.out.println("Namespace " + NAMESPACE + " already exists");
       } else {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -101,7 +101,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     mockServer =
         new InProcessGRPCServer(Collections.singletonList(new HeartbeatInterceptingService()));
     workflowServiceStubs =
-        WorkflowServiceStubs.newInstance(
+        WorkflowServiceStubs.newServiceStubs(
             WorkflowServiceStubsOptions.newBuilder()
                 .setChannel(mockServer.getChannel())
                 .setMetricsScope(options.getMetricsScope())

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -77,7 +77,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
       this.inProcessServer = null;
       this.service = null;
       this.workflowServiceStubs =
-          WorkflowServiceStubs.newInstance(
+          WorkflowServiceStubs.newServiceStubs(
               stubsOptionsBuilder.setTarget(testEnvironmentOptions.getTarget()).build());
       this.testServiceStubs = null;
       this.timeLockingInterceptor = null;
@@ -92,9 +92,9 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
               .setChannel(this.inProcessServer.getChannel())
               .setTarget(null)
               .validateAndBuildWithDefaults();
-      this.workflowServiceStubs = WorkflowServiceStubs.newInstance(workflowServiceStubsOptions);
+      this.workflowServiceStubs = WorkflowServiceStubs.newServiceStubs(workflowServiceStubsOptions);
       this.testServiceStubs =
-          TestServiceStubs.newInstance(
+          TestServiceStubs.newServiceStubs(
               TestServiceStubsOptions.newBuilder(workflowServiceStubsOptions)
                   // we don't want long calls to test service to throw with DEADLINE_EXCEEDED
                   .setRpcTimeout(Duration.ofMillis(Long.MAX_VALUE))
@@ -112,7 +112,7 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
     }
 
     this.operatorServiceStubs =
-        OperatorServiceStubs.newInstance(
+        OperatorServiceStubs.newServiceStubs(
             OperatorServiceStubsOptions.newBuilder()
                 .setChannel(workflowServiceStubs.getRawChannel())
                 .validateAndBuildWithDefaults());


### PR DESCRIPTION
Add and Implemented `ServiceStubs#healthCheck()`, make eager health check during client creation disabled by default.

Closes #828
Corresponded GoSDK change: https://github.com/temporalio/sdk-go/pull/795