### PR TITLE
Add unit test verifying behavior of finishing Activity with CancellationType=ABANDON if it was canceled by the workflow

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply"
+    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply -x spotlessJava"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:
@@ -14,7 +14,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply"
+    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,14 @@ before we can merge in any of your changes
 
 ## Development Environment
 
-* Java 8.
-* Gradle build tool
+* Java 11
 * Docker
+
+## Build
+
+```
+./gradlew clean build
+```
 
 ## Licence headers
 
@@ -26,6 +31,11 @@ To generate licence headers execute
 ```lang=bash
 ./gradlew licenseFormat
 ```
+
+## Code Formatting
+
+Code autoformatting is applied automatically during a full gradle build. Build the project before submitting a PR.
+Code is formatted using `spotless` plugin with `google-java-format` tool.
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Temporal in general:
 - [Install Temporal Server](https://docs.temporal.io/docs/server/quick-install)
 - [Temporal CLI](https://docs.temporal.io/docs/devtools/tctl/)
 
-## Build a configuration
+## Requirements
+
+- Java 1.8+
+
+## Build configuration
 
 [Find the latest release](https://search.maven.org/artifact/io.temporal/temporal-sdk) of the Temporal Java SDK at maven central.
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.5.2' apply false
+    id 'com.diffplug.spotless' version '6.6.1' apply false
     id 'base'
 }
 
@@ -29,7 +29,7 @@ ext {
     // micrometerVersion = '[1.0.0,)!!1.8.3'
     grpcVersion = '1.46.0'
     jacksonVersion = '2.13.1'
-    micrometerVersion = '1.8.5'
+    micrometerVersion = '1.9.0'
 
     protoVersion = '[3.10.0,3.99)!!3.20.1'
     annotationApiVersion = '1.3.2'
@@ -46,7 +46,9 @@ ext {
 
 apply from: "$rootDir/gradle/versioning.gradle"
 apply from: "$rootDir/gradle/java.gradle"
-apply from: "$rootDir/gradle/google-java-format.gradle"
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+    apply from: "$rootDir/gradle/google-java-format.gradle"
+}
 apply from: "$rootDir/gradle/errorprone.gradle"
 apply from: "$rootDir/gradle/licensing.gradle"
 apply from: "$rootDir/gradle/publishing.gradle"

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/AbandonActivityFinishesAfterCancellingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/AbandonActivityFinishesAfterCancellingTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests.cancellation;
+
+import io.temporal.activity.ActivityCancellationType;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Async;
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * This test verifies that an Activity started with {@link ActivityCancellationType#ABANDON} can be
+ * canceled after starting by the workflow and can successfully finish later. And this combination
+ * doesn't cause a problem with workflow state machines.
+ */
+public class AbandonActivityFinishesAfterCancellingTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestAbandonOnCancelActivity.class)
+          .setActivityImplementations(new AbandonButFinishingActivity())
+          .build();
+
+  @Test
+  public void testAbandonOnCancelActivitySuccessfullyFinishesAfterCancelling() {
+    TestWorkflows.NoArgsWorkflow client =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.NoArgsWorkflow.class);
+    WorkflowClient.start(client::execute);
+    WorkflowStub stub = WorkflowStub.fromTyped(client);
+    stub.getResult(Void.class);
+  }
+
+  public static class AbandonButFinishingActivity
+      implements TestActivities.NoArgsReturnsStringActivity {
+    @Override
+    public String execute() {
+      try {
+        Thread.sleep(1_000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      return "done";
+    }
+  }
+
+  public static class TestAbandonOnCancelActivity implements TestWorkflows.NoArgsWorkflow {
+    @Override
+    public void execute() {
+      TestActivities.NoArgsReturnsStringActivity activity =
+          Workflow.newActivityStub(
+              TestActivities.NoArgsReturnsStringActivity.class,
+              ActivityOptions.newBuilder(
+                      SDKTestOptions.newActivityOptionsForTaskQueue(
+                          Workflow.getInfo().getTaskQueue()))
+                  .setCancellationType(ActivityCancellationType.ABANDON)
+                  .build());
+      CancellationScope cancellationScope =
+          Workflow.newCancellationScope(() -> Async.function(activity::execute));
+      cancellationScope.run();
+      Workflow.sleep(200); // End of the WFT
+      cancellationScope.cancel();
+      // to don't let time skipping if enabled to finish the workflow before the first activity is
+      // finished
+      activity.execute(); // End of the WFT
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/AbandonOnCancelActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/AbandonOnCancelActivityTest.java
@@ -17,7 +17,10 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.workflow.activityTests;
+package io.temporal.workflow.activityTests.cancellation;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.temporal.activity.ActivityCancellationType;
 import io.temporal.activity.ActivityOptions;
@@ -35,7 +38,6 @@ import io.temporal.workflow.shared.TestActivities.CompletionClientActivitiesImpl
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -70,14 +72,15 @@ public class AbandonOnCancelActivityTest {
     long start = testWorkflowRule.getTestEnvironment().currentTimeMillis();
     try {
       stub.getResult(String.class);
-      Assert.fail("unreachable");
+      fail("unreachable");
     } catch (WorkflowFailedException e) {
-      Assert.assertTrue(e.getCause() instanceof CanceledFailure);
+      assertTrue(e.getCause() instanceof CanceledFailure);
     }
     long elapsed = testWorkflowRule.getTestEnvironment().currentTimeMillis() - start;
-    Assert.assertTrue(String.valueOf(elapsed), elapsed < 500);
+    assertTrue(String.valueOf(elapsed), elapsed < 500);
     activitiesImpl.assertInvocations("activityWithDelay");
-    Assert.assertTrue(
+    assertTrue(
+        "Activity with CancellationType=ABANDON should never have a requested cancellation in history",
         testWorkflowRule
             .getHistoryEvents(execution, EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED)
             .isEmpty());


### PR DESCRIPTION
This test verifies that an Activity started with {@link ActivityCancellationType#ABANDON} can be canceled after starting by the workflow and can successfully finish later. And this combination doesn't cause a problem with workflow state machines.