### PR TITLE
Improve illegal custom interceptors error reporting

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -113,5 +113,6 @@ interface DeterministicRunner {
   WorkflowThread newWorkflowThread(Runnable runnable, boolean detached, @Nullable String name);
 
   /** Creates a new instance of a workflow callback thread. */
+  @Nonnull
   WorkflowThread newCallbackThread(Runnable runnable, @Nullable String name);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -175,14 +175,20 @@ class DeterministicRunnerImpl implements DeterministicRunner {
       do {
         if (!toExecuteInWorkflowThread.isEmpty()) {
           for (NamedRunnable nr : toExecuteInWorkflowThread) {
-            Object thread =
+            Object callbackThread =
                 workflowContext
                     .getWorkflowInboundInterceptor()
                     .newCallbackThread(nr.runnable, nr.name);
             Preconditions.checkState(
-                thread != null,
-                "[BUG] One of the custom interceptors overrode newCallbackThread result to null. "
+                callbackThread != null,
+                "[BUG] One of the custom interceptors illegally overrode newCallbackThread result to null. "
                     + "Check WorkflowInboundCallsInterceptor#newCallbackThread contract.");
+            Preconditions.checkState(
+                callbackThread instanceof WorkflowThread,
+                "[BUG] One of the custom interceptors illegally overrode newCallbackThread result. "
+                    + "Check WorkflowInboundCallsInterceptor#newCallbackThread contract. "
+                    + "Illegal object returned from the interceptors chain: "
+                    + callbackThread);
           }
 
           // It is important to prepend threads as there are callbacks

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -79,17 +79,22 @@ public final class WorkflowInternal {
   public static final int DEFAULT_VERSION = -1;
 
   public static @Nonnull WorkflowThread newWorkflowMethodThread(Runnable runnable, String name) {
-    WorkflowThread workflowThread =
-        (WorkflowThread)
-            currentThreadInternal()
-                .getWorkflowContext()
-                .getWorkflowInboundInterceptor()
-                .newWorkflowMethodThread(runnable, name);
+    Object workflowThread =
+        currentThreadInternal()
+            .getWorkflowContext()
+            .getWorkflowInboundInterceptor()
+            .newWorkflowMethodThread(runnable, name);
     Preconditions.checkState(
         workflowThread != null,
-        "[BUG] One of the custom interceptors overrode newWorkflowMethodThread result to null. "
+        "[BUG] One of the custom interceptors illegally overrode newWorkflowMethodThread result to null. "
             + "Check WorkflowInboundCallsInterceptor#newWorkflowMethodThread contract.");
-    return workflowThread;
+    Preconditions.checkState(
+        workflowThread instanceof WorkflowThread,
+        "[BUG] One of the custom interceptors illegally overrode newWorkflowMethodThread result. "
+            + "Check WorkflowInboundCallsInterceptor#newWorkflowMethodThread contract. "
+            + "Illegal object returned from the interceptors chain: "
+            + workflowThread);
+    return (WorkflowThread) workflowThread;
   }
 
   public static Promise<Void> newTimer(Duration duration) {


### PR DESCRIPTION
Improve the exception message that users get if custom interceptors return an illegal object from `newThreadX` methods.