### PR TITLE
Cleanup forced worker shutdown from interrupted exceptions in the log

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -143,6 +143,8 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       }
 
       return result;
+    } catch (InterruptedException e) {
+      throw e;
     } catch (Throwable e) {
       // Note here that the executor might not be in the cache, even when the caching is on. In that
       // case we need to close the executor explicitly. For items in the cache, invalidation

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
@@ -38,7 +38,8 @@ public interface WorkflowRunTaskHandler {
    * @return true if new workflow task should be force created synchronously as local activities are
    *     still running.
    */
-  WorkflowTaskResult handleWorkflowTask(PollWorkflowTaskQueueResponseOrBuilder workflowTask);
+  WorkflowTaskResult handleWorkflowTask(PollWorkflowTaskQueueResponseOrBuilder workflowTask)
+      throws InterruptedException;
 
   QueryResult handleQueryWorkflowTask(
       PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowQuery query);

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -365,7 +365,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
           // TODO consider propagating as an original interrupted exception to the top level
           throw new Error("Worker executor thread interrupted during stopping of a coroutine", e);
         } catch (ExecutionException e) {
-          throw new Error("[BUG] Unexpected failure stopping of a coroutine", e);
+          throw new Error("[BUG] Unexpected failure while stopping a coroutine", e);
         }
       }
     } finally {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -361,10 +361,11 @@ class DeterministicRunnerImpl implements DeterministicRunner {
           future.get();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
-          log.warn("Unexpected interrupt during Deterministic Runner closing");
-          return;
+          // Worker is likely stopped with shutdownNow()
+          // TODO consider propagating as an original interrupted exception to the top level
+          throw new Error("Worker executor thread interrupted during stopping of a coroutine", e);
         } catch (ExecutionException e) {
-          throw new Error("[BUG] Unexpected failure stopping coroutine", e);
+          throw new Error("[BUG] Unexpected failure stopping of a coroutine", e);
         }
       }
     } finally {


### PR DESCRIPTION
## What was changed

One of the previous changes introduced a bunch of excessive logging during the forced worker shutdown.
Improve handling of interrupted exceptions