### PR TITLE
Invalidate cached workflow state if worker fails to send the result to the server

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowExecutorCache.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowExecutorCache.java
@@ -184,12 +184,12 @@ public final class WorkflowExecutorCache {
   }
 
   public void invalidate(
-      WorkflowExecution execution, Scope metricsScope, String reason, Throwable cause) {
+      WorkflowExecution execution, Scope workflowTypeScope, String reason, Throwable cause) {
     cacheLock.lock();
     try {
       String runId = execution.getRunId();
       log.trace(
-          "Invalidating {}-{} because of {}, value is present in the cache: {}",
+          "Invalidating {}-{} because of '{}', value is present in the cache: {}",
           execution.getWorkflowId(),
           runId,
           reason,
@@ -197,7 +197,7 @@ public final class WorkflowExecutorCache {
           cause);
       cache.invalidate(runId);
       inProcessing.remove(runId);
-      metricsScope.counter(MetricsType.STICKY_CACHE_TOTAL_FORCED_EVICTION).inc(1);
+      workflowTypeScope.counter(MetricsType.STICKY_CACHE_TOTAL_FORCED_EVICTION).inc(1);
     } finally {
       cacheLock.unlock();
       this.metricsScope.gauge(MetricsType.STICKY_CACHE_SIZE).update(size());

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -40,6 +40,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.*;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +76,7 @@ public class SyncWorkflowWorker
       String taskQueue,
       SingleWorkerOptions singleWorkerOptions,
       SingleWorkerOptions localActivityOptions,
-      WorkflowExecutorCache cache,
+      @Nonnull WorkflowExecutorCache cache,
       String stickyTaskQueueName,
       Duration stickyWorkflowTaskScheduleToStartTimeout,
       WorkflowThreadExecutor workflowThreadExecutor) {
@@ -116,7 +117,13 @@ public class SyncWorkflowWorker
 
     workflowWorker =
         new WorkflowWorker(
-            service, namespace, taskQueue, stickyTaskQueueName, singleWorkerOptions, taskHandler);
+            service,
+            namespace,
+            taskQueue,
+            stickyTaskQueueName,
+            singleWorkerOptions,
+            cache,
+            taskHandler);
 
     // Exists to support Worker#replayWorkflowExecution functionality.
     // This handler has to be non-sticky to avoid evicting actual executions from the cache

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -46,6 +46,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nonnull;
 
 /**
  * Hosts activity and workflow implementations. Uses long poll to receive activity and workflow
@@ -75,7 +76,7 @@ public final class Worker {
       WorkerFactoryOptions factoryOptions,
       WorkerOptions options,
       Scope metricsScope,
-      WorkflowExecutorCache cache,
+      @Nonnull WorkflowExecutorCache cache,
       String stickyTaskQueueName,
       WorkflowThreadExecutor workflowThreadExecutor,
       List<ContextPropagator> contextPropagators) {

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -40,6 +40,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,7 @@ public final class WorkerFactory {
   private final WorkerFactoryOptions factoryOptions;
 
   private final StickyPoller stickyPoller;
-  private final WorkflowExecutorCache cache;
+  private final @Nonnull WorkflowExecutorCache cache;
 
   private State state = State.Initial;
 


### PR DESCRIPTION
## What was changed
Invalidate cached workflow state if Worker fails to send the result to the server

## Why?
If the server goes down, a worker may finish processing workflow tasks and fail to report the advancement to the Temporal Server.
If this happens, if the server goes up and dispatches the WFT to the same worker, the worker has more advanced execution in its cache than the Temporal Server is aware of. 

## How was this tested
This change needs to be thoroughly tested, but there is no framework for such testing right now in place in JavaSDK.
Follow-up task to implement the absent testing functionality and the test: https://github.com/temporalio/sdk-java/issues/1266