### PR TITLE
Upgrade CI docker images from openjdk to eclipse-temurin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,12 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.50.0' // [1.34.0,)
-    jacksonVersion = '2.13.4.20221012' // [2.9.0,)
-    micrometerVersion = '1.9.4' // [1.0.0,)
+    grpcVersion = '1.50.2' // [1.34.0,)
+    jacksonVersion = '2.13.4.20221013' // [2.9.0,)
+    micrometerVersion = '1.9.5' // [1.0.0,)
 
     slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which decide on 1.x
-    protoVersion = '3.21.6' // [3.10.0,)
+    protoVersion = '3.21.8' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
     tallyVersion = '0.11.1' // [0.4.0,)
@@ -43,11 +43,11 @@ ext {
 
     jsonPathVersion = '2.7.0' // compileOnly
 
-    springBootVersion = '2.7.4'// [2.4.0,)
+    springBootVersion = '2.7.5'// [2.4.0,)
 
     // test scoped
     logbackVersion = '1.2.11'
-    mockitoVersion = '4.8.0'
+    mockitoVersion = '4.8.1'
     junitVersion = '4.13.2'
 }
 

--- a/docker/buildkite/Dockerfile-JDK11
+++ b/docker/buildkite/Dockerfile-JDK11
@@ -1,4 +1,4 @@
-FROM openjdk:11-slim
+FROM eclipse-temurin:11-focal
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y protobuf-compiler git

--- a/docker/buildkite/Dockerfile-JDK18
+++ b/docker/buildkite/Dockerfile-JDK18
@@ -1,4 +1,4 @@
-FROM openjdk:18-slim
+FROM eclipse-temurin:11-focal
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y protobuf-compiler git

--- a/docker/buildkite/Dockerfile-JDK8
+++ b/docker/buildkite/Dockerfile-JDK8
@@ -1,4 +1,4 @@
-FROM openjdk:8-slim
+FROM eclipse-temurin:11-focal
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y protobuf-compiler git


### PR DESCRIPTION
openjdk DockerHub repo is Deprecated.
Moving from openjdk:x-slim to eclipse-temurin:x-jammy as a most compatible replacement