### PR TITLE
Polish ConnectedWorkflowServiceStubs method

### DIFF
--- a/temporal-kotlin/src/main/kotlin/io/temporal/serviceclient/WorkflowServiceStubsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/serviceclient/WorkflowServiceStubsExt.kt
@@ -23,6 +23,7 @@ import io.temporal.kotlin.TemporalDsl
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.toJavaDuration
+import java.time.Duration as JavaDuration
 
 /**
  * Create gRPC connection stubs using default options.
@@ -73,10 +74,39 @@ inline fun LazyWorkflowServiceStubs(
  *
  * @see WorkflowServiceStubs.newConnectedServiceStubs
  */
-@OptIn(ExperimentalTime::class)
+@ExperimentalTime
+@Deprecated(
+  "Use ConnectedWorkflowServiceStubs(timeout, options)",
+  ReplaceWith("ConnectedWorkflowServiceStubs(timeout, options)")
+)
 inline fun ConnectedWorkflowServiceStubs(
   options: @TemporalDsl WorkflowServiceStubsOptions.Builder.() -> Unit,
   timeout: Duration
 ): WorkflowServiceStubs {
-  return WorkflowServiceStubs.newConnectedServiceStubs(WorkflowServiceStubsOptions(options), timeout.toJavaDuration())
+  return ConnectedWorkflowServiceStubs(timeout, options)
+}
+
+/**
+ * Create WorkflowService gRPC stubs using provided [options].
+ *
+ * @see WorkflowServiceStubs.newConnectedServiceStubs
+ */
+@ExperimentalTime
+inline fun ConnectedWorkflowServiceStubs(
+  timeout: Duration,
+  options: @TemporalDsl WorkflowServiceStubsOptions.Builder.() -> Unit,
+): WorkflowServiceStubs {
+  return ConnectedWorkflowServiceStubs(timeout.toJavaDuration(), options)
+}
+
+/**
+ * Create WorkflowService gRPC stubs using provided [options].
+ *
+ * @see WorkflowServiceStubs.newConnectedServiceStubs
+ */
+inline fun ConnectedWorkflowServiceStubs(
+  timeout: JavaDuration? = null,
+  options: @TemporalDsl WorkflowServiceStubsOptions.Builder.() -> Unit,
+): WorkflowServiceStubs {
+  return WorkflowServiceStubs.newConnectedServiceStubs(WorkflowServiceStubsOptions(options), timeout)
 }


### PR DESCRIPTION
## What was changed

* move options lambda to the last argument of the function to support DSL-like usage
* add a variation that accepts `java.time.Duration` timeout
* make timeout optional and nullable

## Why?

This change adapts the `ConnectedWorkflowServiceStubs` method that was introduced in SDK 1.11.0 to Kotlin idioms.

1. In order for the method to work as a "DSL" its lambda argument has to be the last. E.g. the existing method could be called as
    ```kotlin
    ConnectedWorkflowServiceStubs({
      setTarget("myhost")
    }, 30.seconds)
    ```
    however if the options lambda is moved as the last argument it could be called as
    ```kotlin
    ConnectedWorkflowServiceStubs(30.seconds) {
      setTarget("myhost")
    }
    ```
2. The underlying `WorkflowServiceStubs.newConnectedServiceStubs` method supports a `null` value of `timeout` but the Kotlin wrapper doesn't allow `null` to be passed. Null is also set as the default value so the call could look like
    ```kotlin
    ConnectedWorkflowServiceStubs {
      setTarget("myhost")
    }
    ```
3. Sometimes the client code might have a `timeout` as an instance of Java's `java.time.Duration`. We could accept both types by adding an extra overload.
4. Change the way `@ExperimentalTime` is used. There are 2 ways to use classes/methods marked as `Experimental*` - either by directly annotating with that `@Experimental*` annotation or via `@OptIn(Experimental*)`. The former means the unstable status is the responsibility of the consumer (might introduce a breaking change in the future); the latter means it's the library author's responsibility (clients won't see anything even if the experimental feature is changed in the future). In our case, the `kotlin.time.Duration` is in the method's signature so its experimental status might be pushed to the client. - **this might be a breaking change for consumers of the `ConnectedWorkflowServiceStubs` method**.

## Checklist

1. Closes: **-**

2. How was this tested: **manually**

3. Any docs updates needed? **none**