### PR TITLE
Spring Boot Autoconfiguration doesn't require temporal-testing module to be in classpath anymore

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/RootNamespaceAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/RootNamespaceAutoConfiguration.java
@@ -27,8 +27,8 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import io.temporal.spring.boot.autoconfigure.template.ClientTemplate;
 import io.temporal.spring.boot.autoconfigure.template.NamespaceTemplate;
+import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAdapter;
 import io.temporal.spring.boot.autoconfigure.template.WorkersTemplate;
-import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
 import java.util.Collection;
@@ -75,8 +75,8 @@ public class RootNamespaceAutoConfiguration {
       @Qualifier("mainDataConverter") @Autowired(required = false) @Nullable
           DataConverter mainDataConverter,
       @Autowired(required = false) @Nullable Tracer otTracer,
-      @Qualifier("temporalTestWorkflowEnvironment") @Autowired(required = false) @Nullable
-          TestWorkflowEnvironment testWorkflowEnvironment) {
+      @Qualifier("temporalTestWorkflowEnvironmentAdapter") @Autowired(required = false) @Nullable
+          TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
 
     DataConverter chosenDataConverter = null;
     if (dataConverters.size() == 1) {

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/ServiceStubsAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/ServiceStubsAutoConfiguration.java
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import io.temporal.spring.boot.autoconfigure.template.ServiceStubsTemplate;
-import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAdapter;
 import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,8 +46,8 @@ public class ServiceStubsAutoConfiguration {
       // Spring Boot configures and exposes Micrometer MeterRegistry bean in the
       // spring-boot-starter-actuator dependency
       @Autowired(required = false) @Nullable MeterRegistry meterRegistry,
-      @Qualifier("temporalTestWorkflowEnvironment") @Autowired(required = false) @Nullable
-          TestWorkflowEnvironment testWorkflowEnvironment) {
+      @Qualifier("temporalTestWorkflowEnvironmentAdapter") @Autowired(required = false) @Nullable
+          TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
     return new ServiceStubsTemplate(
         properties.getConnection(), meterRegistry, testWorkflowEnvironment);
   }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestServerAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestServerAutoConfiguration.java
@@ -21,7 +21,9 @@
 package io.temporal.spring.boot.autoconfigure;
 
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
+import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAdapter;
 import io.temporal.testing.TestWorkflowEnvironment;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -37,8 +39,15 @@ import org.springframework.context.annotation.Configuration;
     name = "test-server.enabled",
     havingValue = "true")
 public class TestServerAutoConfiguration {
+  @Bean(name = "temporalTestWorkflowEnvironmentAdapter")
+  public TestWorkflowEnvironmentAdapter testTestWorkflowEnvironmentAdapter(
+      @Qualifier("temporalTestWorkflowEnvironment")
+          TestWorkflowEnvironment testWorkflowEnvironment) {
+    return new TestWorkflowEnvironmentAdapterImpl(testWorkflowEnvironment);
+  }
+
   @Bean(name = "temporalTestWorkflowEnvironment", destroyMethod = "close")
-  public TestWorkflowEnvironment testServer() {
+  public TestWorkflowEnvironment testWorkflowEnvironment() {
     return TestWorkflowEnvironment.newInstance();
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestWorkflowEnvironmentAdapterImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestWorkflowEnvironmentAdapterImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAdapter;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.WorkerFactory;
+
+class TestWorkflowEnvironmentAdapterImpl implements TestWorkflowEnvironmentAdapter {
+  private final TestWorkflowEnvironment delegate;
+
+  TestWorkflowEnvironmentAdapterImpl(TestWorkflowEnvironment testWorkflowEnvironment) {
+    this.delegate = testWorkflowEnvironment;
+  }
+
+  @Override
+  public WorkflowClient getWorkflowClient() {
+    return delegate.getWorkflowClient();
+  }
+
+  @Override
+  public WorkerFactory getWorkerFactory() {
+    return delegate.getWorkerFactory();
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ClientTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ClientTemplate.java
@@ -28,7 +28,6 @@ import io.temporal.opentracing.OpenTracingClientInterceptor;
 import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
-import io.temporal.testing.TestWorkflowEnvironment;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -38,7 +37,7 @@ public class ClientTemplate {
   private final @Nullable DataConverter dataConverter;
   private final @Nullable Tracer tracer;
   // if not null, we work with an environment with defined test server
-  private final @Nullable TestWorkflowEnvironment testWorkflowEnvironment;
+  private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
 
   private WorkflowClient workflowClient;
 
@@ -47,7 +46,7 @@ public class ClientTemplate {
       @Nonnull WorkflowServiceStubs workflowServiceStubs,
       @Nullable DataConverter dataConverter,
       @Nullable Tracer tracer,
-      @Nullable TestWorkflowEnvironment testWorkflowEnvironment) {
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
     this.namespaceProperties = namespaceProperties;
     this.workflowServiceStubs = workflowServiceStubs;
     this.dataConverter = dataConverter;

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/NamespaceTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/NamespaceTemplate.java
@@ -25,7 +25,6 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
-import io.temporal.testing.TestWorkflowEnvironment;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -35,7 +34,7 @@ public class NamespaceTemplate {
   private final @Nonnull WorkflowServiceStubs workflowServiceStubs;
   private final @Nullable DataConverter dataConverter;
   private final @Nullable Tracer tracer;
-  private final @Nullable TestWorkflowEnvironment testWorkflowEnvironment;
+  private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
 
   private ClientTemplate clientTemplate;
   private WorkersTemplate workersTemplate;
@@ -46,7 +45,7 @@ public class NamespaceTemplate {
       @Nonnull WorkflowServiceStubs workflowServiceStubs,
       @Nullable DataConverter dataConverter,
       @Nullable Tracer tracer,
-      @Nullable TestWorkflowEnvironment testWorkflowEnvironment) {
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
     this.properties = properties;
     this.namespaceProperties = namespaceProperties;
     this.workflowServiceStubs = workflowServiceStubs;

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
@@ -29,7 +29,6 @@ import io.temporal.serviceclient.SimpleSslContextBuilder;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.spring.boot.autoconfigure.properties.ConnectionProperties;
-import io.temporal.testing.TestWorkflowEnvironment;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,14 +47,14 @@ public class ServiceStubsTemplate {
   private final @Nullable MeterRegistry meterRegistry;
 
   // if not null, we work with an environment with defined test server
-  private final @Nullable TestWorkflowEnvironment testWorkflowEnvironment;
+  private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
 
   private WorkflowServiceStubs workflowServiceStubs;
 
   public ServiceStubsTemplate(
       @Nonnull ConnectionProperties connectionProperties,
       @Nullable MeterRegistry meterRegistry,
-      @Nullable TestWorkflowEnvironment testWorkflowEnvironment) {
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
     this.connectionProperties = connectionProperties;
     this.meterRegistry = meterRegistry;
     this.testWorkflowEnvironment = testWorkflowEnvironment;

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/TestWorkflowEnvironmentAdapter.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/TestWorkflowEnvironmentAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.template;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.WorkerFactory;
+
+/**
+ * Creates a level of indirection over the {@link TestWorkflowEnvironment} that allows the
+ * AutoConfiguration and Starter to work with temporal-testing dependency in classpath. Otherwise,
+ * users face {@link java.lang.NoClassDefFoundError} for {@link TestWorkflowEnvironment}.
+ */
+public interface TestWorkflowEnvironmentAdapter {
+
+  WorkflowClient getWorkflowClient();
+
+  WorkerFactory getWorkerFactory();
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -31,7 +31,6 @@ import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import io.temporal.spring.boot.autoconfigure.properties.WorkerProperties;
-import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.TypeAlreadyRegisteredException;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
@@ -64,7 +63,7 @@ public class WorkersTemplate implements BeanFactoryAware {
   private final @Nullable Tracer tracer;
 
   // if not null, we work with an environment with defined test server
-  private final @Nullable TestWorkflowEnvironment testWorkflowEnvironment;
+  private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
 
   private final ClientTemplate clientTemplate;
 
@@ -78,7 +77,7 @@ public class WorkersTemplate implements BeanFactoryAware {
       @Nonnull NamespaceProperties namespaceProperties,
       @Nullable ClientTemplate clientTemplate,
       @Nullable Tracer tracer,
-      @Nullable TestWorkflowEnvironment testWorkflowEnvironment) {
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
     this.properties = properties;
     this.namespaceProperties = namespaceProperties;
     this.tracer = tracer;


### PR DESCRIPTION
Bring a level of indirection to don't require test framework classes to be in classpath for non-test functionality

Solves

```
Caused by: java.lang.IllegalStateException: Failed to introspect Class [io.temporal.spring.boot.autoconfigure.ServiceStubsAutoConfiguration] from ClassLoader [jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc]
[12:25](https://temporaltechnologies.slack.com/archives/D029WJKUN15/p1660926322965759)
Caused by: java.lang.NoClassDefFoundError: io/temporal/testing/TestWorkflowEnvironment
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method) ~[na:na]
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3166) ~[na:na]
	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2309) ~[na:na]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:467) ~[spring-core-5.3.22.jar:5.3.22]
```

when users don't even configure TestServer to be used.

Towards #8 