### PR TITLE
Rework LocalActivities waiting code to use nanoseconds

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/InternalWorkflowTaskException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/InternalWorkflowTaskException.java
@@ -18,9 +18,13 @@
  * limitations under the License.
  */
 
-package io.temporal.internal.replay;
+package io.temporal.internal.statemachines;
 
-public final class InternalWorkflowTaskException extends RuntimeException {
+/**
+ * Originated by Temporal State Machines and happens during application of the events inside
+ * #handleEvent call.
+ */
+final class InternalWorkflowTaskException extends RuntimeException {
 
   public InternalWorkflowTaskException(String message, Throwable cause) {
     super(message, cause);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityPollTask.java
@@ -41,9 +41,7 @@ final class LocalActivityPollTask
   public LocalActivityTask poll() {
     try {
       LocalActivityTask task = pendingTasks.take();
-      if (log.isTraceEnabled()) {
-        log.trace("LocalActivity Task poll returned: " + task.getActivityId());
-      }
+      log.trace("LocalActivity Task poll returned: {}", task.getActivityId());
       return task;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -55,16 +53,13 @@ final class LocalActivityPollTask
   public Boolean apply(LocalActivityTask task, Duration maxWaitAllowed) {
     try {
       boolean accepted = pendingTasks.offer(task, maxWaitAllowed.toMillis(), TimeUnit.MILLISECONDS);
-      if (log.isTraceEnabled()) {
-        if (accepted) {
-          log.trace("LocalActivity queued: " + task.getActivityId());
-        } else {
-          log.trace(
-              "LocalActivity queue timed out for "
-                  + task.getActivityId()
-                  + " maxWaitAllowed="
-                  + maxWaitAllowed);
-        }
+      if (accepted) {
+        log.trace("LocalActivity queued: {}" + task.getActivityId());
+      } else {
+        log.trace(
+            "LocalActivity queue submitting timed out for activity {}, maxWaitAllowed: {}",
+            task.getActivityId(),
+            maxWaitAllowed);
       }
       return accepted;
     } catch (InterruptedException e) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
@@ -36,7 +36,6 @@ import io.temporal.api.history.v1.TimerFiredEventAttributes;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.history.MarkerUtils;
 import io.temporal.internal.history.VersionMarkerUtils;
-import io.temporal.internal.replay.InternalWorkflowTaskException;
 import io.temporal.worker.NonDeterministicException;
 import io.temporal.workflow.Functions;
 import java.util.ArrayList;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 
 /** Default rpc retry options for long polls like waiting for the workflow finishing and result. */
 public class DefaultStubLongPollRpcRetryOptions {
-  public static final Duration INITIAL_INTERVAL = Duration.ofMillis(1);
+  public static final Duration INITIAL_INTERVAL = Duration.ofMillis(50);
   public static final Duration MAXIMUM_INTERVAL = Duration.ofMinutes(1);
   public static final double BACKOFF = 1.2;
 


### PR DESCRIPTION
## What was changed
Rework LocalActivities waiting code to use nanoseconds
Some other refactorings improving comprehension

## Why?
System.currentTimeMillis shouldn't be used for timeouts and it's non monotonic