### PR TITLE
Add log waring if workflow eviction / closure is taking too long time

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -63,6 +63,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
    * When these attributes are present upon completion of the workflow code the ContinueAsNew
    * command is emitted instead of the workflow completion.
    */
+  @Nullable
   ContinueAsNewWorkflowExecutionCommandAttributes getContinueAsNewOnCompletion();
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -135,6 +135,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
     workflowContext.setCancelRequested(flag);
   }
 
+  @Nullable
   @Override
   public ContinueAsNewWorkflowExecutionCommandAttributes getContinueAsNewOnCompletion() {
     return workflowContext.getContinueAsNewOnCompletion();

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -137,11 +137,6 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
       handleWorkflowTaskImpl(workflowTask);
       processLocalActivityRequests(startTimeNanos);
       List<Command> commands = workflowStateMachines.takeCommands();
-      if (replayWorkflowExecutor.isCompleted()) {
-        // it's important for query, otherwise the WorkflowRunTaskHandler is responsible for closing
-        // and invalidation
-        close();
-      }
       Map<String, WorkflowQueryResult> queryResults = executeQueries(workflowTask.getQueriesMap());
       return WorkflowTaskResult.newBuilder()
           .setCommands(commands)
@@ -160,11 +155,6 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
     lock.lock();
     try {
       handleWorkflowTaskImpl(workflowTask);
-      if (replayWorkflowExecutor.isCompleted()) {
-        // it's important for query, otherwise the WorkflowRunTaskHandler is responsible for closing
-        // and invalidation
-        close();
-      }
       Optional<Payloads> resultPayloads = replayWorkflowExecutor.query(query);
       return new QueryResult(resultPayloads, replayWorkflowExecutor.isCompleted());
     } finally {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/AsyncInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/AsyncInternal.java
@@ -298,15 +298,14 @@ public final class AsyncInternal {
     } else {
       CompletablePromise<R> result = Workflow.newPromise();
       WorkflowThread.newThread(
-              () -> {
-                try {
-                  result.complete(func.apply());
-                } catch (Exception e) {
-                  result.completeExceptionally(Workflow.wrap(e));
-                }
-              },
-              false)
-          .start();
+          () -> {
+            try {
+              result.complete(func.apply());
+            } catch (Exception e) {
+              result.completeExceptionally(Workflow.wrap(e));
+            }
+          },
+          false);
       return result;
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunner.java
@@ -76,9 +76,6 @@ interface DeterministicRunner {
    */
   void runUntilAllBlocked(long deadlockDetectionTimeout);
 
-  /** IsDone returns true when all of threads are completed */
-  boolean isDone();
-
   /**
    * Request cancellation of the computation. Calls {@link CancellationScope#cancel(String)} on the
    * root scope that wraps the root Runnable.

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -20,6 +20,7 @@
 
 package io.temporal.internal.sync;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 import io.temporal.common.context.ContextPropagator;
@@ -37,9 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
@@ -222,15 +221,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
                     + callbackThread);
           }
 
-          // It is important to prepend threads as there are callbacks
-          // like signals that have to run before any other threads.
-          // Otherwise signal might be never processed if it was received
-          // after workflow decided to close.
-          // Adding the callbacks in the same order as they appear in history.
-          for (int i = callbackThreadsToAdd.size() - 1; i >= 0; i--) {
-            threads.add(callbackThreadsToAdd.get(i));
-          }
-          callbackThreadsToAdd.clear();
+          appendCallbackThreadsLocked();
         }
         toExecuteInWorkflowThread.clear();
         progress = false;
@@ -251,8 +242,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
             }
           }
         }
-        threads.addAll(workflowThreadsToAdd);
-        workflowThreadsToAdd.clear();
+        appendWorkflowThreadsLocked();
       } while (progress && !threads.isEmpty());
     } catch (PotentialDeadlockException e) {
       String triggerThreadStackTrace = "";
@@ -280,11 +270,14 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     }
   }
 
-  @Override
-  public boolean isDone() {
+  @VisibleForTesting
+  protected boolean isDone() {
     lock.lock();
     try {
-      return closeFuture.isDone() || threads.isEmpty();
+      return closeFuture.isDone()
+          || !closeRequested
+              && noThreadsToBeExecuted(); // if close requested, we should wait for the closeFuture
+      // to be filled
     } finally {
       lock.unlock();
     }
@@ -302,7 +295,6 @@ class DeterministicRunnerImpl implements DeterministicRunner {
    */
   @Override
   public void close() {
-    List<Future<?>> threadFutures = new ArrayList<>();
     lock.lock();
     if (closeFuture.isDone()) {
       lock.unlock();
@@ -324,41 +316,66 @@ class DeterministicRunnerImpl implements DeterministicRunner {
       closeFuture.join();
       return;
     }
+
     closeStarted = true;
+    // lock is taken here
     try {
-      try {
-        threads.addAll(workflowThreadsToAdd);
-        workflowThreadsToAdd.clear();
-
-        for (WorkflowThread c : threads) {
-          threadFutures.add(c.stopNow());
-        }
-        threads.clear();
-
-        // We cannot use an iterator to unregister failed Promises since f.get()
-        // will remove the promise directly from failedPromises. This causes an
-        // ConcurrentModificationException
-        // For this reason we will loop over a copy of failedPromises.
-        Set<Promise<?>> failedPromisesLoop = new HashSet<>(failedPromises);
-        for (Promise<?> f : failedPromisesLoop) {
-          try {
-            f.get();
-            throw new Error("unreachable");
-          } catch (RuntimeException e) {
-            log.warn(
-                "Promise completed with exception and was never accessed. The ignored exception:",
-                CheckedExceptionWrapper.unwrap(e));
-          }
-        }
-      } finally {
-        lock.unlock();
-      }
-
-      // Context is destroyed in c.StopNow(). Wait on all tasks outside the lock since
-      // these tasks use the same lock to execute.
-      for (Future<?> future : threadFutures) {
+      // in some circumstances when a workflow broke Deadline Detector,
+      // runUntilAllBlocked may return while workflow threads are still running.
+      // If this happens, these threads may potentially start new additional threads that will be
+      // in workflowThreadsToAdd and callbackThreadsToAdd.
+      // That's why we need to make sure that all the spawned threads were shut down in a cycle.
+      while (!noThreadsToBeExecuted()) {
+        List<WorkflowThreadStopFuture> threadFutures = new ArrayList<>();
         try {
-          future.get();
+          toExecuteInWorkflowThread.clear();
+          appendWorkflowThreadsLocked();
+          appendCallbackThreadsLocked();
+          for (WorkflowThread workflowThread : threads) {
+            threadFutures.add(
+                new WorkflowThreadStopFuture(workflowThread, workflowThread.stopNow()));
+          }
+          threads.clear();
+
+          // We cannot use an iterator to unregister failed Promises since f.get()
+          // will remove the promise directly from failedPromises. This causes an
+          // ConcurrentModificationException
+          // For this reason we will loop over a copy of failedPromises.
+          Set<Promise<?>> failedPromisesLoop = new HashSet<>(failedPromises);
+          for (Promise<?> f : failedPromisesLoop) {
+            try {
+              f.get();
+              throw new Error("unreachable");
+            } catch (RuntimeException e) {
+              log.warn(
+                  "Promise completed with exception and was never accessed. The ignored exception:",
+                  CheckedExceptionWrapper.unwrap(e));
+            }
+          }
+        } finally {
+          // we need to unlock for the further code because threads will not be able to proceed with
+          // destruction
+          // otherwise.
+          lock.unlock();
+        }
+
+        // Wait on all tasks outside the lock since these tasks use the same lock to execute.
+        try {
+          for (WorkflowThreadStopFuture threadFuture : threadFutures) {
+            try {
+              threadFuture.stopFuture.get(10, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+              WorkflowThread workflowThread = threadFuture.workflowThread;
+              log.error(
+                  "[BUG] Workflow thread '{}' of workflow '{}' can't be destroyed in time. "
+                      + "This will lead to a workflow cache leak. "
+                      + "This problem is usually caused by a workflow implementation swallowing java.lang.Error instead of rethrowing it. "
+                      + " Thread dump of the stuck thread:\n{}",
+                  workflowThread.getName(),
+                  workflowContext.getContext().getWorkflowId(),
+                  workflowThread.getStackTrace());
+            }
+          }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           // Worker is likely stopped with shutdownNow()
@@ -366,10 +383,14 @@ class DeterministicRunnerImpl implements DeterministicRunner {
           throw new Error("Worker executor thread interrupted during stopping of a coroutine", e);
         } catch (ExecutionException e) {
           throw new Error("[BUG] Unexpected failure while stopping a coroutine", e);
+        } finally {
+          // acquire the lock back as it should be taken for the loop condition check.
+          lock.lock();
         }
       }
     } finally {
       closeFuture.complete(null);
+      lock.unlock();
     }
   }
 
@@ -378,9 +399,6 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     StringBuilder result = new StringBuilder();
     lock.lock();
     try {
-      if (closeFuture.isDone()) {
-        return "Workflow is closed.";
-      }
       for (WorkflowThread coroutine : threads) {
         if (result.length() > 0) {
           result.append("\n");
@@ -391,6 +409,26 @@ class DeterministicRunnerImpl implements DeterministicRunner {
       lock.unlock();
     }
     return result.toString();
+  }
+
+  private void appendWorkflowThreadsLocked() {
+    threads.addAll(workflowThreadsToAdd);
+    workflowThreadsToAdd.clear();
+  }
+
+  private void appendCallbackThreadsLocked() {
+    // TODO I'm not sure this comment makes sense, because threads list has comparator and we use
+    // thread priorities anyway.
+
+    // It is important to prepend threads as there are callbacks
+    // like signals that have to run before any other threads.
+    // Otherwise signal might be never processed if it was received
+    // after workflow decided to close.
+    // Adding the callbacks in the same order as they appear in history.
+    for (int i = callbackThreadsToAdd.size() - 1; i >= 0; i--) {
+      threads.add(callbackThreadsToAdd.get(i));
+    }
+    callbackThreadsToAdd.clear();
   }
 
   /** Creates a new instance of a root workflow thread. */
@@ -525,6 +563,16 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     }
   }
 
+  /**
+   * @return true if there is no threads to be processed left for this workflow.
+   */
+  private boolean noThreadsToBeExecuted() {
+    return threads.isEmpty()
+        && workflowThreadsToAdd.isEmpty()
+        && callbackThreadsToAdd.isEmpty()
+        && toExecuteInWorkflowThread.isEmpty();
+  }
+
   @SuppressWarnings("unchecked")
   <T> Optional<T> getRunnerLocal(RunnerLocalInternal<T> key) {
     if (!runnerLocalMap.containsKey(key)) {
@@ -574,6 +622,16 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     private NamedRunnable(String name, Runnable runnable) {
       this.name = name;
       this.runnable = runnable;
+    }
+  }
+
+  private static class WorkflowThreadStopFuture {
+    private final WorkflowThread workflowThread;
+    private final Future<?> stopFuture;
+
+    public WorkflowThreadStopFuture(WorkflowThread workflowThread, Future<?> stopFuture) {
+      this.workflowThread = workflowThread;
+      this.stopFuture = stopFuture;
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -93,7 +93,7 @@ public class DeterministicRunnerTest {
 
   @Test
   public void testYield() {
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -178,7 +178,7 @@ public class DeterministicRunnerTest {
 
   @Test
   public void testRootFailure() {
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -202,7 +202,7 @@ public class DeterministicRunnerTest {
 
   @Test
   public void testDispatcherStop() {
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -232,7 +232,7 @@ public class DeterministicRunnerTest {
 
   @Test
   public void testDispatcherExit() {
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -273,7 +273,7 @@ public class DeterministicRunnerTest {
   @Test
   public void testRootCancellation() {
     trace.add("init");
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -301,7 +301,7 @@ public class DeterministicRunnerTest {
   @Test
   public void testExplicitScopeCancellation() {
     trace.add("init");
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -345,7 +345,7 @@ public class DeterministicRunnerTest {
   @Test
   public void testExplicitDetachedScopeCancellation() {
     trace.add("init");
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -402,7 +402,7 @@ public class DeterministicRunnerTest {
   @Test
   public void testExplicitThreadCancellation() {
     trace.add("init");
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -447,7 +447,7 @@ public class DeterministicRunnerTest {
   @Test
   public void testExplicitCancellationOnFailure() {
     trace.add("init");
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -507,7 +507,7 @@ public class DeterministicRunnerTest {
   @Test
   public void testDetachedCancellation() {
     trace.add("init");
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -562,7 +562,7 @@ public class DeterministicRunnerTest {
 
   @Test
   public void testChild() {
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),
@@ -620,7 +620,7 @@ public class DeterministicRunnerTest {
 
   @Test
   public void testChildTree() {
-    DeterministicRunner d =
+    DeterministicRunnerImpl d =
         new DeterministicRunnerImpl(
             threadPool::submit,
             DummySyncWorkflowContext.newDummySyncWorkflowContext(),

--- a/temporal-sdk/src/test/java/io/temporal/workflow/SyncTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/SyncTest.java
@@ -20,10 +20,8 @@
 
 package io.temporal.workflow;
 
-import static io.temporal.client.WorkflowClient.QUERY_TYPE_STACK_TRACE;
 import static org.junit.Assert.*;
 
-import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
@@ -35,7 +33,6 @@ import io.temporal.workflow.shared.TestActivities;
 import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
 import io.temporal.workflow.shared.TestActivities.VariousTestActivities;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
-import java.time.Duration;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -79,31 +76,6 @@ public class SyncTest {
             "activity ActivityWithDelay",
             "executeActivity Activity2",
             "activity Activity2");
-  }
-
-  @Test
-  public void testSyncUntypedAndStackTrace() {
-    completionClientActivitiesImpl.setCompletionClient(
-        testWorkflowRule.getWorkflowClient().newActivityCompletionClient());
-    WorkflowStub workflowStub =
-        testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow1");
-    WorkflowExecution execution = workflowStub.start(testWorkflowRule.getTaskQueue());
-    testWorkflowRule.sleep(Duration.ofMillis(500));
-    String stackTrace = workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class);
-    assertTrue(stackTrace, stackTrace.contains("TestSyncWorkflowImpl.execute"));
-    assertTrue(stackTrace, stackTrace.contains("activityWithDelay"));
-    // Test stub created from workflow execution.
-    workflowStub =
-        testWorkflowRule
-            .getWorkflowClient()
-            .newUntypedWorkflowStub(execution, workflowStub.getWorkflowType());
-    stackTrace = workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class);
-    assertTrue(stackTrace, stackTrace.contains("TestSyncWorkflowImpl.execute"));
-    assertTrue(stackTrace, stackTrace.contains("activityWithDelay"));
-    String result = workflowStub.getResult(String.class);
-    assertEquals("activity10", result);
-    // No stacktrace after the workflow is closed. Assert message.
-    assertEquals("Workflow is closed.", workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class));
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/StackTraceQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/StackTraceQueryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.queryTests;
+
+import static io.temporal.client.WorkflowClient.QUERY_TYPE_STACK_TRACE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Async;
+import io.temporal.workflow.Promise;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class StackTraceQueryTest {
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testUntypedStubStackTrace() {
+    WorkflowStub workflowStub =
+        testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestWorkflow1");
+    WorkflowExecution execution = workflowStub.start(testWorkflowRule.getTaskQueue());
+    testWorkflowRule.sleep(Duration.ofMillis(500));
+    String stackTrace = workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class);
+    assertTrue(stackTrace, stackTrace.contains("TestWorkflowImpl.execute"));
+    assertTrue(stackTrace, stackTrace.contains("sleepActivity"));
+    // Test stub created from workflow execution.
+    workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(execution, workflowStub.getWorkflowType());
+    stackTrace = workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class);
+    assertTrue(stackTrace, stackTrace.contains("TestWorkflowImpl.execute"));
+    assertTrue(stackTrace, stackTrace.contains("sleepActivity"));
+
+    // wait for a completion
+    workflowStub.getResult(String.class);
+    // No stacktrace after the workflow is completed. Assert message.
+    assertEquals("Workflow is closed.", workflowStub.query(QUERY_TYPE_STACK_TRACE, String.class));
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      TestActivities.VariousTestActivities activities =
+          Workflow.newActivityStub(
+              TestActivities.VariousTestActivities.class,
+              SDKTestOptions.newActivityOptionsForTaskQueue(taskQueue));
+
+      // Invoke synchronously in a separate thread for testing purposes only.
+      // In real workflows use
+      // Async.function(activities::sleepActivity, 1000, 10)
+      Promise<String> a1 = Async.function(() -> activities.sleepActivity(1000L, 10));
+      Workflow.sleep(2000);
+      return a1.get();
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -40,6 +40,7 @@ import io.temporal.internal.replay.StartChildWorkflowExecutionParameters;
 import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.*;
+import javax.annotation.Nullable;
 
 public class DummySyncWorkflowContext {
   public static SyncWorkflowContext newDummySyncWorkflowContext() {
@@ -82,6 +83,7 @@ public class DummySyncWorkflowContext {
       throw new UnsupportedOperationException("not implemented");
     }
 
+    @Nullable
     @Override
     public ContinueAsNewWorkflowExecutionCommandAttributes getContinueAsNewOnCompletion() {
       throw new UnsupportedOperationException("not implemented");


### PR DESCRIPTION
## What was changed
Add log warning if workflow eviction / closure is taking too long time to close.
Add guards making sure all threads are drained.