### PR TITLE
Align Test Server direct query behavior with the real server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.5.1' apply false
+    id 'com.diffplug.spotless' version '6.5.2' apply false
     id 'base'
 }
 

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -9,7 +9,7 @@ plugins {
 //    id 'org.jetbrains.kotlin.jvm' version '1.5.32'
 //    id 'org.jetbrains.kotlin.jvm' version '1.6.20'
     id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}"
-    id 'org.jlleitschuh.gradle.ktlint' version '10.2.1'
+    id 'org.jlleitschuh.gradle.ktlint' version '10.3.0'
 }
 
 apply plugin: 'org.jetbrains.kotlin.jvm'

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -31,7 +31,6 @@ import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.common.converter.DataConverterException;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * Provides a wrapper with convenience methods over raw protobuf {@link History} object representing
@@ -123,7 +122,6 @@ public final class WorkflowExecutionHistory {
     return history.getEventsList();
   }
 
-  @Nullable
   public HistoryEvent getLastEvent() {
     int eventsCount = history.getEventsCount();
     return eventsCount > 0 ? history.getEvents(eventsCount - 1) : null;

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -352,6 +352,8 @@ public final class WorkerFactory {
     log.info("awaitTermination done: {}", this);
   }
 
+  // TODO we should hide an actual implementation of WorkerFactory under WorkerFactory interface and
+  // expose this method on the implementation only
   @VisibleForTesting
   WorkflowExecutorCache getCache() {
     return this.cache;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/QueryCausingReplayWithLocalActivityInLastWFTTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/QueryCausingReplayWithLocalActivityInLastWFTTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.queryTests;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
+import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+// Covers a very specific scenario where
+// 1. the last completed workflow task has local activity markers
+// 2. workflow execution is not completed
+// 3. the workflow is evicted from the cache
+// 4. workflow gets a "direct (legacy) query" to execute
+// https://github.com/temporalio/sdk-java/issues/1190
+public class QueryCausingReplayWithLocalActivityInLastWFTTest {
+
+  private final TestActivitiesImpl activitiesImpl = new TestActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestLocalActivityAndQueryWorkflow.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testLocalActivityAndQuery() {
+    TestWorkflows.TestWorkflowWithQuery workflowStub =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowWithQuery.class);
+    WorkflowExecution execution = WorkflowClient.start(workflowStub::execute);
+    // Don't do waitForOKQuery wait here, it changes the structure of history events in a way that
+    // doesn't reproduce the problem
+    testWorkflowRule.waitForTheEndOfWFT(execution);
+
+    testWorkflowRule.invalidateWorkflowCache();
+    assertEquals("updated", workflowStub.query());
+    assertEquals("done", WorkflowStub.fromTyped(workflowStub).getResult(String.class));
+
+    // local activity is expected to be triggered only once
+    activitiesImpl.assertInvocations("activity");
+  }
+
+  public static final class TestLocalActivityAndQueryWorkflow
+      implements TestWorkflows.TestWorkflowWithQuery {
+
+    String message = "initial";
+
+    @Override
+    public String execute() {
+      VariousTestActivities localActivities =
+          Workflow.newLocalActivityStub(
+              VariousTestActivities.class,
+              SDKTestOptions.newLocalActivityOptions().toBuilder().build());
+      localActivities.activity();
+      message = "updated";
+      Workflow.sleep(4_000);
+      return "done";
+    }
+
+    @Override
+    public String query() {
+      return message;
+    }
+  }
+}

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -339,11 +339,10 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
         if (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_STARTED) {
           if (!iterator.hasNext()
               || iterator.peek().getEventType() == EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED) {
-            previousStaredEventId = startedEventId;
-            startedEventId = event.getEventId();
+            previousStaredEventId = event.getEventId();
+            startedEventId = previousStaredEventId;
           }
         } else if (WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
-          previousStaredEventId = startedEventId;
           startedEventId = 0;
           if (iterator.hasNext()) {
             throw Status.INTERNAL
@@ -353,6 +352,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
         }
       }
       task.setPreviousStartedEventId(previousStaredEventId);
+      // it's not a real workflow task and the server sends 0 for startedEventId for such a workflow
+      // task
       task.setStartedEventId(startedEventId);
       if (taskQueue.getTaskQueueName().equals(task.getWorkflowExecutionTaskQueue().getName())) {
         history.addAllEvents(events);


### PR DESCRIPTION
## What was changed

Add a unit test for a specific corner case of a direct query after completion of local activity.
Align Test Server behavior with real Temporal Server for such a direct query.

## Why?

The current unexpected behavior of Temporal Test Server causes state machine problems.

Closes #1190