### PR TITLE
Fix Version State Machine ignoring range check during replay if the history was unversioned

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -772,6 +772,9 @@ public final class WorkflowStateMachines {
         maxSupported,
         (v, e) -> {
           callback.apply(v, e);
+          // without this getVersion call will trigger the end of WFT,
+          // instead we want to prepare subsequent commands and unblock the execution one more
+          // time.
           eventLoop();
         });
   }

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -270,8 +270,6 @@ public class LocalActivityStateMachineTest {
   @Test
   public void testLocalActivityStateMachineForcedWorkflowTaskFailure() {
     class TestListener extends TestEntityManagerListenerBase {
-      Optional<Payloads> result;
-
       @Override
       protected void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
         ExecuteLocalActivityParameters parameters1 =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/DefaultVersionNotSupportedDuringReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/DefaultVersionNotSupportedDuringReplayTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow.versionTests;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.internal.statemachines.UnsupportedVersion;
+import io.temporal.testUtils.Signal;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflowReturnString;
+import io.temporal.workflow.unsafe.WorkflowUnsafe;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies a situation with a workflow is executed without versioning and after that is getting
+ * replayed on a code version that doesn't support the {@link
+ * io.temporal.workflow.Workflow#DEFAULT_VERSION} anymore
+ */
+public class DefaultVersionNotSupportedDuringReplayTest {
+
+  private static final Signal unsupportedVersionExceptionThrown = new Signal();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestVersionNotSupportedWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testVersionNotSupported() throws InterruptedException {
+    TestWorkflowReturnString workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflowReturnString.class);
+
+    WorkflowClient.start(workflowStub::execute);
+
+    unsupportedVersionExceptionThrown.waitForSignal();
+  }
+
+  public static class TestVersionNotSupportedWorkflowImpl implements TestWorkflowReturnString {
+
+    @Override
+    public String execute() {
+      if (WorkflowUnsafe.isReplaying()) {
+        try {
+          Workflow.getVersion("test_change", 2, 3);
+        } catch (UnsupportedVersion e) {
+          unsupportedVersionExceptionThrown.signal();
+          throw e;
+        }
+      }
+
+      Workflow.sleep(Duration.ofMillis(500));
+      throw new RuntimeException(); // force replay by failing WFT
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/VersionNotSupportedWithConflictingRangesExecutionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/VersionNotSupportedWithConflictingRangesExecutionTest.java
@@ -37,15 +37,20 @@ import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class VersionNotSupportedTest {
+/**
+ * Verifies a situation with a workflow having two getVersion calls.These calls have version ranges
+ * that are incompatible with each other.
+ */
+public class VersionNotSupportedWithConflictingRangesExecutionTest {
 
   private static boolean hasReplayed;
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(TestVersionNotSupportedWorkflowImpl.class)
+          .setWorkflowTypes(WorkflowWithIncompatibleRangesForTheSameChangeId.class)
           .setActivityImplementations(new TestActivitiesImpl())
+          // needed for a quick retry / replay
           .setWorkerFactoryOptions(
               WorkerFactoryOptions.newBuilder()
                   .setWorkflowHostLocalTaskQueueScheduleToStartTimeout(Duration.ZERO)
@@ -68,7 +73,7 @@ public class VersionNotSupportedTest {
     assertTrue(hasReplayed);
   }
 
-  public static class TestVersionNotSupportedWorkflowImpl implements TestWorkflow1 {
+  public static class WorkflowWithIncompatibleRangesForTheSameChangeId implements TestWorkflow1 {
 
     @Override
     public String execute(String taskQueue) {
@@ -87,8 +92,6 @@ public class VersionNotSupportedTest {
         result += testActivities.activity2("activity2", 2); // This is executed.
       }
 
-      // Catching error from getVersion is only for unit test purpose.
-      // Do not ever do it in production code.
       try {
         Workflow.getVersion("test_change", 2, 3);
       } catch (Error e) {


### PR DESCRIPTION
## What was changed

Fix Version State Machine ignoring range check during replay if the history was unversioned.

## How was this tested

Unit test verifying situation when getVersion check is added during replay and wasn't there during the original execution.

Closes #1239