### PR TITLE
Add per-module Jacoco config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,16 +1,5 @@
 steps:
-  - label: ":fire_extinguisher: JDK18 minimized build"
-    agents:
-      queue: "default"
-      docker: "*"
-    command: "./gradlew --no-daemon testClasses build -x test -x nativeImage -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply"
-    timeout_in_minutes: 15
-    plugins:
-      - docker-compose#v3.8.0:
-          run: jdk18
-          config: docker/buildkite/docker-compose.yaml
-
-  - label: ":java: Unit test with in-memory test service"
+  - label: ":java: JDK18 Unit test with in-memory test service"
     agents:
       queue: "default"
       docker: "*"
@@ -18,10 +7,10 @@ steps:
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:
-          run: unit-test-test-service-jdk8
+          run: unit-test-test-service-jdk18
           config: docker/buildkite/docker-compose.yaml
 
-  - label: ":docker: Unit test with docker service"
+  - label: ":docker: JDK8 Unit test with docker service"
     agents:
       queue: "default"
       docker: "*"

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,10 @@ plugins {
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'com.diffplug.spotless' version '6.5.0' apply false
+    id 'base'
 }
 
-subprojects {
+allprojects {
     repositories {
         mavenCentral()
     }
@@ -50,3 +51,6 @@ apply from: "$rootDir/gradle/errorprone.gradle"
 apply from: "$rootDir/gradle/licensing.gradle"
 apply from: "$rootDir/gradle/publishing.gradle"
 apply from: "$rootDir/gradle/dependencyManagement.gradle"
+if (project.project.hasProperty("jacoco")) {
+    apply from: "$rootDir/gradle/jacoco.gradle"
+}

--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -40,10 +40,10 @@ services:
     volumes:
       - "../../:/temporal-java-client"
 
-  unit-test-test-service-jdk8:
+  unit-test-test-service-jdk18:
     build:
       context: ../../
-      dockerfile: ./docker/buildkite/Dockerfile-JDK8
+      dockerfile: ./docker/buildkite/Dockerfile-JDK18
     environment:
       - "USER=unittest"
       - "USE_DOCKER_SERVICE=false"

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,28 @@
+//./gradlew jacocoTestReport -Pjacoco
+
+subprojects {
+    apply plugin: 'jacoco'
+
+    jacoco {
+        toolVersion = "0.8.8"
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.enabled false
+            csv.enabled true
+        }
+
+        afterEvaluate {
+            classDirectories.setFrom(files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: ["**/generated/**"])
+            }))
+        }
+    }
+
+    test {
+        // Some tests don't work with Jacoco.
+        // It's not a bug, they are just written assuming that they are working not with a proxy, but a pure instance
+        exclude 'io/temporal/workflow/KotlinAsyncChildWorkflowTest.class'
+    }
+}


### PR DESCRIPTION
Add Jacoco configuration that produces reports for each module.
Some tests refactoring to remove flakes caused by increased execution times with instrumentation for code coverage.