### PR TITLE
Test Environments now respect metricsScope passed in TestEnvironmentOptions and ServiceStubOptions

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestEnvironmentOptions.java
@@ -76,11 +76,15 @@ public final class TestEnvironmentOptions {
     private Builder() {}
 
     private Builder(TestEnvironmentOptions o) {
-      workerFactoryOptions = o.workerFactoryOptions;
-      workflowClientOptions = o.workflowClientOptions;
-      useExternalService = o.useExternalService;
-      target = o.target;
-      useTimeskipping = o.useTimeskipping;
+      this.workerFactoryOptions = o.workerFactoryOptions;
+      this.workflowClientOptions = o.workflowClientOptions;
+      this.workflowServiceStubsOptions = o.workflowServiceStubsOptions;
+      this.metricsScope = o.metricsScope;
+      this.useExternalService = o.useExternalService;
+      this.target = o.target;
+      this.initialTimeMillis = o.initialTimeMillis;
+      this.useTimeskipping = o.useTimeskipping;
+      this.searchAttributes = o.searchAttributes;
     }
 
     public Builder setWorkflowClientOptions(WorkflowClientOptions workflowClientOptions) {

--- a/temporal-testing/src/test/java/io/temporal/testing/junit5/TestActivityExtensionTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/junit5/TestActivityExtensionTest.java
@@ -23,20 +23,29 @@ package io.temporal.testing.junit5;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.uber.m3.tally.NoopScope;
 import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.testing.TestActivityEnvironment;
 import io.temporal.testing.TestActivityExtension;
+import io.temporal.testing.TestEnvironmentOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TestActivityExtensionTest {
 
+  public static class CustomMetricsScope extends NoopScope {}
+
   @RegisterExtension
   public static final TestActivityExtension activityExtension =
-      TestActivityExtension.newBuilder().setActivityImplementations(new MyActivityImpl()).build();
+      TestActivityExtension.newBuilder()
+          .setTestEnvironmentOptions(
+              TestEnvironmentOptions.newBuilder().setMetricsScope(new CustomMetricsScope()).build())
+          .setActivityImplementations(new MyActivityImpl())
+          .build();
 
   @ActivityInterface
   public interface MyActivity {
@@ -47,6 +56,9 @@ public class TestActivityExtensionTest {
   private static class MyActivityImpl implements MyActivity {
     @Override
     public String activity1(String input) {
+      assertTrue(
+          Activity.getExecutionContext().getMetricsScope() instanceof CustomMetricsScope,
+          "The custom metrics scope should be available for the activity");
       return Activity.getExecutionContext().getInfo().getActivityType() + "-" + input;
     }
   }


### PR DESCRIPTION
# What was done

Both `TestActivityEnvironment` and `TestWorkflowEnvironment` are accepting custom metricsScope from two sources: `TestEnvironmentOptions#metricsScope` and `TestEnvironmentOptions#workflowServiceStubsOptions#metricsScope`, where it is overridden by the user.

# Why

Both environments had several bugs in how `TestEnvironmentOptions#workflowServiceStubsOptions#metricsScope` is treated, `TestActivityEnvironment` was respecting `TestEnvironmentOptions#metricsScope` only for `WorkflowClientOptions` purposes, but not passing it as activity custom metrics scope.
 
Closes #1412