### PR TITLE
Fix TestActivityEnvironmentInternal#close preventing subsequent usages of the class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     micrometerVersion = '1.9.2' // [1.0.0,)
 
     slf4jVersion = '1.7.36' // [1.4.0,)
-    protoVersion = '3.21.3' // [3.10.0,)
+    protoVersion = '3.21.4' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
     tallyVersion = '0.11.1' // [0.4.0,)

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityOptionsTest.java
@@ -33,10 +33,7 @@ import io.temporal.workflow.shared.TestActivities.TestActivityImpl;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.Timeout;
 
 public class ActivityOptionsTest {
@@ -49,6 +46,11 @@ public class ActivityOptionsTest {
   @Before
   public void setUp() {
     testEnv = TestActivityEnvironment.newInstance();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    testEnv.close();
   }
 
   @MethodRetry(

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
@@ -27,10 +27,7 @@ import io.temporal.workflow.shared.TestActivities.TestLocalActivityImpl;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.Timeout;
 
 public class LocalActivityMethodOptionsTest {
@@ -67,6 +64,11 @@ public class LocalActivityMethodOptionsTest {
   @Before
   public void setUp() {
     testEnv = TestActivityEnvironment.newInstance();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    testEnv.close();
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +54,11 @@ public class ActivityTestingTest {
   @Before
   public void setUp() {
     testEnvironment = TestActivityEnvironment.newInstance();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    testEnvironment.close();
   }
 
   @ActivityInterface

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -74,11 +74,10 @@ import org.slf4j.LoggerFactory;
 public final class TestActivityEnvironmentInternal implements TestActivityEnvironment {
   private static final Logger log = LoggerFactory.getLogger(TestActivityEnvironmentInternal.class);
 
-  private static final ScheduledExecutorService heartbeatExecutor =
-      Executors.newScheduledThreadPool(20);
-  private static final ExecutorService activityWorkerExecutor =
+  private final ScheduledExecutorService heartbeatExecutor = Executors.newScheduledThreadPool(20);
+  private final ExecutorService activityWorkerExecutor =
       Executors.newSingleThreadExecutor(r -> new Thread(r, "test-service-activity-worker"));
-  private static final ExecutorService deterministicRunnerExecutor =
+  private final ExecutorService deterministicRunnerExecutor =
       new ThreadPoolExecutor(
           1,
           1000,


### PR DESCRIPTION
Fix TestActivityEnvironmentInternal#close preventing subsequent usages of the class by shutting down static members in the instance #close method.
 
Closes #928 #1133