### PR TITLE
Implement dynamic sticky queue polling based on the reported backlog

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -93,8 +93,8 @@ public final class WorkflowInternal {
         workflowThread instanceof WorkflowThread,
         "[BUG] One of the custom interceptors illegally overrode newWorkflowMethodThread result. "
             + "Check WorkflowInboundCallsInterceptor#newWorkflowMethodThread contract. "
-            + "Illegal object returned from the interceptors chain: "
-            + workflowThread);
+            + "Illegal object returned from the interceptors chain: %s",
+        workflowThread);
     return (WorkflowThread) workflowThread;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/StickyQueueBalancer.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/StickyQueueBalancer.java
@@ -46,8 +46,7 @@ public class StickyQueueBalancer {
       // If pollersCount >= stickyBacklogSize > 0 we want to go back to a normal ratio to avoid a
       // situation that too many pollers (all of them in the worst case) will open only sticky queue
       // polls observing a stickyBacklogSize == 1 for example (which actually can be 0 already at
-      // that
-      // moment) and get stuck causing dip in worker load.
+      // that moment) and get stuck causing dip in worker load.
       if (stickyBacklogSize > pollersCount || stickyPollers.get() <= normalPollers.get()) {
         stickyPollers.incrementAndGet();
         return TaskQueueKind.TASK_QUEUE_KIND_STICKY;

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/StickyQueueBalancer.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/StickyQueueBalancer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+import io.temporal.api.enums.v1.TaskQueueKind;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class StickyQueueBalancer {
+  private final int pollersCount;
+  private final boolean stickyQueueEnabled;
+  private final AtomicInteger stickyPollers = new AtomicInteger(0);
+  private final AtomicInteger normalPollers = new AtomicInteger(0);
+
+  private volatile long stickyBacklogSize = 0;
+
+  public StickyQueueBalancer(int pollersCount, boolean stickyQueueEnabled) {
+    this.pollersCount = pollersCount;
+    this.stickyQueueEnabled = stickyQueueEnabled;
+  }
+
+  /**
+   * @return task queue kind that should be used for the next poll
+   */
+  public TaskQueueKind makePoll() {
+    if (stickyQueueEnabled) {
+      // If pollersCount >= stickyBacklogSize > 0 we want to go back to a normal ratio to avoid a
+      // situation that too many pollers (all of them in the worst case) will open only sticky queue
+      // polls observing a stickyBacklogSize == 1 for example (which actually can be 0 already at
+      // that
+      // moment) and get stuck causing dip in worker load.
+      if (stickyBacklogSize > pollersCount || stickyPollers.get() <= normalPollers.get()) {
+        stickyPollers.incrementAndGet();
+        return TaskQueueKind.TASK_QUEUE_KIND_STICKY;
+      }
+    }
+    normalPollers.incrementAndGet();
+    return TaskQueueKind.TASK_QUEUE_KIND_NORMAL;
+  }
+
+  /**
+   * @param taskQueueKind what kind of task queue poll was just finished
+   */
+  public void finishPoll(TaskQueueKind taskQueueKind) {
+    switch (taskQueueKind) {
+      case TASK_QUEUE_KIND_NORMAL:
+        normalPollers.decrementAndGet();
+        break;
+      case TASK_QUEUE_KIND_STICKY:
+        stickyPollers.decrementAndGet();
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid task queue kind: " + taskQueueKind);
+    }
+  }
+
+  /**
+   * @param taskQueueKind what kind of task queue poll was just finished
+   * @param backlogSize backlog size from the poll response, helps to determine if the sticky queue
+   *     is backlogged
+   */
+  public void finishPoll(TaskQueueKind taskQueueKind, long backlogSize) {
+    finishPoll(taskQueueKind);
+    if (TaskQueueKind.TASK_QUEUE_KIND_STICKY.equals(taskQueueKind)) {
+      stickyBacklogSize = backlogSize;
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
@@ -21,24 +21,12 @@
 package io.temporal.internal.worker;
 
 class WorkerThreadsNameHelper {
-  private static final String STICKY_WORKFLOW_POLL_THREAD_NAME_PREFIX =
-      "Sticky Workflow Poller taskQueue=";
   private static final String WORKFLOW_POLL_THREAD_NAME_PREFIX = "Workflow Poller taskQueue=";
   private static final String LOCAL_ACTIVITY_POLL_THREAD_NAME_PREFIX =
       "Local Activity Poller taskQueue=";
   private static final String ACTIVITY_POLL_THREAD_NAME_PREFIX = "Activity Poller taskQueue=";
   public static final String SHUTDOWN_MANAGER_THREAD_NAME_PREFIX = "TemporalShutdownManager";
   public static final String ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX = "TemporalActivityHeartbeat-";
-
-  public static String getStickyQueueWorkflowPollerThreadPrefix(
-      String namespace, String taskQueue) {
-    return STICKY_WORKFLOW_POLL_THREAD_NAME_PREFIX
-        + "\""
-        + taskQueue
-        + "\", namespace=\""
-        + namespace
-        + "\"";
-  }
 
   public static String getWorkflowPollerThreadPrefix(String namespace, String taskQueue) {
     return WORKFLOW_POLL_THREAD_NAME_PREFIX

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -117,8 +117,8 @@ final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
     PollWorkflowTaskQueueRequest request = isSticky ? stickyPollRequest : pollRequest;
     Scope scope = isSticky ? stickyMetricsScope : metricsScope;
 
+    log.trace("poll request begin: {}", request);
     try {
-      log.trace("poll request begin: {}", request);
       PollWorkflowTaskQueueResponse response = doPoll(request, scope);
       if (response == null) {
         return null;
@@ -137,12 +137,12 @@ final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
   @Nullable
   private PollWorkflowTaskQueueResponse doPoll(
       PollWorkflowTaskQueueRequest request, Scope metricsScope) {
-    PollWorkflowTaskQueueResponse response = serviceStub.pollWorkflowTaskQueue(pollRequest);
+    PollWorkflowTaskQueueResponse response = serviceStub.pollWorkflowTaskQueue(request);
 
     if (log.isTraceEnabled()) {
       log.trace(
           "poll request returned workflow task: taskQueue={}, workflowType={}, workflowExecution={}, startedEventId={}, previousStartedEventId={}{}",
-          request.getTaskQueue(),
+          request.getTaskQueue().getName(),
           response.getWorkflowType(),
           response.getWorkflowExecution(),
           response.getStartedEventId(),

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -23,12 +23,14 @@ package io.temporal.internal.worker;
 import static io.temporal.serviceclient.MetricsTag.METRICS_TAGS_CALL_OPTIONS_KEY;
 
 import com.uber.m3.tally.Scope;
+import com.uber.m3.util.ImmutableMap;
 import io.temporal.api.enums.v1.TaskQueueKind;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import java.util.Objects;
@@ -38,54 +40,71 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
+final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
   private static final Logger log = LoggerFactory.getLogger(WorkflowPollTask.class);
 
-  private final String taskQueue;
   private final Semaphore workflowTaskExecutorSemaphore;
+  private final StickyQueueBalancer stickyQueueBalancer;
   private final Scope metricsScope;
+  private final Scope stickyMetricsScope;
   private final WorkflowServiceGrpc.WorkflowServiceBlockingStub serviceStub;
   private final PollWorkflowTaskQueueRequest pollRequest;
+  private final PollWorkflowTaskQueueRequest stickyPollRequest;
 
   public WorkflowPollTask(
       @Nonnull WorkflowServiceStubs service,
       @Nonnull String namespace,
       @Nonnull String taskQueue,
-      @Nonnull TaskQueueKind taskQueueKind,
+      @Nullable String stickyTaskQueue,
       @Nonnull String identity,
       @Nullable String binaryChecksum,
       @Nonnull Semaphore workflowTaskExecutorSemaphore,
-      @Nonnull Scope metricsScope) {
-    this.taskQueue = Objects.requireNonNull(taskQueue);
-    this.workflowTaskExecutorSemaphore = workflowTaskExecutorSemaphore;
-    this.metricsScope = Objects.requireNonNull(metricsScope);
+      @Nonnull StickyQueueBalancer stickyQueueBalancer,
+      @Nonnull Scope workerMetricsScope) {
+    this.workflowTaskExecutorSemaphore = Objects.requireNonNull(workflowTaskExecutorSemaphore);
+    this.stickyQueueBalancer = Objects.requireNonNull(stickyQueueBalancer);
+    this.metricsScope = Objects.requireNonNull(workerMetricsScope);
+    this.stickyMetricsScope =
+        workerMetricsScope.tagged(
+            new ImmutableMap.Builder<String, String>(1)
+                .put(MetricsTag.TASK_QUEUE, String.format("%s:%s", taskQueue, "sticky"))
+                .build());
     this.serviceStub =
         Objects.requireNonNull(service)
             .blockingStub()
             .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope);
 
-    this.pollRequest =
+    PollWorkflowTaskQueueRequest.Builder pollRequestBuilder =
         PollWorkflowTaskQueueRequest.newBuilder()
             .setNamespace(Objects.requireNonNull(namespace))
             .setIdentity(Objects.requireNonNull(identity))
-            .setBinaryChecksum(binaryChecksum)
+            .setBinaryChecksum(binaryChecksum);
+
+    this.pollRequest =
+        pollRequestBuilder
             .setTaskQueue(
                 TaskQueue.newBuilder()
                     .setName(taskQueue)
                     // For matching performance optimizations of Temporal Server it's important to
                     // know if the poll comes for a sticky or a normal queue. Because sticky queues
                     // have only 1 partition, no forwarding is needed.
-                    .setKind(Objects.requireNonNull(taskQueueKind))
+                    .setKind(TaskQueueKind.TASK_QUEUE_KIND_NORMAL)
+                    .build())
+            .build();
+
+    this.stickyPollRequest =
+        pollRequestBuilder
+            .setTaskQueue(
+                TaskQueue.newBuilder()
+                    .setName(stickyTaskQueue)
+                    .setKind(TaskQueueKind.TASK_QUEUE_KIND_STICKY)
                     .build())
             .build();
   }
 
   @Override
   public WorkflowTask poll() {
-    log.trace("poll request begin: {}", pollRequest);
-    PollWorkflowTaskQueueResponse response;
     boolean isSuccessful = false;
-
     try {
       workflowTaskExecutorSemaphore.acquire();
     } catch (InterruptedException e) {
@@ -93,33 +112,53 @@ public final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
       return null;
     }
 
-    try {
-      response = serviceStub.pollWorkflowTaskQueue(pollRequest);
-      if (log.isTraceEnabled()) {
-        log.trace(
-            "poll request returned workflow task: taskQueue={}, workflowType={}, workflowExecution={}, startedEventId={}, previousStartedEventId={}{}",
-            taskQueue,
-            response.getWorkflowType(),
-            response.getWorkflowExecution(),
-            response.getStartedEventId(),
-            response.getPreviousStartedEventId(),
-            response.hasQuery() ? ", queryType=" + response.getQuery().getQueryType() : "");
-      }
+    TaskQueueKind taskQueueKind = stickyQueueBalancer.makePoll();
+    boolean isSticky = TaskQueueKind.TASK_QUEUE_KIND_STICKY.equals(taskQueueKind);
+    PollWorkflowTaskQueueRequest request = isSticky ? stickyPollRequest : pollRequest;
+    Scope scope = isSticky ? stickyMetricsScope : metricsScope;
 
-      if (response == null || response.getTaskToken().isEmpty()) {
-        metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_EMPTY_COUNTER).inc(1);
+    try {
+      log.trace("poll request begin: {}", request);
+      PollWorkflowTaskQueueResponse response = doPoll(request, scope);
+      if (response == null) {
         return null;
       }
-      metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_SUCCEED_COUNTER).inc(1);
-      metricsScope
-          .timer(MetricsType.WORKFLOW_TASK_SCHEDULE_TO_START_LATENCY)
-          .record(
-              ProtobufTimeUtils.toM3Duration(
-                  response.getStartedTime(), response.getScheduledTime()));
       isSuccessful = true;
+      stickyQueueBalancer.finishPoll(taskQueueKind, response.getBacklogCountHint());
       return new WorkflowTask(response, workflowTaskExecutorSemaphore::release);
     } finally {
-      if (!isSuccessful) workflowTaskExecutorSemaphore.release();
+      if (!isSuccessful) {
+        workflowTaskExecutorSemaphore.release();
+        stickyQueueBalancer.finishPoll(taskQueueKind);
+      }
     }
+  }
+
+  @Nullable
+  private PollWorkflowTaskQueueResponse doPoll(
+      PollWorkflowTaskQueueRequest request, Scope metricsScope) {
+    PollWorkflowTaskQueueResponse response = serviceStub.pollWorkflowTaskQueue(pollRequest);
+
+    if (log.isTraceEnabled()) {
+      log.trace(
+          "poll request returned workflow task: taskQueue={}, workflowType={}, workflowExecution={}, startedEventId={}, previousStartedEventId={}{}",
+          request.getTaskQueue(),
+          response.getWorkflowType(),
+          response.getWorkflowExecution(),
+          response.getStartedEventId(),
+          response.getPreviousStartedEventId(),
+          response.hasQuery() ? ", queryType=" + response.getQuery().getQueryType() : "");
+    }
+
+    if (response == null || response.getTaskToken().isEmpty()) {
+      metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_EMPTY_COUNTER).inc(1);
+      return null;
+    }
+    metricsScope.counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_SUCCEED_COUNTER).inc(1);
+    metricsScope
+        .timer(MetricsType.WORKFLOW_TASK_SCHEDULE_TO_START_LATENCY)
+        .record(
+            ProtobufTimeUtils.toM3Duration(response.getStartedTime(), response.getScheduledTime()));
+    return response;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 final class WorkflowWorker implements SuspendableWorker {
-  private static final double STICKY_TO_NORMAL_RATIO = 5;
-
   private static final Logger log = LoggerFactory.getLogger(WorkflowWorker.class);
 
   private final WorkflowRunLockManager runLocks = new WorkflowRunLockManager();

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -52,7 +52,7 @@ public final class WorkerOptions {
 
   public static final class Builder {
 
-    private static final int DEFAULT_MAX_CONCURRENT_WORKFLOW_TASK_POLLERS = 2;
+    private static final int DEFAULT_MAX_CONCURRENT_WORKFLOW_TASK_POLLERS = 5;
     private static final int DEFAULT_MAX_CONCURRENT_ACTIVITY_TASK_POLLERS = 5;
     private static final int DEFAULT_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE = 200;
     private static final int DEFAULT_MAX_CONCURRENT_ACTIVITY_EXECUTION_SIZE = 200;
@@ -181,7 +181,7 @@ public final class WorkerOptions {
      * workflow tasks will be using host local task queue due to caching. So try incrementing {@link
      * WorkerFactoryOptions.Builder#setWorkflowHostLocalPollThreadCount(int)} before this one.
      *
-     * <p>Default is 2.
+     * <p>Default is 5.
      */
     public Builder setMaxConcurrentWorkflowTaskPollers(int maxConcurrentWorkflowTaskPollers) {
       this.maxConcurrentWorkflowTaskPollers = maxConcurrentWorkflowTaskPollers;

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerIsNotGettingStartedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerIsNotGettingStartedTest.java
@@ -41,8 +41,6 @@ public class WorkerIsNotGettingStartedTest {
   private static final String TASK_QUEUE = "test-workflow";
   private static final String ACTIVITY_POLLER_THREAD_NAME_PREFIX = "Activity Poller task";
   private static final String WORKFLOW_POLLER_THREAD_NAME_PREFIX = "Workflow Poller task";
-  private static final String WORKFLOW_HOST_LOCAL_POLLER_THREAD_NAME_PREFIX =
-      "Sticky Workflow Poll";
 
   private TestWorkflowEnvironment env;
   private Worker worker;
@@ -79,8 +77,6 @@ public class WorkerIsNotGettingStartedTest {
         Thread.getAllStackTraces().keySet().stream()
             .map((t) -> t.getName().substring(0, Math.min(20, t.getName().length())))
             .collect(groupingBy(Function.identity(), Collectors.counting()));
-    assertEquals(
-        WORKFLOW_POLL_COUNT * 5, (long) threads.get(WORKFLOW_HOST_LOCAL_POLLER_THREAD_NAME_PREFIX));
     assertEquals(WORKFLOW_POLL_COUNT, (long) threads.get(WORKFLOW_POLLER_THREAD_NAME_PREFIX));
     assertFalse(threads.containsKey(ACTIVITY_POLLER_THREAD_NAME_PREFIX));
     assertNull(worker.activityWorker);

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerThreadCountTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerThreadCountTest.java
@@ -39,8 +39,7 @@ public class WorkerPollerThreadCountTest {
 
   private static final String ACTIVITY_POLLER_THREAD_NAME_PREFIX = "Activity Poller task";
   private static final String WORKFLOW_POLLER_THREAD_NAME_PREFIX = "Workflow Poller task";
-  private static final String WORKFLOW_HOST_LOCAL_POLLER_THREAD_NAME_PREFIX =
-      "Sticky Workflow Poll";
+
   private static final int WORKFLOW_POLL_COUNT = 11;
   private static final int ACTIVITY_POLL_COUNT = 18;
 
@@ -97,8 +96,6 @@ public class WorkerPollerThreadCountTest {
         Thread.getAllStackTraces().keySet().stream()
             .map((t) -> t.getName().substring(0, Math.min(20, t.getName().length())))
             .collect(groupingBy(Function.identity(), Collectors.counting()));
-    assertEquals(
-        WORKFLOW_POLL_COUNT * 5, (long) threads.get(WORKFLOW_HOST_LOCAL_POLLER_THREAD_NAME_PREFIX));
     assertEquals(WORKFLOW_POLL_COUNT, (long) threads.get(WORKFLOW_POLLER_THREAD_NAME_PREFIX));
     assertEquals(ACTIVITY_POLL_COUNT, (long) threads.get(ACTIVITY_POLLER_THREAD_NAME_PREFIX));
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -88,13 +88,6 @@ public class MetricsTest {
           .put(MetricsTag.TASK_QUEUE, TASK_QUEUE)
           .build();
 
-  private static final Map<String, String> TAGS_STICKY_TASK_QUEUE =
-      new ImmutableMap.Builder<String, String>()
-          .putAll(MetricsTag.defaultTags(NAMESPACE))
-          .put(MetricsTag.WORKER_TYPE, WorkerMetricsTag.WorkerType.WORKFLOW_WORKER.getValue())
-          .put(MetricsTag.TASK_QUEUE, TASK_QUEUE + ":sticky")
-          .build();
-
   private static final Map<String, String> TAGS_LOCAL_ACTIVITY_WORKER =
       new ImmutableMap.Builder<String, String>()
           .putAll(TAGS_TASK_QUEUE)
@@ -173,11 +166,9 @@ public class MetricsTest {
     reporter.assertCounter("temporal_worker_start", TAGS_ACTIVITY_WORKER, 1);
     reporter.assertCounter("temporal_worker_start", TAGS_LOCAL_ACTIVITY_WORKER, 1);
 
-    reporter.assertCounter("temporal_poller_start", TAGS_WORKFLOW_WORKER, 2);
+    reporter.assertCounter("temporal_poller_start", TAGS_WORKFLOW_WORKER, 5);
     reporter.assertCounter("temporal_poller_start", TAGS_ACTIVITY_WORKER, 5);
     reporter.assertCounter("temporal_poller_start", TAGS_LOCAL_ACTIVITY_WORKER, 1);
-    // sticky
-    reporter.assertCounter("temporal_poller_start", TAGS_STICKY_TASK_QUEUE, 10);
   }
 
   @Test


### PR DESCRIPTION
## What was changed

This PR brings behavior similar to GoSDK that balances the number of sticky pollers based on the knowledge of the sticky queue backlog received from the server

## Why?

After looking at the behavior of workers in the high throughput scenario, it's clear that the static sticky:normal ratio is prone to the following scenario:
Under a high volume of Workflow Tasks workers continue to pull tasks from the normal queue when the sticky queue is already backlogged. This leads to the growth of sticky queues even more which in turn leads to the expiration of sticky workflow tasks and workflow cache churn. This effectively causes a snowballing effect causing more replays and decreasing of Workers throughput. The worker should pull less from a normal task queue if it can't manage its sticky queue.

Closes #998