### PR TITLE
Separate Global DefaultDataConverter and Standard DataConverter notion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,12 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.47.0' // [1.34.0,)
+    grpcVersion = '1.48.0' // [1.34.0,)
     jacksonVersion = '2.13.1' // [2.9.0,)
     micrometerVersion = '1.9.2' // [1.0.0,)
-    springBootVersion = '2.7.1'// [2.4.0,)
 
     slf4jVersion = '1.7.36' // [1.4.0,)
-    protoVersion = '3.20.1' // [3.10.0,)
+    protoVersion = '3.21.3' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
     tallyVersion = '0.11.1' // [0.4.0,)

--- a/temporal-kotlin/src/test/kotlin/io/temporal/common/converter/DataConverterExtTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/common/converter/DataConverterExtTest.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 
 class DataConverterExtTest {
 
-  private val dataConverter = DataConverter.getDefaultInstance()
+  private val dataConverter = DefaultDataConverter.STANDARD_INSTANCE
 
   @Test
   fun `fromPayload method should resolve generic parameters`() {

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ContextAccessor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ContextAccessor.java
@@ -25,7 +25,8 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.temporal.api.common.v1.Payload;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.common.converter.StdConverterBackwardsCompatAdapter;
 import io.temporal.common.interceptors.Header;
 import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.opentracing.OpenTracingSpanContextCodec;
@@ -55,7 +56,8 @@ public class ContextAccessor {
 
   public void writeSpanContextToHeader(SpanContext spanContext, Header header, Tracer tracer) {
     Map<String, String> serializedSpanContext = codec.encode(spanContext, tracer);
-    Optional<Payload> payload = DataConverter.getDefaultInstance().toPayload(serializedSpanContext);
+    Optional<Payload> payload =
+        DefaultDataConverter.STANDARD_INSTANCE.toPayload(serializedSpanContext);
     header.getValues().put(TRACER_HEADER_KEY, payload.get());
   }
 
@@ -66,8 +68,8 @@ public class ContextAccessor {
     }
     @SuppressWarnings("unchecked")
     Map<String, String> serializedSpanContext =
-        DataConverter.getDefaultInstance()
-            .fromPayload(payload, HashMap.class, HASH_MAP_STRING_STRING_TYPE);
+        StdConverterBackwardsCompatAdapter.fromPayload(
+            payload, HashMap.class, HASH_MAP_STRING_STRING_TYPE);
     return codec.decode(serializedSpanContext, tracer);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientOptions.java
@@ -23,6 +23,7 @@ package io.temporal.client;
 import io.temporal.api.enums.v1.QueryRejectCondition;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.GlobalDataConverter;
 import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import java.lang.management.ManagementFactory;
 import java.util.Arrays;
@@ -163,7 +164,7 @@ public final class WorkflowClientOptions {
       String name = identity == null ? ManagementFactory.getRuntimeMXBean().getName() : identity;
       return new WorkflowClientOptions(
           namespace == null ? DEFAULT_NAMESPACE : namespace,
-          dataConverter == null ? DataConverter.getDefaultInstance() : dataConverter,
+          dataConverter == null ? GlobalDataConverter.get() : dataConverter,
           interceptors == null ? EMPTY_INTERCEPTOR_ARRAY : interceptors,
           name,
           binaryChecksum == null ? DEFAULT_BINARY_CHECKSUM : binaryChecksum,

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
@@ -45,7 +45,8 @@ public interface DataConverter {
 
   /**
    * @param value
-   * @return a {@link Payload} which is a protobuf message containing byte-array serialized representation of {@code value}
+   * @return a {@link Payload} which is a protobuf message containing byte-array serialized
+   *     representation of {@code value}
    * @param <T>
    */
   <T> Optional<Payload> toPayload(T value);

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
@@ -35,10 +35,19 @@ import java.util.Optional;
  */
 public interface DataConverter {
 
+  /**
+   * @deprecated use {@link GlobalDataConverter#get()}
+   */
+  @Deprecated
   static DataConverter getDefaultInstance() {
-    return DefaultDataConverter.getDefaultInstance();
+    return GlobalDataConverter.get();
   }
 
+  /**
+   * @param value
+   * @return a {@link Payload} that is a byte-array serialized representation of {@code value}
+   * @param <T>
+   */
   <T> Optional<Payload> toPayload(T value);
 
   <T> T fromPayload(Payload payload, Class<T> valueClass, Type valueType);

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
@@ -45,7 +45,7 @@ public interface DataConverter {
 
   /**
    * @param value
-   * @return a {@link Payload} that is a byte-array serialized representation of {@code value}
+   * @return a {@link Payload} which is a protobuf message containing byte-array serialized representation of {@code value}
    * @param <T>
    */
   <T> Optional<Payload> toPayload(T value);

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
@@ -56,7 +56,7 @@ public class DefaultDataConverter implements DataConverter {
    * io.temporal.client.WorkflowClientOptions.Builder#setDataConverter(DataConverter)} or {@link
    * GlobalDataConverter#register(DataConverter)} (less preferred).
    *
-   * <p>This data converter is also always used to perform serialization of values essential for
+   * <p>This data converter is also always used (regardless of whether or not users have supplied their own converter) to perform serialization of values essential for
    * functionality of Temporal SDK, Server, tctl or WebUI:
    *
    * <ul>

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DefaultDataConverter.java
@@ -56,8 +56,9 @@ public class DefaultDataConverter implements DataConverter {
    * io.temporal.client.WorkflowClientOptions.Builder#setDataConverter(DataConverter)} or {@link
    * GlobalDataConverter#register(DataConverter)} (less preferred).
    *
-   * <p>This data converter is also always used (regardless of whether or not users have supplied their own converter) to perform serialization of values essential for
-   * functionality of Temporal SDK, Server, tctl or WebUI:
+   * <p>This data converter is also always used (regardless of whether or not users have supplied
+   * their own converter) to perform serialization of values essential for functionality of Temporal
+   * SDK, Server, tctl or WebUI:
    *
    * <ul>
    *   <li>Local Activity, Version, MutableSideEffect Markers metadata like id, time, name

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/GlobalDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/GlobalDataConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.common.converter;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class GlobalDataConverter {
+  private GlobalDataConverter() {}
+
+  private static final AtomicReference<DataConverter> globalDataConverterInstance =
+      new AtomicReference<>(DefaultDataConverter.STANDARD_INSTANCE);
+
+  /**
+   * Override the global data converter default.
+   *
+   * <p>Consider using {@link
+   * io.temporal.client.WorkflowClientOptions.Builder#setDataConverter(DataConverter)} to set data
+   * converter per client / worker instance to avoid conflicts if your setup requires different
+   * converters for different clients / workers.
+   */
+  public static void register(DataConverter converter) {
+    globalDataConverterInstance.set(converter);
+  }
+
+  public static DataConverter get() {
+    return globalDataConverterInstance.get();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/StdConverterBackwardsCompatAdapter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/StdConverterBackwardsCompatAdapter.java
@@ -30,11 +30,11 @@ import java.util.Optional;
  * functionality. See comments on {@link DefaultDataConverter#STANDARD_INSTANCE}
  *
  * <p>Unfortunately, bad code hygiene and overload of the word "default" with several meanings in
- * DefaultDataConverter led to a situation where a user-defined converter may be used to
- * serialize these internal fields instead. This problem is solved now and all SDK internal fields
- * are serialized using Standard data converter. But users may already have workflows created by
- * older SDKs and overridden "default" (in meaning "global") converter containing payloads in
- * internal fields that must be deserialized using the user-defined converter.
+ * DefaultDataConverter led to a situation where a user-defined converter may be used to serialize
+ * these internal fields instead. This problem is solved now and all SDK internal fields are
+ * serialized using Standard data converter. But users may already have workflows created by older
+ * SDKs and overridden "default" (in meaning "global") converter containing payloads in internal
+ * fields that must be deserialized using the user-defined converter.
  *
  * <p>This class provides a compatibility layer for deserialization of such internal fields by first
  * using {@link DefaultDataConverter#STANDARD_INSTANCE} and falling back to {@link

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/StdConverterBackwardsCompatAdapter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/StdConverterBackwardsCompatAdapter.java
@@ -30,13 +30,13 @@ import java.util.Optional;
  * functionality. See comments on {@link DefaultDataConverter#STANDARD_INSTANCE}
  *
  * <p>Unfortunately, bad code hygiene and overload of the word "default" with several meanings in
- * DefaultDataConverter was leading to a situation when a user-defined converter may be used to
+ * DefaultDataConverter led to a situation where a user-defined converter may be used to
  * serialize these internal fields instead. This problem is solved now and all SDK internal fields
  * are serialized using Standard data converter. But users may already have workflows created by
  * older SDKs and overridden "default" (in meaning "global") converter containing payloads in
  * internal fields that must be deserialized using the user-defined converter.
  *
- * <p>This class provides compatibility layer for deserialization of such internal fields by first
+ * <p>This class provides a compatibility layer for deserialization of such internal fields by first
  * using {@link DefaultDataConverter#STANDARD_INSTANCE} and falling back to {@link
  * GlobalDataConverter#get()} in case of an exception.
  */

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/StdConverterBackwardsCompatAdapter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/StdConverterBackwardsCompatAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.common.converter;
+
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * Temporal SDK should use Standard data converter for fields needed for internal essential
+ * functionality. See comments on {@link DefaultDataConverter#STANDARD_INSTANCE}
+ *
+ * <p>Unfortunately, bad code hygiene and overload of the word "default" with several meanings in
+ * DefaultDataConverter was leading to a situation when a user-defined converter may be used to
+ * serialize these internal fields instead. This problem is solved now and all SDK internal fields
+ * are serialized using Standard data converter. But users may already have workflows created by
+ * older SDKs and overridden "default" (in meaning "global") converter containing payloads in
+ * internal fields that must be deserialized using the user-defined converter.
+ *
+ * <p>This class provides compatibility layer for deserialization of such internal fields by first
+ * using {@link DefaultDataConverter#STANDARD_INSTANCE} and falling back to {@link
+ * GlobalDataConverter#get()} in case of an exception.
+ */
+public class StdConverterBackwardsCompatAdapter {
+  public static <T> T fromPayload(Payload payload, Class<T> valueClass, Type valueType) {
+    try {
+      return DefaultDataConverter.STANDARD_INSTANCE.fromPayload(payload, valueClass, valueType);
+    } catch (DataConverterException e) {
+      try {
+        return GlobalDataConverter.get().fromPayload(payload, valueClass, valueType);
+      } catch (DataConverterException legacyEx) {
+        throw e;
+      }
+    }
+  }
+
+  public static <T> T fromPayloads(
+      int index, Optional<Payloads> content, Class<T> valueType, Type valueGenericType)
+      throws DataConverterException {
+    try {
+      return DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+          index, content, valueType, valueGenericType);
+    } catch (DataConverterException e) {
+      try {
+        return GlobalDataConverter.get().fromPayloads(index, content, valueType, valueGenericType);
+      } catch (DataConverterException legacyEx) {
+        throw e;
+      }
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/FailureConverter.java
@@ -66,6 +66,12 @@ public class FailureConverter {
 
   private static final Pattern TRACE_ELEMENT_PATTERN = Pattern.compile(TRACE_ELEMENT_REGEXP);
 
+  /**
+   * @param failure TemporalFailure proto to deserialize into an exception
+   * @param dataConverter to be used to convert {@code Failure#failure_info#details} if present
+   *     which contain additional user supplied details.
+   * @return deserialized exception
+   */
   public static RuntimeException failureToException(Failure failure, DataConverter dataConverter) {
     if (failure == null) {
       return null;

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SearchAttributePayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SearchAttributePayloadConverter.java
@@ -69,7 +69,7 @@ final class SearchAttributePayloadConverter {
       return (Payload) instance;
     }
 
-    Payload payload = DefaultDataConverter.STANDARD_DATA_CONVERTER.toPayload(instance).get();
+    Payload payload = DefaultDataConverter.STANDARD_INSTANCE.toPayload(instance).get();
 
     IndexedValueType type = extractIndexValueTypeName(instance);
 
@@ -133,10 +133,10 @@ final class SearchAttributePayloadConverter {
     try {
       // single-value search attribute
       return Collections.singletonList(
-          DefaultDataConverter.STANDARD_DATA_CONVERTER.fromPayload(payload, type, type));
+          DefaultDataConverter.STANDARD_INSTANCE.fromPayload(payload, type, type));
     } catch (Exception e) {
       try {
-        return DefaultDataConverter.STANDARD_DATA_CONVERTER.fromPayload(
+        return DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
             payload, List.class, createListType(type));
       } catch (Exception ex) {
         throw new IllegalArgumentException(
@@ -152,7 +152,7 @@ final class SearchAttributePayloadConverter {
   private boolean isUnset(@Nonnull Payload payload) {
     try {
       List<?> o =
-          DefaultDataConverter.STANDARD_DATA_CONVERTER.fromPayload(payload, List.class, List.class);
+          DefaultDataConverter.STANDARD_INSTANCE.fromPayload(payload, List.class, List.class);
       if (o.size() == 0) {
         // this is an "unset" token, we don't need a type for it
         return true;

--- a/temporal-sdk/src/main/java/io/temporal/internal/history/MarkerUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/history/MarkerUtils.java
@@ -24,12 +24,11 @@ import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.StdConverterBackwardsCompatAdapter;
 import java.util.Optional;
 
 public class MarkerUtils {
   public static final String VERSION_MARKER_NAME = "Version";
-  public static final DataConverter DATA_CONVERTER = DataConverter.getDefaultInstance();
 
   /**
    * @param event {@code HistoryEvent} to inspect
@@ -45,15 +44,19 @@ public class MarkerUtils {
   }
 
   /**
-   * @param markerAttributes
-   * @param key
-   * @param simpleValueType
-   * @param <T>
-   * @return
+   * This method should be used to extract values from the marker persisted by the SDK itself. These
+   * values are converted using standard data converter to be always accessible by the SDK.
+   *
+   * @param markerAttributes marker attributes to extract the value frm
+   * @param key key of the value in {@code markerAttributes} details map
+   * @param simpleValueType class of a non-generic value to extract
+   * @param <T> type of the value to extract
+   * @return the value deserialized using standard data converter
    */
   public static <T> T getValueFromMarker(
       MarkerRecordedEventAttributes markerAttributes, String key, Class<T> simpleValueType) {
     Optional<Payloads> payloads = Optional.ofNullable(markerAttributes.getDetailsMap().get(key));
-    return DATA_CONVERTER.fromPayloads(0, payloads, simpleValueType, simpleValueType);
+    return StdConverterBackwardsCompatAdapter.fromPayloads(
+        0, payloads, simpleValueType, simpleValueType);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/history/VersionMarkerUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/history/VersionMarkerUtils.java
@@ -25,9 +25,9 @@ import io.temporal.api.command.v1.RecordMarkerCommandAttributes;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
+import io.temporal.common.converter.DefaultDataConverter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 public class VersionMarkerUtils {
@@ -44,10 +44,7 @@ public class VersionMarkerUtils {
     if (!hasVersionMarkerStructure(event)) {
       return null;
     }
-    Map<String, Payloads> detailsMap = event.getMarkerRecordedEventAttributes().getDetailsMap();
-    Optional<Payloads> oid = Optional.ofNullable(detailsMap.get(MARKER_CHANGE_ID_KEY));
-    String changeId = MarkerUtils.DATA_CONVERTER.fromPayloads(0, oid, String.class, String.class);
-    return changeId;
+    return getChangeId(event.getMarkerRecordedEventAttributes());
   }
 
   /**
@@ -72,8 +69,10 @@ public class VersionMarkerUtils {
       String changeId, Integer version) {
     Preconditions.checkNotNull(version, "version");
     Map<String, Payloads> details = new HashMap<>();
-    details.put(MARKER_CHANGE_ID_KEY, MarkerUtils.DATA_CONVERTER.toPayloads(changeId).get());
-    details.put(MARKER_VERSION_KEY, MarkerUtils.DATA_CONVERTER.toPayloads(version).get());
+    details.put(
+        MARKER_CHANGE_ID_KEY, DefaultDataConverter.STANDARD_INSTANCE.toPayloads(changeId).get());
+    details.put(
+        MARKER_VERSION_KEY, DefaultDataConverter.STANDARD_INSTANCE.toPayloads(version).get());
     return RecordMarkerCommandAttributes.newBuilder()
         .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
         .putAllDetails(details)

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/SideEffectStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/SideEffectStateMachine.java
@@ -50,7 +50,6 @@ final class SideEffectStateMachine
     MARKER_COMMAND_RECORDED,
   }
 
-  private static final String MARKER_HEADER_KEY = "header";
   static final String MARKER_DATA_KEY = "data";
   static final String SIDE_EFFECT_MARKER_NAME = "SideEffect";
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -181,7 +181,7 @@ class SyncWorkflow implements ReplayWorkflow {
     if (WorkflowClient.QUERY_TYPE_STACK_TRACE.equals(query.getQueryType())) {
       // stack trace query result should be readable for UI even if user specifies a custom data
       // converter
-      return DefaultDataConverter.STANDARD_DATA_CONVERTER.toPayloads(runner.stackTrace());
+      return DefaultDataConverter.STANDARD_INSTANCE.toPayloads(runner.stackTrace());
     }
     Optional<Payloads> args =
         query.hasQueryArgs() ? Optional.of(query.getQueryArgs()) : Optional.empty();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -804,10 +804,7 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
       }
       Map<String, Object> searchAttributes = options.getSearchAttributes();
       if (searchAttributes != null) {
-        attributes.setSearchAttributes(
-            SearchAttributes.newBuilder()
-                .putAllIndexedFields(
-                    intoPayloadMap(DataConverter.getDefaultInstance(), searchAttributes)));
+        attributes.setSearchAttributes(SearchAttributesUtil.encode(searchAttributes));
       }
       Map<String, Object> memo = options.getMemo();
       if (memo != null) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -610,6 +610,8 @@ public final class WorkflowInternal {
   public static Optional<Exception> getPreviousRunFailure() {
     return getRootWorkflowContext()
         .getPreviousRunFailure()
-        .map(f -> FailureConverter.failureToException(f, DataConverter.getDefaultInstance()));
+        // Temporal Failure Values are additional user payload and serialized using user data
+        // converter
+        .map(f -> FailureConverter.failureToException(f, getDataConverter()));
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SingleWorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SingleWorkerOptions.java
@@ -24,6 +24,7 @@ import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.Scope;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.GlobalDataConverter;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import java.time.Duration;
 import java.util.List;
@@ -143,7 +144,7 @@ public final class SingleWorkerOptions {
 
       DataConverter dataConverter = this.dataConverter;
       if (dataConverter == null) {
-        dataConverter = DataConverter.getDefaultInstance();
+        dataConverter = GlobalDataConverter.get();
       }
 
       Scope metricsScope = this.metricsScope;

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/EncodedValuesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/EncodedValuesTest.java
@@ -72,7 +72,7 @@ public class EncodedValuesTest {
     list.add(new Pair(10, "foo"));
     list.add(new Pair(12, "bar"));
     EncodedValues v = new EncodedValues(list);
-    DataConverter converter = DefaultDataConverter.getDefaultInstance();
+    DataConverter converter = GlobalDataConverter.get();
     v.setDataConverter(converter);
     Optional<Payloads> payloads = v.toPayloads();
     Values v2 = new EncodedValues(payloads, converter);

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/JsonDataConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/JsonDataConverterTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 public class JsonDataConverterTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
 
   public static void foo(List<UUID> arg) {}
 

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/ProtoPayloadConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/ProtoPayloadConverterTest.java
@@ -40,7 +40,7 @@ public class ProtoPayloadConverterTest {
 
   @Test
   public void testProtoJson() {
-    DataConverter converter = DataConverter.getDefaultInstance();
+    DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
     WorkflowExecution execution =
         WorkflowExecution.newBuilder()
             .setWorkflowId(UUID.randomUUID().toString())
@@ -86,7 +86,7 @@ public class ProtoPayloadConverterTest {
 
   @Test
   public void testProtoMessageType() {
-    DataConverter converter = DataConverter.getDefaultInstance();
+    DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
     WorkflowExecution execution =
         WorkflowExecution.newBuilder()
             .setWorkflowId(UUID.randomUUID().toString())

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/ActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/ActivityStateMachineTest.java
@@ -43,6 +43,7 @@ import io.temporal.api.history.v1.ActivityTaskTimedOutEventAttributes;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.replay.ExecuteActivityParameters;
 import io.temporal.workflow.Functions;
 import java.util.ArrayList;
@@ -53,7 +54,7 @@ import org.junit.Test;
 
 public class ActivityStateMachineTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
   private static final List<
           StateMachine<
               ActivityStateMachine.State, ActivityStateMachine.ExplicitEvent, ActivityStateMachine>>

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -38,6 +38,7 @@ import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.replay.ExecuteLocalActivityParameters;
 import io.temporal.internal.worker.ActivityTaskHandler;
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ import org.junit.Test;
 
 public class LocalActivityStateMachineTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
   private WorkflowStateMachines stateMachines;
 
   private static final List<

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/MutableSideEffectStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/MutableSideEffectStateMachineTest.java
@@ -39,6 +39,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
 import io.temporal.api.history.v1.TimerFiredEventAttributes;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +48,7 @@ import org.junit.Test;
 
 public class MutableSideEffectStateMachineTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
   private WorkflowStateMachines stateMachines;
 
   private static final List<

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/SideEffectStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/SideEffectStateMachineTest.java
@@ -35,6 +35,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
 import io.temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +44,7 @@ import org.junit.Test;
 
 public class SideEffectStateMachineTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
   private WorkflowStateMachines stateMachines;
 
   private static final List<

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TimerStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TimerStateMachineTest.java
@@ -34,6 +34,7 @@ import io.temporal.api.history.v1.TimerFiredEventAttributes;
 import io.temporal.api.history.v1.TimerStartedEventAttributes;
 import io.temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.workflow.Functions;
 import java.time.Duration;
@@ -45,7 +46,7 @@ import org.junit.Test;
 
 public class TimerStateMachineTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
   private WorkflowStateMachines stateMachines;
 
   private static final List<

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
@@ -34,6 +34,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
 import io.temporal.api.history.v1.TimerFiredEventAttributes;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.history.MarkerUtils;
 import io.temporal.internal.history.VersionMarkerUtils;
 import io.temporal.worker.NonDeterministicException;
@@ -47,7 +48,7 @@ import org.junit.Test;
 
 public class VersionStateMachineTest {
 
-  private final DataConverter converter = DataConverter.getDefaultInstance();
+  private final DataConverter converter = DefaultDataConverter.STANDARD_INSTANCE;
   private WorkflowStateMachines stateMachines;
 
   private static final List<

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -35,7 +35,7 @@ import io.temporal.api.query.v1.WorkflowQuery;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
 import io.temporal.common.RetryOptions;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.Signal;
 import io.temporal.internal.replay.*;
@@ -670,7 +670,7 @@ public class DeterministicRunnerTest {
         new DeterministicRunnerImpl(
             threadPool::submit,
             new SyncWorkflowContext(
-                replayWorkflowContext, DataConverter.getDefaultInstance(), null, null, null),
+                replayWorkflowContext, DefaultDataConverter.STANDARD_INSTANCE, null, null, null),
             () -> {
               Promise<Void> thread =
                   Async.procedure(
@@ -696,7 +696,7 @@ public class DeterministicRunnerTest {
         new DeterministicRunnerImpl(
             threadPool::submit,
             new SyncWorkflowContext(
-                replayWorkflowContext, DataConverter.getDefaultInstance(), null, null, null),
+                replayWorkflowContext, DefaultDataConverter.STANDARD_INSTANCE, null, null, null),
             () -> {
               Promise<Void> thread =
                   Async.procedure(

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/QueryDispatcherTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/QueryDispatcherTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.temporal.api.common.v1.Payloads;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.common.interceptors.WorkflowInboundCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
 import java.lang.reflect.Type;
@@ -45,7 +45,7 @@ public class QueryDispatcherTest {
 
   private QueryDispatcher initializeDispatcher(String... queries) {
     // Initialize the dispatcher.
-    dispatcher = new QueryDispatcher(DataConverter.getDefaultInstance());
+    dispatcher = new QueryDispatcher(DefaultDataConverter.STANDARD_INSTANCE);
     for (String query : queries) {
       WorkflowOutboundCallsInterceptor.RegisterQueryInput request =
           new WorkflowOutboundCallsInterceptor.RegisterQueryInput(

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/SyncWorkflowContextTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/SyncWorkflowContextTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.temporal.api.common.v1.SearchAttributes;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.common.SearchAttributesUtil;
 import io.temporal.internal.replay.ReplayWorkflowContext;
 import java.util.HashMap;
@@ -41,7 +41,7 @@ public class SyncWorkflowContextTest {
   public void setUp() {
     this.context =
         new SyncWorkflowContext(
-            mockReplayWorkflowContext, DataConverter.getDefaultInstance(), null, null, null);
+            mockReplayWorkflowContext, DefaultDataConverter.STANDARD_INSTANCE, null, null, null);
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownHeartBeatingActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownHeartBeatingActivityTest.java
@@ -31,7 +31,7 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.ActivityWorkerShutdownException;
 import io.temporal.client.WorkflowClient;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerFactory;
@@ -79,8 +79,8 @@ public class CleanWorkerShutdownHeartBeatingActivityTest {
         found = true;
         Payloads ar = e.getActivityTaskCompletedEventAttributes().getResult();
         String r =
-            DataConverter.getDefaultInstance()
-                .fromPayloads(0, Optional.of(ar), String.class, String.class);
+            DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+                0, Optional.of(ar), String.class, String.class);
         assertEquals(EXPECTED_RESULT, r);
       }
     }

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownTest.java
@@ -29,7 +29,7 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestActivities.TestActivity1;
@@ -72,8 +72,8 @@ public class CleanWorkerShutdownTest {
         found = true;
         Payloads ar = e.getActivityTaskCompletedEventAttributes().getResult();
         String r =
-            DataConverter.getDefaultInstance()
-                .fromPayloads(0, Optional.of(ar), String.class, String.class);
+            DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+                0, Optional.of(ar), String.class, String.class);
         assertEquals(COMPLETED, r);
       }
     }
@@ -95,8 +95,8 @@ public class CleanWorkerShutdownTest {
         found = true;
         Payloads ar = e.getActivityTaskCompletedEventAttributes().getResult();
         String r =
-            DataConverter.getDefaultInstance()
-                .fromPayloads(0, Optional.of(ar), String.class, String.class);
+            DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+                0, Optional.of(ar), String.class, String.class);
         assertEquals(INTERRUPTED, r);
       }
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ContextPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ContextPropagationTest.java
@@ -29,7 +29,7 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.context.ContextPropagator;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.testing.WorkflowTestingTest;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
@@ -276,7 +276,7 @@ public class ContextPropagationTest {
       String testKey = (String) context;
       if (testKey != null) {
         return Collections.singletonMap(
-            "test", DataConverter.getDefaultInstance().toPayload(testKey).get());
+            "test", DefaultDataConverter.STANDARD_INSTANCE.toPayload(testKey).get());
       } else {
         return Collections.emptyMap();
       }
@@ -285,8 +285,8 @@ public class ContextPropagationTest {
     @Override
     public Object deserializeContext(Map<String, Payload> context) {
       if (context.containsKey("test")) {
-        return DataConverter.getDefaultInstance()
-            .fromPayload(context.get("test"), String.class, String.class);
+        return DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            context.get("test"), String.class, String.class);
 
       } else {
         return null;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/TestLocalActivity.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/TestLocalActivity.java
@@ -29,7 +29,7 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowStub;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.testing.internal.SDKTestOptions;
@@ -85,18 +85,17 @@ public class TestLocalActivity {
         testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
     for (HistoryEvent marker : markers) {
       String activityType =
-          DataConverter.getDefaultInstance()
-              .fromPayloads(
-                  0,
-                  Optional.of(
-                      marker.getMarkerRecordedEventAttributes().getDetailsMap().get("type")),
-                  String.class,
-                  String.class);
+          DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+              0,
+              Optional.of(marker.getMarkerRecordedEventAttributes().getDetailsMap().get("type")),
+              String.class,
+              String.class);
       if (activityType.equals("Activity2")) {
         Optional<Payloads> input =
             Optional.of(marker.getMarkerRecordedEventAttributes().getDetailsMap().get("input"));
         String arg0 =
-            DataConverter.getDefaultInstance().fromPayloads(0, input, String.class, String.class);
+            DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+                0, input, String.class, String.class);
         assertEquals("test", arg0);
       }
     }
@@ -129,13 +128,11 @@ public class TestLocalActivity {
         testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
     for (HistoryEvent marker : markers) {
       String activityType =
-          DataConverter.getDefaultInstance()
-              .fromPayloads(
-                  0,
-                  Optional.of(
-                      marker.getMarkerRecordedEventAttributes().getDetailsMap().get("type")),
-                  String.class,
-                  String.class);
+          DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
+              0,
+              Optional.of(marker.getMarkerRecordedEventAttributes().getDetailsMap().get("type")),
+              String.class,
+              String.class);
       if (activityType.equals("Activity2")) {
         assertFalse(marker.getMarkerRecordedEventAttributes().getDetailsMap().containsKey("input"));
       }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/LocalActivityAndQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/LocalActivityAndQueryTest.java
@@ -29,7 +29,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
@@ -93,7 +93,8 @@ public class LocalActivityAndQueryTest {
         testWorkflowRule.getHistoryEvent(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
     Optional<Payloads> input =
         Optional.of(marker.getMarkerRecordedEventAttributes().getDetailsMap().get("input"));
-    long arg0 = DataConverter.getDefaultInstance().fromPayloads(0, input, Long.class, Long.class);
+    long arg0 =
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(0, input, Long.class, Long.class);
     assertEquals(1000, arg0);
   }
 

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,5 +1,9 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
+ext {
+    springBootVersion = '2.7.2'// [2.4.0,)
+}
+
 dependencies {
     api(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
 

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -31,7 +31,7 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.common.context.ContextPropagator;
-import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.replay.ExecuteActivityParameters;
 import io.temporal.internal.replay.ExecuteLocalActivityParameters;
@@ -45,7 +45,11 @@ public class DummySyncWorkflowContext {
   public static SyncWorkflowContext newDummySyncWorkflowContext() {
     SyncWorkflowContext context =
         new SyncWorkflowContext(
-            new DummyReplayWorkflowContext(), DataConverter.getDefaultInstance(), null, null, null);
+            new DummyReplayWorkflowContext(),
+            DefaultDataConverter.STANDARD_INSTANCE,
+            null,
+            null,
+            null);
     context.initHeadOutboundCallsInterceptor(context);
     context.initHeadInboundCallsInterceptor(
         new BaseRootWorkflowInboundCallsInterceptor(context) {


### PR DESCRIPTION
SDK code was cleaned up to never use user-defined converter for serialization of internal Temporal SDK fields and values.

Why?
Bad code hygiene and overload of the word "default" with several meanings in DefaultDataConverter (1. Global user converter, 2. Standard instance with standard payload converters and 3. Default implementation of DefaultDataConverter) was leading to a situation when a user-defined converter may be used to serialize these internal fields instead.
The main culprit is that `DefaultDataConverter#getDefaultInstance` and `DefaultDataConverter#newDefaultInstance` may be leading to completely different results.

This situation is improved now. The setting of Global DataConverter is separated in a separate GlobalDataConverter class which will prevent future misuse of this user-defined converter for internal temporal fields.
All code usages were replaced with using `DefaultDataConveter#STANDARD_INSTANCE` where it was possible.

Places that were reading values from the history have to be handled using a compatibility layer implemented in `StdConverterBackwardsCompatAdapter` that falls back into GlobalConverter that previously may be used for serialization if `DefaultDataConveter#STANDARD_INSTANCE` fails to deserialize the values.
