### PR TITLE
Fix workflow_active_thread_count, abstract WorkflowThreadExecutor instead of using a broad thread pool

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -21,7 +21,6 @@ package io.temporal.internal.sync;
 
 import io.temporal.internal.replay.WorkflowExecutorCache;
 import io.temporal.workflow.CancellationScope;
-import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -44,23 +43,26 @@ interface DeterministicRunner {
    * @return instance of the DeterministicRunner.
    */
   static DeterministicRunner newRunner(
-      ExecutorService threadPool,
+      WorkflowThreadExecutor workflowThreadExecutor,
       SyncWorkflowContext workflowContext,
       Runnable root,
       WorkflowExecutorCache cache) {
-    return new DeterministicRunnerImpl(threadPool, workflowContext, root, cache);
+    return new DeterministicRunnerImpl(workflowThreadExecutor, workflowContext, root, cache);
   }
 
   /**
    * Create new instance of DeterministicRunner
    *
+   * @param workflowThreadExecutor executor for workflow thread Runnables
    * @param workflowContext workflow context to use
    * @param root function that root thread of the runner executes.
    * @return instance of the DeterministicRunner.
    */
   static DeterministicRunner newRunner(
-      ExecutorService threadPool, SyncWorkflowContext workflowContext, Runnable root) {
-    return new DeterministicRunnerImpl(threadPool, workflowContext, root, null);
+      WorkflowThreadExecutor workflowThreadExecutor,
+      SyncWorkflowContext workflowContext,
+      Runnable root) {
+    return new DeterministicRunnerImpl(workflowThreadExecutor, workflowContext, root, null);
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,17 +77,17 @@ final class POJOWorkflowImplementationFactory implements ReplayWorkflowFactory {
   /** If present then it is called for any unknown workflow type. */
   private Functions.Func<? extends DynamicWorkflow> dynamicWorkflowImplementationFactory;
 
-  private final ExecutorService threadPool;
+  private final WorkflowThreadExecutor workflowThreadExecutor;
   private final WorkflowExecutorCache cache;
 
   POJOWorkflowImplementationFactory(
       SingleWorkerOptions singleWorkerOptions,
-      ExecutorService threadPool,
+      WorkflowThreadExecutor workflowThreadExecutor,
       WorkerInterceptor[] workerInterceptors,
       WorkflowExecutorCache cache) {
     Objects.requireNonNull(singleWorkerOptions);
     this.dataConverter = singleWorkerOptions.getDataConverter();
-    this.threadPool = Objects.requireNonNull(threadPool);
+    this.workflowThreadExecutor = Objects.requireNonNull(workflowThreadExecutor);
     this.workerInterceptors = Objects.requireNonNull(workerInterceptors);
     this.cache = cache;
     this.contextPropagators = singleWorkerOptions.getContextPropagators();
@@ -235,7 +234,7 @@ final class POJOWorkflowImplementationFactory implements ReplayWorkflowFactory {
         workflow,
         options,
         dataConverter,
-        threadPool,
+        workflowThreadExecutor,
         cache,
         contextPropagators,
         defaultDeadlockDetectionTimeout);

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -39,7 +39,6 @@ import io.temporal.worker.WorkflowImplementationOptions;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +52,7 @@ class SyncWorkflow implements ReplayWorkflow {
 
   private final DataConverter dataConverter;
   private final List<ContextPropagator> contextPropagators;
-  private final ExecutorService threadPool;
+  private final WorkflowThreadExecutor workflowThreadExecutor;
   private final SyncWorkflowDefinition workflow;
   private final WorkflowImplementationOptions workflowImplementationOptions;
   private final WorkflowExecutorCache cache;
@@ -67,7 +66,7 @@ class SyncWorkflow implements ReplayWorkflow {
       SyncWorkflowDefinition workflow,
       WorkflowImplementationOptions workflowImplementationOptions,
       DataConverter dataConverter,
-      ExecutorService threadPool,
+      WorkflowThreadExecutor workflowThreadExecutor,
       WorkflowExecutorCache cache,
       List<ContextPropagator> contextPropagators,
       long defaultDeadlockDetectionTimeout) {
@@ -77,7 +76,7 @@ class SyncWorkflow implements ReplayWorkflow {
             ? WorkflowImplementationOptions.newBuilder().build()
             : workflowImplementationOptions;
     this.dataConverter = Objects.requireNonNull(dataConverter);
-    this.threadPool = Objects.requireNonNull(threadPool);
+    this.workflowThreadExecutor = Objects.requireNonNull(workflowThreadExecutor);
     this.cache = cache;
     this.contextPropagators = contextPropagators;
     this.defaultDeadlockDetectionTimeout = defaultDeadlockDetectionTimeout;
@@ -129,7 +128,7 @@ class SyncWorkflow implements ReplayWorkflow {
     // 3. main workflow method
     runner =
         DeterministicRunner.newRunner(
-            threadPool,
+            workflowThreadExecutor,
             syncContext,
             () -> {
               workflow.initialize();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
@@ -79,9 +79,7 @@ public class SyncWorkflowWorker
       WorkflowExecutorCache cache,
       String stickyTaskQueueName,
       Duration stickyWorkflowTaskScheduleToStartTimeout,
-      ThreadPoolExecutor workflowThreadPool) {
-    Objects.requireNonNull(workflowThreadPool);
-
+      WorkflowThreadExecutor workflowThreadExecutor) {
     this.identity = singleWorkerOptions.getIdentity();
     this.namespace = namespace;
     this.taskQueue = taskQueue;
@@ -90,7 +88,10 @@ public class SyncWorkflowWorker
 
     factory =
         new POJOWorkflowImplementationFactory(
-            singleWorkerOptions, workflowThreadPool, workerInterceptors, cache);
+            singleWorkerOptions,
+            Objects.requireNonNull(workflowThreadExecutor),
+            workerInterceptors,
+            cache);
 
     ActivityExecutionContextFactory laActivityExecutionContextFactory =
         new LocalActivityExecutionContextFactoryImpl();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadExecutor.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.sync;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import javax.annotation.Nonnull;
+
+/**
+ * Abstracts the {@link java.util.concurrent.ThreadPoolExecutor} that is used to submit workflow
+ * thread tasks to allow higher levels to define additional wrapping logic like worker-wide metric
+ * reporting.
+ */
+public interface WorkflowThreadExecutor {
+  /**
+   * Submits a Runnable task for execution and returns a Future representing that task. The Future's
+   * {@code get} method will return {@code null} upon <em>successful</em> completion.
+   *
+   * <p>This method's descriptor is a 1-1 copy of {@link
+   * java.util.concurrent.ThreadPoolExecutor#submit(Runnable)}
+   *
+   * @param task the task to submit
+   * @return a Future representing pending completion of the task
+   * @throws RejectedExecutionException if the task cannot be scheduled for execution
+   * @throws NullPointerException if the task is null
+   */
+  Future<?> submit(@Nonnull Runnable task);
+}

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -34,6 +34,7 @@ import io.temporal.internal.replay.WorkflowExecutorCache;
 import io.temporal.internal.sync.SyncActivityWorker;
 import io.temporal.internal.sync.SyncWorkflowWorker;
 import io.temporal.internal.sync.WorkflowInternal;
+import io.temporal.internal.sync.WorkflowThreadExecutor;
 import io.temporal.internal.worker.PollerOptions;
 import io.temporal.internal.worker.ShutdownManager;
 import io.temporal.internal.worker.SingleWorkerOptions;
@@ -46,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -71,7 +71,7 @@ public final class Worker implements Suspendable {
    *     activity task queue polls.
    * @param options Options (like {@link DataConverter} override) for configuring worker.
    * @param stickyTaskQueueName
-   * @param workflowThreadPool thread pool to be used for workflow method threads
+   * @param workflowThreadExecutor workflow methods thread executor
    */
   Worker(
       WorkflowClient client,
@@ -81,7 +81,7 @@ public final class Worker implements Suspendable {
       Scope metricsScope,
       WorkflowExecutorCache cache,
       String stickyTaskQueueName,
-      ThreadPoolExecutor workflowThreadPool,
+      WorkflowThreadExecutor workflowThreadExecutor,
       List<ContextPropagator> contextPropagators) {
 
     Objects.requireNonNull(client, "client should not be null");
@@ -134,7 +134,7 @@ public final class Worker implements Suspendable {
             cache,
             stickyTaskQueueName,
             factoryOptions.getWorkflowHostLocalTaskQueueScheduleToStartTimeout(),
-            workflowThreadPool);
+            workflowThreadExecutor);
   }
 
   private static SingleWorkerOptions toActivityOptions(

--- a/temporal-sdk/src/test/java/io/temporal/common/reporter/TestStatsReporter.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/reporter/TestStatsReporter.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 public final class TestStatsReporter implements StatsReporter {
 
@@ -72,6 +73,10 @@ public final class TestStatsReporter implements StatsReporter {
   }
 
   public void assertGauge(String name, Map<String, String> tags, double expected) {
+    assertGauge(name, tags, val -> Math.abs(expected - val) < 1e-3);
+  }
+
+  public void assertGauge(String name, Map<String, String> tags, Predicate<Double> isExpected) {
     String metricName = getMetricName(name, tags);
     Double value = gauges.get(metricName);
     if (value == null) {
@@ -81,7 +86,7 @@ public final class TestStatsReporter implements StatsReporter {
               + "', reported metrics: \n "
               + String.join("\n ", gauges.keySet()));
     }
-    assertEquals(String.valueOf(value), expected, value, 1e-3);
+    assertTrue(String.valueOf(value), isExpected.test(value));
   }
 
   public void assertTimer(String name, Map<String, String> tags) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -92,7 +92,7 @@ public class DeterministicRunnerTest {
   public void testYield() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               status = "started";
@@ -135,7 +135,7 @@ public class DeterministicRunnerTest {
     Duration expiration = Duration.ofMinutes(5);
     DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("started");
@@ -177,7 +177,7 @@ public class DeterministicRunnerTest {
   public void testRootFailure() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               status = "started";
@@ -201,7 +201,7 @@ public class DeterministicRunnerTest {
   public void testDispatcherStop() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               status = "started";
@@ -231,7 +231,7 @@ public class DeterministicRunnerTest {
   public void testDispatcherExit() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -273,7 +273,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -301,7 +301,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -345,7 +345,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -402,7 +402,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -447,7 +447,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -507,7 +507,7 @@ public class DeterministicRunnerTest {
     trace.add("init");
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root started");
@@ -562,7 +562,7 @@ public class DeterministicRunnerTest {
   public void testChild() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> async =
@@ -620,7 +620,7 @@ public class DeterministicRunnerTest {
   public void testChildTree() {
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             new TestChildTreeRunnable(0)::apply);
     d.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
@@ -666,7 +666,7 @@ public class DeterministicRunnerTest {
 
     DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             new SyncWorkflowContext(
                 replayWorkflowContext, DataConverter.getDefaultInstance(), null, null, null),
             () -> {
@@ -692,7 +692,7 @@ public class DeterministicRunnerTest {
 
     DeterministicRunnerImpl d2 =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             new SyncWorkflowContext(
                 replayWorkflowContext, DataConverter.getDefaultInstance(), null, null, null),
             () -> {
@@ -729,7 +729,7 @@ public class DeterministicRunnerTest {
 
     DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> thread =
@@ -754,7 +754,7 @@ public class DeterministicRunnerTest {
 
     DeterministicRunnerImpl d2 =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> thread =
@@ -809,7 +809,7 @@ public class DeterministicRunnerTest {
 
     DeterministicRunner d =
         new DeterministicRunnerImpl(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               Promise<Void> async = Async.procedure(() -> status = "started");

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
@@ -61,7 +61,7 @@ public class PromiseTest {
   public void testFailure() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<Boolean> f = Workflow.newPromise();
@@ -96,7 +96,7 @@ public class PromiseTest {
   public void testGet() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
@@ -117,7 +117,7 @@ public class PromiseTest {
   public void testCancellableGet() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
@@ -138,7 +138,7 @@ public class PromiseTest {
   public void testCancellableGetCancellation() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               CompletablePromise<String> f = Workflow.newPromise();
@@ -216,7 +216,7 @@ public class PromiseTest {
   public void testMultiple() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -271,7 +271,7 @@ public class PromiseTest {
   public void tstAsync() {
     DeterministicRunner runner =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -306,7 +306,7 @@ public class PromiseTest {
   public void testAsyncFailure() {
     DeterministicRunner runner =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -350,7 +350,7 @@ public class PromiseTest {
   public void testAllOf() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -411,7 +411,7 @@ public class PromiseTest {
   public void testAllOfImmediatelyReady() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -454,7 +454,7 @@ public class PromiseTest {
   public void testAnyOf() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -516,7 +516,7 @@ public class PromiseTest {
   public void testAllOfArray() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -578,7 +578,7 @@ public class PromiseTest {
   public void testAnyOfArray() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");
@@ -641,7 +641,7 @@ public class PromiseTest {
   public void testAnyOfImmediatelyReady() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               trace.add("root begin");

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
@@ -57,7 +57,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testTakeBlocking() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -98,7 +98,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -133,7 +133,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testCancellableTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -296,7 +296,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testPutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -332,7 +332,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testCancellablePutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newQueue(1);
@@ -368,7 +368,7 @@ public class WorkflowInternalDeprecatedQueueTest {
   public void testMap() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Integer> queue = WorkflowInternal.newQueue(1);

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -60,7 +60,7 @@ public class WorkflowInternalQueueTest {
   public void testTakeBlocking() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -101,7 +101,7 @@ public class WorkflowInternalQueueTest {
   public void testTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -136,7 +136,7 @@ public class WorkflowInternalQueueTest {
   public void testCancellableTakeCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -299,7 +299,7 @@ public class WorkflowInternalQueueTest {
   public void testPutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -335,7 +335,7 @@ public class WorkflowInternalQueueTest {
   public void testCancellablePutCanceled() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Boolean> f = WorkflowInternal.newWorkflowQueue(1);
@@ -371,7 +371,7 @@ public class WorkflowInternalQueueTest {
   public void testMap() {
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               WorkflowQueue<Integer> queue = WorkflowInternal.newWorkflowQueue(1);
@@ -425,7 +425,7 @@ public class WorkflowInternalQueueTest {
     int[] result = new int[3];
     DeterministicRunner r =
         DeterministicRunner.newRunner(
-            threadPool,
+            threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               queue.put(1);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -455,11 +455,13 @@ public class MetricsTest {
 
     Thread.sleep(REPORTING_FLUSH_TIME);
     reporter.assertGauge(STICKY_CACHE_SIZE, TAGS_NAMESPACE, 1);
+    reporter.assertGauge(WORKFLOW_ACTIVE_THREAD_COUNT, TAGS_NAMESPACE, val -> val == 1 || val == 2);
 
     wfFuture.get();
 
     Thread.sleep(REPORTING_FLUSH_TIME);
     reporter.assertGauge(STICKY_CACHE_SIZE, TAGS_NAMESPACE, 0);
+    reporter.assertGauge(WORKFLOW_ACTIVE_THREAD_COUNT, TAGS_NAMESPACE, 0);
   }
 
   @WorkflowInterface

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DeterministicRunnerWrapper.java
@@ -26,12 +26,12 @@ import java.util.concurrent.*;
 
 public class DeterministicRunnerWrapper implements InvocationHandler {
   private final InvocationHandler invocationHandler;
-  private final ExecutorService executorService;
+  private final WorkflowThreadExecutor workflowThreadExecutor;
 
   public DeterministicRunnerWrapper(
-      InvocationHandler invocationHandler, ExecutorService executorService) {
+      InvocationHandler invocationHandler, WorkflowThreadExecutor workflowThreadExecutor) {
     this.invocationHandler = Objects.requireNonNull(invocationHandler);
-    this.executorService = Objects.requireNonNull(executorService);
+    this.workflowThreadExecutor = Objects.requireNonNull(workflowThreadExecutor);
   }
 
   @Override
@@ -39,7 +39,7 @@ public class DeterministicRunnerWrapper implements InvocationHandler {
     CompletableFuture<Object> result = new CompletableFuture<>();
     DeterministicRunner runner =
         new DeterministicRunnerImpl(
-            executorService,
+            workflowThreadExecutor,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
             () -> {
               try {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -187,7 +187,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
         ActivityInvocationHandler.newInstance(
             activityInterface, options, null, new TestActivityExecutor());
     invocationHandler =
-        new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor);
+        new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor::submit);
     return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
   }
 
@@ -203,7 +203,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
         ActivityInvocationHandler.newInstance(
             activityInterface, options, null, new TestActivityExecutor());
     invocationHandler =
-        new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor);
+        new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor::submit);
     return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
   }
 
@@ -223,7 +223,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
         LocalActivityInvocationHandler.newInstance(
             activityInterface, options, activityMethodOptions, new TestActivityExecutor());
     invocationHandler =
-        new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor);
+        new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor::submit);
     return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
   }
 


### PR DESCRIPTION
## What was changed

Abstract WorkflowThreadExecutor instead of using a broad thread pool in WorkflowThread class. WorkflowThread needs only the regular `submit` method.
Initialize WorkflowThreadExecutor in WorkerFactory to use the root worker metric scope.

## Why
WorkerThread doesn't need to log the worker_active_thread metric. This metric belongs to `WorkerFactory` level scope and logging of this metric should be performed on that level.

Closes #1179