### PR TITLE
History iteration should never ever fail a workflow execution

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
@@ -131,12 +131,10 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
         throw Status.DEADLINE_EXCEEDED
             .withDescription(
                 "getWorkflowExecutionHistory pagination took longer than workflow task timeout")
+            .withCause(ex)
             .asRuntimeException();
       }
       throw ex;
-    } catch (Exception e) {
-      // TODO Error? Why?
-      throw new Error(e);
     }
   }
 }


### PR DESCRIPTION
## What was changed

After this change, workflow history iteration exceptions never fail workflow executions.
Even if `Throwable` is set on the failWorkflowExceptionTypes.

## Why

It's likely never an intention or expectation of the user that a workflow will start to fail on such internal machinery as workflow iterations and because of a temporary unavailable or a slow server. Also, workflow iteration exceptions are not like the state machine's `NonDeterministicException`, they are always retryable and recoverable. So it seems like failing a workflow execution on history iteration failures because of connectivity issues is always a bad idea. Instead, a Workflow Task should be failed.