### PR TITLE
Provide task queue kind in long polls for workflow tasks

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/StickyPoller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/StickyPoller.java
@@ -22,6 +22,7 @@ package io.temporal.internal.worker;
 
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
+import io.temporal.api.enums.v1.TaskQueueKind;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.serviceclient.MetricsTag;
@@ -54,6 +55,7 @@ public class StickyPoller implements SuspendableWorker {
                 workflowServiceStubs,
                 namespace,
                 stickyTaskQueueName,
+                TaskQueueKind.TASK_QUEUE_KIND_STICKY,
                 workflowClientOptions.getIdentity(),
                 workflowClientOptions.getBinaryChecksum(),
                 stickyScope),

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -28,6 +28,7 @@ import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.TaskQueueKind;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.internal.logging.LoggerTag;
 import io.temporal.internal.replay.WorkflowExecutorCache;
@@ -109,6 +110,7 @@ final class WorkflowWorker
                   service,
                   namespace,
                   taskQueue,
+                  TaskQueueKind.TASK_QUEUE_KIND_NORMAL,
                   options.getIdentity(),
                   options.getBinaryChecksum(),
                   workerMetricsScope),


### PR DESCRIPTION
## Why?

For matching performance optimizations of Temporal Server it's important to know if the poll comes for a sticky or a normal queue. Because sticky queues have only 1 partition, no forwarding is needed.