### PR TITLE
Fix absent request level metrics not logging with incorrectly implemented custom grpc interceptor

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
@@ -74,7 +74,7 @@ public class PotentialDeadlockException extends RuntimeException {
     return super.getMessage()
         + " {"
         + ("detectionTimestamp=" + detectionTimestamp)
-        + ("threadDumpTimestamp=" + threadDumpTimestamp)
+        + (", threadDumpTimestamp=" + threadDumpTimestamp)
         + "} \n\n"
         + triggerThreadStackTrace
         + (!otherThreadsDump.isEmpty()


### PR DESCRIPTION
## What was changed
Now GrpcMetricsInterceptor tolerates incorrectly implemented user interceptor that throws from onClose (onClose grpc method contract prohibits throwing from it).
Also includes a small optimization avoiding the creation of a map of tags for each request failure.

## Why?
If a user has incorrectly implemented custom interceptor that throws in some situation, Temporal SDK will fail logging request level metrics potentially complicating detection of the problem.