### PR TITLE
Add pre-commit hook that ensures code is formatted before committing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,12 @@ To generate licence headers execute
 
 ## Code Formatting
 
-Code autoformatting is applied automatically during a full gradle build. Build the project before submitting a PR.
-Code is formatted using `spotless` plugin with `google-java-format` tool.
+Code in this project is formatted using `spotless` gradle plugin with `google-java-format` tool.
+Code autoformatting is applied automatically during a full gradle build.
+Or you can run `./gradlew spotlessApply` manually to check and apply formatting.
+
+You can use template git pre-commit hook in `./pre-commit` that ensures that the code is formatted
+before each commit. See comments in `./pre-commit` for installation info.
 
 ## Commit Messages
 

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Copy this script into .git/hooks to reduce amount of commit that will fail in CI with formatting issues
+# Make this script executable by running chmod +x pre-commit
+
+./gradlew spotlessApply


### PR DESCRIPTION
Add pre-commit hook that ensures code is formatted before committing and information about this hook in Contributing doc.