### PR TITLE
Test Server responds NOT_FOUND if the activity is in incorrect state

### DIFF
--- a/temporal-kotlin/src/test/kotlin/io/temporal/activity/ActivityExecutionContextExtTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/activity/ActivityExecutionContextExtTest.kt
@@ -25,6 +25,7 @@ import io.temporal.common.converter.DefaultDataConverter
 import io.temporal.common.converter.JacksonJsonPayloadConverter
 import io.temporal.common.converter.KotlinObjectMapperFactory
 import io.temporal.testing.TestWorkflowRule
+import io.temporal.testing.internal.SDKTestWorkflowRule
 import io.temporal.workflow.Workflow
 import io.temporal.workflow.WorkflowInterface
 import io.temporal.workflow.WorkflowMethod
@@ -38,7 +39,7 @@ class ActivityExecutionContextExtTest {
 
   @Rule
   @JvmField
-  var testWorkflowRule = TestWorkflowRule.newBuilder()
+  var testWorkflowRule = SDKTestWorkflowRule.newBuilder()
     .setWorkflowTypes(TestWorkflowImpl::class.java)
     .setActivityImplementations(TestActivityForHeartbeatDetails())
     .setWorkflowClientOptions(

--- a/temporal-kotlin/src/test/kotlin/io/temporal/client/WorkflowClientExtTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/client/WorkflowClientExtTest.kt
@@ -22,7 +22,7 @@ package io.temporal.client
 import io.temporal.common.converter.DefaultDataConverter
 import io.temporal.common.converter.JacksonJsonPayloadConverter
 import io.temporal.common.converter.KotlinObjectMapperFactory
-import io.temporal.testing.TestWorkflowRule
+import io.temporal.testing.internal.SDKTestWorkflowRule
 import io.temporal.workflow.SignalMethod
 import io.temporal.workflow.Workflow
 import io.temporal.workflow.WorkflowInterface
@@ -36,7 +36,7 @@ class WorkflowClientExtTest {
 
   @Rule
   @JvmField
-  val testWorkflowRule = TestWorkflowRule.newBuilder()
+  val testWorkflowRule = SDKTestWorkflowRule.newBuilder()
     .setWorkflowTypes(TestWorkflowImpl::class.java)
     .setWorkflowClientOptions(
       WorkflowClientOptions {
@@ -45,7 +45,7 @@ class WorkflowClientExtTest {
     )
     .build()
 
-  @Test(timeout = 5000)
+  @Test
   fun `signalWithStart extension should work the same as the original method`() {
     val workflowClient = testWorkflowRule.workflowClient
 
@@ -54,18 +54,18 @@ class WorkflowClientExtTest {
       setTaskQueue(testWorkflowRule.taskQueue)
     }
     workflowClient.signalWithStart {
-      add { typedStub.start(Duration.ofHours(10)) }
+      add { typedStub.start(Duration.ofSeconds(3)) }
       add { typedStub.collectString("v1") }
     }
 
-    testWorkflowRule.testEnvironment.sleep(Duration.ofHours(1))
+    testWorkflowRule.testEnvironment.sleep(Duration.ofSeconds(1))
 
     val typedStub2 = workflowClient.newWorkflowStub<TestWorkflow> {
       setWorkflowId("1")
       setTaskQueue(testWorkflowRule.taskQueue)
     }
     workflowClient.signalWithStart {
-      add { typedStub2.start(Duration.ofHours(20)) }
+      add { typedStub2.start(Duration.ofSeconds(5)) }
       add { typedStub2.collectString("v2") }
     }
 

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityOptionsTest.java
@@ -34,9 +34,12 @@ import java.time.Duration;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class ActivityOptionsTest {
+  public @Rule Timeout timeout = Timeout.seconds(10);
 
   private TestActivityEnvironment testEnv;
   private ActivityOptions defaultOps = ActivityTestOptions.newActivityOptions1();

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
@@ -28,9 +28,13 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class LocalActivityMethodOptionsTest {
+
+  public @Rule Timeout timeout = Timeout.seconds(10);
 
   private static final LocalActivityOptions defaultOps =
       LocalActivityOptions.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
@@ -39,11 +39,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class ActivityTestingTest {
 
   private TestActivityEnvironment testEnvironment;
+
+  public @Rule Timeout timeout = Timeout.seconds(10);
 
   @Before
   public void setUp() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.enums.v1.TimeoutType;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.failure.TimeoutFailure;
+import io.temporal.internal.testing.WorkflowTestingTest;
+import io.temporal.testing.TestEnvironmentOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class ActivityTimeoutTest {
+  private TestWorkflowEnvironment testEnvironment;
+  private static final String TASK_QUEUE = "test-activities";
+
+  public @Rule Timeout timeout = Timeout.seconds(10);
+
+  @Before
+  public void setUp() {
+    TestEnvironmentOptions options = TestEnvironmentOptions.newBuilder().build();
+    testEnvironment = TestWorkflowEnvironment.newInstance(options);
+  }
+
+  @After
+  public void tearDown() {
+    testEnvironment.close();
+  }
+
+  @Test
+  public void testActivityStartToCloseTimeout() {
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(
+        WorkflowTestingTest.TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(new WorkflowTestingTest.TimingOutActivityImpl());
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    WorkflowTestingTest.TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(WorkflowTestingTest.TestActivityTimeoutWorkflow.class, options);
+    try {
+      workflow.workflow(10, 10, 1, true);
+      fail("unreacheable");
+    } catch (WorkflowException e) {
+      assertTrue(e.getCause() instanceof ActivityFailure);
+      assertEquals(
+          TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+          ((TimeoutFailure) e.getCause().getCause()).getTimeoutType());
+      assertEquals(
+          TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE,
+          ((TimeoutFailure) e.getCause().getCause().getCause()).getTimeoutType());
+    }
+  }
+
+  @Test
+  public void testActivityScheduleToStartTimeout() {
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(
+        WorkflowTestingTest.TestActivityTimeoutWorkflowImpl.class);
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    WorkflowTestingTest.TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(WorkflowTestingTest.TestActivityTimeoutWorkflow.class, options);
+    try {
+      workflow.workflow(10, 1, 10, true);
+      fail("unreacheable");
+    } catch (WorkflowException e) {
+      assertTrue(e.getCause() instanceof ActivityFailure);
+      assertEquals(
+          TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_START,
+          ((TimeoutFailure) e.getCause().getCause()).getTimeoutType());
+    }
+  }
+
+  @Test
+  public void testActivityScheduleToCloseTimeout() {
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(
+        WorkflowTestingTest.TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(new WorkflowTestingTest.TimingOutActivityImpl());
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    WorkflowTestingTest.TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(WorkflowTestingTest.TestActivityTimeoutWorkflow.class, options);
+    try {
+      workflow.workflow(2, 10, 1, false);
+      fail("unreacheable");
+    } catch (WorkflowException e) {
+      assertTrue(e.getCause() instanceof ActivityFailure);
+      assertEquals(
+          TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+          ((TimeoutFailure) e.getCause().getCause()).getTimeoutType());
+      assertEquals(
+          TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE,
+          ((TimeoutFailure) e.getCause().getCause().getCause()).getTimeoutType());
+    }
+  }
+}

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -475,7 +475,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       StreamObserver<PollActivityTaskQueueResponse> responseObserver) {
     try (Context.CancellableContext ctx = deadlineCtx(getLongPollDeadline())) {
 
-      PollActivityTaskQueueResponse.Builder task = null;
+      PollActivityTaskQueueResponse.Builder task;
       try {
         task = pollTaskQueue(ctx, store.pollActivityTaskQueue(pollRequest));
       } catch (ExecutionException e) {
@@ -499,7 +499,6 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         mutableState.startActivityTask(task, pollRequest);
         responseObserver.onNext(task.build());
         responseObserver.onCompleted();
-        return;
       } catch (StatusRuntimeException e) {
         if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
           if (log.isDebugEnabled()) {
@@ -512,7 +511,6 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
             log.error("unexpected", e);
           }
           responseObserver.onError(e);
-          return;
         }
       }
     }


### PR DESCRIPTION
Test Server responds NOT_FOUND if the activity is in an incorrect state for a worker trying to finish the activity.
Timeouts are also added to the tests that don't use SDK Test Rule.

Partially addresses #1081