### PR TITLE
Fix state machines NullPointerException during one of the modes of child workflow cancellation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/CanceledFailure.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/CanceledFailure.java
@@ -24,12 +24,14 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.EncodedValues;
 import io.temporal.common.converter.Values;
 import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** <b>This exception is expected to be thrown only by the Temporal framework code.</b> */
 public final class CanceledFailure extends TemporalFailure {
   private final Values details;
 
-  public CanceledFailure(String message, Values details, Throwable cause) {
+  public CanceledFailure(String message, @Nonnull Values details, @Nullable Throwable cause) {
     super(message, message, cause);
     this.details = Objects.requireNonNull(details);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ChildWorkflowStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ChildWorkflowStateMachine.java
@@ -216,7 +216,7 @@ final class ChildWorkflowStateMachine
             WorkflowExecution.newBuilder().setWorkflowId(workflowId).build(),
             namespace,
             RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE,
-            new CanceledFailure("Child immediately canceled", null, null));
+            new CanceledFailure("Child immediately canceled"));
     completionCallback.apply(Optional.empty(), failure);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -42,7 +42,6 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.*;
-import io.temporal.common.converter.EncodedValues;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.history.MarkerUtils;
 import io.temporal.internal.history.VersionMarkerUtils;
@@ -639,8 +638,7 @@ public final class WorkflowStateMachines {
 
   private void notifyChildCanceled(
       Functions.Proc2<Optional<Payloads>, Exception> completionCallback) {
-    CanceledFailure failure =
-        new CanceledFailure("Child canceled", new EncodedValues(Optional.empty()), null);
+    CanceledFailure failure = new CanceledFailure("Child canceled");
     completionCallback.apply(Optional.empty(), failure);
     eventLoop();
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
@@ -36,8 +36,8 @@ import io.temporal.workflow.ChildWorkflowOptions;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestActivities;
 import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
+import io.temporal.workflow.shared.TestWorkflows;
 import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
-import io.temporal.workflow.shared.TestWorkflows.TestWorkflowCancellationType;
 import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Before;
@@ -146,7 +146,7 @@ public class ChildWorkflowCancellationTest {
         detachedScopeFinished.isSignalled());
   }
 
-  public static class TestParentWorkflowImpl implements TestWorkflowCancellationType {
+  public static class TestParentWorkflowImpl implements TestWorkflows.TestWorkflowCancellationType {
 
     @Override
     public void execute(ChildWorkflowCancellationType cancellationType) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowImmediateCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowImmediateCancellationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.childWorkflowTests;
+
+import static org.junit.Assert.*;
+
+import io.temporal.failure.CanceledFailure;
+import io.temporal.failure.ChildWorkflowFailure;
+import io.temporal.testUtils.Signal;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Async;
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.Promise;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflowReturnString;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * This test ensures that the behavior of immediate (inside the same WFT as scheduling) child
+ * workflow cancellation by the parent workflow.
+ *
+ * @see <a href="https://github.com/temporalio/sdk-java/issues/1037">Issue #1037</a>
+ */
+public class ChildWorkflowImmediateCancellationTest {
+
+  private static final Signal CHILD_EXECUTED = new Signal();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestParentWorkflowImpl.class, TestChildWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testChildWorkflowImmediatelyCancelledByParent() throws InterruptedException {
+    TestWorkflowReturnString workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflowReturnString.class);
+    assertEquals("ok", workflow.execute());
+    assertFalse(CHILD_EXECUTED.waitForSignal(1, TimeUnit.SECONDS));
+  }
+
+  public static class TestParentWorkflowImpl implements TestWorkflowReturnString {
+    @Override
+    public String execute() {
+      NoArgsWorkflow child = Workflow.newChildWorkflowStub(NoArgsWorkflow.class);
+      AtomicReference<Promise<Void>> childPromise = new AtomicReference<>();
+      CancellationScope cancellationScope =
+          Workflow.newCancellationScope(() -> childPromise.set(Async.procedure(child::execute)));
+      cancellationScope.run();
+      cancellationScope.cancel();
+      cancellationScope.getCancellationRequest().get();
+      ChildWorkflowFailure childWorkflowFailure =
+          assertThrows(ChildWorkflowFailure.class, () -> childPromise.get().get());
+      Throwable cause = childWorkflowFailure.getCause();
+      assertTrue(cause instanceof CanceledFailure);
+      return "ok";
+    }
+  }
+
+  public static class TestChildWorkflowImpl implements NoArgsWorkflow {
+    @Override
+    public void execute() {
+      CHILD_EXECUTED.signal();
+      Workflow.sleep(Duration.ofHours(1));
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/StartChildWorkflowWithCancellationScopeAndCancelParentTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/StartChildWorkflowWithCancellationScopeAndCancelParentTest.java
@@ -33,8 +33,8 @@ import io.temporal.workflow.ChildWorkflowCancellationType;
 import io.temporal.workflow.ChildWorkflowOptions;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
 import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
-import io.temporal.workflow.shared.TestWorkflows.TestWorkflowCancellationType;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Rule;
@@ -63,7 +63,7 @@ public class StartChildWorkflowWithCancellationScopeAndCancelParentTest {
   }
 
   public static class ParentThatStartsChildInCancellationScope
-      implements TestWorkflowCancellationType {
+      implements TestWorkflows.TestWorkflowCancellationType {
     @Override
     public void execute(ChildWorkflowCancellationType cancellationType) {
       NoArgsWorkflow child =


### PR DESCRIPTION
## Why

One of the state machine internal branches (modes) of cancelation was throwing a trivial NulPointer.

## How was this tested

Unit test covering this scenario of child workflow cancelation

Closes #1037
