### PR TITLE
SDK doesn't allow a single WorkflowTask poller and forces the value to '2' if specified

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -50,12 +50,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hosts activity and workflow implementations. Uses long poll to receive activity and workflow
  * tasks and processes them in a correspondent thread pool.
  */
 public final class Worker {
+  private static final Logger log = LoggerFactory.getLogger(Worker.class);
   private final WorkerOptions options;
   private final String taskQueue;
   final SyncWorkflowWorker workflowWorker;
@@ -512,11 +515,16 @@ public final class Worker {
           factoryOptions.getWorkflowHostLocalTaskQueueScheduleToStartTimeout();
     }
 
+    int maxConcurrentWorkflowTaskPollers = options.getMaxConcurrentWorkflowTaskPollers();
+    if (maxConcurrentWorkflowTaskPollers == 1) {
+      log.warn(
+          "WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers was set to 1. This is an illegal value. The number of Workflow Task Pollers is forced to 2. See documentation on WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers");
+      maxConcurrentWorkflowTaskPollers = 2;
+    }
+
     return toSingleWorkerOptions(factoryOptions, options, clientOptions, contextPropagators)
         .setPollerOptions(
-            PollerOptions.newBuilder()
-                .setPollThreadCount(options.getMaxConcurrentWorkflowTaskPollers())
-                .build())
+            PollerOptions.newBuilder().setPollThreadCount(maxConcurrentWorkflowTaskPollers).build())
         .setTaskExecutorThreadPoolSize(options.getMaxConcurrentWorkflowTaskExecutionSize())
         .setStickyQueueScheduleToStartTimeout(stickyQueueScheduleToStartTimeout)
         .setDefaultDeadlockDetectionTimeout(options.getDefaultDeadlockDetectionTimeout())

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -181,7 +181,7 @@ public final class WorkerOptions {
      * workflow tasks. Changing this value will affect the rate at which the worker is able to
      * consume tasks from a task queue.
      *
-     * <p>Due to internal logic where pollers alternate between stick and non-sticky queues, this
+     * <p>Due to internal logic where pollers alternate between sticky and non-sticky queues, this
      * value cannot be 1 and will be adjusted to 2 if set to that value.
      *
      * <p>Default is 5.

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -177,9 +177,12 @@ public final class WorkerOptions {
     }
 
     /**
-     * Number of simultaneous poll requests on workflow task queue. Note that the majority of the
-     * workflow tasks will be using host local task queue due to caching. So try incrementing {@link
-     * WorkerFactoryOptions.Builder#setWorkflowHostLocalPollThreadCount(int)} before this one.
+     * Sets the maximum number of simultaneous long poll requests to the Temporal Server to retrieve
+     * workflow tasks. Changing this value will affect the rate at which the worker is able to
+     * consume tasks from a task queue.
+     *
+     * <p>Due to internal logic where pollers alternate between stick and non-sticky queues, this
+     * value cannot be 1 and will be adjusted to 2 if set to that value.
      *
      * <p>Default is 5.
      */


### PR DESCRIPTION
After #1438 `WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers(1)` became an illegal configuration leading a worker to listen only on a sticky task queue. In this PR worker will override 1 to 2 and log a warning about it.