### PR TITLE
Reduce eagerly executed work needed to create an ActivityStub

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOActivityInterfaceMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOActivityInterfaceMetadata.java
@@ -20,11 +20,13 @@
 
 package io.temporal.common.metadata;
 
+import com.uber.m3.util.ImmutableList;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import javax.annotation.Nonnull;
 
 /**
  * Metadata of an activity interface.
@@ -112,9 +114,10 @@ public final class POJOActivityInterfaceMetadata {
   }
 
   public List<POJOActivityMethodMetadata> getMethodsMetadata() {
-    return new ArrayList<>(methods.values());
+    return new ImmutableList<>(methods.values());
   }
 
+  @Nonnull
   public POJOActivityMethodMetadata getMethodMetadata(Method method) {
     POJOActivityMethodMetadata result = methods.get(method);
     if (result == null) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandler.java
@@ -52,10 +52,10 @@ public class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
       WorkflowOutboundCallsInterceptor activityExecutor,
       ActivityOptions options,
       Map<String, ActivityOptions> methodOptions) {
+    super(activityInterface);
     this.options = options;
     this.activityMethodOptions = (methodOptions == null) ? new HashMap<>() : methodOptions;
     this.activityExecutor = activityExecutor;
-    init(activityInterface);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/LocalActivityInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/LocalActivityInvocationHandler.java
@@ -52,10 +52,10 @@ public class LocalActivityInvocationHandler extends ActivityInvocationHandlerBas
       WorkflowOutboundCallsInterceptor activityExecutor,
       LocalActivityOptions options,
       Map<String, LocalActivityOptions> methodOptions) {
+    super(activityInterface);
     this.options = options;
     this.activityMethodOptions = (methodOptions == null) ? new HashMap<>() : methodOptions;
     this.activityExecutor = activityExecutor;
-    init(activityInterface);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## What was changed
Reduce eagerly executed work needed to create an `ActivityStub`.
`ActivityStub`s are lighter to create. 

## Why

Currently, during the creation of an activity stub we eagerly prepare all of its methods to be called.
It leads to a huge amount of stubs preparation work every time JavaSDK creates a workflow instance.
Most of this work is lost because not all methods are called. Also if instances get evicted from the cache, it's also repetitive throwaway work. It also increases the amount of memory needed for each retained workflow instance.