### PR TITLE
Port config of default Jackson timestamp deserialization to kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.9.1' apply false
+    id 'com.diffplug.spotless' version '6.10.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.14" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -29,7 +29,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.48.1' // [1.34.0,)
+    grpcVersion = '1.49.0' // [1.34.0,)
     jacksonVersion = '2.13.1' // [2.9.0,)
     micrometerVersion = '1.9.3' // [1.0.0,)
 

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jlleitschuh.gradle.ktlint' version '10.3.0'
+    id 'org.jlleitschuh.gradle.ktlint' version '11.0.0'
 }
 
 apply plugin: 'org.jetbrains.kotlin.jvm'

--- a/temporal-kotlin/src/main/kotlin/io/temporal/common/converter/KotlinObjectMapperFactory.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/common/converter/KotlinObjectMapperFactory.kt
@@ -20,23 +20,15 @@
 
 package io.temporal.common.converter
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect
-import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 
 class KotlinObjectMapperFactory {
   companion object {
     @JvmStatic
     fun new(): ObjectMapper {
-      val mapper = ObjectMapper()
-      mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-      mapper.registerModule(JavaTimeModule())
-      mapper.registerModule(Jdk8Module())
-      mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+      val mapper = JacksonJsonPayloadConverter.newDefaultObjectMapper()
+
       // use deprecated constructor instead of builder to maintain compatibility with old jackson versions
       @Suppress("deprecation")
       val km = KotlinModule()

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/JacksonJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/JacksonJsonPayloadConverter.java
@@ -39,8 +39,14 @@ public class JacksonJsonPayloadConverter implements PayloadConverter {
 
   private final ObjectMapper mapper;
 
-  public JacksonJsonPayloadConverter() {
-    mapper = new ObjectMapper();
+  /**
+   * Can be used as a starting point for custom user configurations of ObjectMapper.
+   *
+   * @return a default configuration of {@link ObjectMapper} used by {@link
+   *     JacksonJsonPayloadConverter}.
+   */
+  public static ObjectMapper newDefaultObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
     // preserve the original value of timezone coming from the server in Payload
     // without adjusting to the host timezone
     // may be important if the replay is happening on a host in another timezone
@@ -49,6 +55,11 @@ public class JacksonJsonPayloadConverter implements PayloadConverter {
     mapper.registerModule(new JavaTimeModule());
     mapper.registerModule(new Jdk8Module());
     mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    return mapper;
+  }
+
+  public JacksonJsonPayloadConverter() {
+    this(newDefaultObjectMapper());
   }
 
   public JacksonJsonPayloadConverter(ObjectMapper mapper) {


### PR DESCRIPTION
## What was changed

Code is reorganized in a way that the same basic Jackson config is used in java and kotlin modules. This also brings `mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)` to default kotlin config that may help prevent non-deterministic problems in case the replaying host has a different time zone than the original executor.
