### PR TITLE
Make DeterministicRunner#close always block until the closing is done

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowExecutorCache.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowExecutorCache.java
@@ -37,9 +37,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ThreadSafe
 public final class WorkflowExecutorCache {
   private final Logger log = LoggerFactory.getLogger(WorkflowExecutorCache.class);
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -80,20 +80,12 @@ interface DeterministicRunner {
   boolean isDone();
 
   /**
-   * @return exit value passed to {@link WorkflowThread#exit(Object)}
-   */
-  Object getExitValue();
-
-  /**
    * Request cancellation of the computation. Calls {@link CancellationScope#cancel(String)} on the
    * root scope that wraps the root Runnable.
    */
   void cancel(String reason);
 
-  /**
-   * Destroys all threads by throwing {@link DestroyWorkflowThreadError} without waiting for their
-   * completion
-   */
+  /** Destroys all controlled workflow threads, blocks until the threads are destroyed */
   void close();
 
   /** Stack trace of all threads owned by the DeterministicRunner instance */

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -823,7 +823,7 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     payloads.ifPresent(attributes::setInput);
 
     context.continueAsNewOnCompletion(attributes.build());
-    WorkflowThread.exit(null);
+    WorkflowThread.exit();
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
@@ -103,14 +103,12 @@ public interface WorkflowThread extends CancellationScope {
   /**
    * Stop executing all workflow threads and puts {@link DeterministicRunner} into closed state. To
    * be called only from a workflow thread.
-   *
-   * @param value accessible through {@link DeterministicRunner#getExitValue()}.
    */
-  static <R> void exit(R value) {
-    currentThreadInternal().exitThread(value); // needed to close WorkflowThreadContext
+  static void exit() {
+    currentThreadInternal().exitThread(); // needed to close WorkflowThreadContext
   }
 
-  <R> void exitThread(R value);
+  void exitThread();
 
   <T> void setThreadLocal(WorkflowThreadLocalInternal<T> key, T value);
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WorkflowThreadContext {
+class WorkflowThreadContext {
   private static final Logger log = LoggerFactory.getLogger(WorkflowThreadContext.class);
 
   // Shared runner lock
@@ -61,6 +61,11 @@ public class WorkflowThreadContext {
     this.evaluationCondition = lock.newCondition();
   }
 
+  /**
+   * Initial yield allows the workflow thread to block at the start before exercising any user code.
+   * This gives a control over when the execution may be started. It also provides happens-before
+   * relationship with other threads and DeterministicRunnerImpl through shared lock.
+   */
   public void initialYield() {
     Status status = getStatus();
     if (status == Status.DONE) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -102,7 +102,7 @@ class WorkflowThreadImpl implements WorkflowThread {
       ContextThreadLocal.propagateContextToCurrentThread(this.propagatedContexts);
       try {
         // initialYield blocks thread until the first runUntilBlocked is called.
-        // Otherwise r starts executing without control of the sync.
+        // Otherwise, r starts executing without control of the sync.
         threadContext.initialYield();
         cancellationScope.run();
       } catch (DestroyWorkflowThreadError e) {
@@ -400,8 +400,8 @@ class WorkflowThreadImpl implements WorkflowThread {
   }
 
   @Override
-  public <R> void exitThread(R value) {
-    runner.exit(value);
+  public void exitThread() {
+    runner.exit();
     throw new DestroyWorkflowThreadError("exit");
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
@@ -56,7 +56,9 @@ public class ActivityTimeoutTest {
     testEnvironment.close();
   }
 
-  @Test
+  // TODO This test takes longer than it should to complete because
+  //  of the cached heartbeat that prevents a quit shutdown
+  @Test(timeout = 11_000)
   public void testActivityStartToCloseTimeout() {
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(


### PR DESCRIPTION
## What was changed

`DeterministicRunner#close` now returns always after the closing is fully completed.

## Why?
Previous behavior may be causing rejected executions from the cache because the threads were not actually released yet even when the executions are gone from the cache.

## How was this tested
Unit test executes two `#close` in parallel and checking that they return only when the workflow thread is finished which fails on a current master.