### PR TITLE
Deprecate addWorkflowImplementationFactory and give a register* alternative with an expected contract

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,10 @@ allprojects {
 ext {
     // Platforms
     grpcVersion = '1.49.0' // [1.34.0,)
-    jacksonVersion = '2.13.1' // [2.9.0,)
+    jacksonVersion = '2.13.4' // [2.9.0,)
     micrometerVersion = '1.9.3' // [1.0.0,)
 
-    slf4jVersion = '1.7.36' // [1.4.0,)
+    slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which decide on 1.x
     protoVersion = '3.21.5' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)

--- a/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkerExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkerExt.kt
@@ -66,7 +66,12 @@ inline fun <reified T : Any> Worker.registerWorkflowImplementationType(
  * @param factory factory that when called creates a new instance of the workflow implementation
  * object.
  * @see Worker.addWorkflowImplementationFactory
+ * @deprecated See deprecation notes on [Worker.addWorkflowImplementationFactory]
  */
+@Deprecated(
+  "Use Worker.registerWorkflowImplementationFactory instead",
+  ReplaceWith("Worker.registerWorkflowImplementationTypes(factory, options)")
+)
 inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
   options: WorkflowImplementationOptions,
   noinline factory: () -> T
@@ -75,6 +80,26 @@ inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
 }
 
 /**
+ * Configures a factory to use when an instance of a workflow implementation is created.
+ * Please read an original [Worker.registerWorkflowImplementationFactory] method doc because
+ * this method has a limited usage.
+ *
+ * @param T Workflow interface that this factory implements
+ * @param factory factory that when called creates a new instance of the workflow implementation
+ * object.
+ * @param options custom workflow implementation options for a worker
+ * @see Worker.registerWorkflowImplementationFactory
+ */
+inline fun <reified T : Any> Worker.registerWorkflowImplementationFactory(
+  noinline factory: () -> T,
+  options: WorkflowImplementationOptions
+) {
+  registerWorkflowImplementationFactory(T::class.java, factory, options)
+}
+
+/**
+ * This method may behave differently from your expectations!
+ * Read deprecation and migration notes on [Worker.addWorkflowImplementationFactory].
  * Configures a factory to use when an instance of a workflow implementation is created.
  *
  * ```kotlin
@@ -90,8 +115,24 @@ inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
  * object.
  * @see Worker.addWorkflowImplementationFactory
  */
+@Deprecated("Use Worker.registerWorkflowImplementationFactory instead", ReplaceWith("Worker.registerWorkflowImplementationTypes(factory)"))
 inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
   noinline factory: () -> T
 ) {
   addWorkflowImplementationFactory(T::class.java, factory)
+}
+
+/**
+ * Configures a factory to use when an instance of a workflow implementation is created. <br>
+ * Please read an original [Worker.registerWorkflowImplementationFactory] method doc because this method has a limited usage
+ *
+ * @param T Workflow interface that this factory implements
+ * @param factory factory that when called creates a new instance of the workflow implementation
+ * object.
+ * @see Worker.registerWorkflowImplementationFactory
+ */
+inline fun <reified T : Any> Worker.registerWorkflowImplementationFactory(
+  noinline factory: () -> T
+) {
+  registerWorkflowImplementationFactory(T::class.java, factory)
 }

