### PR TITLE
Implement executor slots reservation for workflow tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
     // Platforms
     grpcVersion = '1.49.0' // [1.34.0,)
     jacksonVersion = '2.13.4' // [2.9.0,)
-    micrometerVersion = '1.9.3' // [1.0.0,)
+    micrometerVersion = '1.9.4' // [1.0.0,)
 
     slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which decide on 1.x
     protoVersion = '3.21.5' // [3.10.0,)
@@ -45,7 +45,7 @@ ext {
 
     // test scoped
     logbackVersion = '1.2.11'
-    mockitoVersion = '4.7.0'
+    mockitoVersion = '4.8.0'
     junitVersion = '4.13.2'
 }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -27,25 +27,25 @@ import io.temporal.api.enums.v1.TaskQueueKind;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import java.util.Objects;
+import java.util.concurrent.Semaphore;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class WorkflowPollTask implements Poller.PollTask<PollWorkflowTaskQueueResponse> {
+public final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
   private static final Logger log = LoggerFactory.getLogger(WorkflowPollTask.class);
 
-  private final WorkflowServiceStubs service;
-  private final String namespace;
   private final String taskQueue;
-  private final TaskQueueKind taskQueueKind;
-  private final String identity;
-  private final String binaryChecksum;
+  private final Semaphore workflowTaskExecutorSemaphore;
   private final Scope metricsScope;
+  private final WorkflowServiceGrpc.WorkflowServiceBlockingStub serviceStub;
+  private final PollWorkflowTaskQueueRequest pollRequest;
 
   public WorkflowPollTask(
       @Nonnull WorkflowServiceStubs service,
@@ -54,65 +54,72 @@ public final class WorkflowPollTask implements Poller.PollTask<PollWorkflowTaskQ
       @Nonnull TaskQueueKind taskQueueKind,
       @Nonnull String identity,
       @Nullable String binaryChecksum,
+      @Nonnull Semaphore workflowTaskExecutorSemaphore,
       @Nonnull Scope metricsScope) {
-    this.service = Objects.requireNonNull(service);
-    this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
-    this.taskQueueKind = Objects.requireNonNull(taskQueueKind);
-    this.identity = Objects.requireNonNull(identity);
-    this.binaryChecksum = binaryChecksum;
+    this.workflowTaskExecutorSemaphore = workflowTaskExecutorSemaphore;
     this.metricsScope = Objects.requireNonNull(metricsScope);
-  }
+    this.serviceStub =
+        Objects.requireNonNull(service)
+            .blockingStub()
+            .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope);
 
-  @Override
-  public PollWorkflowTaskQueueResponse poll() {
-    PollWorkflowTaskQueueRequest pollRequest =
+    this.pollRequest =
         PollWorkflowTaskQueueRequest.newBuilder()
-            .setNamespace(namespace)
+            .setNamespace(Objects.requireNonNull(namespace))
+            .setIdentity(Objects.requireNonNull(identity))
             .setBinaryChecksum(binaryChecksum)
-            .setIdentity(identity)
             .setTaskQueue(
                 TaskQueue.newBuilder()
                     .setName(taskQueue)
                     // For matching performance optimizations of Temporal Server it's important to
                     // know if the poll comes for a sticky or a normal queue. Because sticky queues
                     // have only 1 partition, no forwarding is needed.
-                    .setKind(taskQueueKind)
+                    .setKind(Objects.requireNonNull(taskQueueKind))
                     .build())
             .build();
+  }
 
