### PR TITLE
Upgrade protoc for Apple Silicone builds

### DIFF
--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -57,11 +57,11 @@ protobuf {
     // For aarch64 (M1) using oldest version with binary available for this platform
     if (System.getProperty("os.arch") == 'aarch64') {
         protoc {
-            artifact = 'com.google.protobuf:protoc:3.17.3'
+            artifact = 'com.google.protobuf:protoc:3.21.5'
         }
         plugins {
             grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.42.1'
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.1'
             }
         }
     } else {

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -61,11 +61,11 @@ protobuf {
     // For aarch64 (M1) using oldest version with binary available for this platform
     if (System.getProperty("os.arch") == 'aarch64') {
         protoc {
-            artifact = 'com.google.protobuf:protoc:3.17.3'
+            artifact = 'com.google.protobuf:protoc:3.21.5'
         }
         plugins {
             grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.42.1'
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.1'
             }
         }
     } else {


### PR DESCRIPTION
Unfortunately, protobuf compiler continues to be haunted by problems with Apple Silicone. Upgrade to the latest release  to address problems like:
https://github.com/protocolbuffers/protobuf/issues/10136
https://github.com/protocolbuffers/protobuf/issues/9893

This change only affects builds executed on Apple Silicone and will not be applied to JavaSDK releases. We keep these dependencies as outdated as possible to provide the best backward compatibility for users.
