### PR TITLE
Reduce threads churn by increasing pool timeouts

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollTaskExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollTaskExecutor.java
@@ -67,7 +67,7 @@ final class PollTaskExecutor<T> implements ShutdownableTaskExecutor<T> {
     this.metricsScope = Objects.requireNonNull(metricsScope);
 
     this.taskExecutor =
-        new ThreadPoolExecutor(0, workerTaskSlots, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+        new ThreadPoolExecutor(0, workerTaskSlots, 1, TimeUnit.MINUTES, new SynchronousQueue<>());
     this.availableTaskSlots = new AtomicInteger(workerTaskSlots);
     publishSlotsMetric();
 

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -103,7 +103,7 @@ public final class WorkerFactory {
             0,
             this.factoryOptions.getMaxWorkflowThreadCount(),
             1,
-            TimeUnit.SECONDS,
+            TimeUnit.MINUTES,
             new SynchronousQueue<>());
     this.workflowThreadPool.setThreadFactory(
         r -> new Thread(r, "workflow-thread-" + workflowThreadCounter.incrementAndGet()));


### PR DESCRIPTION
# What

Change thread inactivity timeout from 1 second to 1 minute

# Why

Based on perf tests, thread churning for executors is real with the current settings.