### PR TITLE
Reduce deterministic runner lock reentrance

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -98,7 +98,7 @@ class WorkflowThreadContext {
         maybeEvaluateLocked(reason);
       }
 
-      setStatus(Status.RUNNING);
+      status = Status.RUNNING;
       yieldReason = null;
     } catch (InterruptedException e) {
       // Throwing Error in workflow code aborts workflow task without failing workflow.
@@ -169,6 +169,16 @@ class WorkflowThreadContext {
       throw new Error("Unexpected interrupt", e);
     } finally {
       evaluationFunction = null;
+      lock.unlock();
+    }
+  }
+
+  public void verifyAndStart() {
+    lock.lock();
+    try {
+      Preconditions.checkState(this.status == Status.CREATED, "already started");
+      this.status = Status.RUNNING;
+    } finally {
       lock.unlock();
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -228,8 +228,7 @@ class WorkflowThreadImpl implements WorkflowThread {
 
   @Override
   public void start() {
-    Preconditions.checkState(context.getStatus() == Status.CREATED, "already started");
-    context.setStatus(Status.RUNNING);
+    context.verifyAndStart();
     while (true) {
       try {
         taskFuture = workflowThreadExecutor.submit(task);


### PR DESCRIPTION
Trivial optimization that reduces reentry into the deterministic lock in WorkflowThread context.