### PR TITLE
Fix guard clause to allow passing key and cert chain as strings

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
@@ -113,8 +113,10 @@ public class ServiceStubsTemplate {
       @Nullable ConnectionProperties.MTLSProperties mtlsProperties,
       WorkflowServiceStubsOptions.Builder stubsOptionsBuilder) {
     if (mtlsProperties == null
-        || (mtlsProperties.getKeyFile() == null && mtlsProperties.getCertChainFile() == null)
-        || (mtlsProperties.getKey() == null && mtlsProperties.getCertChain() == null)) {
+        || (mtlsProperties.getKeyFile() == null
+            && mtlsProperties.getCertChainFile() == null
+            && mtlsProperties.getKey() == null
+            && mtlsProperties.getCertChain() == null)) {
       return;
     }
 

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
@@ -113,7 +113,8 @@ public class ServiceStubsTemplate {
       @Nullable ConnectionProperties.MTLSProperties mtlsProperties,
       WorkflowServiceStubsOptions.Builder stubsOptionsBuilder) {
     if (mtlsProperties == null
-        || (mtlsProperties.getKeyFile() == null && mtlsProperties.getCertChainFile() == null)) {
+        || (mtlsProperties.getKeyFile() == null && mtlsProperties.getCertChainFile() == null)
+        || (mtlsProperties.getKey() == null && mtlsProperties.getCertChain() == null)) {
       return;
     }
 


### PR DESCRIPTION
Fixes guard clause in spring-boot-autoconfig to allow passing key and cert chain as strings.