### PR TITLE
Make Temporal standard non-retryable gRPC codes not configurable

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkerInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkerInterceptor.java
@@ -35,11 +35,11 @@ import io.temporal.common.Experimental;
  * public class CustomWorkerInterceptor extends WorkerInterceptorBase {
  *   // remove if you don't need to have a custom WorkflowInboundCallsInterceptor or
  *   // WorkflowOutboundCallsInterceptor
- *   @Override
+ *   {@literal @}Override
  *   public WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next) {
  *     return new CustomWorkflowInboundCallsInterceptor(next) {
  *       // remove if you don't need to have a custom WorkflowOutboundCallsInterceptor
- *       @Override
+ *       {@literal @}Override
  *       public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
  *         next.init(new CustomWorkflowOutboundCallsInterceptor(outboundCalls));
  *       }
@@ -47,7 +47,7 @@ import io.temporal.common.Experimental;
  *   }
  *
  *   // remove if you don't need to have a custom ActivityInboundCallsInterceptor
- *   @Override
+ *   {@literal @}Override
  *   public ActivityInboundCallsInterceptor interceptActivity(ActivityInboundCallsInterceptor next) {
  *     return new CustomActivityInboundCallsInterceptor(next);
  *   }
@@ -79,7 +79,6 @@ import io.temporal.common.Experimental;
  *     // override only the methods you need
  *   }
  * }
- *
  * }</pre>
  */
 @Experimental

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
@@ -39,10 +39,7 @@ class GrpcRetryerUtils {
    * not.
    *
    * @param currentException exception to analyze
-   * @param previousException previous exception happened before this one, {@code null} if {@code
-   *     currentException} is the first exception in the chain
    * @param options retry options
-   * @param grpcContextDeadline current grpc context deadline
    * @return null if the {@code exception} can be retried, a final exception to throw in the
    *     external code otherwise.
    */
@@ -56,6 +53,15 @@ class GrpcRetryerUtils {
         // https://github.com/grpc-ecosystem/go-grpc-middleware/blob/master/retry/retry.go#L287
       case CANCELLED:
         return new CancellationException("The gRPC request was cancelled");
+      case INVALID_ARGUMENT:
+      case NOT_FOUND:
+      case ALREADY_EXISTS:
+      case FAILED_PRECONDITION:
+      case PERMISSION_DENIED:
+      case UNAUTHENTICATED:
+      case UNIMPLEMENTED:
+        // never retry these codes
+        return currentException;
       case DEADLINE_EXCEEDED:
         // By default, we keep retrying with DEADLINE_EXCEEDED assuming that it's the deadline of
         // one attempt which expired, but not the whole sequence.

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -45,9 +45,6 @@ public class DefaultStubLongPollRpcRetryOptions {
             .setBackoffCoefficient(BACKOFF)
             .setMaximumInterval(MAXIMUM_INTERVAL);
 
-    DefaultStubServiceOperationRpcRetryOptions.TEMPORAL_SERVER_DEFAULT_NON_RETRY.forEach(
-        roBuilder::addDoNotRetry);
-
     return roBuilder;
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -20,11 +20,8 @@
 
 package io.temporal.serviceclient.rpcretry;
 
-import io.grpc.Status;
 import io.temporal.serviceclient.RpcRetryOptions;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Default rpc retry options for outgoing requests to the temporal server that supposed to be
@@ -36,22 +33,6 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   public static final Duration EXPIRATION_INTERVAL = Duration.ofMinutes(1);
   public static final Duration MAXIMUM_INTERVAL;
   public static final double BACKOFF = 2;
-
-  public static final List<RpcRetryOptions.DoNotRetryItem> TEMPORAL_SERVER_DEFAULT_NON_RETRY =
-      new ArrayList<RpcRetryOptions.DoNotRetryItem>() {
-        {
-          // CANCELLED is always considered non-retryable
-          // DEADLINE_EXCEEDED is handled in a special way (retry till the root gRPC context is
-          // expired)
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.INVALID_ARGUMENT, null));
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.NOT_FOUND, null));
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.ALREADY_EXISTS, null));
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.FAILED_PRECONDITION, null));
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.PERMISSION_DENIED, null));
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.UNAUTHENTICATED, null));
-          add(new RpcRetryOptions.DoNotRetryItem(Status.Code.UNIMPLEMENTED, null));
-        }
-      };
 
   public static final RpcRetryOptions INSTANCE;
 
@@ -66,13 +47,10 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   }
 
   public static RpcRetryOptions.Builder getBuilder() {
-    RpcRetryOptions.Builder roBuilder =
-        RpcRetryOptions.newBuilder()
-            .setInitialInterval(INITIAL_INTERVAL)
-            .setExpiration(EXPIRATION_INTERVAL)
-            .setBackoffCoefficient(BACKOFF)
-            .setMaximumInterval(MAXIMUM_INTERVAL);
-    TEMPORAL_SERVER_DEFAULT_NON_RETRY.forEach(roBuilder::addDoNotRetry);
-    return roBuilder;
+    return RpcRetryOptions.newBuilder()
+        .setInitialInterval(INITIAL_INTERVAL)
+        .setExpiration(EXPIRATION_INTERVAL)
+        .setBackoffCoefficient(BACKOFF)
+        .setMaximumInterval(MAXIMUM_INTERVAL);
   }
 }

--- a/temporal-testing/src/test/java/io/temporal/testing/functional/TimeLockingInterceptorAsyncTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/functional/TimeLockingInterceptorAsyncTest.java
@@ -1,20 +1,21 @@
 /*
- *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
  *
- *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
- *  use this file except in compliance with the License. A copy of the License is
- *  located at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://aws.amazon.com/apache2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  or in the "license" file accompanying this file. This file is distributed on
- *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *  express or implied. See the License for the specific language governing
- *  permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.temporal.testing.functional;


### PR DESCRIPTION
Make Temporal standard non-retryable gRPC codes not configurable. Users can't make Temporal non-retryable code retryable after this PR, users can still add own code/failure types pairs.
Improve documentation around retrying of query rpc requests and generally around `RpcRetryOptions`.