### PR TITLE
Rework async long poll to use the same configuration as the main long poll

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollAsyncHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollAsyncHelper.java
@@ -21,7 +21,6 @@ package io.temporal.internal.client;
 
 import static io.temporal.internal.common.WorkflowExecutionUtils.getResultFromCloseEvent;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import io.grpc.Deadline;
 import io.temporal.api.common.v1.Payloads;
@@ -32,13 +31,9 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.internal.client.external.GenericWorkflowClient;
 import io.temporal.internal.common.WorkflowExecutionUtils;
-import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
-import io.temporal.serviceclient.RpcRetryOptions;
-import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.rpcretry.DefaultStubLongPollRpcRetryOptions;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.*;
 
@@ -46,15 +41,15 @@ import java.util.concurrent.*;
 final class WorkflowClientLongPollAsyncHelper {
 
   static CompletableFuture<Optional<Payloads>> getWorkflowExecutionResultAsync(
-      WorkflowServiceStubs service,
-      RootWorkflowClientHelper workflowClientHelper,
+      GenericWorkflowClient genericClient,
+      WorkflowClientRequestFactory workflowClientHelper,
       WorkflowExecution workflowExecution,
       Optional<String> workflowType,
       long timeout,
       TimeUnit unit,
       DataConverter converter) {
     return getInstanceCloseEventAsync(
-            service, workflowClientHelper, workflowExecution, ByteString.EMPTY, timeout, unit)
+            genericClient, workflowClientHelper, workflowExecution, ByteString.EMPTY, timeout, unit)
         .thenApply(
             (closeEvent) ->
                 getResultFromCloseEvent(workflowExecution, workflowType, closeEvent, converter));
@@ -62,37 +57,34 @@ final class WorkflowClientLongPollAsyncHelper {
 
   /** Returns an instance closing event, potentially waiting for workflow to complete. */
   private static CompletableFuture<HistoryEvent> getInstanceCloseEventAsync(
-      WorkflowServiceStubs service,
-      RootWorkflowClientHelper workflowClientHelper,
+      GenericWorkflowClient genericClient,
+      WorkflowClientRequestFactory workflowClientHelper,
       final WorkflowExecution workflowExecution,
       ByteString pageToken,
       long timeout,
       TimeUnit unit) {
-    // TODO: Interrupt service long poll call on timeout and on interrupt
-    long start = System.currentTimeMillis();
     GetWorkflowExecutionHistoryRequest request =
         workflowClientHelper.newHistoryLongPollRequest(workflowExecution, pageToken);
+    Deadline deadline = Deadline.after(timeout, unit);
     CompletableFuture<GetWorkflowExecutionHistoryResponse> response =
-        getWorkflowExecutionHistoryAsync(service, request, timeout, unit);
+        genericClient.longPollHistoryAsync(request, deadline);
     return response.thenComposeAsync(
         (r) -> {
-          if (timeout != 0 && System.currentTimeMillis() - start > unit.toMillis(timeout)) {
+          // TODO to fix https://github.com/temporalio/sdk-java/issues/1177 we need to process
+          //  DEADLINE_EXCEEDED
+          //  or an underlying TimeoutException
+          if (deadline.isExpired()) {
+            // TODO check that such throwing populates a stacktrace into TimeoutException. It likely
+            // doesn't.
+            //  Instead a CompletionException should be used
             throw CheckedExceptionWrapper.wrap(
-                new TimeoutException(
-                    "WorkflowId="
-                        + workflowExecution.getWorkflowId()
-                        + ", runId="
-                        + workflowExecution.getRunId()
-                        + ", timeout="
-                        + timeout
-                        + ", unit="
-                        + unit));
+                WorkflowClientLongPollHelper.newTimeoutException(workflowExecution, timeout, unit));
           }
           History history = r.getHistory();
           if (history.getEventsCount() == 0) {
             // Empty poll returned
             return getInstanceCloseEventAsync(
-                service, workflowClientHelper, workflowExecution, pageToken, timeout, unit);
+                genericClient, workflowClientHelper, workflowExecution, pageToken, timeout, unit);
           }
           HistoryEvent event = history.getEvents(0);
           if (!WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
@@ -109,7 +101,7 @@ final class WorkflowClientLongPollAsyncHelper {
                             .getNewExecutionRunId())
                     .build();
             return getInstanceCloseEventAsync(
-                service,
+                genericClient,
                 workflowClientHelper,
                 nextWorkflowExecution,
                 r.getNextPageToken(),
@@ -117,43 +109,6 @@ final class WorkflowClientLongPollAsyncHelper {
                 unit);
           }
           return CompletableFuture.completedFuture(event);
-        });
-  }
-
-  private static CompletableFuture<GetWorkflowExecutionHistoryResponse>
-      getWorkflowExecutionHistoryAsync(
-          WorkflowServiceStubs service,
-          GetWorkflowExecutionHistoryRequest r,
-          long timeout,
-          TimeUnit unit) {
-    long start = System.currentTimeMillis();
-
-    RpcRetryOptions retryOptions =
-        DefaultStubLongPollRpcRetryOptions.getBuilder()
-            .setExpiration(Duration.ofMillis(unit.toMillis(timeout)))
-            .build();
-
-    return GrpcRetryer.retryWithResultAsync(
-        retryOptions,
-        () -> {
-          CompletableFuture<GetWorkflowExecutionHistoryResponse> result = new CompletableFuture<>();
-          long elapsedInRetry = System.currentTimeMillis() - start;
-          Deadline expirationInRetry =
-              Deadline.after(unit.toMillis(timeout) - elapsedInRetry, TimeUnit.MILLISECONDS);
-          ListenableFuture<GetWorkflowExecutionHistoryResponse> resultFuture =
-              service.futureStub().withDeadline(expirationInRetry).getWorkflowExecutionHistory(r);
-          resultFuture.addListener(
-              () -> {
-                try {
-                  result.complete(resultFuture.get());
-                } catch (ExecutionException e) {
-                  result.completeExceptionally(e.getCause());
-                } catch (Exception e) {
-                  result.completeExceptionally(e);
-                }
-              },
-              ForkJoinPool.commonPool());
-          return result;
         });
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientRequestFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientRequestFactory.java
@@ -44,10 +44,10 @@ import java.util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-final class RootWorkflowClientHelper {
+final class WorkflowClientRequestFactory {
   private final WorkflowClientOptions clientOptions;
 
-  public RootWorkflowClientHelper(WorkflowClientOptions clientOptions) {
+  public WorkflowClientRequestFactory(WorkflowClientOptions clientOptions) {
     this.clientOptions = clientOptions;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
@@ -19,11 +19,12 @@
 
 package io.temporal.internal.client.external;
 
+import io.grpc.Deadline;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.*;
-import io.temporal.serviceclient.WorkflowServiceStubs;
+import java.util.concurrent.CompletableFuture;
 
-public interface GenericWorkflowClientExternal {
+public interface GenericWorkflowClient {
 
   WorkflowExecution start(StartWorkflowExecutionRequest request);
 
@@ -37,5 +38,9 @@ public interface GenericWorkflowClientExternal {
 
   void terminate(TerminateWorkflowExecutionRequest request);
 
-  WorkflowServiceStubs getService();
+  GetWorkflowExecutionHistoryResponse longPollHistory(
+      GetWorkflowExecutionHistoryRequest request, Deadline deadline);
+
+  CompletableFuture<GetWorkflowExecutionHistoryResponse> longPollHistoryAsync(
+      GetWorkflowExecutionHistoryRequest request, Deadline deadline);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowClientInternal.java
@@ -35,8 +35,8 @@ import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import io.temporal.internal.WorkflowThreadMarker;
 import io.temporal.internal.client.RootWorkflowClientInvoker;
-import io.temporal.internal.client.external.GenericWorkflowClientExternal;
-import io.temporal.internal.client.external.GenericWorkflowClientExternalImpl;
+import io.temporal.internal.client.external.GenericWorkflowClient;
+import io.temporal.internal.client.external.GenericWorkflowClientImpl;
 import io.temporal.internal.client.external.ManualActivityCompletionClientFactory;
 import io.temporal.internal.sync.WorkflowInvocationHandler.InvocationType;
 import io.temporal.serviceclient.MetricsTag;
@@ -54,7 +54,7 @@ import java.util.concurrent.CompletableFuture;
 
 public final class WorkflowClientInternal implements WorkflowClient {
 
-  private final GenericWorkflowClientExternal genericClient;
+  private final GenericWorkflowClient genericClient;
   private final WorkflowClientOptions options;
   private final ManualActivityCompletionClientFactory manualActivityCompletionClientFactory;
   private final WorkflowClientInterceptor[] interceptors;
@@ -87,7 +87,7 @@ public final class WorkflowClientInternal implements WorkflowClient {
             .getOptions()
             .getMetricsScope()
             .tagged(MetricsTag.defaultTags(options.getNamespace()));
-    this.genericClient = new GenericWorkflowClientExternalImpl(workflowServiceStubs, metricsScope);
+    this.genericClient = new GenericWorkflowClientImpl(workflowServiceStubs, metricsScope);
     this.interceptors = options.getInterceptors();
     this.workflowClientCallsInvoker = initializeClientInvoker();
     this.manualActivityCompletionClientFactory =

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/LongPollUtil.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/LongPollUtil.java
@@ -33,7 +33,7 @@ class LongPollUtil {
     }
     if (method == WorkflowServiceGrpc.getGetWorkflowExecutionHistoryMethod()) {
       Boolean longPoll = callOptions.getOption(MetricsTag.HISTORY_LONG_POLL_CALL_OPTIONS_KEY);
-      return longPoll != null && longPoll.booleanValue();
+      return Boolean.TRUE.equals(longPoll);
     }
     return false;
   }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/MetricsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/MetricsTest.java
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient;
+
+import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
+import static junit.framework.TestCase.assertEquals;
+
+import com.uber.m3.tally.RootScopeBuilder;
+import com.uber.m3.tally.Scope;
+import com.uber.m3.tally.StatsReporter;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.reporter.MicrometerClientStatsReporter;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MetricsTest {
+
+  private static final long REPORTING_FLUSH_TIME = 50;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(QuicklyCompletingWorkflowImpl.class)
+          .build();
+
+  private SimpleMeterRegistry registry;
+  private WorkflowServiceStubs clientStubs;
+  private WorkflowClient workflowClient;
+
+  private static final List<Tag> TAGS_NAMESPACE =
+      MetricsTag.defaultTags(NAMESPACE).entrySet().stream()
+          .map(
+              nameValueEntry ->
+                  new ImmutableTag(nameValueEntry.getKey(), nameValueEntry.getValue()))
+          .collect(Collectors.toList());
+
+  private static List<Tag> TAGS_NAMESPACE_QUEUE;
+
+  @Before
+  public void setUp() {
+    this.registry = new SimpleMeterRegistry();
+    StatsReporter reporter = new MicrometerClientStatsReporter(registry);
+    Scope metricsScope =
+        new RootScopeBuilder()
+            .reporter(reporter)
+            .reportEvery(com.uber.m3.util.Duration.ofMillis(REPORTING_FLUSH_TIME >> 1));
+
+    testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs();
+    WorkflowServiceStubsOptions options =
+        testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs().getOptions();
+    WorkflowServiceStubsOptions modifiedOptions =
+        WorkflowServiceStubsOptions.newBuilder(options).setMetricsScope(metricsScope).build();
+
+    this.clientStubs = WorkflowServiceStubs.newServiceStubs(modifiedOptions);
+    this.workflowClient =
+        WorkflowClient.newInstance(clientStubs, testWorkflowRule.getWorkflowClient().getOptions());
+
+    TAGS_NAMESPACE_QUEUE =
+        replaceTags(TAGS_NAMESPACE, MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue());
+  }
+
+  @After
+  public void tearDown() {
+    this.clientStubs.shutdownNow();
+    this.registry.close();
+  }
+
+  @Test
+  public void testSynchronousStartAndGetResult() throws InterruptedException {
+    QuicklyCompletingWorkflow quicklyCompletingWorkflow =
+        workflowClient.newWorkflowStub(
+            QuicklyCompletingWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+    quicklyCompletingWorkflow.execute();
+    Thread.sleep(REPORTING_FLUSH_TIME);
+
+    List<Tag> startRequestTags =
+        replaceTags(
+            TAGS_NAMESPACE_QUEUE,
+            MetricsTag.OPERATION_NAME,
+            "StartWorkflowExecution",
+            MetricsTag.WORKFLOW_TYPE,
+            "QuicklyCompletingWorkflow");
+
+    assertIntCounter(1, registry.counter(MetricsType.TEMPORAL_REQUEST, startRequestTags));
+
+    List<Tag> longPollRequestTags =
+        replaceTag(TAGS_NAMESPACE, MetricsTag.OPERATION_NAME, "GetWorkflowExecutionHistory");
+
+    assertIntCounter(1, registry.counter(MetricsType.TEMPORAL_LONG_REQUEST, longPollRequestTags));
+  }
+
+  @Test
+  public void testAsynchronousStartAndGetResult() throws InterruptedException, ExecutionException {
+    QuicklyCompletingWorkflow quicklyCompletingWorkflow =
+        workflowClient.newWorkflowStub(
+            QuicklyCompletingWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+    WorkflowStub workflowStub = WorkflowStub.fromTyped(quicklyCompletingWorkflow);
+    workflowStub.start();
+    workflowStub.getResultAsync(String.class).get();
+    Thread.sleep(REPORTING_FLUSH_TIME);
+
+    List<Tag> startRequestTags =
+        replaceTags(
+            TAGS_NAMESPACE_QUEUE,
+            MetricsTag.OPERATION_NAME,
+            "StartWorkflowExecution",
+            MetricsTag.WORKFLOW_TYPE,
+            "QuicklyCompletingWorkflow");
+
+    assertIntCounter(1, registry.counter(MetricsType.TEMPORAL_REQUEST, startRequestTags));
+
+    List<Tag> longPollRequestTags =
+        replaceTag(TAGS_NAMESPACE, MetricsTag.OPERATION_NAME, "GetWorkflowExecutionHistory");
+
+    assertIntCounter(1, registry.counter(MetricsType.TEMPORAL_LONG_REQUEST, longPollRequestTags));
+  }
+
+  private static List<Tag> replaceTags(List<Tag> tags, String... nameValuePairs) {
+    for (int i = 0; i < nameValuePairs.length; i += 2) {
+      tags = replaceTag(tags, nameValuePairs[i], nameValuePairs[i + 1]);
+    }
+    return tags;
+  }
+
+  private static List<Tag> replaceTag(List<Tag> tags, String name, String value) {
+    List<Tag> result =
+        tags.stream().filter(tag -> !name.equals(tag.getKey())).collect(Collectors.toList());
+    result.add(new ImmutableTag(name, value));
+    return result;
+  }
+
+  private void assertIntCounter(int expectedValue, Counter counter) {
+    assertEquals(expectedValue, Math.round(counter.count()));
+  }
+
+  @WorkflowInterface
+  public interface QuicklyCompletingWorkflow {
+    @WorkflowMethod
+    String execute();
+  }
+
+  public static class QuicklyCompletingWorkflowImpl implements QuicklyCompletingWorkflow {
+
+    @Override
+    public String execute() {
+      return "done";
+    }
+  }
+}


### PR DESCRIPTION
## What was changed

Refactored WorkflowClientLongPollHelper and WorkflowClientLongPollAsyncHelper to simplify implementation and
use the same parameters for performing long polls.
Add a framework for testing client metrics behavior in isolation from the worker metrics.
This PR also prepares the ground for https://github.com/temporalio/sdk-java/issues/1203 and https://github.com/temporalio/sdk-java/issues/1177

Closes #1197