### PR TITLE
Switch to the latest server in CI/CD

### DIFF
--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "9042:9042"
 
   temporal:
-    image: temporaliotest/auto-setup:sha-8ed1157
+    image: temporaliotest/auto-setup:latest
     ports:
       - "7233:7233"
       - "7234:7234"


### PR DESCRIPTION
Earlier a specific server version was fixed because of the regression in heartbeat behavior in the main branch. The problem is fixed, restoring the usage of the latest server build for CI/CD.