### PR TITLE
Dependency updates and spring-boot-starter pom fix for Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,17 @@ buildscript {
 }
 
 plugins {
-    id 'net.ltgt.errorprone' version '2.0.2' apply false
+    id 'net.ltgt.errorprone' version '3.0.1' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'com.diffplug.spotless' version '6.11.0' apply false
-    id 'com.github.nbaztec.coveralls-jacoco' version "1.2.14" apply false
+    id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
     //    id 'org.jetbrains.kotlin.jvm' version '1.5.32'
     //    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
-    //    id 'org.jetbrains.kotlin.jvm' version '1.7.10'
+    //    id 'org.jetbrains.kotlin.jvm' version '1.7.20'
     id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}" apply false
     id 'base'
 }
@@ -29,8 +29,8 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.49.1' // [1.34.0,)
-    jacksonVersion = '2.13.4' // [2.9.0,)
+    grpcVersion = '1.50.0' // [1.34.0,)
+    jacksonVersion = '2.13.4.20221012' // [2.9.0,)
     micrometerVersion = '1.9.4' // [1.0.0,)
 
     slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which decide on 1.x
@@ -42,6 +42,8 @@ ext {
     gsonVersion = '2.9.1' // [2.0,)
 
     jsonPathVersion = '2.7.0' // compileOnly
+
+    springBootVersion = '2.7.4'// [2.4.0,)
 
     // test scoped
     logbackVersion = '1.2.11'

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -5,7 +5,7 @@ subprojects {
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
         if (JavaVersion.current().isJava11Compatible()) {
-            errorprone('com.google.errorprone:error_prone_core:2.11.0')
+            errorprone('com.google.errorprone:error_prone_core:2.16')
         } else {
             errorprone('com.google.errorprone:error_prone_core:2.10.0')
         }
@@ -13,5 +13,6 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.errorprone.disableWarningsInGeneratedCode = true
+        options.errorprone.excludedPaths = '.*/build/generated/.*'
     }
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -151,15 +151,11 @@ public class SpanFactory {
     toSpan.setTag(StandardTagNames.FAILED, true);
     toSpan.setTag(Tags.ERROR, options.getIsErrorPredicate().test(failReason));
 
-    Map<String, Object> logPayload =
-        new HashMap<String, Object>() {
-          {
-            put(Fields.EVENT, "error");
-            put(Fields.ERROR_KIND, failReason.getClass().getName());
-            put(Fields.ERROR_OBJECT, failReason);
-            put(Fields.STACK, Throwables.getStackTraceAsString(failReason));
-          }
-        };
+    Map<String, Object> logPayload = new HashMap<>();
+    logPayload.put(Fields.EVENT, "error");
+    logPayload.put(Fields.ERROR_KIND, failReason.getClass().getName());
+    logPayload.put(Fields.ERROR_OBJECT, failReason);
+    logPayload.put(Fields.STACK, Throwables.getStackTraceAsString(failReason));
 
     String message = failReason.getMessage();
     if (message != null) {

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -228,7 +228,7 @@ public final class LocalActivityOptions {
     if (this == o) return true;
     if (!(o instanceof LocalActivityOptions)) return false;
     LocalActivityOptions that = (LocalActivityOptions) o;
-    return doNotIncludeArgumentsIntoMarker == that.doNotIncludeArgumentsIntoMarker
+    return Objects.equal(doNotIncludeArgumentsIntoMarker, that.doNotIncludeArgumentsIntoMarker)
         && Objects.equal(scheduleToCloseTimeout, that.scheduleToCloseTimeout)
         && Objects.equal(localRetryThreshold, that.localRetryThreshold)
         && Objects.equal(startToCloseTimeout, that.startToCloseTimeout)

--- a/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
@@ -33,6 +33,7 @@ import io.temporal.workflow.shared.TestActivities.TestLocalActivity;
 import io.temporal.workflow.shared.TestActivities.TestLocalActivityImpl;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowReturnMap;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Rule;
@@ -45,19 +46,11 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
   private static final ActivityOptions activity2Ops =
       SDKTestOptions.newActivityOptions20sScheduleToClose();
   private static final Map<String, ActivityOptions> activity2options =
-      new HashMap<String, ActivityOptions>() {
-        {
-          put("Activity2", activity2Ops);
-        }
-      };
+      Collections.singletonMap("Activity2", activity2Ops);
   private static final Map<String, ActivityOptions> defaultActivity2options =
-      new HashMap<String, ActivityOptions>() {
-        {
-          put(
-              "Activity2",
-              ActivityOptions.newBuilder().setHeartbeatTimeout(Duration.ofSeconds(2)).build());
-        }
-      };
+      Collections.singletonMap(
+          "Activity2",
+          ActivityOptions.newBuilder().setHeartbeatTimeout(Duration.ofSeconds(2)).build());
 
   // local activity options
   private static final LocalActivityOptions localActivityWorkflowOps =
@@ -67,19 +60,11 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
   private static final LocalActivityOptions localActivity2Ops =
       SDKTestOptions.newLocalActivityOptions20sScheduleToClose();
   private static final Map<String, LocalActivityOptions> localActivity2options =
-      new HashMap<String, LocalActivityOptions>() {
-        {
-          put("LocalActivity2", localActivity2Ops);
-        }
-      };
+      Collections.singletonMap("LocalActivity2", localActivity2Ops);
   private static final Map<String, LocalActivityOptions> defaultLocalActivity2options =
-      new HashMap<String, LocalActivityOptions>() {
-        {
-          put(
-              "LocalActivity2",
-              LocalActivityOptions.newBuilder().setDoNotIncludeArgumentsIntoMarker(false).build());
-        }
-      };
+      Collections.singletonMap(
+          "LocalActivity2",
+          LocalActivityOptions.newBuilder().setDoNotIncludeArgumentsIntoMarker(false).build());
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
@@ -25,7 +25,7 @@ import io.temporal.testing.TestActivityEnvironment;
 import io.temporal.workflow.shared.TestActivities.TestLocalActivity;
 import io.temporal.workflow.shared.TestActivities.TestLocalActivityImpl;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import org.junit.*;
 import org.junit.rules.Timeout;
@@ -54,11 +54,7 @@ public class LocalActivityMethodOptionsTest {
   private static final LocalActivityOptions methodOps2 =
       LocalActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(4)).build();
   private static final Map<String, LocalActivityOptions> perMethodOptionsMap =
-      new HashMap<String, LocalActivityOptions>() {
-        {
-          put("LocalActivity1", methodOps2);
-        }
-      };
+      Collections.singletonMap("LocalActivity1", methodOps2);
   private TestActivityEnvironment testEnv;
 
   @Before

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MemoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MemoTest.java
@@ -40,6 +40,7 @@ import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc;
 import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Rule;
@@ -54,14 +55,7 @@ public class MemoTest {
   private static final String MEMO_KEY_MISSING = "testKey3";
   private static final Map<String, Object> MEMO =
       ImmutableMap.of(
-          MEMO_KEY,
-          MEMO_VALUE,
-          MEMO_KEY_2,
-          new HashMap<String, Integer>() {
-            {
-              put(MEMO_KEY_2, MEMO_VALUE_2);
-            }
-          });
+          MEMO_KEY, MEMO_VALUE, MEMO_KEY_2, Collections.singletonMap(MEMO_KEY_2, MEMO_VALUE_2));
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -61,6 +61,7 @@ import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
 import io.temporal.workflow.shared.TestWorkflows.ReceiveSignalObjectWorkflow;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflowReturnString;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -273,14 +274,10 @@ public class MetricsTest {
     // Wait for reporter
     Thread.sleep(REPORTING_FLUSH_TIME);
 
-    Map<String, String> tags =
-        new LinkedHashMap<String, String>() {
-          {
-            putAll(MetricsTag.defaultTags(NAMESPACE));
-            put(MetricsTag.TASK_QUEUE, TASK_QUEUE);
-            put(MetricsTag.WORKFLOW_TYPE, "ReceiveSignalObjectWorkflow");
-          }
-        };
+    Map<String, String> tags = new HashMap<>(MetricsTag.defaultTags(NAMESPACE));
+    tags.put(MetricsTag.TASK_QUEUE, TASK_QUEUE);
+    tags.put(MetricsTag.WORKFLOW_TYPE, "ReceiveSignalObjectWorkflow");
+
     reporter.assertCounter(CORRUPTED_SIGNALS_COUNTER, tags, 1);
   }
 
@@ -304,13 +301,8 @@ public class MetricsTest {
     // Wait for reporter
     Thread.sleep(REPORTING_FLUSH_TIME);
 
-    Map<String, String> tags =
-        new LinkedHashMap<String, String>() {
-          {
-            putAll(MetricsTag.defaultTags(MetricsTag.DEFAULT_VALUE));
-            put(MetricsTag.OPERATION_NAME, "DescribeNamespace");
-          }
-        };
+    Map<String, String> tags = new HashMap<>(MetricsTag.defaultTags(MetricsTag.DEFAULT_VALUE));
+    tags.put(MetricsTag.OPERATION_NAME, "DescribeNamespace");
     reporter.assertCounter(TEMPORAL_REQUEST, tags, 1);
     tags.put(MetricsTag.STATUS_CODE, "INVALID_ARGUMENT");
     reporter.assertCounter(TEMPORAL_REQUEST_FAILURE, tags, 1);
@@ -379,15 +371,9 @@ public class MetricsTest {
     // Wait for reporter
     Thread.sleep(REPORTING_FLUSH_TIME);
 
-    Map<String, String> tags =
-        new LinkedHashMap<String, String>() {
-          {
-            putAll(MetricsTag.defaultTags(MetricsTag.DEFAULT_VALUE));
-            put(MetricsTag.OPERATION_NAME, "StartWorkflowExecution");
-          }
-        };
+    Map<String, String> tags = new HashMap<>(MetricsTag.defaultTags(MetricsTag.DEFAULT_VALUE));
+    tags.put(MetricsTag.OPERATION_NAME, "StartWorkflowExecution");
     reporter.assertCounter(TEMPORAL_REQUEST, tags, 1);
-
     tags.put(MetricsTag.STATUS_CODE, "INVALID_ARGUMENT");
     reporter.assertCounter(TEMPORAL_REQUEST_FAILURE, tags, 1);
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/SearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/SearchAttributesTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
@@ -71,16 +72,17 @@ public class SearchAttributesTest {
   private static final String TEST_UNKNOWN_KEY = "UnknownKey";
 
   private static final Map<String, Object> DEFAULT_SEARCH_ATTRIBUTES =
-      Collections.unmodifiableMap(
-          new HashMap<String, Object>() {
-            {
-              put(TEST_KEY_STRING, TEST_VALUE_STRING);
-              put(TEST_KEY_INTEGER, TEST_VALUE_LONG);
-              put(TEST_KEY_DOUBLE, TEST_VALUE_DOUBLE);
-              put(TEST_KEY_BOOL, TEST_VALUE_BOOL);
-              put(TEST_KEY_DATE_TIME, TEST_VALUE_DATE_TIME);
-            }
-          });
+      ImmutableMap.of(
+          TEST_KEY_STRING,
+          TEST_VALUE_STRING,
+          TEST_KEY_INTEGER,
+          TEST_VALUE_LONG,
+          TEST_KEY_DOUBLE,
+          TEST_VALUE_DOUBLE,
+          TEST_KEY_BOOL,
+          TEST_VALUE_BOOL,
+          TEST_KEY_DATE_TIME,
+          TEST_VALUE_DATE_TIME);
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.activity.ActivityInfo;
@@ -171,25 +172,25 @@ public class TestActivities {
     @Override
     public Map<String, Duration> activity1() {
       ActivityInfo info = Activity.getExecutionContext().getInfo();
-      return new HashMap<String, Duration>() {
-        {
-          put("HeartbeatTimeout", info.getHeartbeatTimeout());
-          put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-          put("StartToCloseTimeout", info.getStartToCloseTimeout());
-        }
-      };
+      return ImmutableMap.of(
+          "HeartbeatTimeout",
+          info.getHeartbeatTimeout(),
+          "ScheduleToCloseTimeout",
+          info.getScheduleToCloseTimeout(),
+          "StartToCloseTimeout",
+          info.getStartToCloseTimeout());
     }
 
     @Override
     public Map<String, Duration> activity2() {
       ActivityInfo info = Activity.getExecutionContext().getInfo();
-      return new HashMap<String, Duration>() {
-        {
-          put("HeartbeatTimeout", info.getHeartbeatTimeout());
-          put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-          put("StartToCloseTimeout", info.getStartToCloseTimeout());
-        }
-      };
+      return ImmutableMap.of(
+          "HeartbeatTimeout",
+          info.getHeartbeatTimeout(),
+          "ScheduleToCloseTimeout",
+          info.getScheduleToCloseTimeout(),
+          "StartToCloseTimeout",
+          info.getStartToCloseTimeout());
     }
   }
 
@@ -198,23 +199,21 @@ public class TestActivities {
     @Override
     public Map<String, Duration> localActivity1() {
       ActivityInfo info = Activity.getExecutionContext().getInfo();
-      return new HashMap<String, Duration>() {
-        {
-          put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-          put("StartToCloseTimeout", info.getStartToCloseTimeout());
-        }
-      };
+      return ImmutableMap.of(
+          "ScheduleToCloseTimeout",
+          info.getScheduleToCloseTimeout(),
+          "StartToCloseTimeout",
+          info.getStartToCloseTimeout());
     }
 
     @Override
     public Map<String, Duration> localActivity2() {
       ActivityInfo info = Activity.getExecutionContext().getInfo();
-      return new HashMap<String, Duration>() {
-        {
-          put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-          put("StartToCloseTimeout", info.getStartToCloseTimeout());
-        }
-      };
+      return ImmutableMap.of(
+          "ScheduleToCloseTimeout",
+          info.getScheduleToCloseTimeout(),
+          "StartToCloseTimeout",
+          info.getStartToCloseTimeout());
     }
   }
 

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -57,11 +57,11 @@ protobuf {
     // For aarch64 (M1) using oldest version with binary available for this platform
     if (System.getProperty("os.arch") == 'aarch64') {
         protoc {
-            artifact = 'com.google.protobuf:protoc:3.21.6'
+            artifact = 'com.google.protobuf:protoc:3.21.7'
         }
         plugins {
             grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.1'
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.2'
             }
         }
     } else {
@@ -70,7 +70,7 @@ protobuf {
         }
         plugins {
             grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.34.0'
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
             }
         }
     }

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,10 +1,8 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    springBootVersion = '2.7.4'// [2.4.0,)
-
-    otelVersion = '1.18.0'
-    otShimVersion = '1.18.0-alpha'
+    otelVersion = '1.19.0'
+    otShimVersion = '1.19.0-alpha'
 }
 
 dependencies {

--- a/temporal-spring-boot-starter-alpha/build.gradle
+++ b/temporal-spring-boot-starter-alpha/build.gradle
@@ -1,6 +1,11 @@
 description = '''Spring Boot Starter for Temporal Java SDK'''
 
 dependencies {
+    // This platform is the same defined in temporal-spring-boot-autoconfigure-alpha and it doesn't need to be here
+    // for gradle, but it is needed for maven and maven pom. Looks like Maven doesn't transitively propagate BOMs.
+    // https://github.com/temporalio/sdk-java/issues/1479
+    api(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
+
     api project(':temporal-spring-boot-autoconfigure-alpha')
     implementation "org.springframework.boot:spring-boot-starter"
 }

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -61,11 +61,11 @@ protobuf {
     // For aarch64 (M1) using oldest version with binary available for this platform
     if (System.getProperty("os.arch") == 'aarch64') {
         protoc {
-            artifact = 'com.google.protobuf:protoc:3.21.6'
+            artifact = 'com.google.protobuf:protoc:3.21.7'
         }
         plugins {
             grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.1'
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.2'
             }
         }
     } else {
@@ -74,7 +74,7 @@ protobuf {
         }
         plugins {
             grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.34.0'
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
             }
         }
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestVisibilityStoreImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestVisibilityStoreImpl.java
@@ -20,6 +20,7 @@
 
 package io.temporal.internal.testservice;
 
+import com.google.common.collect.ImmutableMap;
 import io.grpc.Status;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.SearchAttributes;
@@ -43,17 +44,16 @@ class TestVisibilityStoreImpl implements TestVisibilityStore {
   private static final String DEFAULT_KEY_BOOL = "CustomBoolField";
 
   private final Map<String, IndexedValueType> searchAttributes =
-      new ConcurrentHashMap<String, IndexedValueType>() {
-        {
-          put(DEFAULT_KEY_STRING, IndexedValueType.INDEXED_VALUE_TYPE_TEXT);
-          put(DEFAULT_KEY_TEXT, IndexedValueType.INDEXED_VALUE_TYPE_TEXT);
-          put(DEFAULT_KEY_KEYWORD, IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD);
-          put(DEFAULT_KEY_INTEGER, IndexedValueType.INDEXED_VALUE_TYPE_INT);
-          put(DEFAULT_KEY_DOUBLE, IndexedValueType.INDEXED_VALUE_TYPE_DOUBLE);
-          put(DEFAULT_KEY_BOOL, IndexedValueType.INDEXED_VALUE_TYPE_BOOL);
-          put(DEFAULT_KEY_DATE_TIME, IndexedValueType.INDEXED_VALUE_TYPE_DATETIME);
-        }
-      };
+      new ConcurrentHashMap<>(
+          ImmutableMap.<String, IndexedValueType>builder()
+              .put(DEFAULT_KEY_STRING, IndexedValueType.INDEXED_VALUE_TYPE_TEXT)
+              .put(DEFAULT_KEY_TEXT, IndexedValueType.INDEXED_VALUE_TYPE_TEXT)
+              .put(DEFAULT_KEY_KEYWORD, IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD)
+              .put(DEFAULT_KEY_INTEGER, IndexedValueType.INDEXED_VALUE_TYPE_INT)
+              .put(DEFAULT_KEY_DOUBLE, IndexedValueType.INDEXED_VALUE_TYPE_DOUBLE)
+              .put(DEFAULT_KEY_BOOL, IndexedValueType.INDEXED_VALUE_TYPE_BOOL)
+              .put(DEFAULT_KEY_DATE_TIME, IndexedValueType.INDEXED_VALUE_TYPE_DATETIME)
+              .build());
 
   private final Map<ExecutionId, SearchAttributes> executionSearchAttributes = new HashMap<>();
 


### PR DESCRIPTION
Update dependencies
Adapt the code to comply with new error-prone
Add a direct dependency to `org.springframework.boot:spring-boot-dependencies` BOM in temporal-spring-boot-starter-alpha to fix the problem with Maven not picking up platforms from the transitive dependencies.

Closes #1479