-    if (log.isTraceEnabled()) {
-      log.trace("poll request begin: " + pollRequest);
-    }
-    PollWorkflowTaskQueueResponse result;
-    result =
-        service
-            .blockingStub()
-            .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-            .pollWorkflowTaskQueue(pollRequest);
-    if (log.isTraceEnabled()) {
-      log.trace(
-          "poll request returned workflow task: workflowType="
-              + result.getWorkflowType()
-              + ", workflowExecution="
-              + result.getWorkflowExecution()
-              + ", startedEventId="
-              + result.getStartedEventId()
-              + ", previousStartedEventId="
-              + result.getPreviousStartedEventId()
-              + (result.getQuery() != null
-                  ? ", queryType=" + result.getQuery().getQueryType()
-                  : ""));
-    }
+  @Override
+  public WorkflowTask poll() {
+    log.trace("poll request begin: {}", pollRequest);
+    PollWorkflowTaskQueueResponse response;
+    boolean isSuccessful = false;
 
-    if (result == null || result.getTaskToken().isEmpty()) {
-      metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_EMPTY_COUNTER).inc(1);
+    try {
+      workflowTaskExecutorSemaphore.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       return null;
     }
-    metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_SUCCEED_COUNTER).inc(1);
-    metricsScope
-        .timer(MetricsType.WORKFLOW_TASK_SCHEDULE_TO_START_LATENCY)
-        .record(ProtobufTimeUtils.toM3Duration(result.getStartedTime(), result.getScheduledTime()));
-    return result;
+
+    try {
+      response = serviceStub.pollWorkflowTaskQueue(pollRequest);
+      if (log.isTraceEnabled()) {
+        log.trace(
+            "poll request returned workflow task: taskQueue={}, workflowType={}, workflowExecution={}, startedEventId={}, previousStartedEventId={}{}",
+            taskQueue,
+            response.getWorkflowType(),
+            response.getWorkflowExecution(),
+            response.getStartedEventId(),
+            response.getPreviousStartedEventId(),
+            response.hasQuery() ? ", queryType=" + response.getQuery().getQueryType() : "");
+      }
+
+      if (response == null || response.getTaskToken().isEmpty()) {
+        metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_EMPTY_COUNTER).inc(1);
+        return null;
+      }
+      metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_SUCCEED_COUNTER).inc(1);
+      metricsScope
+          .timer(MetricsType.WORKFLOW_TASK_SCHEDULE_TO_START_LATENCY)
+          .record(
+              ProtobufTimeUtils.toM3Duration(
+                  response.getStartedTime(), response.getScheduledTime()));
+      isSuccessful = true;
+      return new WorkflowTask(response, workflowTaskExecutorSemaphore::release);
+    } finally {
+      if (!isSuccessful) workflowTaskExecutorSemaphore.release();
+    }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowTask.java
@@ -20,22 +20,22 @@
 
 package io.temporal.internal.worker;
 
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.workflow.Functions;
 import javax.annotation.Nonnull;
 
-public final class ActivityTask {
-  private final @Nonnull PollActivityTaskQueueResponse response;
-  private final @Nonnull Functions.Proc completionCallback;
+public class WorkflowTask {
+  @Nonnull private final PollWorkflowTaskQueueResponse response;
+  @Nonnull private final Functions.Proc completionCallback;
 
-  public ActivityTask(
-      @Nonnull PollActivityTaskQueueResponse response, @Nonnull Functions.Proc completionCallback) {
+  public WorkflowTask(
+      @Nonnull PollWorkflowTaskQueueResponse response, @Nonnull Functions.Proc completionCallback) {
     this.response = response;
     this.completionCallback = completionCallback;
   }
 
   @Nonnull
-  public PollActivityTaskQueueResponse getResponse() {
+  public PollWorkflowTaskQueueResponse getResponse() {
     return response;
   }
 

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -3,8 +3,8 @@ description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 ext {
     springBootVersion = '2.7.3'// [2.4.0,)
 
-    otelVersion = '1.17.0'
-    otShimVersion = '1.17.0-alpha'
+    otelVersion = '1.18.0'
+    otShimVersion = '1.18.0-alpha'
 }
 
 dependencies {


### PR DESCRIPTION
Now Workflow Task pollers reserve executor slots before attempting to perform a long poll.
This behavior is now aligned with the same mechanic for activities and what happens in GoSDK & Core.

Towards #998