### PR TITLE
Add log waring if workflow eviction / closure is taking too long time to close

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/AsyncInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/AsyncInternal.java
@@ -298,15 +298,14 @@ public final class AsyncInternal {
     } else {
       CompletablePromise<R> result = Workflow.newPromise();
       WorkflowThread.newThread(
-              () -> {
-                try {
-                  result.complete(func.apply());
-                } catch (Exception e) {
-                  result.completeExceptionally(Workflow.wrap(e));
-                }
-              },
-              false)
-          .start();
+          () -> {
+            try {
+              result.complete(func.apply());
+            } catch (Exception e) {
+              result.completeExceptionally(Workflow.wrap(e));
+            }
+          },
+          false);
       return result;
     }
   }

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        // 0.11.0 and later are build on JDK 11 bytecode version
+        graalVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '0.12.0' : '0.10.0'}"
+    }
+}
+
 plugins {
     id 'application'
-    id 'com.palantir.graal' version '0.10.0'
-    id 'com.palantir.docker' version '0.33.0'
+    id 'com.palantir.graal' version "${graalVersion}"
+    id 'com.palantir.docker' version '0.34.0'
     id 'com.google.protobuf' version '0.8.18'
 }
 


### PR DESCRIPTION
## What was changed

Add log warning if workflow eviction / closure is taking too long time to close.
Add guards making sure all threads are drained.