--- a/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkerExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkerExt.kt
@@ -69,8 +69,8 @@ inline fun <reified T : Any> Worker.registerWorkflowImplementationType(
  * @deprecated See deprecation notes on [Worker.addWorkflowImplementationFactory]
  */
 @Deprecated(
-  "Use Worker.registerWorkflowImplementationFactory instead",
-  ReplaceWith("Worker.registerWorkflowImplementationTypes(factory, options)")
+  "Use registerWorkflowImplementationFactory instead",
+  ReplaceWith("this.registerWorkflowImplementationFactory(options, factory)")
 )
 inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
   options: WorkflowImplementationOptions,
@@ -91,8 +91,8 @@ inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
  * @see Worker.registerWorkflowImplementationFactory
  */
 inline fun <reified T : Any> Worker.registerWorkflowImplementationFactory(
-  noinline factory: () -> T,
-  options: WorkflowImplementationOptions
+  options: WorkflowImplementationOptions,
+  noinline factory: () -> T
 ) {
   registerWorkflowImplementationFactory(T::class.java, factory, options)
 }
@@ -115,7 +115,7 @@ inline fun <reified T : Any> Worker.registerWorkflowImplementationFactory(
  * object.
  * @see Worker.addWorkflowImplementationFactory
  */
-@Deprecated("Use Worker.registerWorkflowImplementationFactory instead", ReplaceWith("this.registerWorkflowImplementationFactory(factory)"))
+@Deprecated("Use registerWorkflowImplementationFactory instead", ReplaceWith("this.registerWorkflowImplementationFactory(factory)"))
 inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
   noinline factory: () -> T
 ) {

--- a/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkerExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkerExt.kt
@@ -115,7 +115,7 @@ inline fun <reified T : Any> Worker.registerWorkflowImplementationFactory(
  * object.
  * @see Worker.addWorkflowImplementationFactory
  */
-@Deprecated("Use Worker.registerWorkflowImplementationFactory instead", ReplaceWith("Worker.registerWorkflowImplementationTypes(factory)"))
+@Deprecated("Use Worker.registerWorkflowImplementationFactory instead", ReplaceWith("this.registerWorkflowImplementationFactory(factory)"))
 inline fun <reified T : Any> Worker.addWorkflowImplementationFactory(
   noinline factory: () -> T
 ) {

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/CodecDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/CodecDataConverter.java
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull;
  *
  * <p>The underlying {@link DataConverter} is expected to be responsible for conversion between user
  * objects and bytes represented as {@link Payloads}, while the underlying chain of codecs is
- * responsible for a subsequent byte <-> byte manipulation such as encryption or compression
+ * responsible for a subsequent byte &lt;-&gt; byte manipulation such as encryption or compression
  */
 public class CodecDataConverter implements DataConverter, PayloadCodec {
   private final DataConverter dataConverter;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -103,14 +103,6 @@ public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFa
     }
   }
 
-  public <R> void addWorkflowImplementationFactory(Class<R> clazz, Functions.Func<R> factory) {
-    WorkflowImplementationOptions unitTestingOptions =
-        WorkflowImplementationOptions.newBuilder()
-            .setFailWorkflowExceptionTypes(Throwable.class)
-            .build();
-    addWorkflowImplementationFactory(unitTestingOptions, clazz, factory);
-  }
-
   /**
    * @param clazz has to be a workflow interface class. The only exception is if it's a
    *     DynamicWorkflow class.

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -146,13 +146,9 @@ public class SyncWorkflowWorker
     factory.registerWorkflowImplementationTypes(options, workflowImplementationTypes);
   }
 
-  public <R> void addWorkflowImplementationFactory(
+  public <R> void registerWorkflowImplementationFactory(
       WorkflowImplementationOptions options, Class<R> clazz, Func<R> factory) {
     this.factory.addWorkflowImplementationFactory(options, clazz, factory);
-  }
-
-  public <R> void addWorkflowImplementationFactory(Class<R> clazz, Func<R> factory) {
-    this.factory.addWorkflowImplementationFactory(clazz, factory);
   }
 
   public void registerLocalActivityImplementations(Object... activitiesImplementation) {

--- a/temporal-sdk/src/main/java/io/temporal/payload/codec/ZlibPayloadCodec.java
+++ b/temporal-sdk/src/main/java/io/temporal/payload/codec/ZlibPayloadCodec.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
  * <p>Please note that this is by no means the best solution for lots of small payloads which is
  * typical for a lot of applications. You can use this implementation as an example and base for
  * your own implementation using the compressor of your choice, for example <a
- * link="https://github.com/xerial/snappy-java">Google Snappy</>
+ * href="https://github.com/xerial/snappy-java">Google Snappy</a>
  */
 public class ZlibPayloadCodec implements PayloadCodec {
   static final ByteString METADATA_ENCODING_ZLIB = ByteString.copyFromUtf8("binary/zlib");

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -376,7 +376,7 @@ public class WorkflowTestingTest {
     String details = "timeout Details";
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(SimulatedTimeoutParentWorkflow.class);
-    worker.addWorkflowImplementationFactory(
+    worker.registerWorkflowImplementationFactory(
         TestWorkflow2.class,
         () -> {
           TestWorkflow2 child = mock(TestWorkflow2.class);

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -276,7 +276,7 @@ public class WorkersTemplate implements BeanFactoryAware {
     }
 
     for (POJOWorkflowMethodMetadata workflowMethod : workflowMetadata.getWorkflowMethods()) {
-      worker.addWorkflowImplementationFactory(
+      worker.registerWorkflowImplementationFactory(
           (Class<T>) workflowMethod.getWorkflowInterface(),
           () -> (T) beanFactory.createBean(clazz));
     }

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -400,7 +400,7 @@ public class SDKTestWorkflowRule implements TestRule {
     this.getTestEnvironment()
         .getWorkerFactory()
         .getWorker(this.getTaskQueue())
-        .addWorkflowImplementationFactory(factoryImpl, factoryFunc);
+        .registerWorkflowImplementationFactory(factoryImpl, factoryFunc);
   }
 
   public void regenerateHistoryForReplay(WorkflowExecution execution, String fileName) {


### PR DESCRIPTION
# Why

Before this change `addWorkflowImplementationFactory(Class workflowInterface, Func<R> factory)` had a surprising behavior: it sets `WorkflowImplementationOptions.Builder#setFailWorkflowTypes` to `Throwable`. This leads to Workflow Execution failures on every exception that is thrown from the Workflow code (not just `TemporalFailures`). No other workflow implementation registration methods behave like that. Neither an overloaded `addWorkflowImplementationFactory` nor `registerWorkflowImplementationTypes`.

# What changed

`addWorkflowImplementationFactory(Class workflowInterface, Func<R> factory)` is deprecated and replaced with `registerWorkflowImplementationFactory`. New method doesn't set `WorkflowImplementationOptions.Builder#setFailWorkflowTypes` to `Throwable`.

`addWorkflowImplementationFactory(WorkflowImplementationOptions options, Class workflowInterface, Func<R> factory)` is deprecated and replaced with `registerWorkflowImplementationFactory`. 1-1 replacement.

To get an old behavior of `addWorkflowImplementationFactory(Class workflowInterface, Func<R> factory)`, users should explicitly pass `WorkflowImplementationOptions.newBuilder().setFailWorkflowExceptionTypes(Throwable.class).build()` as a third parameter of `registerWorkflowImplementationFactory(Class, Func, WorkflowImplementationOptions.newBuilder)`.

Additional clarifications were added:
1. Discouraging the usage of these methods in production code and 
2. Danger of dependency injection into workflow instances

Closes #1408 