### PR TITLE
Make getResult methods to throw TimeoutException instead of raw gRPC DEADLINE_EXCEEDED

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollHelper.java
@@ -123,16 +123,11 @@ final class WorkflowClientLongPollHelper {
         throw e;
       }
 
-      if (response == null || !response.hasHistory()) {
-        continue;
-      }
-
-      pageToken = response.getNextPageToken();
       History history = response.getHistory();
       if (history.getEventsCount() > 0) {
-        HistoryEvent event = history.getEvents(0);
+        HistoryEvent event = history.getEvents(0); // should be only one event
         if (!WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(event)) {
-          throw new RuntimeException("Last history event is not completion event: " + event);
+          throw new RuntimeException("Unexpected workflow execution closing event: " + event);
         }
         // Workflow called continueAsNew. Start polling the new execution with new runId.
         if (event.getEventType() == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW) {
@@ -148,6 +143,9 @@ final class WorkflowClientLongPollHelper {
           continue;
         }
         return event;
+      }
+      if (!response.getNextPageToken().isEmpty()) {
+        pageToken = response.getNextPageToken();
       }
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientLongPollHelper.java
@@ -21,6 +21,8 @@ package io.temporal.internal.client;
 
 import com.google.protobuf.ByteString;
 import io.grpc.Deadline;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.*;
@@ -35,6 +37,7 @@ import io.temporal.internal.common.WorkflowExecutionUtils;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nonnull;
 
 /** This class encapsulates sync long poll logic of {@link RootWorkflowClientInvoker} */
 final class WorkflowClientLongPollHelper {
@@ -51,7 +54,7 @@ final class WorkflowClientLongPollHelper {
   static Optional<Payloads> getWorkflowExecutionResult(
       GenericWorkflowClient genericClient,
       WorkflowClientRequestFactory workflowClientHelper,
-      WorkflowExecution workflowExecution,
+      @Nonnull WorkflowExecution workflowExecution,
       Optional<String> workflowType,
       DataConverter converter,
       long timeout,
@@ -75,7 +78,7 @@ final class WorkflowClientLongPollHelper {
   static WorkflowExecutionStatus waitForWorkflowInstanceCompletion(
       GenericWorkflowClient genericClient,
       WorkflowClientRequestFactory workflowClientHelper,
-      WorkflowExecution workflowExecution,
+      @Nonnull WorkflowExecution workflowExecution,
       long timeout,
       TimeUnit unit)
       throws TimeoutException {
@@ -95,25 +98,30 @@ final class WorkflowClientLongPollHelper {
   private static HistoryEvent getInstanceCloseEvent(
       GenericWorkflowClient genericClient,
       WorkflowClientRequestFactory workflowClientHelper,
-      WorkflowExecution workflowExecution,
+      @Nonnull WorkflowExecution workflowExecution,
       long timeout,
       TimeUnit unit)
       throws TimeoutException {
     ByteString pageToken = ByteString.EMPTY;
     GetWorkflowExecutionHistoryResponse response;
-    Deadline deadline = Deadline.after(timeout, unit);
+    Deadline longPollTimeoutDeadline = Deadline.after(timeout, unit);
 
-    do {
-      if (deadline.isExpired()) {
-        throw newTimeoutException(workflowExecution, timeout, unit);
-      }
-
+    while (true) {
       GetWorkflowExecutionHistoryRequest request =
           workflowClientHelper.newHistoryLongPollRequest(workflowExecution, pageToken);
-      // TODO to fix https://github.com/temporalio/sdk-java/issues/1177 we need to process
-      //  DEADLINE_EXCEEDED correctly. It may be thrown if a deadline of one request is exceeded,
-      //  but the total timeout is not.
-      response = genericClient.longPollHistory(request, deadline);
+
+      try {
+        response = genericClient.longPollHistory(request, longPollTimeoutDeadline);
+      } catch (StatusRuntimeException e) {
+        if (longPollTimeoutDeadline.isExpired()
+            && Status.Code.DEADLINE_EXCEEDED.equals(e.getStatus().getCode())) {
+          // we want to form timeout exception only if the original deadline is indeed expired.
+          // Otherwise, we should rethrow a raw DEADLINE_EXCEEDED. throwing TimeoutException
+          // in this case will be highly misleading.
+          throw newTimeoutException(workflowExecution, timeout, unit);
+        }
+        throw e;
+      }
 
       if (response == null || !response.hasHistory()) {
         continue;
@@ -141,11 +149,11 @@ final class WorkflowClientLongPollHelper {
         }
         return event;
       }
-    } while (true);
+    }
   }
 
   static TimeoutException newTimeoutException(
-      WorkflowExecution workflowExecution, long timeout, TimeUnit unit) {
+      @Nonnull WorkflowExecution workflowExecution, long timeout, TimeUnit unit) {
     return new TimeoutException(
         "WorkflowId="
             + workflowExecution.getWorkflowId()

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
@@ -23,6 +23,7 @@ import io.grpc.Deadline;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.*;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 
 public interface GenericWorkflowClient {
 
@@ -39,8 +40,8 @@ public interface GenericWorkflowClient {
   void terminate(TerminateWorkflowExecutionRequest request);
 
   GetWorkflowExecutionHistoryResponse longPollHistory(
-      GetWorkflowExecutionHistoryRequest request, Deadline deadline);
+      @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline);
 
   CompletableFuture<GetWorkflowExecutionHistoryResponse> longPollHistoryAsync(
-      GetWorkflowExecutionHistoryRequest request, Deadline deadline);
+      @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
@@ -33,9 +33,9 @@ import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.RpcRetryOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.rpcretry.DefaultStubLongPollRpcRetryOptions;
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.*;
+import javax.annotation.Nonnull;
 
 public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
 
@@ -141,39 +141,24 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
 
   @Override
   public GetWorkflowExecutionHistoryResponse longPollHistory(
-      GetWorkflowExecutionHistoryRequest request, Deadline deadline) {
-    long millisRemaining = deadline.timeRemaining(TimeUnit.MILLISECONDS);
-    RpcRetryOptions retryOptions =
-        DefaultStubLongPollRpcRetryOptions.getBuilder()
-            // TODO rework together with https://github.com/temporalio/sdk-java/issues/1203
-            .setExpiration(Duration.ofMillis(millisRemaining))
-            .build();
-    // TODO to fix https://github.com/temporalio/sdk-java/issues/1177 we need to process
-    //  DEADLINE_EXCEEDED
+      @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline) {
     return GrpcRetryer.retryWithResult(
-        retryOptions,
+        DefaultStubLongPollRpcRetryOptions.INSTANCE,
         () ->
             service
                 .blockingStub()
                 .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
                 .withOption(HISTORY_LONG_POLL_CALL_OPTIONS_KEY, true)
                 .withDeadline(deadline)
-                .getWorkflowExecutionHistory(request));
+                .getWorkflowExecutionHistory(request),
+        deadline);
   }
 
   @Override
   public CompletableFuture<GetWorkflowExecutionHistoryResponse> longPollHistoryAsync(
-      GetWorkflowExecutionHistoryRequest request, Deadline deadline) {
-    long millisRemaining = deadline.timeRemaining(TimeUnit.MILLISECONDS);
-
-    RpcRetryOptions retryOptions =
-        DefaultStubLongPollRpcRetryOptions.getBuilder()
-            // TODO rework together with https://github.com/temporalio/sdk-java/issues/1203
-            .setExpiration(Duration.ofMillis(millisRemaining))
-            .build();
-
+      @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline) {
     return GrpcRetryer.retryWithResultAsync(
-        retryOptions,
+        DefaultStubLongPollRpcRetryOptions.INSTANCE,
         () -> {
           CompletableFuture<GetWorkflowExecutionHistoryResponse> result = new CompletableFuture<>();
           ListenableFuture<GetWorkflowExecutionHistoryResponse> resultFuture =
@@ -184,8 +169,6 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
                   .withDeadline(deadline)
                   .getWorkflowExecutionHistory(request);
 
-          // TODO to fix https://github.com/temporalio/sdk-java/issues/1177 we need to process
-          //  DEADLINE_EXCEEDED
           resultFuture.addListener(
               () -> {
                 try {
@@ -198,7 +181,8 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
               },
               ForkJoinPool.commonPool());
           return result;
-        });
+        },
+        deadline);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
@@ -58,13 +58,13 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
     StartWorkflowExecutionResponse result;
     result =
         GrpcRetryer.retryWithResult(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, scope)
-                    .startWorkflowExecution(request));
+                    .startWorkflowExecution(request),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
 
     return WorkflowExecution.newBuilder()
         .setRunId(result.getRunId())
@@ -80,13 +80,13 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
             .build();
     Scope scope = metricsScope.tagged(tags);
     GrpcRetryer.retry(
-        RpcRetryOptions.newBuilder()
-            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
         () ->
             service
                 .blockingStub()
                 .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, scope)
-                .signalWorkflowExecution(request));
+                .signalWorkflowExecution(request),
+        RpcRetryOptions.newBuilder()
+            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
   }
 
   @Override
@@ -102,13 +102,13 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
     SignalWithStartWorkflowExecutionResponse result;
     result =
         GrpcRetryer.retryWithResult(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, scope)
-                    .signalWithStartWorkflowExecution(request));
+                    .signalWithStartWorkflowExecution(request),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
     return WorkflowExecution.newBuilder()
         .setRunId(result.getRunId())
         .setWorkflowId(request.getWorkflowId())
@@ -118,32 +118,31 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
   @Override
   public void requestCancel(RequestCancelWorkflowExecutionRequest request) {
     GrpcRetryer.retry(
-        RpcRetryOptions.newBuilder()
-            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
         () ->
             service
                 .blockingStub()
                 .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                .requestCancelWorkflowExecution(request));
+                .requestCancelWorkflowExecution(request),
+        RpcRetryOptions.newBuilder()
+            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
   }
 
   @Override
   public void terminate(TerminateWorkflowExecutionRequest request) {
     GrpcRetryer.retry(
-        RpcRetryOptions.newBuilder()
-            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
         () ->
             service
                 .blockingStub()
                 .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                .terminateWorkflowExecution(request));
+                .terminateWorkflowExecution(request),
+        RpcRetryOptions.newBuilder()
+            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
   }
 
   @Override
   public GetWorkflowExecutionHistoryResponse longPollHistory(
       @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline) {
     return GrpcRetryer.retryWithResult(
-        DefaultStubLongPollRpcRetryOptions.INSTANCE,
         () ->
             service
                 .blockingStub()
@@ -151,14 +150,13 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
                 .withOption(HISTORY_LONG_POLL_CALL_OPTIONS_KEY, true)
                 .withDeadline(deadline)
                 .getWorkflowExecutionHistory(request),
-        deadline);
+        new GrpcRetryer.GrpcRetryerOptions(DefaultStubLongPollRpcRetryOptions.INSTANCE, deadline));
   }
 
   @Override
   public CompletableFuture<GetWorkflowExecutionHistoryResponse> longPollHistoryAsync(
       @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline) {
     return GrpcRetryer.retryWithResultAsync(
-        DefaultStubLongPollRpcRetryOptions.INSTANCE,
         () -> {
           CompletableFuture<GetWorkflowExecutionHistoryResponse> result = new CompletableFuture<>();
           ListenableFuture<GetWorkflowExecutionHistoryResponse> resultFuture =
@@ -182,7 +180,7 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
               ForkJoinPool.commonPool());
           return result;
         },
-        deadline);
+        new GrpcRetryer.GrpcRetryerOptions(DefaultStubLongPollRpcRetryOptions.INSTANCE, deadline));
   }
 
   @Override
@@ -194,12 +192,12 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
     Scope scope = metricsScope.tagged(tags);
 
     return GrpcRetryer.retryWithResult(
-        RpcRetryOptions.newBuilder()
-            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
         () ->
             service
                 .blockingStub()
                 .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, scope)
-                .queryWorkflow(queryParameters));
+                .queryWorkflow(queryParameters),
+        RpcRetryOptions.newBuilder()
+            .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/ManualActivityCompletionClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/ManualActivityCompletionClientImpl.java
@@ -108,13 +108,13 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       payloads.ifPresent(request::setResult);
       try {
         GrpcRetryer.retry(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskCompleted(request.build()));
+                    .respondActivityTaskCompleted(request.build()),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
       } catch (Exception e) {
         processException(e);
       }
@@ -131,13 +131,13 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       payloads.ifPresent(request::setResult);
       try {
         GrpcRetryer.retry(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskCompletedById(request.build()));
+                    .respondActivityTaskCompletedById(request.build()),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
       } catch (Exception e) {
         processException(e);
       }
@@ -157,13 +157,13 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
               .build();
       try {
         GrpcRetryer.retry(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskFailed(request));
+                    .respondActivityTaskFailed(request),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
       } catch (StatusRuntimeException e) {
         if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
           throw new ActivityNotExistsException(e);
@@ -186,13 +186,13 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
               .build();
       try {
         GrpcRetryer.retry(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskFailedById(request));
+                    .respondActivityTaskFailedById(request),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
       } catch (Exception e) {
         processException(e);
       }
@@ -240,13 +240,13 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       convertedDetails.ifPresent(request::setDetails);
       try {
         GrpcRetryer.retry(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskCanceled(request.build()));
+                    .respondActivityTaskCanceled(request.build()),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
       } catch (Exception e) {
         // There is nothing that can be done at this point.
         // so let's just ignore.
@@ -265,13 +265,13 @@ class ManualActivityCompletionClientImpl implements ManualActivityCompletionClie
       convertedDetails.ifPresent(request::setDetails);
       try {
         GrpcRetryer.retry(
-            RpcRetryOptions.newBuilder()
-                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()),
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskCanceledById(request.build()));
+                    .respondActivityTaskCanceledById(request.build()),
+            RpcRetryOptions.newBuilder()
+                .buildWithDefaultsFrom(service.getOptions().getRpcRetryOptions()));
       } catch (Exception e) {
         // There is nothing that can be done at this point.
         // so let's just ignore.

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowHistoryIterator.java
@@ -119,12 +119,12 @@ class WorkflowHistoryIterator implements Iterator<HistoryEvent> {
             .build();
     try {
       return GrpcRetryer.retryWithResult(
-          retryOptions,
           () ->
               service
                   .blockingStub()
                   .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                  .getWorkflowExecutionHistory(request));
+                  .getWorkflowExecutionHistory(request),
+          retryOptions);
     } catch (Exception e) {
       throw new Error(e);
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -269,12 +269,12 @@ public final class ActivityWorker implements SuspendableWorker {
                 .setNamespace(namespace)
                 .build();
         GrpcRetryer.retry(
-            ro,
             () ->
                 service
                     .blockingStub()
                     .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                    .respondActivityTaskCompleted(request));
+                    .respondActivityTaskCompleted(request),
+            ro);
       } else {
         Result.TaskFailedResult taskFailed = response.getTaskFailed();
 
@@ -288,12 +288,12 @@ public final class ActivityWorker implements SuspendableWorker {
           ro = RpcRetryOptions.newBuilder().buildWithDefaultsFrom(ro);
 
           GrpcRetryer.retry(
-              ro,
               () ->
                   service
                       .blockingStub()
                       .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                      .respondActivityTaskFailed(request));
+                      .respondActivityTaskFailed(request),
+              ro);
         } else {
           RespondActivityTaskCanceledRequest taskCanceled = response.getTaskCanceled();
           if (taskCanceled != null) {
@@ -306,12 +306,12 @@ public final class ActivityWorker implements SuspendableWorker {
             ro = RpcRetryOptions.newBuilder().buildWithDefaultsFrom(ro);
 
             GrpcRetryer.retry(
-                ro,
                 () ->
                     service
                         .blockingStub()
                         .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                        .respondActivityTaskCanceled(request));
+                        .respondActivityTaskCanceled(request),
+                ro);
           }
         }
       }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -308,13 +308,13 @@ public final class WorkflowWorker
                   .build();
           AtomicReference<RespondWorkflowTaskCompletedResponse> nextTask = new AtomicReference<>();
           GrpcRetryer.retry(
-              retryOptions,
               () ->
                   nextTask.set(
                       service
                           .blockingStub()
                           .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, workflowTypeMetricsScope)
-                          .respondWorkflowTaskCompleted(request)));
+                          .respondWorkflowTaskCompleted(request)),
+              retryOptions);
           if (nextTask.get().hasWorkflowTask()) {
             return Optional.of(nextTask.get().getWorkflowTask());
           }
