### PR TITLE
Fix leaking Eager Activity Reservation

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "9042:9042"
 
   temporal:
-    image: temporaliotest/auto-setup:latest
+    image: temporaliotest/auto-setup:sha-8ed1157
     ports:
       - "7233:7233"
       - "7234:7234"

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/EagerActivityDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/EagerActivityDispatcher.java
@@ -30,7 +30,7 @@ public interface EagerActivityDispatcher {
 
   void dispatchActivity(PollActivityTaskQueueResponse activity);
 
-  static class NoopEagerActivityDispatcher implements EagerActivityDispatcher {
+  class NoopEagerActivityDispatcher implements EagerActivityDispatcher {
     @Override
     public boolean tryReserveActivitySlot(
         ScheduleActivityTaskCommandAttributesOrBuilder commandAttributes) {


### PR DESCRIPTION
Recently added eager activity dispatch leads to a leaky semaphore. If an activity is actually eagerly dispatched, the semaphore gets incremented twice.

Eager activity dispatch functionality needs better tests for potential semaphore leaks.