### PR TITLE
Cleanup WorkflowExecutorCache

### DIFF
--- a/gradle/linting.gradle
+++ b/gradle/linting.gradle
@@ -15,7 +15,7 @@ subprojects {
                     // needs to be aligned with .editorconfig
                     // https://github.com/diffplug/spotless/tree/main/plugin-gradle#ktlint
                     // reenable filename rule after https://github.com/pinterest/ktlint/issues/1521
-                    .editorConfigOverride(['indent_size': '2', 'disabled_rules': 'filename'])
+                    .editorConfigOverride(['indent_size': '2', 'ktlint_disabled_rules': 'filename'])
         }
     }
 

--- a/temporal-kotlin/.editorconfig
+++ b/temporal-kotlin/.editorconfig
@@ -1,4 +1,4 @@
 [*.{kt,kts}]
 indent_size = 2
 # reenable filename rule after https://github.com/pinterest/ktlint/issues/1521
-disabled_rules = filename
+ktlint_disabled_rules = filename

--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -129,7 +129,7 @@ public final class MetricsType {
   public static final String LOCAL_ACTIVITY_FAILED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_failed";
 
-  // Worker internals, tagged with worker_type
+  // Worker internals, tagged with namespace, task_queue, worker_type
   public static final String WORKER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "worker_start";
   public static final String POLLER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "poller_start";
   // gauge
@@ -140,13 +140,31 @@ public final class MetricsType {
   // Worker Factory
   //
 
+  // tagged with namespace, task_queue, worker_type, workflow_type
   public static final String STICKY_CACHE_HIT = TEMPORAL_METRICS_PREFIX + "sticky_cache_hit";
+  // tagged with namespace, task_queue, worker_type, workflow_type
   public static final String STICKY_CACHE_MISS = TEMPORAL_METRICS_PREFIX + "sticky_cache_miss";
+  // tagged with namespace, task_queue, worker_type, workflow_type
+  @Deprecated
+  // This metric in its current form is useless, it's not possible for users to interpret it for any
+  // meaningful purpose.
+  // We count in workflows that are getting evicted because we are out of threads in workflow thread
+  // pool. (makes sense)
+  // We count in workflows that are getting "evicted" because a full history from the server is
+  // received. (kinda makes sense)
+  // We count in workflows that are getting "evicted" because they are done. But only if they were
+  // added to the cache. (doesn't make sense)
+  // We DON'T count in workflows that are getting "evicted" because the cache is overflown. (doesn't
+  // make sense)
+  // TODO revisit implementation of this metric in Go and if it make sense there, fix the Java
+  // version.
+  //  Otherwise deprecate it everywhere and remove from docs.
   public static final String STICKY_CACHE_TOTAL_FORCED_EVICTION =
       TEMPORAL_METRICS_PREFIX + "sticky_cache_total_forced_eviction";
+  // tagged with namespace, task_queue, worker_type, workflow_type
   public static final String STICKY_CACHE_THREAD_FORCED_EVICTION =
       TEMPORAL_METRICS_PREFIX + "sticky_cache_thread_forced_eviction";
-  // gauge
+  // gauge, tagged with namespace
   public static final String STICKY_CACHE_SIZE = TEMPORAL_METRICS_PREFIX + "sticky_cache_size";
   // gauge
   public static final String WORKFLOW_ACTIVE_THREAD_COUNT =

--- a/temporal-sdk/src/test/java/io/temporal/common/reporter/TestStatsReporter.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/reporter/TestStatsReporter.java
@@ -55,12 +55,18 @@ public final class TestStatsReporter implements StatsReporter {
       fail(
           "Metric '"
               + metricName
-              + "', all reported metrics: \n "
-              + String.join("\n ", counters.keySet()));
+              + "' was reported, with value: '"
+              + counters.get(metricName).get()
+              + "'");
     }
   }
 
   public synchronized void assertCounter(String name, Map<String, String> tags, long expected) {
+    assertCounter(name, tags, actual -> actual == expected);
+  }
+
+  public synchronized void assertCounter(
+      String name, Map<String, String> tags, Predicate<Long> expected) {
     String metricName = getMetricName(name, tags);
     AtomicLong accumulator = counters.get(metricName);
     if (accumulator == null) {
@@ -70,7 +76,8 @@ public final class TestStatsReporter implements StatsReporter {
               + "', reported metrics: \n "
               + String.join("\n ", counters.keySet()));
     }
-    assertEquals(String.valueOf(accumulator.get()), expected, accumulator.get());
+    long actual = accumulator.get();
+    assertTrue("" + actual, expected.test(actual));
   }
 
   public synchronized void assertGauge(String name, Map<String, String> tags, double expected) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -29,16 +29,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class MetricsTag {
-  public static final String ACTIVITY_TYPE = "activity_type";
   public static final String NAMESPACE = "namespace";
   public static final String TASK_QUEUE = "task_queue";
+  public static final String WORKER_TYPE = "worker_type";
+
+  public static final String ACTIVITY_TYPE = "activity_type";
   public static final String WORKFLOW_TYPE = "workflow_type";
   public static final String SIGNAL_NAME = "signal_name";
   public static final String QUERY_TYPE = "query_type";
   public static final String STATUS_CODE = "status_code";
   public static final String EXCEPTION = "exception";
   public static final String OPERATION_NAME = "operation";
-  public static final String WORKER_TYPE = "worker_type";
 
   /** Used to pass metrics scope to the interceptor */
   public static final CallOptions.Key<Scope> METRICS_TAGS_CALL_OPTIONS_KEY =


### PR DESCRIPTION
Cleanup WorkflowExecutorCache from the old pieces that are not relevant anymore after recent optimizations.
Rearrange checks in a flaky `StickyWorkerTest::whenStickyIsEnabledThenTheWorkflowIsCachedChildWorkflow` test.
Add notes regarding `sticky_cache_total_forced_eviction` being unusable in its current shape in java-sdk.