@@ -330,12 +330,12 @@ public final class WorkflowWorker
                     .setTaskToken(taskToken)
                     .build();
             GrpcRetryer.retry(
-                retryOptions,
                 () ->
                     service
                         .blockingStub()
                         .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, workflowTypeMetricsScope)
-                        .respondWorkflowTaskFailed(request));
+                        .respondWorkflowTaskFailed(request),
+                retryOptions);
           } else {
             RespondQueryTaskCompletedRequest queryCompleted = response.getQueryCompleted();
             if (queryCompleted != null) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
@@ -273,7 +273,7 @@ final class ChannelManager {
     RpcRetryOptions retryOptions =
         RpcRetryOptions.newBuilder().setExpiration(timeout).validateBuildWithDefaults();
 
-    GrpcRetryer.retryWithResult(retryOptions, () -> this.healthCheck(healthCheckServiceName, null));
+    GrpcRetryer.retryWithResult(() -> this.healthCheck(healthCheckServiceName, null), retryOptions);
   }
 
   /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -69,6 +69,9 @@ final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       inProcessServer = null;
     }
     this.options = WorkflowServiceStubsOptions.newBuilder(options).validateAndBuildWithDefaults();
+    // if the line above is ever gone, this line still needs to stay to validate an input
+    // rpcRetryOptions
+    this.options.getRpcRetryOptions().validate();
 
     ClientInterceptor deadlineInterceptor =
         new GrpcDeadlineInterceptor(

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -28,7 +28,16 @@ public class DefaultStubLongPollRpcRetryOptions {
   public static final Duration MAXIMUM_INTERVAL = Duration.ofMinutes(1);
   public static final double BACKOFF = 1.2;
 
-  public static RpcRetryOptions.Builder getBuilder() {
+  // partial build because expiration is not set, long polls work with absolute deadlines instead
+  public static final RpcRetryOptions INSTANCE = getBuilder().build();
+
+  static {
+    // retryer code that works with these options passes and accepts an absolute deadline
+    // to ensure that the retry is finite
+    INSTANCE.validate(false);
+  }
+
+  private static RpcRetryOptions.Builder getBuilder() {
     RpcRetryOptions.Builder roBuilder =
         RpcRetryOptions.newBuilder()
             .setInitialInterval(INITIAL_INTERVAL)

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -63,11 +63,10 @@ public class GrpcAsyncRetryerTest {
     try {
       DEFAULT_ASYNC_RETRYER
           .retry(
-              options,
               () -> {
                 throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
               },
-              null)
+              new GrpcRetryer.GrpcRetryerOptions(options, null))
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -92,14 +91,13 @@ public class GrpcAsyncRetryerTest {
     try {
       DEFAULT_ASYNC_RETRYER
           .retry(
-              options,
               () -> {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.completeExceptionally(
                     new StatusRuntimeException(Status.fromCode(STATUS_CODE)));
                 return result;
               },
-              null)
+              new GrpcRetryer.GrpcRetryerOptions(options, null))
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -123,14 +121,13 @@ public class GrpcAsyncRetryerTest {
     try {
       DEFAULT_ASYNC_RETRYER
           .retry(
-              options,
               () -> {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.completeExceptionally(
                     new StatusRuntimeException(Status.fromCode(STATUS_CODE)));
                 return result;
               },
-              null)
+              new GrpcRetryer.GrpcRetryerOptions(options, null))
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -153,13 +150,12 @@ public class GrpcAsyncRetryerTest {
     try {
       DEFAULT_ASYNC_RETRYER
           .retry(
-              options,
               () -> {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.completeExceptionally(new InterruptedException("simulated"));
                 return result;
               },
-              null)
+              new GrpcRetryer.GrpcRetryerOptions(options, null))
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -181,13 +177,12 @@ public class GrpcAsyncRetryerTest {
     try {
       DEFAULT_ASYNC_RETRYER
           .retry(
-              options,
               () -> {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.completeExceptionally(new IllegalArgumentException("simulated"));
                 return result;
               },
-              null)
+              new GrpcRetryer.GrpcRetryerOptions(options, null))
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -217,7 +212,6 @@ public class GrpcAsyncRetryerTest {
               try {
                 DEFAULT_ASYNC_RETRYER
                     .retry(
-                        options,
                         () -> {
                           attempts.incrementAndGet();
                           CompletableFuture<?> future = new CompletableFuture<>();
@@ -226,7 +220,7 @@ public class GrpcAsyncRetryerTest {
                                   Status.fromCode(Status.Code.DEADLINE_EXCEEDED)));
                           return future;
                         },
-                        null)
+                        new GrpcRetryer.GrpcRetryerOptions(options, null))
                     .get();
               } catch (ExecutionException ex) {
                 throw ex.getCause();
@@ -267,7 +261,6 @@ public class GrpcAsyncRetryerTest {
                           try {
                             DEFAULT_ASYNC_RETRYER
                                 .retry(
-                                    options,
                                     () -> {
                                       attempts.incrementAndGet();
                                       CompletableFuture<?> future = new CompletableFuture<>();
@@ -276,7 +269,7 @@ public class GrpcAsyncRetryerTest {
                                               Status.fromCode(Status.Code.DATA_LOSS)));
                                       return future;
                                     },
-                                    null)
+                                    new GrpcRetryer.GrpcRetryerOptions(options, null))
                                 .get();
                           } catch (ExecutionException e) {
                             throw e.getCause();
@@ -313,7 +306,6 @@ public class GrpcAsyncRetryerTest {
                           try {
                             DEFAULT_ASYNC_RETRYER
                                 .retry(
-                                    options,
                                     () -> {
                                       if (Context.current().getDeadline().isExpired()) {
                                         throw new StatusRuntimeException(
@@ -323,7 +315,7 @@ public class GrpcAsyncRetryerTest {
                                             Status.fromCode(Status.Code.DATA_LOSS));
                                       }
                                     },
-                                    null)
+                                    new GrpcRetryer.GrpcRetryerOptions(options, null))
                                 .get();
                           } catch (ExecutionException e) {
                             throw e.getCause();

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -25,7 +25,6 @@ import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.serviceclient.RpcRetryOptions;
-import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,8 +35,7 @@ import org.junit.Test;
 
 public class GrpcAsyncRetryerTest {
 
-  private static final GrpcAsyncRetryer DEFAULT_ASYNC_RETRYER =
-      new GrpcAsyncRetryer(Clock.systemUTC());
+  private static final GrpcAsyncRetryer DEFAULT_ASYNC_RETRYER = new GrpcAsyncRetryer();
 
   private static ScheduledExecutorService scheduledExecutor;
 
@@ -68,7 +66,8 @@ public class GrpcAsyncRetryerTest {
               options,
               () -> {
                 throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
-              })
+              },
+              null)
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -99,7 +98,8 @@ public class GrpcAsyncRetryerTest {
                 result.completeExceptionally(
                     new StatusRuntimeException(Status.fromCode(STATUS_CODE)));
                 return result;
-              })
+              },
+              null)
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -129,7 +129,8 @@ public class GrpcAsyncRetryerTest {
                 result.completeExceptionally(
                     new StatusRuntimeException(Status.fromCode(STATUS_CODE)));
                 return result;
-              })
+              },
+              null)
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -157,7 +158,8 @@ public class GrpcAsyncRetryerTest {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.completeExceptionally(new InterruptedException("simulated"));
                 return result;
-              })
+              },
+              null)
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -184,7 +186,8 @@ public class GrpcAsyncRetryerTest {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.completeExceptionally(new IllegalArgumentException("simulated"));
                 return result;
-              })
+              },
+              null)
           .get();
       fail("unreachable");
     } catch (ExecutionException e) {
@@ -222,7 +225,8 @@ public class GrpcAsyncRetryerTest {
                               new StatusRuntimeException(
                                   Status.fromCode(Status.Code.DEADLINE_EXCEEDED)));
                           return future;
-                        })
+                        },
+                        null)
                     .get();
               } catch (ExecutionException ex) {
                 throw ex.getCause();
@@ -271,7 +275,8 @@ public class GrpcAsyncRetryerTest {
                                           new StatusRuntimeException(
                                               Status.fromCode(Status.Code.DATA_LOSS)));
                                       return future;
-                                    })
+                                    },
+                                    null)
                                 .get();
                           } catch (ExecutionException e) {
                             throw e.getCause();
@@ -317,7 +322,8 @@ public class GrpcAsyncRetryerTest {
                                         throw new StatusRuntimeException(
                                             Status.fromCode(Status.Code.DATA_LOSS));
                                       }
-                                    })
+                                    },
+                                    null)
                                 .get();
                           } catch (ExecutionException e) {
                             throw e.getCause();

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -25,7 +25,6 @@ import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.serviceclient.RpcRetryOptions;
-import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executors;
@@ -39,8 +38,7 @@ import org.junit.Test;
 
 public class GrpcSyncRetryerTest {
 
-  private static final GrpcSyncRetryer DEFAULT_SYNC_RETRYER =
-      new GrpcSyncRetryer(Clock.systemUTC());
+  private static final GrpcSyncRetryer DEFAULT_SYNC_RETRYER = new GrpcSyncRetryer();
 
   private static ScheduledExecutorService scheduledExecutor;
 
@@ -70,7 +68,8 @@ public class GrpcSyncRetryerTest {
           options,
           () -> {
             throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
-          });
+          },
+          null);
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof StatusRuntimeException);
@@ -96,7 +95,8 @@ public class GrpcSyncRetryerTest {
           options,
           () -> {
             throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
-          });
+          },
+          null);
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof StatusRuntimeException);
@@ -120,7 +120,8 @@ public class GrpcSyncRetryerTest {
           options,
           () -> {
             throw new InterruptedException();
-          });
+          },
+          null);
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof CancellationException);
@@ -142,7 +143,8 @@ public class GrpcSyncRetryerTest {
           options,
           () -> {
             throw new IllegalArgumentException("simulated");
-          });
+          },
+          null);
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof IllegalArgumentException);
@@ -174,7 +176,8 @@ public class GrpcSyncRetryerTest {
                     attempts.incrementAndGet();
                     throw new StatusRuntimeException(
                         Status.fromCode(Status.Code.DEADLINE_EXCEEDED));
-                  });
+                  },
+                  null);
             });
 
     assertEquals(Status.Code.DEADLINE_EXCEEDED, e.getStatus().getCode());
