### PR TITLE
testing module now brings json-path as a transitive dependency

### DIFF
--- a/temporal-remote-data-encoder/build.gradle
+++ b/temporal-remote-data-encoder/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     // Jetty 10+ brings a non-production ready slf4j that doesn't work with released logback.
     // It also require Java 11+. That's why we stay on Jetty 9. It's for tests only anyway.
-    testImplementation(platform("org.eclipse.jetty:jetty-bom:9.4.48.v20220622"))
+    testImplementation(platform("org.eclipse.jetty:jetty-bom:9.4.49.v20220914"))
     testImplementation ("org.eclipse.jetty:jetty-server")
     testImplementation ("org.eclipse.jetty:jetty-servlet")
 }

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,7 +1,7 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    springBootVersion = '2.7.3'// [2.4.0,)
+    springBootVersion = '2.7.4'// [2.4.0,)
 
     otelVersion = '1.18.0'
     otShimVersion = '1.18.0-alpha'

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -17,9 +17,14 @@ dependencies {
     api project(':temporal-sdk')
     api project(':temporal-test-server')
 
+    // This dependency is included in temporal-sdk module as optional with compileOnly scope.
+    // To make things easier for users, it's helpful for the testing module to bring this dependency
+    // transitively as most users work with history jsons in tests.
+    implementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
+
     junit4Api 'junit:junit:4.13.2'
 
-    junit5Api platform('org.junit:junit-bom:5.9.0')
+    junit5Api platform('org.junit:junit-bom:5.9.1')
     junit5Api 'org.junit.jupiter:junit-jupiter-api'
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter'


### PR DESCRIPTION
`json-path` is included in `temporal-sdk` module as optional with `compileOnly` scope. It's not needed for most users because it's required only for operations with Temporal History jsons.
To make things easier for users, it's helpful for the testing module to bring this dependency transitively as most users work with history jsons in tests.