### PR TITLE
Rework Local Activity scheduling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ ext {
     // Platforms
     grpcVersion = '1.51.0' // [1.34.0,)
     jacksonVersion = '2.14.0' // [2.9.0,)
-    micrometerVersion = '1.9.5' // [1.0.0,)
+    micrometerVersion = '1.9.6' // [1.0.0,) // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
 
-    slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which decide on 1.x
+    slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which stay on 1.x
     protoVersion = '3.21.9' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
@@ -46,7 +46,7 @@ ext {
     springBootVersion = '2.7.5'// [2.4.0,)
 
     // test scoped
-    logbackVersion = '1.2.11'
+    logbackVersion = '1.2.11' // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
     mockitoVersion = '4.9.0'
     junitVersion = '4.13.2'
 }

--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
@@ -147,9 +147,23 @@ public final class ActivityOptions {
     }
 
     /**
-     * RetryOptions that define how activity is retried in case of failure. If this is not set, then
-     * the server-defined default activity retry policy will be used. To ensure zero retries, set
-     * maximum attempts to 1.
+     * RetryOptions that define how an Activity is retried in case of failure.
+     *
+     * <p>If not provided, the server-defined default activity retry policy will be used. If not
+     * overridden, the server default activity retry policy is:
+     *
+     * <pre><code>
+     *   InitialInterval:         1 second
+     *   BackoffCoefficient:      2
+     *   MaximumInterval:         100 seconds   // 100 * InitialInterval
+     *   MaximumAttempts:         0             // Unlimited
+     *   NonRetryableErrorTypes:  []
+     * </pre></code>
+     *
+     * <p>If both {@link #setScheduleToCloseTimeout(Duration)} and {@link
+     * RetryOptions.Builder#setMaximumAttempts(int)} are not set, the Activity will not be retried.
+     *
+     * <p>To ensure zero retries, set {@link RetryOptions.Builder#setMaximumAttempts(int)} to 1.
      */
     public Builder setRetryOptions(RetryOptions retryOptions) {
       this.retryOptions = retryOptions;

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -126,8 +126,22 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * {@link RetryOptions} that define how an Activity is retried in case of failure. Activities
-     * use a default RetryPolicy if not provided.
+     * {@link RetryOptions} that define how an Activity is retried in case of failure.
+     *
+     * <p>If not provided, the default activity retry policy is:
+     *
+     * <pre><code>
+     *   InitialInterval:         1 second
+     *   BackoffCoefficient:      2
+     *   MaximumInterval:         100 seconds   // 100 * InitialInterval
+     *   MaximumAttempts:         0             // Unlimited
+     *   NonRetryableErrorTypes:  []
+     * </pre></code>
+     *
+     * <p>If both {@link #setScheduleToCloseTimeout(Duration)} and {@link
+     * RetryOptions.Builder#setMaximumAttempts(int)} are not set, the Activity will not be retried.
+     *
+     * <p>To ensure zero retries, set {@link RetryOptions.Builder#setMaximumAttempts(int)} to 1.
      */
     public Builder setRetryOptions(RetryOptions retryOptions) {
       this.retryOptions = retryOptions;

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/RetryOptionsUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/RetryOptionsUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.common;
+
+import io.grpc.Deadline;
+import io.temporal.api.common.v1.RetryPolicy;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.ChildWorkflowFailure;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+public class RetryOptionsUtils {
+  public static boolean isNotRetryable(RetryOptions o, @Nullable Throwable e) {
+    if (e == null) {
+      return false;
+    }
+    if (e instanceof ActivityFailure || e instanceof ChildWorkflowFailure) {
+      e = e.getCause();
+    }
+    String type =
+        e instanceof ApplicationFailure
+            ? ((ApplicationFailure) e).getType()
+            : e.getClass().getName();
+    if (o.getDoNotRetry() != null) {
+      for (String doNotRetry : o.getDoNotRetry()) {
+        if (doNotRetry.equals(type)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public static boolean areAttemptsReached(RetryOptions o, long attempt) {
+    return (o.getMaximumAttempts() != 0 && attempt >= o.getMaximumAttempts());
+  }
+
+  public static boolean isDeadlineReached(@Nullable Deadline deadline, long sleepTimeMs) {
+    return deadline != null && deadline.timeRemaining(TimeUnit.MILLISECONDS) < sleepTimeMs;
+  }
+
+  public static RetryOptions toRetryOptions(RetryPolicy retryPolicy) {
+    RetryOptions.Builder roBuilder = RetryOptions.newBuilder();
+
+    Duration maximumInterval = ProtobufTimeUtils.toJavaDuration(retryPolicy.getMaximumInterval());
+    if (!maximumInterval.isZero()) {
+      roBuilder.setMaximumInterval(maximumInterval);
+    }
+
+    Duration initialInterval = ProtobufTimeUtils.toJavaDuration(retryPolicy.getInitialInterval());
+    if (!initialInterval.isZero()) {
+      roBuilder.setInitialInterval(initialInterval);
+    }
+
+    if (retryPolicy.getBackoffCoefficient() >= 1) {
+      roBuilder.setBackoffCoefficient(retryPolicy.getBackoffCoefficient());
+    }
+
+    if (retryPolicy.getMaximumAttempts() > 0) {
+      roBuilder.setMaximumAttempts(retryPolicy.getMaximumAttempts());
+    }
+
+    roBuilder.setDoNotRetry(
+        retryPolicy
+            .getNonRetryableErrorTypesList()
+            .toArray(new String[retryPolicy.getNonRetryableErrorTypesCount()]));
+
+    return roBuilder.validateBuildWithDefaults();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -51,7 +51,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +66,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
   private final Duration stickyTaskQueueScheduleToStartTimeout;
   private final WorkflowServiceStubs service;
   private final String stickyTaskQueueName;
-  private final BiFunction<LocalActivityTask, Duration, Boolean> localActivityTaskPoller;
+  private final LocalActivityDispatcher localActivityDispatcher;
 
   public ReplayWorkflowTaskHandler(
       String namespace,
@@ -77,7 +76,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       String stickyTaskQueueName,
       Duration stickyTaskQueueScheduleToStartTimeout,
       WorkflowServiceStubs service,
-      BiFunction<LocalActivityTask, Duration, Boolean> localActivityTaskPoller) {
+      LocalActivityDispatcher localActivityDispatcher) {
     this.namespace = namespace;
     this.workflowFactory = asyncWorkflowFactory;
     this.cache = cache;
@@ -85,7 +84,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     this.stickyTaskQueueName = stickyTaskQueueName;
     this.stickyTaskQueueScheduleToStartTimeout = stickyTaskQueueScheduleToStartTimeout;
     this.service = Objects.requireNonNull(service);
-    this.localActivityTaskPoller = localActivityTaskPoller;
+    this.localActivityDispatcher = localActivityDispatcher;
   }
 
   @Override
@@ -365,7 +364,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     }
     ReplayWorkflow workflow = workflowFactory.getWorkflow(workflowType);
     return new ReplayWorkflowRunTaskHandler(
-        namespace, workflow, workflowTask, options, metricsScope, localActivityTaskPoller);
+        namespace, workflow, workflowTask, options, metricsScope, localActivityDispatcher);
   }
 
   private void resetStickyTaskQueue(WorkflowExecution execution) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ExecuteLocalActivityParameters.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ExecuteLocalActivityParameters.java
@@ -20,42 +20,113 @@
 
 package io.temporal.internal.statemachines;
 
+import io.temporal.api.common.v1.ActivityType;
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.internal.common.ProtobufTimeUtils;
 import java.time.Duration;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class ExecuteLocalActivityParameters {
-  private final PollActivityTaskQueueResponse.Builder activityTask;
+  public static final long NOT_SCHEDULED = -1;
+
+  // This builder doesn't have all the fields published yet (a specific attempt for example)
+  // It contains only the fields known at the moment of scheduling from the workflow.
+  // This template gets adjusted for each attempt.
+  private final @Nonnull PollActivityTaskQueueResponse.Builder activityTaskBuilder;
+  private final @Nonnull PollActivityTaskQueueResponse initialActivityTask;
+
   private final Duration localRetryThreshold;
   private final boolean doNotIncludeArgumentsIntoMarker;
 
+  private @Nullable Duration scheduleToStartTimeout;
+
+  /**
+   * Timestamp of the moment when the first attempt of this local activity was scheduled. Comes into
+   * play when localRetryThreshold is reached. If {@link #NOT_SCHEDULED} then the first attempt was
+   * not scheduled yet, and we are going to do it now locally. This timestamp is registered by the
+   * worker performing the first attempt, so this mechanic needs reasonably synchronized worker
+   * clocks.
+   */
+  private long originalScheduledTimestamp = NOT_SCHEDULED;
+
   public ExecuteLocalActivityParameters(
-      PollActivityTaskQueueResponse.Builder activityTask,
-      Duration localRetryThreshold,
-      boolean doNotIncludeArgumentsIntoMarker) {
-    this.activityTask = activityTask;
-    this.localRetryThreshold = localRetryThreshold;
+      @Nonnull PollActivityTaskQueueResponse.Builder activityTaskBuilder,
+      @Nullable Duration scheduleToStartTimeout,
+      boolean doNotIncludeArgumentsIntoMarker,
+      Duration localRetryThreshold) {
+    this.activityTaskBuilder = Objects.requireNonNull(activityTaskBuilder, "activityTaskBuilder");
+    this.initialActivityTask = activityTaskBuilder.build();
+    this.scheduleToStartTimeout = scheduleToStartTimeout;
     this.doNotIncludeArgumentsIntoMarker = doNotIncludeArgumentsIntoMarker;
+    this.localRetryThreshold = localRetryThreshold;
   }
 
-  public PollActivityTaskQueueResponse.Builder getActivityTask() {
-    return activityTask;
+  public String getActivityId() {
+    return activityTaskBuilder.getActivityId();
   }
 
-  public Duration getLocalRetryThreshold() {
-    return localRetryThreshold;
+  public ActivityType getActivityType() {
+    return activityTaskBuilder.getActivityType();
+  }
+
+  public Payloads getInput() {
+    return activityTaskBuilder.getInput();
+  }
+
+  public int getInitialAttempt() {
+    return initialActivityTask.getAttempt();
+  }
+
+  /*
+   * TODO This setter is exposed and the field is made non-final to support the legacy calculation of this timeout.
+   *  This legacy logic doesn't make much sense anymore in presence of workflow task heartbeat and should be replaced
+   *  with an explicit schedule to start timeout coming from the local activity options.
+   */
+  public void setScheduleToStartTimeout(@Nullable Duration scheduleToStartTimeout) {
+    this.scheduleToStartTimeout = scheduleToStartTimeout;
+  }
+
+  @Nullable
+  public Duration getScheduleToStartTimeout() {
+    return scheduleToStartTimeout;
+  }
+
+  @Nullable
+  public Duration getScheduleToCloseTimeout() {
+    if (activityTaskBuilder.hasScheduleToCloseTimeout()) {
+      return ProtobufTimeUtils.toJavaDuration(activityTaskBuilder.getScheduleToCloseTimeout());
+    } else {
+      return null;
+    }
   }
 
   public boolean isDoNotIncludeArgumentsIntoMarker() {
     return doNotIncludeArgumentsIntoMarker;
   }
 
-  @Override
-  public String toString() {
-    return "ExecuteLocalActivityParameters{"
-        + "activityTask="
-        + activityTask
-        + ", localRetryThreshold="
-        + localRetryThreshold
-        + '}';
+  public Duration getLocalRetryThreshold() {
+    return localRetryThreshold;
+  }
+
+  public void setOriginalScheduledTimestamp(long scheduledTimestamp) {
+    this.originalScheduledTimestamp = scheduledTimestamp;
+  }
+
+  public long getOriginalScheduledTimestamp() {
+    return originalScheduledTimestamp;
+  }
+
+  @Nonnull
+  public PollActivityTaskQueueResponse getInitialActivityTask() {
+    return initialActivityTask;
+  }
+
+  // Keep usage of this method limited as modifying the protobuf builder is not thread safe
+  @Nonnull
+  public PollActivityTaskQueueResponse.Builder getActivityTaskBuilder() {
+    return activityTaskBuilder;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -392,13 +392,21 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
             .setWorkflowType(this.replayContext.getWorkflowType())
             .setWorkflowExecution(this.replayContext.getWorkflowExecution())
             .setScheduledTime(ProtobufTimeUtils.getCurrentProtoTime())
-            .setStartToCloseTimeout(
-                ProtobufTimeUtils.toProtoDuration(options.getStartToCloseTimeout()))
-            .setScheduleToCloseTimeout(
-                ProtobufTimeUtils.toProtoDuration(options.getScheduleToCloseTimeout()))
             .setStartedTime(ProtobufTimeUtils.getCurrentProtoTime())
             .setActivityType(ActivityType.newBuilder().setName(name))
             .setAttempt(attempt);
+
+    Duration scheduleToCloseTimeout = options.getScheduleToCloseTimeout();
+    if (scheduleToCloseTimeout != null) {
+      activityTask.setScheduleToCloseTimeout(
+          ProtobufTimeUtils.toProtoDuration(scheduleToCloseTimeout));
+    }
+
+    Duration startToCloseTimeout = options.getStartToCloseTimeout();
+    if (startToCloseTimeout != null) {
+      activityTask.setStartToCloseTimeout(ProtobufTimeUtils.toProtoDuration(startToCloseTimeout));
+    }
+
     io.temporal.api.common.v1.Header grpcHeader =
         toHeaderGrpc(header, extractContextsAndConvertToBytes(contextPropagators));
     activityTask.setHeader(grpcHeader);
@@ -411,7 +419,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
       localRetryThreshold = replayContext.getWorkflowTaskTimeout().multipliedBy(6);
     }
     return new ExecuteLocalActivityParameters(
-        activityTask, localRetryThreshold, options.isDoNotIncludeArgumentsIntoMarker());
+        activityTask, null, options.isDoNotIncludeArgumentsIntoMarker(), localRetryThreshold);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTaskHandler.java
@@ -24,7 +24,6 @@ import com.uber.m3.tally.Scope;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest;
-import java.time.Duration;
 
 /**
  * Interface of an activity task handler.
@@ -40,8 +39,6 @@ public interface ActivityTaskHandler {
     private final TaskFailedResult taskFailed;
     private final RespondActivityTaskCanceledRequest taskCanceled;
     private final boolean manualCompletion;
-    private int attempt;
-    private Duration backoff;
 
     @Override
     public String toString() {
@@ -55,10 +52,6 @@ public interface ActivityTaskHandler {
           + taskFailed
           + ", taskCanceled="
           + taskCanceled
-          + ", attempt="
-          + attempt
-          + ", backoff="
-          + backoff
           + '}';
     }
 
@@ -115,22 +108,6 @@ public interface ActivityTaskHandler {
       return taskCanceled;
     }
 
-    public void setAttempt(int attempt) {
-      this.attempt = attempt;
-    }
-
-    public int getAttempt() {
-      return attempt;
-    }
-
-    public void setBackoff(Duration backoff) {
-      this.backoff = backoff;
-    }
-
-    public Duration getBackoff() {
-      return backoff;
-    }
-
     public boolean isManualCompletion() {
       return manualCompletion;
     }
@@ -138,7 +115,7 @@ public interface ActivityTaskHandler {
 
   /**
    * The implementation should be called when a polling activity worker receives a new activity
-   * task. This method shouldn't throw any exception unless there is a need to not reply to the
+   * task. This method shouldn't throw any Throwables unless there is a need to not reply to the
    * task.
    *
    * @param activityTask activity task which is response to PollActivityTaskQueue call.

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityAttemptTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityAttemptTask.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
+import javax.annotation.Nonnull;
+
+// TODO This class is an absolutely trivial wrapper and may go away with reworking of local activity
+//  scheduling from the generic poller classes.
+class LocalActivityAttemptTask {
+  private final @Nonnull LocalActivityExecutionContext executionContext;
+  private final @Nonnull PollActivityTaskQueueResponse attemptTask;
+
+  public LocalActivityAttemptTask(
+      @Nonnull LocalActivityExecutionContext executionContext,
+      @Nonnull PollActivityTaskQueueResponse attemptTask) {
+    this.executionContext = executionContext;
+    this.attemptTask = attemptTask;
+  }
+
+  @Nonnull
+  public LocalActivityExecutionContext getExecutionContext() {
+    return executionContext;
+  }
+
+  public String getActivityId() {
+    return executionContext.getActivityId();
+  }
+
+  @Nonnull
+  public ExecuteLocalActivityParameters getExecutionParams() {
+    return executionContext.getExecutionParams();
+  }
+
+  @Nonnull
+  public PollActivityTaskQueueResponse getAttemptTask() {
+    return attemptTask;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityDispatcher.java
@@ -23,26 +23,12 @@ package io.temporal.internal.worker;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
 import io.temporal.workflow.Functions;
 
-public class LocalActivityTask {
-  private final ExecuteLocalActivityParameters params;
-  private final Functions.Proc1<ActivityTaskHandler.Result> resultCallback;
-
-  public LocalActivityTask(
-      ExecuteLocalActivityParameters params,
-      Functions.Proc1<ActivityTaskHandler.Result> resultCallback) {
-    this.params = params;
-    this.resultCallback = resultCallback;
-  }
-
-  public String getActivityId() {
-    return params.getActivityTask().getActivityId();
-  }
-
-  public ExecuteLocalActivityParameters getParams() {
-    return params;
-  }
-
-  public Functions.Proc1<ActivityTaskHandler.Result> getResultCallback() {
-    return resultCallback;
-  }
+public interface LocalActivityDispatcher {
+  /**
+   * Synchronously dispatches the local activity to the local activity worker.
+   *
+   * @return true if the local activity was accepted, false if it was rejected
+   */
+  boolean dispatch(
+      ExecuteLocalActivityParameters params, Functions.Proc1<LocalActivityResult> resultCallback);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityExecutionContext.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+import io.grpc.Deadline;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.workflow.v1.PendingActivityInfo;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
+import io.temporal.workflow.Functions;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+class LocalActivityExecutionContext {
+  private final @Nonnull ExecuteLocalActivityParameters executionParams;
+  private final @Nonnull Deadline localRetryDeadline;
+  private final @Nonnull CompletableFuture<LocalActivityResult> executionResult =
+      new CompletableFuture<>();
+
+  private final @Nullable Deadline scheduleToCloseDeadline;
+
+  private final @Nonnull AtomicInteger currentAttempt;
+
+  private final @Nonnull AtomicReference<Failure> lastFailure = new AtomicReference<>();
+
+  private @Nullable ScheduledFuture<?> scheduleToCloseFuture;
+
+  public LocalActivityExecutionContext(
+      @Nonnull ExecuteLocalActivityParameters executionParams,
+      @Nonnull Functions.Proc1<LocalActivityResult> resultCallback,
+      @Nonnull Deadline localRetryDeadline,
+      @Nullable Deadline scheduleToCloseDeadline) {
+    this.executionParams = Objects.requireNonNull(executionParams, "executionParams");
+    this.executionResult.thenAccept(
+        Objects.requireNonNull(resultCallback, "resultCallback")::apply);
+    this.localRetryDeadline = localRetryDeadline;
+    this.scheduleToCloseDeadline = scheduleToCloseDeadline;
+    this.currentAttempt = new AtomicInteger(executionParams.getInitialAttempt());
+  }
+
+  public String getActivityId() {
+    return executionParams.getActivityId();
+  }
+
+  @Nonnull
+  public ExecuteLocalActivityParameters getExecutionParams() {
+    return executionParams;
+  }
+
+  @Nonnull
+  public Deadline getLocalRetryDeadline() {
+    return localRetryDeadline;
+  }
+
+  public int getCurrentAttempt() {
+    return currentAttempt.get();
+  }
+
+  /**
+   * The last failure preserved for this activity execution. This field is mimicking the behavior of
+   * {@link PendingActivityInfo#getLastFailure()} that is maintained by the server in the mutable
+   * state and is used to create ActivityFailures with meaningful causes and returned by {@link
+   * io.temporal.api.workflowservice.v1.WorkflowServiceGrpc.WorkflowServiceBlockingStub#describeWorkflowExecution(DescribeWorkflowExecutionRequest)}
+   */
+  @Nullable
+  public Failure getLastFailure() {
+    return lastFailure.get();
+  }
+
+  @Nonnull
+  public PollActivityTaskQueueResponse getNextAttemptActivityTask(@Nullable Failure lastFailure) {
+    // synchronization here is not absolutely needed as LocalActivityWorker#scheduleNextAttempt
+    // shouldn't be executed concurrently. But to make sure this code is safe for future changes,
+    // let's make this method atomic and protect thread-unsafe protobuf builder modification.
+
+    // executionResult here is used just as an internal monitor object that is final and never
+    // escapes the class
+    synchronized (executionResult) {
+      int nextAttempt = currentAttempt.incrementAndGet();
+      if (lastFailure != null) {
+        this.lastFailure.set(lastFailure);
+      }
+      return executionParams.getActivityTaskBuilder().setAttempt(nextAttempt).build();
+    }
+  }
+
+  @Nullable
+  public Deadline getScheduleToCloseDeadline() {
+    return scheduleToCloseDeadline;
+  }
+
+  public void setScheduleToCloseFuture(@Nullable ScheduledFuture<?> scheduleToCloseFuture) {
+    this.scheduleToCloseFuture = scheduleToCloseFuture;
+  }
+
+  public boolean callback(LocalActivityResult result) {
+    if (scheduleToCloseFuture != null) {
+      scheduleToCloseFuture.cancel(false);
+    }
+    return executionResult.complete(result);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityResult.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.worker;
+
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest;
+import io.temporal.api.workflowservice.v1.RespondActivityTaskCompletedRequest;
+import java.time.Duration;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class LocalActivityResult {
+  private final @Nonnull String activityId;
+  private final @Nullable RespondActivityTaskCompletedRequest executionCompleted;
+  private final @Nullable ExecutionFailedResult executionFailed;
+  private final @Nullable RespondActivityTaskCanceledRequest executionCanceled;
+
+  static LocalActivityResult completed(ActivityTaskHandler.Result ahResult) {
+    return new LocalActivityResult(
+        ahResult.getActivityId(), ahResult.getTaskCompleted(), null, null);
+  }
+
+  static LocalActivityResult failed(
+      String activityId,
+      RetryState retryState,
+      Failure timeoutFailure,
+      int attempt,
+      @Nullable Duration backoff) {
+    ExecutionFailedResult failedResult =
+        new ExecutionFailedResult(retryState, timeoutFailure, attempt, backoff);
+    return new LocalActivityResult(activityId, null, failedResult, null);
+  }
+
+  static LocalActivityResult cancelled(ActivityTaskHandler.Result ahResult) {
+    return new LocalActivityResult(
+        ahResult.getActivityId(), null, null, ahResult.getTaskCanceled());
+  }
+
+  /**
+   * Only zero (manual activity completion) or one request is allowed. Task token and identity
+   * fields shouldn't be filled in. Retry options are the service call. These options override the
+   * default ones set on the activity worker.
+   */
+  public LocalActivityResult(
+      @Nonnull String activityId,
+      @Nullable RespondActivityTaskCompletedRequest executionCompleted,
+      @Nullable ExecutionFailedResult executionFailed,
+      @Nullable RespondActivityTaskCanceledRequest executionCanceled) {
+    this.activityId = activityId;
+    this.executionCompleted = executionCompleted;
+    this.executionFailed = executionFailed;
+    this.executionCanceled = executionCanceled;
+  }
+
+  @Nonnull
+  public String getActivityId() {
+    return activityId;
+  }
+
+  @Nullable
+  public RespondActivityTaskCompletedRequest getExecutionCompleted() {
+    return executionCompleted;
+  }
+
+  @Nullable
+  public ExecutionFailedResult getExecutionFailed() {
+    return executionFailed;
+  }
+
+  @Nullable
+  public RespondActivityTaskCanceledRequest getExecutionCanceled() {
+    return executionCanceled;
+  }
+
+  @Override
+  public String toString() {
+    return "LocalActivityResult{"
+        + "activityId='"
+        + activityId
+        + '\''
+        + ", executionCompleted="
+        + executionCompleted
+        + ", executionFailed="
+        + executionFailed
+        + ", executionCanceled="
+        + executionCanceled
+        + '}';
+  }
+
+  public static class ExecutionFailedResult {
+    @Nonnull private final RetryState retryState;
+    @Nonnull private final Failure failure;
+    private final int lastAttempt;
+    @Nullable private final Duration backoff;
+
+    public ExecutionFailedResult(
+        @Nonnull RetryState retryState,
+        @Nonnull Failure failure,
+        int lastAttempt,
+        @Nullable Duration backoff) {
+      this.retryState = retryState;
+      this.failure = failure;
+      this.lastAttempt = lastAttempt;
+      this.backoff = backoff;
+    }
+
+    @Nonnull
+    public RetryState getRetryState() {
+      return retryState;
+    }
+
+    @Nonnull
+    public Failure getFailure() {
+      return failure;
+    }
+
+    public int getLastAttempt() {
+      return lastAttempt;
+    }
+
+    @Nullable
+    public Duration getBackoff() {
+      return backoff;
+    }
+
+    public boolean isTimeout() {
+      return failure.hasTimeoutFailureInfo();
+    }
+
+    @Override
+    public String toString() {
+      return "ExecutionFailedResult{"
+          + "retryState="
+          + retryState
+          + ", failure="
+          + failure
+          + ", lastAttempt="
+          + lastAttempt
+          + ", backoff="
+          + backoff
+          + '}';
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -20,30 +20,35 @@
 
 package io.temporal.internal.worker;
 
-import com.google.protobuf.util.Timestamps;
+import static io.temporal.internal.worker.LocalActivityResult.failed;
+
+import com.google.common.base.Preconditions;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
-import io.temporal.api.common.v1.RetryPolicy;
+import io.grpc.Deadline;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.api.enums.v1.TimeoutType;
 import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.failure.v1.TimeoutFailureInfo;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
-import io.temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest;
+import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponseOrBuilder;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.FailureConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.internal.common.RetryOptionsUtils;
 import io.temporal.internal.logging.LoggerTag;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerMetricsTag;
+import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
+import java.util.concurrent.*;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -51,14 +56,31 @@ import org.slf4j.MDC;
 final class LocalActivityWorker implements SuspendableWorker {
   private static final Logger log = LoggerFactory.getLogger(LocalActivityWorker.class);
 
-  @Nonnull private SuspendableWorker poller = new NoopSuspendableWorker();
+  // RETRY_STATE_IN_PROGRESS shows that it's not the end
+  // for this local activity execution from the workflow point of view.
+  // It's also not conflicting with any other situations
+  // and uniquely identifies the reach of the local retries
+  // and a need to schedule a timer.
+  private static final RetryState LOCAL_RETRY_LIMIT_RETRY_STATE =
+      RetryState.RETRY_STATE_IN_PROGRESS;
+
   private final ActivityTaskHandler handler;
   private final String namespace;
   private final String taskQueue;
+  private final ScheduledExecutorService scheduledExecutor;
+
   private final SingleWorkerOptions options;
+
+  private static final int QUEUE_SIZE = 1000;
+  private final BlockingQueue<LocalActivityAttemptTask> pendingTasks =
+      new ArrayBlockingQueue<>(QUEUE_SIZE);
   private final LocalActivityPollTask laPollTask;
+  private final LocalActivityDispatcherImpl laScheduler;
+
   private final PollerOptions pollerOptions;
   private final Scope workerMetricsScope;
+
+  @Nonnull private SuspendableWorker poller = new NoopSuspendableWorker();
 
   public LocalActivityWorker(
       @Nonnull String namespace,
@@ -67,8 +89,18 @@ final class LocalActivityWorker implements SuspendableWorker {
       @Nonnull ActivityTaskHandler handler) {
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
+    this.scheduledExecutor =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread thread = new Thread(r);
+              thread.setName(
+                  WorkerThreadsNameHelper.getLocalActivitySchedulerThreadPrefix(
+                      namespace, taskQueue));
+              return thread;
+            });
     this.handler = handler;
-    this.laPollTask = new LocalActivityPollTask();
+    this.laPollTask = new LocalActivityPollTask(pendingTasks);
+    this.laScheduler = new LocalActivityDispatcherImpl();
     this.options = Objects.requireNonNull(options);
     this.pollerOptions = getPollerOptions(options);
     this.workerMetricsScope =
@@ -79,7 +111,7 @@ final class LocalActivityWorker implements SuspendableWorker {
   @Override
   public void start() {
     if (handler.isAnyTypeSupported()) {
-      PollTaskExecutor<LocalActivityTask> pollTaskExecutor =
+      PollTaskExecutor<LocalActivityAttemptTask> pollTaskExecutor =
           new PollTaskExecutor<>(
               namespace,
               taskQueue,
@@ -100,6 +132,360 @@ final class LocalActivityWorker implements SuspendableWorker {
     }
   }
 
+  private boolean submitAnAttempt(LocalActivityAttemptTask task) {
+    try {
+      @Nullable
+      Duration scheduleToStartTimeout = task.getExecutionParams().getScheduleToStartTimeout();
+      boolean accepted =
+          scheduleToStartTimeout != null
+              ? pendingTasks.offer(task, scheduleToStartTimeout.toMillis(), TimeUnit.MILLISECONDS)
+              : pendingTasks.offer(task);
+      if (accepted) {
+        log.trace("LocalActivity queued: {}", task.getActivityId());
+      } else {
+        log.trace(
+            "LocalActivity queue submitting timed out for activity {}, scheduleToStartTimeout: {}",
+            task.getActivityId(),
+            scheduleToStartTimeout);
+      }
+      return accepted;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  /**
+   * @param executionContext execution context of the activity
+   * @param activityTask activity task
+   * @param executionThrowable exception happened during the activity execution. Can be null (for
+   *     startToClose timeout)
+   * @return decision to retry or not with a retry state, backoff or delay to the next attempt if
+   *     applicable
+   */
+  @Nonnull
+  private RetryDecision shouldRetry(
+      LocalActivityExecutionContext executionContext,
+      PollActivityTaskQueueResponse activityTask,
+      @Nullable Throwable executionThrowable) {
+    int currentAttempt = activityTask.getAttempt();
+
+    if (isNonRetryableApplicationFailure(executionThrowable)) {
+      return new RetryDecision(RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE, null);
+    }
+
+    if (executionThrowable instanceof Error) {
+      // TODO Error inside Local Activity shouldn't be failing the local activity call.
+      //  Instead we should fail Workflow Task. Implement a special flag for that in the result.
+      //          task.callback(executionFailed(activityHandlerResult,
+      // RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, currentAttempt));
+      // don't just swallow Error from activities, propagate it to the top
+      throw (Error) executionThrowable;
+    }
+
+    if (isRetryPolicyNotSet(activityTask)) {
+      return new RetryDecision(RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET, null);
+    }
+
+    RetryOptions retryOptions = RetryOptionsUtils.toRetryOptions(activityTask.getRetryPolicy());
+
+    if (RetryOptionsUtils.isNotRetryable(retryOptions, executionThrowable)) {
+      return new RetryDecision(RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE, null);
+    }
+
+    if (RetryOptionsUtils.areAttemptsReached(retryOptions, currentAttempt)) {
+      return new RetryDecision(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, null);
+    }
+
+    long sleepMillis = retryOptions.calculateSleepTime(currentAttempt);
+    if (RetryOptionsUtils.isDeadlineReached(
+        executionContext.getScheduleToCloseDeadline(), sleepMillis)) {
+      return new RetryDecision(RetryState.RETRY_STATE_TIMEOUT, null);
+    }
+
+    if (executionContext.getLocalRetryDeadline().timeRemaining(TimeUnit.MILLISECONDS)
+        <= sleepMillis) {
+      return new RetryDecision(LOCAL_RETRY_LIMIT_RETRY_STATE, Duration.ofMillis(sleepMillis));
+    }
+
+    return new RetryDecision(Duration.ofMillis(sleepMillis));
+  }
+
+  /**
+   * @param executionContext execution context of the activity
+   * @param backoff delay time in milliseconds to the next attempt
+   * @param failure if supplied, it will be used to override {@link
+   *     LocalActivityExecutionContext#getLastFailure()}
+   */
+  private void scheduleNextAttempt(
+      LocalActivityExecutionContext executionContext,
+      @Nonnull Duration backoff,
+      @Nullable Failure failure) {
+    PollActivityTaskQueueResponse nextActivityTask =
+        executionContext.getNextAttemptActivityTask(failure);
+    LocalActivityAttemptTask task =
+        new LocalActivityAttemptTask(executionContext, nextActivityTask);
+    Deadline.after(backoff.toMillis(), TimeUnit.MILLISECONDS)
+        .runOnExpiration(new LocalActivityRetryHandler(task), scheduledExecutor);
+  }
+
+  private class LocalActivityDispatcherImpl implements LocalActivityDispatcher {
+    @Override
+    public boolean dispatch(
+        ExecuteLocalActivityParameters params,
+        Functions.Proc1<LocalActivityResult> resultCallback) {
+
+      long localRetryThresholdMs = params.getLocalRetryThreshold().toMillis();
+      Preconditions.checkState(localRetryThresholdMs > 0, "localRetryThresholdMs must be > 0");
+      Deadline localRetryDeadline = Deadline.after(localRetryThresholdMs, TimeUnit.MILLISECONDS);
+
+      long passedFromOriginalSchedulingMs = 0;
+      if (params.getOriginalScheduledTimestamp() != ExecuteLocalActivityParameters.NOT_SCHEDULED) {
+        passedFromOriginalSchedulingMs =
+            System.currentTimeMillis() - params.getOriginalScheduledTimestamp();
+      } else {
+        params.setOriginalScheduledTimestamp(System.currentTimeMillis());
+      }
+
+      Duration scheduleToCloseTimeout = params.getScheduleToCloseTimeout();
+      Deadline scheduleToCloseDeadline = null;
+      if (scheduleToCloseTimeout != null) {
+        scheduleToCloseDeadline =
+            Deadline.after(
+                scheduleToCloseTimeout.toMillis() - passedFromOriginalSchedulingMs,
+                TimeUnit.MILLISECONDS);
+      }
+
+      LocalActivityExecutionContext executionContext =
+          new LocalActivityExecutionContext(
+              params, resultCallback, localRetryDeadline, scheduleToCloseDeadline);
+
+      LocalActivityAttemptTask task =
+          new LocalActivityAttemptTask(executionContext, params.getInitialActivityTask());
+      boolean accepted = submitAnAttempt(task);
+
+      if (accepted) {
+        if (scheduleToCloseDeadline != null) {
+          ScheduledFuture<?> scheduledScheduleToClose =
+              scheduledExecutor.schedule(
+                  new ScheduleToCloseTimeoutHandler(executionContext),
+                  scheduleToCloseDeadline.timeRemaining(TimeUnit.MILLISECONDS),
+                  TimeUnit.MILLISECONDS);
+          executionContext.setScheduleToCloseFuture(scheduledScheduleToClose);
+        }
+      }
+
+      return accepted;
+    }
+  }
+
+  private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<LocalActivityAttemptTask> {
+
+    private final ActivityTaskHandler handler;
+
+    private TaskHandlerImpl(ActivityTaskHandler handler) {
+      this.handler = handler;
+    }
+
+    @Override
+    public void handle(LocalActivityAttemptTask attemptTask) throws Exception {
+      LocalActivityExecutionContext executionContext = attemptTask.getExecutionContext();
+      PollActivityTaskQueueResponse activityTask = attemptTask.getAttemptTask();
+      String activityId = activityTask.getActivityId();
+
+      Scope metricsScope =
+          workerMetricsScope.tagged(
+              ImmutableMap.of(
+                  MetricsTag.ACTIVITY_TYPE,
+                  activityTask.getActivityType().getName(),
+                  MetricsTag.WORKFLOW_TYPE,
+                  activityTask.getWorkflowType().getName()));
+
+      int currentAttempt = activityTask.getAttempt();
+
+      MDC.put(LoggerTag.ACTIVITY_ID, activityId);
+      MDC.put(LoggerTag.ACTIVITY_TYPE, activityTask.getActivityType().getName());
+      MDC.put(LoggerTag.WORKFLOW_ID, activityTask.getWorkflowExecution().getWorkflowId());
+      MDC.put(LoggerTag.WORKFLOW_TYPE, activityTask.getWorkflowType().getName());
+      MDC.put(LoggerTag.RUN_ID, activityTask.getWorkflowExecution().getRunId());
+      try {
+        ScheduledFuture<?> startToCloseTimeoutFuture = null;
+
+        if (activityTask.hasStartToCloseTimeout()) {
+          startToCloseTimeoutFuture =
+              scheduledExecutor.schedule(
+                  new StartToCloseTimeoutHandler(attemptTask),
+                  ProtobufTimeUtils.toJavaDuration(
+                          attemptTask.getAttemptTask().getStartToCloseTimeout())
+                      .toMillis(),
+                  TimeUnit.MILLISECONDS);
+        }
+
+        metricsScope.counter(MetricsType.LOCAL_ACTIVITY_TOTAL_COUNTER).inc(1);
+
+        ActivityTaskHandler.Result activityHandlerResult;
+        Stopwatch sw = metricsScope.timer(MetricsType.LOCAL_ACTIVITY_EXECUTION_LATENCY).start();
+        try {
+          activityHandlerResult =
+              handler.handle(new ActivityTask(activityTask, () -> {}), metricsScope, true);
+        } finally {
+          sw.stop();
+        }
+
+        // Making sure that the result handling code following this statement is mutual exclusive
+        // with the start to close timeout handler.
+        boolean startToCloseTimeoutFired =
+            startToCloseTimeoutFuture != null && !startToCloseTimeoutFuture.cancel(false);
+
+        if (startToCloseTimeoutFired) {
+          // If start to close timeout fired, the result of this activity execution should be
+          // discarded.
+          // Scheduling of the next attempt is taken care by the StartToCloseTimeoutHandler.
+          return;
+        }
+
+        if (activityHandlerResult.getTaskCompleted() != null) {
+          com.uber.m3.util.Duration e2eDuration =
+              ProtobufTimeUtils.toM3DurationSinceNow(activityTask.getScheduledTime());
+          metricsScope.timer(MetricsType.LOCAL_ACTIVITY_SUCCEED_E2E_LATENCY).record(e2eDuration);
+          executionContext.callback(LocalActivityResult.completed(activityHandlerResult));
+          return;
+        }
+
+        if (activityHandlerResult.getTaskCanceled() != null) {
+          executionContext.callback(LocalActivityResult.cancelled(activityHandlerResult));
+          return;
+        }
+
+        Preconditions.checkState(
+            activityHandlerResult.getTaskFailed() != null,
+            "One of taskCompleted, taskCanceled or taskFailed must be set");
+
+        Failure executionFailure =
+            activityHandlerResult.getTaskFailed().getTaskFailedRequest().getFailure();
+
+        RetryDecision retryDecision =
+            shouldRetry(
+                executionContext, activityTask, activityHandlerResult.getTaskFailed().getFailure());
+        if (retryDecision.doNextAttempt()) {
+          scheduleNextAttempt(
+              executionContext,
+              Objects.requireNonNull(
+                  retryDecision.nextAttemptBackoff,
+                  "nextAttemptBackoff is expected to not be null"),
+              executionFailure);
+        } else {
+          executionContext.callback(
+              failed(
+                  activityId,
+                  retryDecision.retryState,
+                  executionFailure,
+                  currentAttempt,
+                  retryDecision.nextAttemptBackoff));
+        }
+
+      } catch (Throwable ex) {
+        // handleLocalActivity is expected to never throw an exception and return a result
+        // that can be used for a workflow callback if this method throws, it's a bug.
+        log.error("[BUG] Code that expected to never throw an exception threw an exception", ex);
+        Failure failure = FailureConverter.exceptionToFailure(ex);
+        executionContext.callback(
+            failed(
+                activityId,
+                RetryState.RETRY_STATE_INTERNAL_SERVER_ERROR,
+                failure,
+                currentAttempt,
+                null));
+        throw ex;
+      } finally {
+        MDC.remove(LoggerTag.ACTIVITY_ID);
+        MDC.remove(LoggerTag.ACTIVITY_TYPE);
+        MDC.remove(LoggerTag.WORKFLOW_ID);
+        MDC.remove(LoggerTag.WORKFLOW_TYPE);
+        MDC.remove(LoggerTag.RUN_ID);
+      }
+    }
+
+    @Override
+    public Throwable wrapFailure(LocalActivityAttemptTask task, Throwable failure) {
+      return new RuntimeException("Failure processing local activity task.", failure);
+    }
+  }
+
+  private class LocalActivityRetryHandler implements Runnable {
+    private final LocalActivityAttemptTask localActivityAttemptTask;
+
+    private LocalActivityRetryHandler(LocalActivityAttemptTask localActivityAttemptTask) {
+      this.localActivityAttemptTask = localActivityAttemptTask;
+    }
+
+    @Override
+    public void run() {
+      submitAnAttempt(localActivityAttemptTask);
+    }
+  }
+
+  private static class ScheduleToCloseTimeoutHandler implements Runnable {
+    private final LocalActivityExecutionContext executionContext;
+
+    private ScheduleToCloseTimeoutHandler(LocalActivityExecutionContext executionContext) {
+      this.executionContext = executionContext;
+    }
+
+    @Override
+    public void run() {
+      executionContext.callback(
+          failed(
+              executionContext.getActivityId(),
+              RetryState.RETRY_STATE_TIMEOUT,
+              newTimeoutFailure(
+                  TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, executionContext.getLastFailure()),
+              executionContext.getCurrentAttempt(),
+              null));
+    }
+  }
+
+  private class StartToCloseTimeoutHandler implements Runnable {
+    private final LocalActivityAttemptTask attemptTask;
+
+    private StartToCloseTimeoutHandler(LocalActivityAttemptTask attemptTask) {
+      this.attemptTask = attemptTask;
+    }
+
+    @Override
+    public void run() {
+      LocalActivityExecutionContext executionContext = attemptTask.getExecutionContext();
+      PollActivityTaskQueueResponse activityTask = attemptTask.getAttemptTask();
+      String activityId = activityTask.getActivityId();
+
+      int timingOutAttempt = activityTask.getAttempt();
+
+      RetryDecision retryDecision = shouldRetry(executionContext, activityTask, null);
+      if (retryDecision.doNextAttempt()) {
+        scheduleNextAttempt(
+            executionContext,
+            Objects.requireNonNull(
+                retryDecision.nextAttemptBackoff, "nextAttemptBackoff is expected to not be null"),
+            // null because schedule to start / close is not meaningful
+            newTimeoutFailure(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, null));
+      } else {
+        // RetryState.RETRY_STATE_TIMEOUT happens only when scheduleToClose is fired
+        // scheduleToClose timeout is effectively replacing the original startToClose
+        TimeoutType timeoutType =
+            RetryState.RETRY_STATE_TIMEOUT.equals(retryDecision.retryState)
+                ? TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE
+                : TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE;
+        executionContext.callback(
+            failed(
+                activityId,
+                retryDecision.retryState,
+                newTimeoutFailure(timeoutType, executionContext.getLastFailure()),
+                timingOutAttempt,
+                retryDecision.nextAttemptBackoff));
+      }
+    }
+  }
+
   public boolean isAnyTypeSupported() {
     return handler.isAnyTypeSupported();
   }
@@ -116,17 +502,29 @@ final class LocalActivityWorker implements SuspendableWorker {
 
   @Override
   public boolean isTerminated() {
-    return poller.isTerminated();
+    return poller.isTerminated() && scheduledExecutor.isTerminated();
   }
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
-    return poller.shutdown(shutdownManager, interruptTasks);
+    return poller
+        .shutdown(shutdownManager, interruptTasks)
+        .thenCompose(
+            r ->
+                shutdownManager.shutdownExecutor(
+                    scheduledExecutor, this + "#scheduledExecutor", Duration.ofSeconds(1)))
+        .exceptionally(
+            e -> {
+              log.error("[BUG] Unexpected exception during shutdown", e);
+              return null;
+            });
   }
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    poller.awaitTermination(timeout, unit);
+    long timeoutMillis = unit.toMillis(timeout);
+    timeoutMillis = ShutdownManager.awaitTermination(poller, timeoutMillis);
+    ShutdownManager.awaitTermination(scheduledExecutor, timeoutMillis);
   }
 
   @Override
@@ -156,179 +554,49 @@ final class LocalActivityWorker implements SuspendableWorker {
     return pollerOptions;
   }
 
-  public BiFunction<LocalActivityTask, Duration, Boolean> getLocalActivityTaskPoller() {
-    return laPollTask;
+  public LocalActivityDispatcher getLocalActivityScheduler() {
+    return laScheduler;
   }
 
-  private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<LocalActivityTask> {
-
-    private final ActivityTaskHandler handler;
-
-    private TaskHandlerImpl(ActivityTaskHandler handler) {
-      this.handler = handler;
+  private static Failure newTimeoutFailure(TimeoutType timeoutType, @Nullable Failure cause) {
+    TimeoutFailureInfo.Builder info = TimeoutFailureInfo.newBuilder().setTimeoutType(timeoutType);
+    Failure.Builder result = Failure.newBuilder().setTimeoutFailureInfo(info);
+    if (cause != null) {
+      result.setCause(cause);
     }
-
-    @Override
-    public void handle(LocalActivityTask task) throws Exception {
-      ExecuteLocalActivityParameters params = task.getParams();
-      PollActivityTaskQueueResponse.Builder activityTask = params.getActivityTask();
-      Scope metricsScope =
-          workerMetricsScope.tagged(
-              ImmutableMap.of(
-                  MetricsTag.ACTIVITY_TYPE,
-                  activityTask.getActivityType().getName(),
-                  MetricsTag.WORKFLOW_TYPE,
-                  activityTask.getWorkflowType().getName()));
-
-      MDC.put(LoggerTag.ACTIVITY_ID, activityTask.getActivityId());
-      MDC.put(LoggerTag.ACTIVITY_TYPE, activityTask.getActivityType().getName());
-      MDC.put(LoggerTag.WORKFLOW_ID, activityTask.getWorkflowExecution().getWorkflowId());
-      MDC.put(LoggerTag.WORKFLOW_TYPE, activityTask.getWorkflowType().getName());
-      MDC.put(LoggerTag.RUN_ID, activityTask.getWorkflowExecution().getRunId());
-
-      ActivityTaskHandler.Result result = null;
-      try {
-        result =
-            handleLocalActivity(
-                params.getActivityTask(),
-                System.currentTimeMillis(),
-                params.getLocalRetryThreshold().toMillis(),
-                metricsScope);
-      } catch (Throwable ex) {
-        // handleLocalActivity if expected to never throw an exception and return result
-        // that can be used for a workflow callback if this method throws, it's a bug.
-        log.error("[BUG] Code that expected to never throw an exception threw an exception", ex);
-
-        // Even if some unexpected underlying exception happened, wee have to create the result
-        // and make it published to the caller any way. But it's not a normal code path.
-        Failure failure = FailureConverter.exceptionToFailure(ex);
-        RespondActivityTaskFailedRequest.Builder taskFailedRequest =
-            RespondActivityTaskFailedRequest.newBuilder().setFailure(failure);
-        result =
-            new ActivityTaskHandler.Result(
-                params.getActivityTask().getActivityId(),
-                null,
-                new ActivityTaskHandler.Result.TaskFailedResult(taskFailedRequest.build(), ex),
-                null,
-                false);
-        throw ex;
-      } finally {
-        MDC.remove(LoggerTag.ACTIVITY_ID);
-        MDC.remove(LoggerTag.ACTIVITY_TYPE);
-        MDC.remove(LoggerTag.WORKFLOW_ID);
-        MDC.remove(LoggerTag.WORKFLOW_TYPE);
-        MDC.remove(LoggerTag.RUN_ID);
-
-        task.getResultCallback().apply(result);
-      }
-
-      if (result.getTaskFailed() != null && result.getTaskFailed().getFailure() instanceof Error) {
-        // don't just swallow Error from activities, propagate it to the top
-        throw (Error) result.getTaskFailed().getFailure();
-      }
-    }
-
-    @Override
-    public Throwable wrapFailure(LocalActivityTask task, Throwable failure) {
-      return new RuntimeException("Failure processing local activity task.", failure);
-    }
-
-    private @Nonnull ActivityTaskHandler.Result handleLocalActivity(
-        PollActivityTaskQueueResponse.Builder activityTask,
-        long activityStartTimeMs,
-        long localRetryThresholdMs,
-        Scope metricsScope) {
-      int attempt = activityTask.getAttempt();
-
-      metricsScope.counter(MetricsType.LOCAL_ACTIVITY_TOTAL_COUNTER).inc(1);
-
-      ActivityTaskHandler.Result result;
-      Stopwatch sw = metricsScope.timer(MetricsType.LOCAL_ACTIVITY_EXECUTION_LATENCY).start();
-      try {
-        result =
-            handler.handle(new ActivityTask(activityTask.build(), () -> {}), metricsScope, true);
-      } finally {
-        sw.stop();
-      }
-      result.setAttempt(attempt);
-
-      if (isNonRetryableApplicationFailure(result)) {
-        return result;
-      }
-
-      if (result.getTaskCompleted() != null) {
-        com.uber.m3.util.Duration e2eDuration =
-            ProtobufTimeUtils.toM3DurationSinceNow(activityTask.getScheduledTime());
-        metricsScope.timer(MetricsType.LOCAL_ACTIVITY_SUCCEED_E2E_LATENCY).record(e2eDuration);
-      }
-
-      if (result.getTaskCompleted() != null
-          || result.getTaskCanceled() != null
-          || !activityTask.hasRetryPolicy()) {
-        return result;
-      }
-
-      RetryOptions retryOptions = buildRetryOptions(activityTask.getRetryPolicy());
-
-      long sleepMillis = retryOptions.calculateSleepTime(attempt);
-      long elapsedTask = System.currentTimeMillis() - activityStartTimeMs;
-      long sinceScheduled =
-          System.currentTimeMillis() - Timestamps.toMillis(activityTask.getScheduledTime());
-      long elapsedTotal = elapsedTask + sinceScheduled;
-      Duration timeout = ProtobufTimeUtils.toJavaDuration(activityTask.getScheduleToCloseTimeout());
-      Optional<Duration> expiration =
-          timeout.compareTo(Duration.ZERO) > 0 ? Optional.of(timeout) : Optional.empty();
-      if (retryOptions.shouldRethrow(
-          result.getTaskFailed().getFailure(), expiration, attempt, elapsedTotal, sleepMillis)) {
-        return result;
-      } else {
-        result.setBackoff(Duration.ofMillis(sleepMillis));
-      }
-
-      // For small backoff we do local retry. Otherwise we will schedule timer on server side.
-      // TODO(maxim): Use timer queue for retries to avoid tying up a thread.
-      if (elapsedTask + sleepMillis < localRetryThresholdMs) {
-        try {
-          Thread.sleep(sleepMillis);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          // if the activity thread got interrupted, we use the last failed result and exit fast
-          return result;
-        }
-        activityTask.setAttempt(attempt + 1);
-        return handleLocalActivity(
-            activityTask, activityStartTimeMs, localRetryThresholdMs, metricsScope);
-      } else {
-        return result;
-      }
-    }
+    return result.build();
   }
 
-  static RetryOptions buildRetryOptions(RetryPolicy retryPolicy) {
-    String[] doNotRetry = new String[retryPolicy.getNonRetryableErrorTypesCount()];
-    retryPolicy.getNonRetryableErrorTypesList().toArray(doNotRetry);
-    RetryOptions.Builder roBuilder = RetryOptions.newBuilder();
-    Duration maximumInterval = ProtobufTimeUtils.toJavaDuration(retryPolicy.getMaximumInterval());
-    if (!maximumInterval.isZero()) {
-      roBuilder.setMaximumInterval(maximumInterval);
-    }
-    Duration initialInterval = ProtobufTimeUtils.toJavaDuration(retryPolicy.getInitialInterval());
-    if (!initialInterval.isZero()) {
-      roBuilder.setInitialInterval(initialInterval);
-    }
-    if (retryPolicy.getBackoffCoefficient() >= 1) {
-      roBuilder.setBackoffCoefficient(retryPolicy.getBackoffCoefficient());
-    }
-    if (retryPolicy.getMaximumAttempts() > 0) {
-      roBuilder.setMaximumAttempts(retryPolicy.getMaximumAttempts());
-    }
-    return roBuilder.setDoNotRetry(doNotRetry).validateBuildWithDefaults();
+  private static boolean isRetryPolicyNotSet(
+      PollActivityTaskQueueResponseOrBuilder pollActivityTask) {
+    return !pollActivityTask.hasScheduleToCloseTimeout()
+        && (!pollActivityTask.hasRetryPolicy()
+            || pollActivityTask.getRetryPolicy().getMaximumAttempts() <= 0);
   }
 
-  private static boolean isNonRetryableApplicationFailure(ActivityTaskHandler.Result result) {
-    return result.getTaskFailed() != null
-        && result.getTaskFailed().getFailure() != null
-        && result.getTaskFailed().getFailure() instanceof ApplicationFailure
-        && ((ApplicationFailure) result.getTaskFailed().getFailure()).isNonRetryable();
+  private static boolean isNonRetryableApplicationFailure(@Nullable Throwable executionThrowable) {
+    return executionThrowable instanceof ApplicationFailure
+        && ((ApplicationFailure) executionThrowable).isNonRetryable();
+  }
+
+  private static class RetryDecision {
+    private final @Nullable RetryState retryState;
+    private final @Nullable Duration nextAttemptBackoff;
+
+    // No next local attempts
+    public RetryDecision(@Nonnull RetryState retryState, @Nullable Duration nextAttemptBackoff) {
+      this.retryState = retryState;
+      this.nextAttemptBackoff = nextAttemptBackoff;
+    }
+
+    // Do the next attempt
+    public RetryDecision(@Nonnull Duration nextAttemptBackoff) {
+      this.retryState = null;
+      this.nextAttemptBackoff = Objects.requireNonNull(nextAttemptBackoff);
+    }
+
+    public boolean doNextAttempt() {
+      return retryState == null;
+    }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -110,7 +110,7 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             stickyTaskQueueName,
             singleWorkerOptions.getStickyQueueScheduleToStartTimeout(),
             service,
-            laWorker.getLocalActivityTaskPoller());
+            laWorker.getLocalActivityScheduler());
 
     workflowWorker =
         new WorkflowWorker(
@@ -135,7 +135,7 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             null,
             Duration.ZERO,
             service,
-            laWorker.getLocalActivityTaskPoller());
+            laWorker.getLocalActivityScheduler());
 
     queryReplayHelper = new QueryReplayHelper(nonStickyReplayTaskHandler);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerThreadsNameHelper.java
@@ -28,6 +28,9 @@ class WorkerThreadsNameHelper {
   public static final String SHUTDOWN_MANAGER_THREAD_NAME_PREFIX = "TemporalShutdownManager";
   public static final String ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX = "TemporalActivityHeartbeat-";
 
+  public static final String LOCAL_ACTIVITY_SCHEDULER_THREAD_NAME_PREFIX =
+      "LocalActivityScheduler-";
+
   public static String getWorkflowPollerThreadPrefix(String namespace, String taskQueue) {
     return WORKFLOW_POLL_THREAD_NAME_PREFIX
         + "\""
@@ -57,5 +60,9 @@ class WorkerThreadsNameHelper {
 
   public static String getActivityHeartbeatThreadPrefix(String namespace, String taskQueue) {
     return ACTIVITY_HEARTBEAT_THREAD_NAME_PREFIX + namespace + "-" + taskQueue;
+  }
+
+  public static String getLocalActivitySchedulerThreadPrefix(String namespace, String taskQueue) {
+    return LOCAL_ACTIVITY_SCHEDULER_THREAD_NAME_PREFIX + namespace + "-" + taskQueue;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -271,7 +271,8 @@ public final class WorkerOptions {
     public Builder setMaxHeartbeatThrottleInterval(@Nullable Duration interval) {
       Preconditions.checkArgument(
           interval == null || !interval.isNegative(),
-          "Negative maxHeartbeatThrottleInterval value: " + interval);
+          "Negative maxHeartbeatThrottleInterval value: %s",
+          interval);
       this.maxHeartbeatThrottleInterval = interval;
       return this;
     }
@@ -286,7 +287,8 @@ public final class WorkerOptions {
     public Builder setDefaultHeartbeatThrottleInterval(@Nullable Duration interval) {
       Preconditions.checkArgument(
           interval == null || !interval.isNegative(),
-          "Negative defaultHeartbeatThrottleInterval value: " + interval);
+          "Negative defaultHeartbeatThrottleInterval value: %s",
+          interval);
       this.defaultHeartbeatThrottleInterval = interval;
       return this;
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/RetryOptionsUtilsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/RetryOptionsUtilsTest.java
@@ -18,17 +18,16 @@
  * limitations under the License.
  */
 
-package io.temporal.internal.worker;
+package io.temporal.internal.common;
 
 import static org.junit.Assert.assertEquals;
 
 import io.temporal.api.common.v1.RetryPolicy;
 import io.temporal.common.RetryOptions;
-import io.temporal.internal.common.ProtobufTimeUtils;
 import java.time.Duration;
 import org.junit.Test;
 
-public class LocalActivityWorkerTest {
+public class RetryOptionsUtilsTest {
   @Test
   public void buildRetryOptions() {
     Duration initialInterval = Duration.ofSeconds(2);
@@ -42,7 +41,7 @@ public class LocalActivityWorkerTest {
             .addNonRetryableErrorTypes(IllegalStateException.class.getName())
             .build();
 
-    RetryOptions retryOptions = LocalActivityWorker.buildRetryOptions(retryPolicy);
+    RetryOptions retryOptions = RetryOptionsUtils.toRetryOptions(retryPolicy);
     assertEquals(initialInterval, retryOptions.getInitialInterval());
     assertEquals(maxInterval, retryOptions.getMaximumInterval());
     assertEquals(5, retryOptions.getMaximumAttempts());

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
@@ -45,6 +45,7 @@ import io.temporal.internal.common.WorkflowExecutionUtils;
 import io.temporal.internal.history.LocalActivityMarkerUtils;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
 import io.temporal.internal.statemachines.WorkflowStateMachines;
+import io.temporal.internal.worker.LocalActivityDispatcher;
 import io.temporal.internal.worker.SingleWorkerOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkflowImplementationOptions;
@@ -52,7 +53,6 @@ import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestActivities;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
-import java.util.function.BiFunction;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -101,7 +101,7 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
             wft,
             SingleWorkerOptions.newBuilder().build(),
             new NoopScope(),
-            mock(BiFunction.class));
+            mock(LocalActivityDispatcher.class));
 
     stateMachines = handler.getWorkflowStateMachines();
     QueryResult queryResult =
@@ -152,7 +152,8 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
                                               .getMarkerRecordedEventAttributes()))
                                   .build()),
                       null,
-                      false),
+                      false,
+                      null),
                   (r, e) -> {});
               return false;
             })

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatBufferedEventTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatBufferedEventTest.java
@@ -91,7 +91,8 @@ public class LongLocalActivityWorkflowTaskHeartbeatBufferedEventTest {
     public String execute(String taskQueue) {
       VariousTestActivities localActivities =
           Workflow.newLocalActivityStub(
-              VariousTestActivities.class, SDKTestOptions.newLocalActivityOptions());
+              VariousTestActivities.class,
+              SDKTestOptions.newLocalActivityOptions20sScheduleToClose());
       Async.function(localActivities::sleepActivity, 10 * 1000L, 123);
       signaled.get();
       return "foo";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatTest.java
@@ -73,7 +73,8 @@ public class LongLocalActivityWorkflowTaskHeartbeatTest {
     public String execute(String taskQueue) {
       VariousTestActivities localActivities =
           Workflow.newLocalActivityStub(
-              VariousTestActivities.class, SDKTestOptions.newLocalActivityOptions());
+              VariousTestActivities.class,
+              SDKTestOptions.newLocalActivityOptions20sScheduleToClose());
       return localActivities.sleepActivity(5000, 123);
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
@@ -164,7 +164,8 @@ public class ChildWorkflowCancellationTest {
     public void execute() {
       TestActivities.VariousTestActivities localActivities =
           Workflow.newLocalActivityStub(
-              TestActivities.VariousTestActivities.class, SDKTestOptions.newLocalActivityOptions());
+              TestActivities.VariousTestActivities.class,
+              SDKTestOptions.newLocalActivityOptions20sScheduleToClose());
       try {
         Workflow.sleep(Duration.ofHours(1));
       } catch (CanceledFailure e) {


### PR DESCRIPTION
## What was changed

This PR implements a timer thread that independently of the local activity executors performs lifecycle management of local activities and allows to enforce timeouts.
The interface between LA workers and workflow code / state machines is reworked to allow LA workers to communicate different failure reasons / retry back to the workflow.
`startToClose` timeout and `scheduleToClose` timeout supports are implemented.
The ground is prepared for adding scheduleToStart timeout for local activities #1512
The workflow/LA interface is improved to prepare for #1261

## Why?

Previously Local Activities scheduling and management code were trivial.
One thread executes the activities, waits with sleep until the next attempt, and executes the next attempt.
While being simple, there is a bunch of Cons to this approach:
1. Executor thread is retained for the whole time of LA execution from the start until the finish.
2. This model allows us to enforce neither `startToClose` nor `scheduleToClose` timeouts because the only thread that manages an activity invocation is tied to the execution of the activity's code.
3. The is no way to start a new attempt until the end of the previous attempt.

Closes #1004