### PR TITLE
Add gatherRuntimeDeps task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ apply from: "$rootDir/gradle/errorprone.gradle"
 apply from: "$rootDir/gradle/licensing.gradle"
 apply from: "$rootDir/gradle/publishing.gradle"
 apply from: "$rootDir/gradle/dependencyManagement.gradle"
+apply from: "$rootDir/gradle/gatherDependencies.gradle"
 if (project.hasProperty("jacoco")) {
     apply from: "$rootDir/gradle/jacoco.gradle"
 }

--- a/gradle/gatherDependencies.gradle
+++ b/gradle/gatherDependencies.gradle
@@ -1,0 +1,8 @@
+subprojects {
+    // Creates build/runtimeDeps folder in each module that contains all the dependencies
+    // that need to be in the runtime classpath of the module
+    task gatherRuntimeDeps(type: Copy) {
+        from configurations.runtimeClasspath
+        into "${buildDir}/runtimeDeps"
+    }
+}


### PR DESCRIPTION
Adds `gatherRuntimeDeps` gradle task that creates `build/runtimeDeps` folder in each module. This folder contains all the dependencies that need to be in the runtime classpath of the module.
Helps to use java-sdk in projects that check out github repo and build the project from sources instead of using the released versions from Sonatype Rep.
