### PR TITLE
Test Server doesn't reset sticky queue if timeout fired for an outdated workflow task

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -399,7 +399,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
             workflowTask.getPreviousStartedEventId());
       } else {
         log.debug(
-            "Handle Workflow Task {}. {}WorkflowId='{}', RunId='{}', startedEventId='{}', previousStartedEventId:{}",
+            "Handle Workflow Task {}. {}WorkflowId='{}', RunId='{}', TaskQueue='{}', startedEventId='{}', previousStartedEventId:{}",
             createdNew.get() ? "with new executor" : "with existing executor",
             workflowTask.getQueriesMap().isEmpty()
                 ? ""
@@ -410,6 +410,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
                     + ". ",
             execution.getWorkflowId(),
             execution.getRunId(),
+            workflowTask.getWorkflowExecutionTaskQueue().getName(),
             workflowTask.getStartedEventId(),
             workflowTask.getPreviousStartedEventId());
       }

--- a/temporal-sdk/src/test/resources/logback-test.xml
+++ b/temporal-sdk/src/test/resources/logback-test.xml
@@ -31,7 +31,8 @@
 
     <!--    <logger name="io.temporal.internal.retryer.GrpcRetryer" level="TRACE"/>-->
 
-    <logger name="io.temporal.internal.replay.ReplayWorkflowTaskHandler" level="DEBUG"/>
+    <!--    <logger name="io.temporal.internal.replay.ReplayWorkflowTaskHandler" level="DEBUG"/>-->
+    <!--    <logger name="io.temporal.internal.replay.WorkflowExecutorCache" level="TRACE"/>-->
 
     <!--    <logger name="io.temporal.internal.statemachines.StateMachine" level="TRACE"/>-->
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1060,6 +1060,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
 
   // TODO: insert a single  workflow task timeout into the history
   private void timeoutWorkflowTask(long scheduledEventId) {
+    StickyExecutionAttributes previousStickySettings = this.stickyExecutionAttributes;
     try {
       completeWorkflowTaskUpdate(
           ctx -> {
@@ -1067,6 +1068,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
                 || workflowTaskStateMachine.getData().scheduledEventId != scheduledEventId
                 || workflowTaskStateMachine.getState() == State.NONE) {
               // timeout for a previous workflow task
+              stickyExecutionAttributes = previousStickySettings; // rollout sticky options
               return;
             }
             workflowTaskStateMachine


### PR DESCRIPTION
Test Server doesn't reset sticky queue if timeout fired for an outdated workflow task