### PR TITLE
Add documentation to ManualActivityCompletionClient, fix absent service call retries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.5.0' apply false
+    id 'com.diffplug.spotless' version '6.5.1' apply false
     id 'base'
 }
 

--- a/temporal-sdk/src/main/java/io/temporal/activity/ManualActivityCompletionClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ManualActivityCompletionClient.java
@@ -20,14 +20,37 @@
 package io.temporal.activity;
 
 import io.temporal.failure.CanceledFailure;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+/**
+ * This client is attached to a specific activity execution and let user report completion
+ * (successful, failed or confirm cancellation) and perform heartbeats.
+ *
+ * <p>May be obtained by calling {@link ActivityExecutionContext#useLocalManualCompletion()}
+ */
 public interface ManualActivityCompletionClient {
 
-  void complete(Object result);
+  /**
+   * Completes the activity execution successfully.
+   *
+   * @param result of the activity execution
+   */
+  void complete(@Nullable Object result);
 
-  void fail(Throwable failure);
+  /**
+   * Completes the activity execution with failure.
+   *
+   * @param failure the exception to be used as a failure details object
+   */
+  void fail(@Nonnull Throwable failure);
 
-  void recordHeartbeat(Object details) throws CanceledFailure;
+  void recordHeartbeat(@Nullable Object details) throws CanceledFailure;
 
-  void reportCancellation(Object details);
+  /**
+   * Confirms successful cancellation to the server.
+   *
+   * @param details
+   */
+  void reportCancellation(@Nullable Object details);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactoryImpl.java
@@ -22,6 +22,7 @@ package io.temporal.internal.activity;
 import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.internal.client.external.ManualActivityCompletionClientFactory;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.time.Duration;
 import java.util.Objects;
@@ -35,6 +36,7 @@ public class ActivityExecutionContextFactoryImpl implements ActivityExecutionCon
   private final Duration defaultHeartbeatThrottleInterval;
   private final DataConverter dataConverter;
   private final ScheduledExecutorService heartbeatExecutor;
+  private final ManualActivityCompletionClientFactory manualCompletionClientFactory;
 
   public ActivityExecutionContextFactoryImpl(
       WorkflowServiceStubs service,
@@ -52,6 +54,9 @@ public class ActivityExecutionContextFactoryImpl implements ActivityExecutionCon
         Objects.requireNonNull(defaultHeartbeatThrottleInterval);
     this.dataConverter = Objects.requireNonNull(dataConverter);
     this.heartbeatExecutor = Objects.requireNonNull(heartbeatExecutor);
+    this.manualCompletionClientFactory =
+        ManualActivityCompletionClientFactory.newFactory(
+            service, namespace, identity, dataConverter);
   }
 
   @Override
@@ -62,6 +67,7 @@ public class ActivityExecutionContextFactoryImpl implements ActivityExecutionCon
         info,
         dataConverter,
         heartbeatExecutor,
+        manualCompletionClientFactory,
         info.getCompletionHandle(),
         metricsScope,
         identity,

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/CompletionAwareManualCompletionClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/CompletionAwareManualCompletionClient.java
@@ -17,17 +17,18 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.internal.sync;
+package io.temporal.internal.activity;
 
 import io.temporal.activity.ManualActivityCompletionClient;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.workflow.Functions;
+import javax.annotation.Nonnull;
 
-public final class CompletionAwareManualCompletionClient implements ManualActivityCompletionClient {
+final class CompletionAwareManualCompletionClient implements ManualActivityCompletionClient {
   private final ManualActivityCompletionClient client;
   private final Functions.Proc completionHandle;
 
-  public CompletionAwareManualCompletionClient(
+  CompletionAwareManualCompletionClient(
       ManualActivityCompletionClient client, Functions.Proc completionHandle) {
     this.client = client;
     this.completionHandle = completionHandle;
@@ -43,7 +44,7 @@ public final class CompletionAwareManualCompletionClient implements ManualActivi
   }
 
   @Override
-  public void fail(Throwable failure) {
+  public void fail(@Nonnull Throwable failure) {
     try {
       client.fail(failure);
     } finally {

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/ManualActivityCompletionClientFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/ManualActivityCompletionClientFactory.java
@@ -19,12 +19,29 @@
 
 package io.temporal.internal.client.external;
 
+import com.uber.m3.tally.Scope;
 import io.temporal.activity.ManualActivityCompletionClient;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.serviceclient.WorkflowServiceStubs;
 
 public interface ManualActivityCompletionClientFactory {
 
-  ManualActivityCompletionClient getClient(byte[] taskToken);
+  /**
+   * Create a {@link ManualActivityCompletionClientFactory} that emits simple {@link
+   * ManualActivityCompletionClientImpl} implementations
+   */
+  static ManualActivityCompletionClientFactory newFactory(
+      WorkflowServiceStubs service,
+      String namespace,
+      String identity,
+      DataConverter dataConverter) {
+    return new ManualActivityCompletionClientFactoryImpl(
+        service, namespace, identity, dataConverter);
+  }
 
-  ManualActivityCompletionClient getClient(WorkflowExecution execution, String activityId);
+  ManualActivityCompletionClient getClient(byte[] taskToken, Scope metricsScope);
+
+  ManualActivityCompletionClient getClient(
+      WorkflowExecution execution, String activityId, Scope metricsScope);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/ManualActivityCompletionClientFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/ManualActivityCompletionClientFactoryImpl.java
@@ -20,38 +20,28 @@
 package io.temporal.internal.client.external;
 
 import com.uber.m3.tally.Scope;
-import com.uber.m3.util.ImmutableMap;
 import io.temporal.activity.ManualActivityCompletionClient;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.common.converter.DataConverter;
-import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
-import java.util.Map;
 import java.util.Objects;
 
-public class ManualActivityCompletionClientFactoryImpl
-    implements ManualActivityCompletionClientFactory {
+class ManualActivityCompletionClientFactoryImpl implements ManualActivityCompletionClientFactory {
 
   private final WorkflowServiceStubs service;
   private final DataConverter dataConverter;
   private final String namespace;
   private final String identity;
-  private final Scope metricsScope;
 
   public ManualActivityCompletionClientFactoryImpl(
       WorkflowServiceStubs service,
       String namespace,
       String identity,
-      DataConverter dataConverter,
-      Scope metricsScope) {
+      DataConverter dataConverter) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.identity = Objects.requireNonNull(identity);
     this.dataConverter = Objects.requireNonNull(dataConverter);
-
-    Map<String, String> tags =
-        new ImmutableMap.Builder<String, String>(1).put(MetricsTag.NAMESPACE, namespace).build();
-    this.metricsScope = metricsScope.tagged(tags);
   }
 
   public WorkflowServiceStubs getService() {
@@ -63,7 +53,12 @@ public class ManualActivityCompletionClientFactoryImpl
   }
 
   @Override
-  public ManualActivityCompletionClient getClient(byte[] taskToken) {
+  public ManualActivityCompletionClient getClient(byte[] taskToken, Scope metricsScope) {
+    //    Map<String, String> tags =
+    //        new ImmutableMap.Builder<String, String>(1).put(MetricsTag.NAMESPACE,
+    // namespace).build();
+    //    this.metricsScope = metricsScope.tagged(tags);
+
     if (service == null) {
       throw new IllegalStateException("required property service is null");
     }
@@ -78,7 +73,8 @@ public class ManualActivityCompletionClientFactoryImpl
   }
 
   @Override
-  public ManualActivityCompletionClient getClient(WorkflowExecution execution, String activityId) {
+  public ManualActivityCompletionClient getClient(
+      WorkflowExecution execution, String activityId, Scope metricsScope) {
     if (execution == null) {
       throw new IllegalArgumentException("null execution");
     }


### PR DESCRIPTION
## What was changed

Add documentation to ManualActivityCompletionClient, fix absent service call retries.
One code path didn't have service retries which were fixed.
`ManualActivityCompletionClientFactory` was refactored to make the lifecycle of the factory instances saner.

## Why
The public user-facing ManualActivityCompletionClient interface was completely undocumented.

Work towards #752 scope