@@ -213,7 +216,8 @@ public class GrpcSyncRetryerTest {
                                 attempts.incrementAndGet();
                                 throw new StatusRuntimeException(
                                     Status.fromCode(Status.Code.DATA_LOSS));
-                              });
+                              },
+                              null);
                         })));
 
     assertEquals(Status.Code.DATA_LOSS, exception.get().getStatus().getCode());
@@ -253,7 +257,8 @@ public class GrpcSyncRetryerTest {
                                   throw new StatusRuntimeException(
                                       Status.fromCode(Status.Code.DATA_LOSS));
                                 }
-                              });
+                              },
+                              null);
                         })));
 
     assertEquals(

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -65,11 +65,10 @@ public class GrpcSyncRetryerTest {
     long start = System.currentTimeMillis();
     try {
       DEFAULT_SYNC_RETRYER.retry(
-          options,
           () -> {
             throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
           },
-          null);
+          new GrpcRetryer.GrpcRetryerOptions(options, null));
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof StatusRuntimeException);
@@ -92,11 +91,10 @@ public class GrpcSyncRetryerTest {
     long start = System.currentTimeMillis();
     try {
       DEFAULT_SYNC_RETRYER.retry(
-          options,
           () -> {
             throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
           },
-          null);
+          new GrpcRetryer.GrpcRetryerOptions(options, null));
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof StatusRuntimeException);
@@ -117,11 +115,10 @@ public class GrpcSyncRetryerTest {
     long start = System.currentTimeMillis();
     try {
       DEFAULT_SYNC_RETRYER.retry(
-          options,
           () -> {
             throw new InterruptedException();
           },
-          null);
+          new GrpcRetryer.GrpcRetryerOptions(options, null));
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof CancellationException);
@@ -140,11 +137,10 @@ public class GrpcSyncRetryerTest {
     long start = System.currentTimeMillis();
     try {
       DEFAULT_SYNC_RETRYER.retry(
-          options,
           () -> {
             throw new IllegalArgumentException("simulated");
           },
-          null);
+          new GrpcRetryer.GrpcRetryerOptions(options, null));
       fail("unreachable");
     } catch (Exception e) {
       assertTrue(e instanceof IllegalArgumentException);
@@ -169,16 +165,14 @@ public class GrpcSyncRetryerTest {
     StatusRuntimeException e =
         assertThrows(
             StatusRuntimeException.class,
-            () -> {
-              DEFAULT_SYNC_RETRYER.retry(
-                  options,
-                  () -> {
-                    attempts.incrementAndGet();
-                    throw new StatusRuntimeException(
-                        Status.fromCode(Status.Code.DEADLINE_EXCEEDED));
-                  },
-                  null);
-            });
+            () ->
+                DEFAULT_SYNC_RETRYER.retry(
+                    () -> {
+                      attempts.incrementAndGet();
+                      throw new StatusRuntimeException(
+                          Status.fromCode(Status.Code.DEADLINE_EXCEEDED));
+                    },
+                    new GrpcRetryer.GrpcRetryerOptions(options, null)));
 
     assertEquals(Status.Code.DEADLINE_EXCEEDED, e.getStatus().getCode());
     assertTrue(
@@ -209,16 +203,14 @@ public class GrpcSyncRetryerTest {
                 exception.set(
                     assertThrows(
                         StatusRuntimeException.class,
-                        () -> {
-                          DEFAULT_SYNC_RETRYER.retry(
-                              options,
-                              () -> {
-                                attempts.incrementAndGet();
-                                throw new StatusRuntimeException(
-                                    Status.fromCode(Status.Code.DATA_LOSS));
-                              },
-                              null);
-                        })));
+                        () ->
+                            DEFAULT_SYNC_RETRYER.retry(
+                                () -> {
+                                  attempts.incrementAndGet();
+                                  throw new StatusRuntimeException(
+                                      Status.fromCode(Status.Code.DATA_LOSS));
+                                },
+                                new GrpcRetryer.GrpcRetryerOptions(options, null)))));
 
     assertEquals(Status.Code.DATA_LOSS, exception.get().getStatus().getCode());
     assertTrue(
@@ -246,20 +238,18 @@ public class GrpcSyncRetryerTest {
                 exception.set(
                     assertThrows(
                         StatusRuntimeException.class,
-                        () -> {
-                          DEFAULT_SYNC_RETRYER.retry(
-                              options,
-                              () -> {
-                                if (Context.current().getDeadline().isExpired()) {
-                                  throw new StatusRuntimeException(
-                                      Status.fromCode(Status.Code.DEADLINE_EXCEEDED));
-                                } else {
-                                  throw new StatusRuntimeException(
-                                      Status.fromCode(Status.Code.DATA_LOSS));
-                                }
-                              },
-                              null);
-                        })));
+                        () ->
+                            DEFAULT_SYNC_RETRYER.retry(
+                                () -> {
+                                  if (Context.current().getDeadline().isExpired()) {
+                                    throw new StatusRuntimeException(
+                                        Status.fromCode(Status.Code.DEADLINE_EXCEEDED));
+                                  } else {
+                                    throw new StatusRuntimeException(
+                                        Status.fromCode(Status.Code.DATA_LOSS));
+                                  }
+                                },
+                                new GrpcRetryer.GrpcRetryerOptions(options, null)))));
 
     assertEquals(
         "We should get a previous exception in case of DEADLINE_EXCEEDED",

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsAsyncOverMaximumLongPollWaitTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsAsyncOverMaximumLongPollWaitTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient.functional;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.serviceclient.functional.common.TestWorkflows;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * These tests are covering the situation when a getResult wait time crosses a boundary of when
+ * server cuts the long poll and returns an empty response to a history long poll. It's 20 seconds.
+ *
+ * <p>It has a sync version in {@link GetResultsSyncOverMaximumLongPollWaitTest} that is split to
+ * reduce the total execution time
+ */
+public class GetResultsAsyncOverMaximumLongPollWaitTest {
+  private static final int HISTORY_LONG_POLL_TIMEOUT_SECONDS = 20;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setUseTimeskipping(false)
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .build();
+
+  @Test(timeout = 2 * HISTORY_LONG_POLL_TIMEOUT_SECONDS * 1000)
+  public void testGetResultAsync() throws ExecutionException, InterruptedException {
+    TestWorkflows.PrimitiveWorkflow workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class);
+    WorkflowClient.start(workflow::execute);
+    WorkflowStub.fromTyped(workflow).getResultAsync(Void.class).get();
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.PrimitiveWorkflow {
+    @Override
+    public void execute() {
+      Workflow.sleep(Duration.ofSeconds(3 * HISTORY_LONG_POLL_TIMEOUT_SECONDS / 2));
+    }
+  }
+}

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsOverLongPollTimeoutTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsOverLongPollTimeoutTest.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient.functional;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.serviceclient.functional.common.TestWorkflows;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * These tests are covering the situation when a getResult wait time crosses a boundary of one long
+ * poll timeout.
+ */
+public class GetResultsOverLongPollTimeoutTest {
+  private static final int LONG_POLL_TIMEOUT_SECONDS = 5;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setUseTimeskipping(false)
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .build();
+
+  private WorkflowServiceStubs clientStubs;
+  private WorkflowClient workflowClient;
+
+  @Before
+  public void setUp() {
+    testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs();
+    WorkflowServiceStubsOptions options =
+        testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs().getOptions();
+    WorkflowServiceStubsOptions modifiedOptions =
+        WorkflowServiceStubsOptions.newBuilder(options)
+            // Server always cuts a long poll and return earlier than this timeout
+            .setRpcLongPollTimeout(Duration.ofSeconds(LONG_POLL_TIMEOUT_SECONDS))
+            .build();
+
+    this.clientStubs = WorkflowServiceStubs.newServiceStubs(modifiedOptions);
+    this.workflowClient =
+        WorkflowClient.newInstance(clientStubs, testWorkflowRule.getWorkflowClient().getOptions());
+  }
+
+  @After
+  public void tearDown() {
+    clientStubs.shutdown();
+  }
+
+  @Test(timeout = 2 * LONG_POLL_TIMEOUT_SECONDS * 1000)
+  public void testGetResults() {
+    TestWorkflows.PrimitiveWorkflow workflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflows.PrimitiveWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+    WorkflowClient.start(workflow::execute);
+    WorkflowStub.fromTyped(workflow).getResult(Void.class);
+  }
+
+  @Test(timeout = 2 * LONG_POLL_TIMEOUT_SECONDS * 1000)
+  public void testGetResultAsync() throws ExecutionException, InterruptedException {
+    TestWorkflows.PrimitiveWorkflow workflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflows.PrimitiveWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+    WorkflowClient.start(workflow::execute);
+    WorkflowStub.fromTyped(workflow).getResultAsync(Void.class).get();
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.PrimitiveWorkflow {
+    @Override
+    public void execute() {
+      Workflow.sleep(Duration.ofSeconds(3 * LONG_POLL_TIMEOUT_SECONDS / 2));
+    }
+  }
+}

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsOverLongPollTimeoutTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsOverLongPollTimeoutTest.java
@@ -35,7 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * These tests are covering the situation when a getResult wait time crosses a boundary of one long
+ * These tests are covering the situation when a getResult wait time crosses a boundary of a long
  * poll timeout.
  */
 public class GetResultsOverLongPollTimeoutTest {
@@ -58,7 +58,6 @@ public class GetResultsOverLongPollTimeoutTest {
         testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs().getOptions();
     WorkflowServiceStubsOptions modifiedOptions =
         WorkflowServiceStubsOptions.newBuilder(options)
-            // Server always cuts a long poll and return earlier than this timeout
             .setRpcLongPollTimeout(Duration.ofSeconds(LONG_POLL_TIMEOUT_SECONDS))
             .build();
 

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsSyncOverMaximumLongPollWaitTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsSyncOverMaximumLongPollWaitTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient.functional;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.serviceclient.functional.common.TestWorkflows;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * These tests are covering the situation when a getResult wait time crosses a boundary of when
+ * server cuts the long poll and returns an empty response to a history long poll. It's 20 seconds.
+ *
+ * <p>It has a sync version in {@link GetResultsAsyncOverMaximumLongPollWaitTest} that is split to
+ * reduce the total execution time
+ */
+public class GetResultsSyncOverMaximumLongPollWaitTest {
+  private static final int HISTORY_LONG_POLL_TIMEOUT_SECONDS = 20;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setUseTimeskipping(false)
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .build();
+
+  @Test(timeout = 2 * HISTORY_LONG_POLL_TIMEOUT_SECONDS * 1000)
+  public void testGetResults() {
+    TestWorkflows.PrimitiveWorkflow workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class);
+    WorkflowClient.start(workflow::execute);
+    WorkflowStub.fromTyped(workflow).getResult(Void.class);
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.PrimitiveWorkflow {
+    @Override
+    public void execute() {
+      Workflow.sleep(Duration.ofSeconds(3 * HISTORY_LONG_POLL_TIMEOUT_SECONDS / 2));
+    }
+  }
+}

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsTimeoutTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/GetResultsTimeoutTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient.functional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Stopwatch;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.serviceclient.functional.common.TestWorkflows;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetResultsTimeoutTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setUseTimeskipping(false)
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testGetResults() {
+    TestWorkflows.PrimitiveWorkflow workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class);
+    WorkflowClient.start(workflow::execute);
+
+    Stopwatch stopWatch = Stopwatch.createStarted();
+
+    assertThrows(
+        TimeoutException.class,
+        () -> WorkflowStub.fromTyped(workflow).getResult(2, TimeUnit.SECONDS, Void.class));
+
+    stopWatch.stop();
+    long elapsedSeconds = stopWatch.elapsed(TimeUnit.SECONDS);
+    assertTrue(
+        "We shouldn't return too early or too late by the timeout, took "
+            + elapsedSeconds
+            + " seconds",
+        elapsedSeconds >= 1 && elapsedSeconds <= 3);
+  }
+
+  @Test
+  public void testGetResultAsync() {
+    TestWorkflows.PrimitiveWorkflow workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class);
+    WorkflowClient.start(workflow::execute);
+    CompletableFuture<Void> future =
+        WorkflowStub.fromTyped(workflow).getResultAsync(2, TimeUnit.SECONDS, Void.class);
+
+    Stopwatch stopWatch = Stopwatch.createStarted();
+
+    ExecutionException executionException = assertThrows(ExecutionException.class, future::get);
+    assertThat(executionException.getCause(), is(instanceOf(TimeoutException.class)));
+
+    stopWatch.stop();
+    long elapsedSeconds = stopWatch.elapsed(TimeUnit.SECONDS);
+    assertTrue(
+        "We shouldn't return too early or too late by the timeout, took "
+            + elapsedSeconds
+            + " seconds",
+        elapsedSeconds >= 1 && elapsedSeconds <= 3);
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.PrimitiveWorkflow {
+    @Override
+    public void execute() {
+      Workflow.sleep(Duration.ofSeconds(10));
+    }
+  }
+}

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/HealthCheckTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/HealthCheckTest.java
@@ -17,8 +17,10 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.serviceclient;
+package io.temporal.serviceclient.functional;
 
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/MetricsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/MetricsTest.java
@@ -17,7 +17,7 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.serviceclient;
+package io.temporal.serviceclient.functional;
 
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static junit.framework.TestCase.assertEquals;
@@ -33,6 +33,10 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.reporter.MicrometerClientStatsReporter;
+import io.temporal.serviceclient.MetricsTag;
+import io.temporal.serviceclient.MetricsType;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.util.List;

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/common/TestWorkflows.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/common/TestWorkflows.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.serviceclient.functional.common;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+public class TestWorkflows {
+  @WorkflowInterface
+  public interface PrimitiveWorkflow {
+    @WorkflowMethod
+    void execute();
+  }
+}

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
@@ -159,7 +159,9 @@ interface TestWorkflowStore {
       ExecutionId executionId, TaskQueueId taskQueue, PollWorkflowTaskQueueResponse.Builder task);
 
   GetWorkflowExecutionHistoryResponse getWorkflowExecutionHistory(
-      ExecutionId executionId, GetWorkflowExecutionHistoryRequest getRequest, Deadline deadline);
+      ExecutionId executionId,
+      GetWorkflowExecutionHistoryRequest getRequest,
+      Deadline deadlineToReturnEmptyResponse);
 
   void getDiagnostics(StringBuilder result);
 


### PR DESCRIPTION
## What was changed

Make getResult methods to throw `TimeoutException` as the method contract states instead of raw gRPC DEADLINE_EXCEEDED.
getResultAsync now respects the timeout.
Unit tests are added that are covering different kinds of timeouts and retries of the long poll.

Closes #1177
Closes #988
Partially addresses #1203