### PR TITLE
Use longer retry interval on RESOURCE_EXHAUSTED

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -210,7 +210,7 @@ final class Poller<T> implements SuspendableWorker {
               pollerOptions.getBackoffCongestionInitialInterval(),
               pollerOptions.getBackoffMaximumInterval(),
               pollerOptions.getBackoffCoefficient(),
-              pollerOptions.getBackoffMaximumJitter());
+              pollerOptions.getBackoffMaximumJitterCoefficient());
     }
 
     @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollerOptions.java
@@ -58,7 +58,7 @@ public final class PollerOptions {
     private Duration backoffInitialInterval = Duration.ofMillis(100);
     private Duration backoffCongestionInitialInterval = Duration.ofMillis(1000);
     private Duration backoffMaximumInterval = Duration.ofMinutes(1);
-    private double backoffMaximumJitter = 0.1;
+    private double backoffMaximumJitterCoefficient = 0.1;
     private int pollThreadCount = 1;
     private String pollThreadNamePrefix;
     private Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
@@ -75,7 +75,7 @@ public final class PollerOptions {
       this.backoffInitialInterval = options.getBackoffInitialInterval();
       this.backoffCongestionInitialInterval = options.getBackoffCongestionInitialInterval();
       this.backoffMaximumInterval = options.getBackoffMaximumInterval();
-      this.backoffMaximumJitter = options.getBackoffMaximumJitter();
+      this.backoffMaximumJitterCoefficient = options.getBackoffMaximumJitterCoefficient();
       this.pollThreadCount = options.getPollThreadCount();
       this.pollThreadNamePrefix = options.getPollThreadNamePrefix();
       this.uncaughtExceptionHandler = options.getUncaughtExceptionHandler();
@@ -130,8 +130,8 @@ public final class PollerOptions {
      * Maximum amount of jitter to apply. 0.2 means that actual retry time can be +/- 20% of the
      * calculated time. Set to 0 to disable jitter. Must be lower than 1. Default is 0.1.
      */
-    public Builder setBackoffMaximumJitter(double backoffMaximumJitter) {
-      this.backoffMaximumJitter = backoffMaximumJitter;
+    public Builder setBackoffMaximumJitterCoefficient(double backoffMaximumJitterCoefficient) {
+      this.backoffMaximumJitterCoefficient = backoffMaximumJitterCoefficient;
       return this;
     }
 
@@ -177,7 +177,7 @@ public final class PollerOptions {
           backoffInitialInterval,
           backoffCongestionInitialInterval,
           backoffMaximumInterval,
-          backoffMaximumJitter,
+          backoffMaximumJitterCoefficient,
           pollThreadCount,
           uncaughtExceptionHandler,
           pollThreadNamePrefix);
@@ -189,7 +189,7 @@ public final class PollerOptions {
   private final int maximumPollRateIntervalMilliseconds;
   private final double maximumPollRatePerSecond;
   private final double backoffCoefficient;
-  private final double backoffMaximumJitter;
+  private final double backoffMaximumJitterCoefficient;
   private final Duration backoffInitialInterval;
   private final Duration backoffCongestionInitialInterval;
   private final Duration backoffMaximumInterval;
@@ -204,7 +204,7 @@ public final class PollerOptions {
       Duration backoffInitialInterval,
       Duration backoffCongestionInitialInterval,
       Duration backoffMaximumInterval,
-      double backoffMaximumJitter,
+      double backoffMaximumJitterCoefficient,
       int pollThreadCount,
       Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
       String pollThreadNamePrefix) {
@@ -214,7 +214,7 @@ public final class PollerOptions {
     this.backoffInitialInterval = backoffInitialInterval;
     this.backoffCongestionInitialInterval = backoffCongestionInitialInterval;
     this.backoffMaximumInterval = backoffMaximumInterval;
-    this.backoffMaximumJitter = backoffMaximumJitter;
+    this.backoffMaximumJitterCoefficient = backoffMaximumJitterCoefficient;
     this.pollThreadCount = pollThreadCount;
     this.uncaughtExceptionHandler = uncaughtExceptionHandler;
     this.pollThreadNamePrefix = pollThreadNamePrefix;
@@ -244,8 +244,8 @@ public final class PollerOptions {
     return backoffMaximumInterval;
   }
 
-  public double getBackoffMaximumJitter() {
-    return backoffMaximumJitter;
+  public double getBackoffMaximumJitterCoefficient() {
+    return backoffMaximumJitterCoefficient;
   }
 
   public int getPollThreadCount() {
@@ -275,8 +275,8 @@ public final class PollerOptions {
         + backoffCongestionInitialInterval
         + ", backoffMaximumInterval="
         + backoffMaximumInterval
-        + ", backoffMaximumJitter="
-        + backoffMaximumJitter
+        + ", backoffMaximumJitterCoefficient="
+        + backoffMaximumJitterCoefficient
         + ", pollThreadCount="
         + pollThreadCount
         + ", pollThreadNamePrefix='"

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/BackoffThrottler.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/BackoffThrottler.java
@@ -30,8 +30,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 /**
  * Used to throttle code execution in presence of failures using exponential backoff logic.
  *
- * <p>
- * The formula used to calculate the next sleep interval is:
+ * <p>The formula used to calculate the next sleep interval is:
  *
  * <p>
  *
@@ -39,9 +38,10 @@ import javax.annotation.concurrent.NotThreadSafe;
  * min(pow(backoffCoefficient, failureCount - 1) * initialSleep * (1 + jitter), maxSleep);
  * </pre>
  *
- * where <code>initialSleep</code> is either set to <code>regularInitialSleep</code> or <code>congestionInitialSleep</code>
- * based on the <i>most recent</i> failure. Note that it means that attempt X can possibly get a shorter throttle than
- * attempt X-1, if a non-congestion failure occurs after a congestion failure. This is the expected bahaviour for all SDK.
+ * where <code>initialSleep</code> is either set to <code>regularInitialSleep</code> or <code>
+ * congestionInitialSleep</code> based on the <i>most recent</i> failure. Note that it means that
+ * attempt X can possibly get a shorter throttle than attempt X-1, if a non-congestion failure
+ * occurs after a congestion failure. This is the expected bahaviour for all SDK.
  *
  * <p>Example usage:
  *

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/BackoffThrottler.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/BackoffThrottler.java
@@ -28,14 +28,20 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Used to throttle code execution in presence of failures using exponential backoff logic. The
- * formula used to calculate the next sleep interval is:
+ * Used to throttle code execution in presence of failures using exponential backoff logic.
+ *
+ * <p>
+ * The formula used to calculate the next sleep interval is:
  *
  * <p>
  *
  * <pre>
  * min(pow(backoffCoefficient, failureCount - 1) * initialSleep * (1 + jitter), maxSleep);
  * </pre>
+ *
+ * where <code>initialSleep</code> is either set to <code>regularInitialSleep</code> or <code>congestionInitialSleep</code>
+ * based on the <i>most recent</i> failure. Note that it means that attempt X can possibly get a shorter throttle than
+ * attempt X-1, if a non-congestion failure occurs after a congestion failure. This is the expected bahaviour for all SDK.
  *
  * <p>Example usage:
  *

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcAsyncRetryer.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcAsyncRetryer.java
@@ -70,7 +70,7 @@ class GrpcAsyncRetryer<R> {
             rpcOptions.getCongestionInitialInterval(),
             rpcOptions.getMaximumInterval(),
             rpcOptions.getBackoffCoefficient(),
-            rpcOptions.getMaximumJitter());
+            rpcOptions.getMaximumJitterCoefficient());
   }
 
   public CompletableFuture<R> retry() {

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
@@ -76,6 +76,8 @@ class GrpcRetryerUtils {
         // By default, we keep retrying with DEADLINE_EXCEEDED assuming that it's the deadline of
         // one attempt which expired, but not the whole sequence.
         break;
+      case RESOURCE_EXHAUSTED:
+        break;
       default:
         for (RpcRetryOptions.DoNotRetryItem pair : options.getDoNotRetry()) {
           if (pair.getCode() == code

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
@@ -76,8 +76,6 @@ class GrpcRetryerUtils {
         // By default, we keep retrying with DEADLINE_EXCEEDED assuming that it's the deadline of
         // one attempt which expired, but not the whole sequence.
         break;
-      case RESOURCE_EXHAUSTED:
-        break;
       default:
         for (RpcRetryOptions.DoNotRetryItem pair : options.getDoNotRetry()) {
           if (pair.getCode() == code

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcSyncRetryer.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcSyncRetryer.java
@@ -51,7 +51,7 @@ class GrpcSyncRetryer {
             rpcOptions.getCongestionInitialInterval(),
             rpcOptions.getMaximumInterval(),
             rpcOptions.getBackoffCoefficient(),
-            rpcOptions.getMaximumJitter());
+            rpcOptions.getMaximumJitterCoefficient());
 
     int attempt = 0;
     StatusRuntimeException lastMeaningfulException = null;

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcSyncRetryer.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcSyncRetryer.java
@@ -48,8 +48,10 @@ class GrpcSyncRetryer {
     BackoffThrottler throttler =
         new BackoffThrottler(
             rpcOptions.getInitialInterval(),
+            rpcOptions.getCongestionInitialInterval(),
             rpcOptions.getMaximumInterval(),
-            rpcOptions.getBackoffCoefficient());
+            rpcOptions.getBackoffCoefficient(),
+            rpcOptions.getMaximumJitter());
 
     int attempt = 0;
     StatusRuntimeException lastMeaningfulException = null;
@@ -79,7 +81,7 @@ class GrpcSyncRetryer {
         }
         lastMeaningfulException =
             GrpcRetryerUtils.lastMeaningfulException(e, lastMeaningfulException);
-        throttler.failure();
+        throttler.failure(e.getStatus().getCode());
       }
       // No catch block for any other exceptions because we don't retry them, we pass them through.
       // It's designed this way because it's GrpcRetryer, not general purpose retryer.

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -96,7 +96,7 @@ public final class RpcRetryOptions {
     private Duration maximumInterval;
 
     // 0 is a valid value for maximumJitter, and yet, it is not the default value for maximumJitter.
-    // Use NaN instead as a marker for unconfigured jitter
+    // Use NaN instead as a marker for not configured jitter
     private double maximumJitter = Double.NaN;
 
     private List<DoNotRetryItem> doNotRetry = new ArrayList<>();

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -26,8 +26,10 @@ import java.time.Duration;
 /** Default rpc retry options for long polls like waiting for the workflow finishing and result. */
 public class DefaultStubLongPollRpcRetryOptions {
   public static final Duration INITIAL_INTERVAL = Duration.ofMillis(50);
+  public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
   public static final Duration MAXIMUM_INTERVAL = Duration.ofMinutes(1);
   public static final double BACKOFF = 1.2;
+  public static final double MAXIMUM_JITTER = 0.1;
 
   // partial build because expiration is not set, long polls work with absolute deadlines instead
   public static final RpcRetryOptions INSTANCE = getBuilder().build();
@@ -42,8 +44,10 @@ public class DefaultStubLongPollRpcRetryOptions {
     RpcRetryOptions.Builder roBuilder =
         RpcRetryOptions.newBuilder()
             .setInitialInterval(INITIAL_INTERVAL)
+            .setCongestionInitialInterval(CONGESTION_INITIAL_INTERVAL)
             .setBackoffCoefficient(BACKOFF)
-            .setMaximumInterval(MAXIMUM_INTERVAL);
+            .setMaximumInterval(MAXIMUM_INTERVAL)
+            .setMaximumJitter(MAXIMUM_JITTER);
 
     return roBuilder;
   }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -29,7 +29,7 @@ public class DefaultStubLongPollRpcRetryOptions {
   public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
   public static final Duration MAXIMUM_INTERVAL = Duration.ofMinutes(1);
   public static final double BACKOFF = 1.2;
-  public static final double MAXIMUM_JITTER = 0.1;
+  public static final double MAXIMUM_JITTER_COEFFICIENT = 0.1;
 
   // partial build because expiration is not set, long polls work with absolute deadlines instead
   public static final RpcRetryOptions INSTANCE = getBuilder().build();
@@ -47,7 +47,7 @@ public class DefaultStubLongPollRpcRetryOptions {
             .setCongestionInitialInterval(CONGESTION_INITIAL_INTERVAL)
             .setBackoffCoefficient(BACKOFF)
             .setMaximumInterval(MAXIMUM_INTERVAL)
-            .setMaximumJitter(MAXIMUM_JITTER);
+            .setMaximumJitterCoefficient(MAXIMUM_JITTER_COEFFICIENT);
 
     return roBuilder;
   }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -30,9 +30,11 @@ import java.time.Duration;
  */
 public class DefaultStubServiceOperationRpcRetryOptions {
   public static final Duration INITIAL_INTERVAL = Duration.ofMillis(50);
+  public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
   public static final Duration EXPIRATION_INTERVAL = Duration.ofMinutes(1);
   public static final Duration MAXIMUM_INTERVAL;
   public static final double BACKOFF = 2;
+  public static final double MAXIMUM_JITTER = 0.1;
 
   public static final RpcRetryOptions INSTANCE;
 
@@ -49,8 +51,10 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   public static RpcRetryOptions.Builder getBuilder() {
     return RpcRetryOptions.newBuilder()
         .setInitialInterval(INITIAL_INTERVAL)
+        .setCongestionInitialInterval(CONGESTION_INITIAL_INTERVAL)
         .setExpiration(EXPIRATION_INTERVAL)
         .setBackoffCoefficient(BACKOFF)
-        .setMaximumInterval(MAXIMUM_INTERVAL);
+        .setMaximumInterval(MAXIMUM_INTERVAL)
+        .setMaximumJitter(MAXIMUM_JITTER);
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -34,7 +34,7 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   public static final Duration EXPIRATION_INTERVAL = Duration.ofMinutes(1);
   public static final Duration MAXIMUM_INTERVAL;
   public static final double BACKOFF = 2;
-  public static final double MAXIMUM_JITTER = 0.1;
+  public static final double MAXIMUM_JITTER_COEFFICIENT = 0.1;
 
   public static final RpcRetryOptions INSTANCE;
 
@@ -55,6 +55,6 @@ public class DefaultStubServiceOperationRpcRetryOptions {
         .setExpiration(EXPIRATION_INTERVAL)
         .setBackoffCoefficient(BACKOFF)
         .setMaximumInterval(MAXIMUM_INTERVAL)
-        .setMaximumJitter(MAXIMUM_JITTER);
+        .setMaximumJitterCoefficient(MAXIMUM_JITTER_COEFFICIENT);
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -58,7 +58,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(10))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -92,7 +92,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(10))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -128,7 +128,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .addDoNotRetry(STATUS_CODE, null)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
@@ -164,7 +164,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -197,7 +197,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -232,7 +232,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -279,7 +279,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(50000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -328,7 +328,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
 
     final AtomicReference<StatusRuntimeException> exception = new AtomicReference<>();
@@ -375,7 +375,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(1))
             .setCongestionInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .setMaximumAttempts(3)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
@@ -406,7 +406,7 @@ public class GrpcAsyncRetryerTest {
     long elapsedTime = System.currentTimeMillis() - start;
     assertTrue("We should retry RESOURCE_EXHAUSTED failures.", attempts.get() > 2);
     assertTrue(
-        "We should retry RESOURCE_EXHAUSTED failures using longInitialInterval.",
+        "We should retry RESOURCE_EXHAUSTED failures using congestionInitialInterval.",
         elapsedTime >= 2000);
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -80,7 +80,7 @@ public class GrpcAsyncRetryerTest {
     }
 
     assertTrue("Should retry on DATA_LOSS failures.", attempts.get() > 1);
-    assertTrue(System.currentTimeMillis() - start > 500);
+    assertTrue(System.currentTimeMillis() - start >= 500);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class GrpcAsyncRetryerTest {
     }
 
     assertTrue("Should retry on DATA_LOSS failures.", attempts.get() > 1);
-    assertTrue(System.currentTimeMillis() - start > 500);
+    assertTrue(System.currentTimeMillis() - start >= 500);
   }
 
   @Test
@@ -265,7 +265,7 @@ public class GrpcAsyncRetryerTest {
 
     assertTrue(
         "We should retry DEADLINE_EXCEEDED if global Grpc Deadline, attempts, time are not exhausted.",
-        System.currentTimeMillis() - start > 500);
+        System.currentTimeMillis() - start >= 500);
 
     assertTrue(
         "We should retry DEADLINE_EXCEEDED if global Grpc Deadline, attempts, time are not exhausted.",
@@ -407,6 +407,6 @@ public class GrpcAsyncRetryerTest {
     assertTrue("We should retry RESOURCE_EXHAUSTED failures.", attempts.get() > 2);
     assertTrue(
         "We should retry RESOURCE_EXHAUSTED failures using longInitialInterval.",
-        elapsedTime > 2000);
+        elapsedTime >= 2000);
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -58,6 +58,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(10))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -91,6 +92,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(10))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -126,6 +128,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
+            .setMaximumJitter(0)
             .addDoNotRetry(STATUS_CODE, null)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
@@ -161,6 +164,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -193,6 +197,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -227,6 +232,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -273,6 +279,7 @@ public class GrpcAsyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(50000))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -321,6 +328,7 @@ public class GrpcAsyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
+            .setMaximumJitter(0)
             .validateBuildWithDefaults();
 
     final AtomicReference<StatusRuntimeException> exception = new AtomicReference<>();
@@ -358,5 +366,47 @@ public class GrpcAsyncRetryerTest {
         "We should get a previous exception in case of DEADLINE_EXCEEDED",
         Status.Code.DATA_LOSS,
         exception.get().getStatus().getCode());
+  }
+
+  @Test
+  public void testResourceExhaustedFailure() throws InterruptedException {
+    RpcRetryOptions options =
+        RpcRetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofMillis(1))
+            .setCongestionInitialInterval(Duration.ofMillis(1000))
+            .setMaximumInterval(Duration.ofMillis(1000))
+            .setMaximumJitter(0)
+            .setMaximumAttempts(3)
+            .validateBuildWithDefaults();
+    long start = System.currentTimeMillis();
+    final AtomicInteger attempts = new AtomicInteger();
+
+    try {
+      new GrpcAsyncRetryer<>(
+              scheduledExecutor,
+              () -> {
+                attempts.incrementAndGet();
+                CompletableFuture<?> future = new CompletableFuture<>();
+                future.completeExceptionally(
+                    new StatusRuntimeException(Status.fromCode(Status.Code.RESOURCE_EXHAUSTED)));
+                return future;
+              },
+              new GrpcRetryer.GrpcRetryerOptions(options, null),
+              GetSystemInfoResponse.Capabilities.getDefaultInstance())
+          .retry()
+          .get();
+      fail("unreachable");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof StatusRuntimeException);
+      assertEquals(
+          Status.Code.RESOURCE_EXHAUSTED,
+          ((StatusRuntimeException) e.getCause()).getStatus().getCode());
+    }
+
+    long elapsedTime = System.currentTimeMillis() - start;
+    assertTrue("We should retry RESOURCE_EXHAUSTED failures.", attempts.get() > 2);
+    assertTrue(
+        "We should retry RESOURCE_EXHAUSTED failures using longInitialInterval.",
+        elapsedTime > 2000);
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -82,7 +82,7 @@ public class GrpcSyncRetryerTest {
     }
 
     assertTrue("Should retry on DATA_LOSS failures.", attempts.get() > 1);
-    assertTrue(System.currentTimeMillis() - start > 500);
+    assertTrue(System.currentTimeMillis() - start >= 500);
   }
 
   @Test
@@ -200,7 +200,7 @@ public class GrpcSyncRetryerTest {
     assertEquals(Status.Code.DEADLINE_EXCEEDED, e.getStatus().getCode());
     assertTrue(
         "We should retry DEADLINE_EXCEEDED if global Grpc Deadline, attempts, time are not exhausted.",
-        System.currentTimeMillis() - start > 500);
+        System.currentTimeMillis() - start >= 500);
 
     assertTrue(
         "We should retry DEADLINE_EXCEEDED if global Grpc Deadline, attempts, time are not exhausted.",
@@ -314,8 +314,8 @@ public class GrpcSyncRetryerTest {
     long elapsedTime = System.currentTimeMillis() - start;
     assertTrue("We should retry RESOURCE_EXHAUSTED failures.", attempts.get() > 2);
     assertTrue(
-        "We should retry RESOURCE_EXHAUSTED failures using longInitialInterval.",
-        elapsedTime > 2000);
+        "We should retry RESOURCE_EXHAUSTED failures using congestionInitialInterval.",
+        elapsedTime >= 2000);
   }
 
   @Test

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -63,7 +63,7 @@ public class GrpcSyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(10))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -93,7 +93,7 @@ public class GrpcSyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .addDoNotRetry(STATUS_CODE, null)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
@@ -123,7 +123,7 @@ public class GrpcSyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -149,7 +149,7 @@ public class GrpcSyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -179,7 +179,7 @@ public class GrpcSyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(500))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -214,7 +214,7 @@ public class GrpcSyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
             .setExpiration(Duration.ofMillis(50000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
     final AtomicInteger attempts = new AtomicInteger();
@@ -252,7 +252,7 @@ public class GrpcSyncRetryerTest {
         RpcRetryOptions.newBuilder()
             .setInitialInterval(Duration.ofMillis(100))
             .setMaximumInterval(Duration.ofMillis(100))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .validateBuildWithDefaults();
 
     final AtomicReference<StatusRuntimeException> exception = new AtomicReference<>();
@@ -291,7 +291,7 @@ public class GrpcSyncRetryerTest {
             .setInitialInterval(Duration.ofMillis(1))
             .setCongestionInitialInterval(Duration.ofMillis(1000))
             .setMaximumInterval(Duration.ofMillis(1000))
-            .setMaximumJitter(0)
+            .setMaximumJitterCoefficient(0)
             .setMaximumAttempts(3)
             .validateBuildWithDefaults();
     long start = System.currentTimeMillis();
@@ -336,6 +336,6 @@ public class GrpcSyncRetryerTest {
 
     // The following were added latter; they must silently use default values if unspecified
     assertEquals(Duration.ofMillis(1000), options.getCongestionInitialInterval());
-    assertEquals(0.1, options.getMaximumJitter(), 0.01);
+    assertEquals(0.1, options.getMaximumJitterCoefficient(), 0.01);
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -317,4 +317,25 @@ public class GrpcSyncRetryerTest {
         "We should retry RESOURCE_EXHAUSTED failures using longInitialInterval.",
         elapsedTime > 2000);
   }
+
+  @Test
+  public void testCongestionAndJitterAreNotMandatory() {
+    RpcRetryOptions options =
+        RpcRetryOptions.newBuilder(
+                RpcRetryOptions.newBuilder()
+                    .setInitialInterval(Duration.ofMillis(1))
+                    .setMaximumInterval(Duration.ofMillis(1000))
+                    .setMaximumAttempts(3)
+                    .build())
+            .validateBuildWithDefaults();
+
+    // The following options matches the values above
+    assertEquals(Duration.ofMillis(1), options.getInitialInterval());
+    assertEquals(Duration.ofMillis(1000), options.getMaximumInterval());
+    assertEquals(3, options.getMaximumAttempts());
+
+    // The following were added latter; they must silently use default values if unspecified
+    assertEquals(Duration.ofMillis(1000), options.getCongestionInitialInterval());
+    assertEquals(0.1, options.getMaximumJitter(), 0.01);
+  }
 }


### PR DESCRIPTION
# What was changed

Added longer retry interval on gRPC failures of type `RESOURCE_EXHAUSTED`. This interval delay is configurable by the user, but defaults to 1000 ms.

# Why

This failure code indicates the server is having a hard time. Aggressive retry will worsen the situation and could lead to more serious outage. See https://github.com/temporalio/sdk-features/issues/96