### PR TITLE
Port static and jacoco synthetic methods fix from Activity interfaces to Workflows interfaces

### DIFF
--- a/temporal-kotlin/src/main/kotlin/io/temporal/common/metadata/WorkflowMetadata.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/common/metadata/WorkflowMetadata.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.jvm.javaMethod
  * ```
  */
 fun workflowName(workflowClass: Class<*>): String {
-  val workflowInterfaceMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowClass)
+  val workflowInterfaceMetadata = POJOWorkflowInterfaceMetadata.newStubInstance(workflowClass)
   return workflowInterfaceMetadata.workflowType.orElse(null)
     ?: throw IllegalArgumentException("$workflowClass does not define a workflow method")
 }
@@ -72,7 +72,7 @@ fun workflowQueryType(method: KFunction<*>): String {
 private fun workflowMethodName(method: KFunction<*>, type: WorkflowMethodType): String {
   val javaMethod = method.javaMethod
     ?: throw IllegalArgumentException("Invalid method reference $method")
-  val interfaceMetadata = POJOWorkflowInterfaceMetadata.newInstance(javaMethod.declaringClass)
+  val interfaceMetadata = POJOWorkflowInterfaceMetadata.newStubInstance(javaMethod.declaringClass)
   val methodMetadata = interfaceMetadata.methodsMetadata.find { it.workflowMethod == javaMethod }
     ?: throw IllegalArgumentException("Not a workflow method reference $method")
   if (methodMetadata.type != type) {

--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowImplMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowImplMetadata.java
@@ -107,9 +107,9 @@ public final class POJOWorkflowImplMetadata {
       POJOWorkflowInterfaceMetadata interfaceMetadata;
       if (listener) {
         interfaceMetadata =
-            POJOWorkflowInterfaceMetadata.newInstanceSkipWorkflowAnnotationCheck(anInterface);
+            POJOWorkflowInterfaceMetadata.newStubInstanceSkipWorkflowAnnotationCheck(anInterface);
       } else {
-        interfaceMetadata = POJOWorkflowInterfaceMetadata.newImplementationInterface(anInterface);
+        interfaceMetadata = POJOWorkflowInterfaceMetadata.newImplementationInstance(anInterface);
       }
       workflowInterfaces.add(interfaceMetadata);
       List<POJOWorkflowMethodMetadata> methods = interfaceMetadata.getMethodsMetadata();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowInvocationHandler.java
@@ -44,7 +44,7 @@ class ChildWorkflowInvocationHandler implements InvocationHandler {
       Class<?> workflowInterface,
       ChildWorkflowOptions options,
       WorkflowOutboundCallsInterceptor outboundCallsInterceptor) {
-    workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowInterface);
+    workflowMetadata = POJOWorkflowInterfaceMetadata.newStubInstance(workflowInterface);
     Optional<POJOWorkflowMethodMetadata> workflowMethodMetadata =
         workflowMetadata.getWorkflowMethod();
     if (!workflowMethodMetadata.isPresent()) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ContinueAsNewWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ContinueAsNewWorkflowInvocationHandler.java
@@ -38,7 +38,7 @@ class ContinueAsNewWorkflowInvocationHandler implements InvocationHandler {
       Class<?> interfaceClass,
       @Nullable ContinueAsNewOptions options,
       WorkflowOutboundCallsInterceptor outboundCallsInterceptor) {
-    workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(interfaceClass);
+    workflowMetadata = POJOWorkflowInterfaceMetadata.newStubInstance(interfaceClass);
     if (!workflowMetadata.getWorkflowMethod().isPresent()) {
       throw new IllegalArgumentException(
           "Missing method annotated with @WorkflowMethod: " + interfaceClass.getName());

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowInvocationHandler.java
@@ -38,7 +38,7 @@ class ExternalWorkflowInvocationHandler implements InvocationHandler {
       Class<?> workflowInterface,
       WorkflowExecution execution,
       WorkflowOutboundCallsInterceptor workflowOutboundCallsInterceptor) {
-    workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowInterface);
+    workflowMetadata = POJOWorkflowInterfaceMetadata.newStubInstance(workflowInterface);
     stub = new ExternalWorkflowStubImpl(execution, workflowOutboundCallsInterceptor);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -125,7 +125,7 @@ public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFa
     }
     workflowImplementationFactories.put(clazz, factory);
     POJOWorkflowInterfaceMetadata workflowMetadata =
-        POJOWorkflowInterfaceMetadata.newInstance(clazz);
+        POJOWorkflowInterfaceMetadata.newStubInstance(clazz);
     if (!workflowMetadata.getWorkflowMethod().isPresent()) {
       throw new IllegalArgumentException(
           "Workflow interface doesn't contain a method annotated with @WorkflowMethod: " + clazz);

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -603,7 +603,7 @@ public final class WorkflowInternal {
    */
   public static String getWorkflowType(Class<?> workflowInterfaceClass) {
     POJOWorkflowInterfaceMetadata metadata =
-        POJOWorkflowInterfaceMetadata.newInstance(workflowInterfaceClass);
+        POJOWorkflowInterfaceMetadata.newStubInstance(workflowInterfaceClass);
     return metadata.getWorkflowType().get();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInvocationHandler.java
@@ -116,7 +116,7 @@ class WorkflowInvocationHandler implements InvocationHandler {
       WorkflowClientCallsInterceptor workflowClientCallsInvoker,
       WorkflowExecution execution) {
     workflowMetadata =
-        POJOWorkflowInterfaceMetadata.newInstanceSkipWorkflowAnnotationCheck(workflowInterface);
+        POJOWorkflowInterfaceMetadata.newStubInstanceSkipWorkflowAnnotationCheck(workflowInterface);
     Optional<String> workflowType = workflowMetadata.getWorkflowType();
     WorkflowStub stub =
         new WorkflowStubImpl(clientOptions, workflowClientCallsInvoker, workflowType, execution);
@@ -133,7 +133,7 @@ class WorkflowInvocationHandler implements InvocationHandler {
       WorkflowClientCallsInterceptor workflowClientCallsInvoker,
       WorkflowOptions options) {
     Objects.requireNonNull(options, "options");
-    workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowInterface);
+    workflowMetadata = POJOWorkflowInterfaceMetadata.newStubInstance(workflowInterface);
     Optional<POJOWorkflowMethodMetadata> workflowMethodMetadata =
         workflowMetadata.getWorkflowMethod();
     if (!workflowMethodMetadata.isPresent()) {

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/testclasses/WorkflowInterfaceWithOneWorkflowMethod.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/testclasses/WorkflowInterfaceWithOneWorkflowMethod.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.common.metadata.testclasses;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface WorkflowInterfaceWithOneWorkflowMethod {
+  @WorkflowMethod
+  boolean workflowMethod();
+}

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -169,7 +169,7 @@ public class TestWorkflowExtension
     try {
       // If POJOWorkflowInterfaceMetadata can be instantiated then parameterType is a proper
       // workflow interface and can be injected
-      POJOWorkflowInterfaceMetadata.newInstance(parameterType);
+      POJOWorkflowInterfaceMetadata.newStubInstance(parameterType);
       return true;
     } catch (Exception e) {
       return false;


### PR DESCRIPTION
This PR ports fix made for Activity Interface metadata resolution made in https://github.com/temporalio/sdk-java/pull/1083 into Workflow Interface metadata resolution logic.

Closes #1331