### PR TITLE
Limit eager activity dispatch for one workflow task completion

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/Config.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/Config.java
@@ -25,4 +25,10 @@ public final class Config {
 
   /** Force new workflow task after workflow task timeout multiplied by this coefficient. */
   public static final double WORKFLOW_TAK_HEARTBEAT_COEFFICIENT = 4d / 5d;
+
+  /**
+   * Limit how many eager activities can be requested by the SDK in one workflow task completion
+   * response.
+   */
+  public static int EAGER_ACTIVITIES_LIMIT = 3;
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/EagerActivitySlotsReservation.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/EagerActivitySlotsReservation.java
@@ -27,6 +27,7 @@ import io.temporal.api.enums.v1.CommandType;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedResponse;
+import io.temporal.internal.Config;
 import java.io.Closeable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -52,7 +53,8 @@ class EagerActivitySlotsReservation implements Closeable {
           command.getScheduleActivityTaskCommandAttributes();
       if (!commandAttributes.getRequestEagerExecution()) continue;
 
-      if (this.eagerActivityDispatcher.tryReserveActivitySlot(commandAttributes)) {
+      if (this.outstandingReservationSlotsCount < Config.EAGER_ACTIVITIES_LIMIT
+          && this.eagerActivityDispatcher.tryReserveActivitySlot(commandAttributes)) {
         this.outstandingReservationSlotsCount++;
       } else {
         mutableRequest.setCommands(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/EagerActivityDispatchingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/EagerActivityDispatchingTest.java
@@ -28,6 +28,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
+import io.temporal.internal.Config;
 import io.temporal.internal.common.WorkflowExecutionHistory;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.*;
 
-public class TestEagerActivityExecution {
+public class EagerActivityDispatchingTest {
 
   private final String taskQueue = "test-eageractivities";
   private TestWorkflowEnvironment env;
@@ -226,7 +227,8 @@ public class TestEagerActivityExecution {
                   .build());
 
       ArrayList<Promise<String>> promises = new ArrayList<>();
-      for (int i = 0; i < 10; i++) promises.add(Async.function(testActivities::activity));
+      for (int i = 0; i < Config.EAGER_ACTIVITIES_LIMIT; i++)
+        promises.add(Async.function(testActivities::activity));
       Promise.allOf(promises).get();
     }
   }


### PR DESCRIPTION
# Why

Some workflow executions may cause a lot of activity invocations. With eager activity dispatch, all of these activity invocations may be dispatched to one worker causing an imbalance in workers' load.

# What

Limit the activities that may be eagerly dispatched in one workflow task completion to 3 for now.
It's an open question if this should be configurable.
