### PR TITLE
Rework some reflection out of Test Server to help Graal

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/StatusUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/StatusUtils.java
@@ -90,15 +90,8 @@ public class StatusUtils {
   private static <T extends GeneratedMessageV3> Any packAny(
       T details, Descriptors.Descriptor descriptor) {
     return Any.newBuilder()
-        .setTypeUrl(getTypeUrl("type.googleapis.com", descriptor))
+        .setTypeUrl("type.googleapis.com/" + descriptor.getFullName())
         .setValue(details.toByteString())
         .build();
-  }
-
-  private static String getTypeUrl(
-      java.lang.String typeUrlPrefix, com.google.protobuf.Descriptors.Descriptor descriptor) {
-    return typeUrlPrefix.endsWith("/")
-        ? typeUrlPrefix + descriptor.getFullName()
-        : typeUrlPrefix + "/" + descriptor.getFullName();
   }
 }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1398,7 +1398,8 @@ class StateMachines {
             result.completeExceptionally(
                 StatusUtils.newException(
                     Status.INTERNAL.withDescription(value.getErrorMessage()),
-                    QueryFailedFailure.getDefaultInstance()));
+                    QueryFailedFailure.getDefaultInstance(),
+                    QueryFailedFailure.getDescriptor()));
             break;
           default:
             throw Status.INVALID_ARGUMENT

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -536,7 +536,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
                         .completeExceptionally(
                             StatusUtils.newException(
                                 Status.INTERNAL.withDescription(result.getErrorMessage()),
-                                QueryFailedFailure.getDefaultInstance()));
+                                QueryFailedFailure.getDefaultInstance(),
+                                QueryFailedFailure.getDescriptor()));
                     break;
                   case UNRECOGNIZED:
                     throw Status.INVALID_ARGUMENT
@@ -2171,7 +2172,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         StatusRuntimeException error =
             StatusUtils.newException(
                 Status.INVALID_ARGUMENT.withDescription(completeRequest.getErrorMessage()),
-                QueryFailedFailure.getDefaultInstance());
+                QueryFailedFailure.getDefaultInstance(),
+                QueryFailedFailure.getDescriptor());
         result.completeExceptionally(error);
         break;
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -286,7 +286,8 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         Status.ALREADY_EXISTS.withDescription(
             String.format(
                 "WorkflowId: %s, " + "RunId: %s", execution.getWorkflowId(), execution.getRunId())),
-        error);
+        error,
+        WorkflowExecutionAlreadyStartedFailure.getDescriptor());
   }
 
   private StartWorkflowExecutionResponse startWorkflowExecutionNoRunningCheckLocked(


### PR DESCRIPTION
## What was changed
Rework some reflection out of Test Server to help Graal

## Why?
Graal doesn't like `Any.pack()` which goes into reflection to fetch a Descriptor.

Closes #1220