### PR TITLE
Switch from dependency version ranges to specific versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,28 +20,23 @@ allprojects {
 }
 
 ext {
-    // Platforms.
-    // We have to use specific versions with platforms until Maven 4.0.0 is released
-    // See https://github.com/temporalio/sdk-java/issues/1033
-    //
-    // grpcVersion = '[1.34.0,)!!1.47.0'
-    // jacksonVersion = '[2.9.0,)!!2.13.1'
-    // micrometerVersion = '[1.0.0,)!!1.9.2'
-    // springBootVersion = '[2.4.0,)!!2.7.1'
-    grpcVersion = '1.47.0'
-    jacksonVersion = '2.13.1'
-    micrometerVersion = '1.9.2'
-    springBootVersion = '2.7.1'
+    // Platforms
+    grpcVersion = '1.47.0' // [1.34.0,)
+    jacksonVersion = '2.13.1' // [2.9.0,)
+    micrometerVersion = '1.9.2' // [1.0.0,)
+    springBootVersion = '2.7.1'// [2.4.0,)
 
-    slf4jVersion = '[1.4.0,)!!1.7.36'
-    protoVersion = '[3.10.0,3.99)!!3.20.1'
+    slf4jVersion = '1.7.36' // [1.4.0,)
+    protoVersion = '3.20.1' // [3.10.0,)
     annotationApiVersion = '1.3.2'
-    guavaVersion = '[10.0,)!!31.1-jre'
-    tallyVersion = '[0.4.0,)!!0.11.1'
+    guavaVersion = '31.1-jre' // [10.0,)
+    tallyVersion = '0.11.1' // [0.4.0,)
 
-    jsonPathVersion = '2.7.0'
-    gsonVersion = '[2.0,)!!2.9.0'
+    gsonVersion = '2.9.0' // [2.0,)
 
+    jsonPathVersion = '2.7.0' // compileOnly
+
+    // test scoped
     logbackVersion = '1.2.11'
     mockitoVersion = '4.6.1'
     junitVersion = '4.13.2'

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     }
 
     implementation "com.google.guava:guava:$guavaVersion"
-    implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.6'
+    implementation group: 'com.cronutils', name: 'cron-utils', version: '9.1.7'
 
     testImplementation project(':temporal-testing')
     testImplementation "junit:junit:${junitVersion}"


### PR DESCRIPTION
By using ranges we were trying to relax requirements for users who were stuck on older lib versions by providing clear boundaries of supported versions.
Dependency version ranges create too many troubles with Maven users if some Temporal SDK dependency releases postfixed versions that are broken or incompatible and there is no existing solution to the problem. Maven supports either a range or a specific version, but not both. Which is a worse problem than the original problem we were having. It's time to move on.