### PR TITLE
Guard against applying new events to workflow state machines if there is a gap

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -204,6 +204,14 @@ public final class WorkflowStateMachines {
       // already handled
       return;
     }
+    Preconditions.checkState(
+        eventId == lastHandledEventId + 1,
+        "History is out of order. "
+            + "There is a gap between the last event workflow state machine observed and currently handling event. "
+            + "Last processed eventId: %s, handling eventId: %s",
+        lastHandledEventId,
+        eventId);
+
     lastHandledEventId = eventId;
     boolean readyToPeek = wftBuffer.addEvent(event, hasNextEvent);
     if (readyToPeek) {


### PR DESCRIPTION
## What was changed

Add an exception that guards against situations when new events may be applied to an outdated state machine.
This is theoretically possible if Worker on a sticky queue receives a partial history and has an outdated cached workflow instance.
In practice, this should never happen according to the sticky queues design, but it's safer to have a guard in place.