### PR TITLE
Make stacktrace query result to be serialized using standard data converter only

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
@@ -52,8 +52,10 @@ public class DefaultDataConverter implements DataConverter {
     new JacksonJsonPayloadConverter()
   };
 
+  public static final DataConverter STANDARD_DATA_CONVERTER = newDefaultInstance();
+
   private static final AtomicReference<DataConverter> defaultDataConverterInstance =
-      new AtomicReference<>(newDefaultInstance());
+      new AtomicReference<>(STANDARD_DATA_CONVERTER);
 
   private final Map<String, PayloadConverter> converterMap = new ConcurrentHashMap<>();
 
@@ -64,10 +66,12 @@ public class DefaultDataConverter implements DataConverter {
   }
 
   /**
-   * Override the global data converter default. Consider overriding data converter per client
-   * instance (using {@link
-   * io.temporal.client.WorkflowClientOptions.Builder#setDataConverter(DataConverter)} to avoid
-   * potential conflicts.
+   * Override the global data converter default.
+   *
+   * <p>Consider using {@link
+   * io.temporal.client.WorkflowClientOptions.Builder#setDataConverter(DataConverter)} to set data
+   * converter per client / worker instance to avoid conflicts if your setup requires different
+   * converters for different clients / workers.
    */
   public static void setDefaultDataConverter(DataConverter converter) {
     defaultDataConverterInstance.set(converter);

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SearchAttributePayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SearchAttributePayloadConverter.java
@@ -43,8 +43,6 @@ final class SearchAttributePayloadConverter {
 
   private static final String METADATA_TYPE_KEY = "type";
 
-  private final DefaultDataConverter defaultDataConverter =
-      DefaultDataConverter.newDefaultInstance();
   public static final SearchAttributePayloadConverter INSTANCE =
       new SearchAttributePayloadConverter();
 
@@ -71,7 +69,7 @@ final class SearchAttributePayloadConverter {
       return (Payload) instance;
     }
 
-    Payload payload = defaultDataConverter.toPayload(instance).get();
+    Payload payload = DefaultDataConverter.STANDARD_DATA_CONVERTER.toPayload(instance).get();
 
     IndexedValueType type = extractIndexValueTypeName(instance);
 
@@ -134,10 +132,12 @@ final class SearchAttributePayloadConverter {
 
     try {
       // single-value search attribute
-      return Collections.singletonList(defaultDataConverter.fromPayload(payload, type, type));
+      return Collections.singletonList(
+          DefaultDataConverter.STANDARD_DATA_CONVERTER.fromPayload(payload, type, type));
     } catch (Exception e) {
       try {
-        return defaultDataConverter.fromPayload(payload, List.class, createListType(type));
+        return DefaultDataConverter.STANDARD_DATA_CONVERTER.fromPayload(
+            payload, List.class, createListType(type));
       } catch (Exception ex) {
         throw new IllegalArgumentException(
             ("Payload "
@@ -151,7 +151,8 @@ final class SearchAttributePayloadConverter {
 
   private boolean isUnset(@Nonnull Payload payload) {
     try {
-      List<?> o = defaultDataConverter.fromPayload(payload, List.class, List.class);
+      List<?> o =
+          DefaultDataConverter.STANDARD_DATA_CONVERTER.fromPayload(payload, List.class, List.class);
       if (o.size() == 0) {
         // this is an "unset" token, we don't need a type for it
         return true;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -30,6 +30,7 @@ import io.temporal.api.query.v1.WorkflowQuery;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.FailureConverter;
 import io.temporal.internal.replay.ReplayWorkflow;
 import io.temporal.internal.replay.ReplayWorkflowContext;
@@ -178,7 +179,9 @@ class SyncWorkflow implements ReplayWorkflow {
       return Optional.empty();
     }
     if (WorkflowClient.QUERY_TYPE_STACK_TRACE.equals(query.getQueryType())) {
-      return dataConverter.toPayloads(runner.stackTrace());
+      // stack trace query result should be readable for UI even if user specifies a custom data
+      // converter
+      return DefaultDataConverter.STANDARD_DATA_CONVERTER.toPayloads(runner.stackTrace());
     }
     Optional<Payloads> args =
         query.hasQueryArgs() ? Optional.of(query.getQueryArgs()) : Optional.empty();


### PR DESCRIPTION
## What was changed

Currently, before the change, stacktrace query uses user-defined data converter to serialize its result.
After the change a standard default converter will always be used for serialization of stacktrace query result.

## Why?
Stacktrace query is a built-in query for UI and tctl usage, hence a default converter should be used.
