### PR TITLE
More activity timeout failure compliance tests and improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.50.2' // [1.34.0,)
+    grpcVersion = '1.51.0' // [1.34.0,)
     jacksonVersion = '2.14.0' // [2.9.0,)
     micrometerVersion = '1.9.5' // [1.0.0,)
 
@@ -47,7 +47,7 @@ ext {
 
     // test scoped
     logbackVersion = '1.2.11'
-    mockitoVersion = '4.8.1'
+    mockitoVersion = '4.9.0'
     junitVersion = '4.13.2'
 }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
@@ -23,6 +23,7 @@ package io.temporal.workflow.activityTests;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
+import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.enums.v1.RetryState;
@@ -32,6 +33,7 @@ import io.temporal.client.WorkflowException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ActivityFailure;
+import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.TimeoutFailure;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
@@ -39,10 +41,15 @@ import io.temporal.worker.Worker;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.activityTests.ActivityTimeoutTest.ControlledActivityImpl.Outcome;
 import io.temporal.workflow.shared.TestActivities;
 import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.hamcrest.CoreMatchers;
@@ -81,12 +88,26 @@ public class ActivityTimeoutTest {
     testEnvironment.close();
   }
 
+  /**
+   * An activity reaches startToClose timeout once, max retries are set to 1.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE})
+   *
+   * <p>Note {@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE} of the last attempt is getting
+   * effectively replaced in-place by {@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE}, it doesn't
+   * go into the cause chain.
+   */
   @Test
   @Parameters({"false"})
-  public void testActivityStartToCloseTimeout(boolean local) {
+  public void maximumAttemptsReached_startToCloseTimingOutActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Collections.singletonList(Outcome.SLEEP), 1, 100);
+
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
-    worker.registerActivitiesImplementations(new TimingOutActivityImpl());
+    worker.registerActivitiesImplementations(activity);
     testEnvironment.start();
     WorkflowClient client = testEnvironment.getWorkflowClient();
     WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
@@ -94,7 +115,7 @@ public class ActivityTimeoutTest {
         client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
 
     WorkflowException e =
-        assertThrows(WorkflowException.class, () -> workflow.workflow(10, 10, 1, true, local));
+        assertThrows(WorkflowException.class, () -> workflow.workflow(-1, -1, 1, 1, local));
 
     assertTrue(e.getCause() instanceof ActivityFailure);
     ActivityFailure activityFailure = (ActivityFailure) e.getCause();
@@ -109,12 +130,164 @@ public class ActivityTimeoutTest {
         ((TimeoutFailure) activityFailure.getCause()).getTimeoutType());
 
     assertNull(activityFailure.getCause().getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * Two startToClose timeouts of the activity limited by the max retries set to 2.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE})
+   */
+  @Test
+  @Parameters({"false"})
+  public void maximumAttemptsReached_twiceStartToCloseTimingOutActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Collections.singletonList(Outcome.SLEEP), 2, 100);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> workflow.workflow(-1, -1, 1, 2, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, activityFailure.getRetryState());
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose.getTimeoutType());
+
+    assertTrue(startToClose.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose2 = (TimeoutFailure) startToClose.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose2.getTimeoutType());
+
+    assertNull(startToClose2.getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * Two startToClose timeouts of the activity limited by the max retries set to 3.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE})
+   *
+   * <p>This structure is the same as in {@link
+   * #maximumAttemptsReached_twiceStartToCloseTimingOutActivity}, depth of failures under the root
+   * ActivityFailure is limited by 2
+   */
+  @Test
+  @Parameters({"false"})
+  public void maximumAttemptsReached_threeStartToCloseTimingOutActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Collections.singletonList(Outcome.SLEEP), 3, 100);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> workflow.workflow(-1, -1, 1, 3, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, activityFailure.getRetryState());
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose.getTimeoutType());
+
+    assertTrue(startToClose.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose2 = (TimeoutFailure) startToClose.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose2.getTimeoutType());
+
+    assertNull(startToClose2.getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * This test hits a scenario when activity
+   *
+   * <ul>
+   *   <li>fails on the first attempt
+   *   <li>reaches startToClose on the second attempt
+   *   <li>attempts are limited by 2
+   * </ul>
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE}) -> <br>
+   * {@link ApplicationFailure}
+   */
+  @Test
+  @Parameters({"false"})
+  public void maximumAttemptsReached_onceFailing_onceStartToCloseTimingOutActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Arrays.asList(Outcome.FAIL, Outcome.SLEEP), 2, 5);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    final int ATTEMPTS_COUNT = 2;
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(
+            WorkflowException.class, () -> workflow.workflow(10, -1, 1, ATTEMPTS_COUNT, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, activityFailure.getRetryState());
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose.getTimeoutType());
+
+    assertTrue(startToClose.getCause() instanceof ApplicationFailure);
+    assertEquals(
+        "intentional failure", ((ApplicationFailure) startToClose.getCause()).getOriginalMessage());
+
+    assertNull(startToClose.getCause().getCause());
+
+    activity.verifyAttempts();
   }
 
   // TODO Parametrize when scheduleToStart support is added for local activities
   @Parameters({"false"})
   @Test
-  public void testActivityScheduleToStartTimeout(boolean local) {
+  public void scheduleToStartTimeout(boolean local) {
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
     testEnvironment.start();
@@ -124,10 +297,13 @@ public class ActivityTimeoutTest {
         client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
 
     WorkflowException e =
-        assertThrows(WorkflowException.class, () -> workflow.workflow(10, 1, 10, true, local));
+        assertThrows(WorkflowException.class, () -> workflow.workflow(10, 1, 10, 1, local));
 
     assertTrue(e.getCause() instanceof ActivityFailure);
     ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
     assertEquals(RetryState.RETRY_STATE_NON_RETRYABLE_FAILURE, activityFailure.getRetryState());
 
     assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
@@ -138,12 +314,27 @@ public class ActivityTimeoutTest {
     assertNull(activityFailure.getCause().getCause());
   }
 
+  /**
+   * This test hits a scenario when an activity reaches startToClose timeout on the first attempt
+   * and reaches scheduleToClose timeout after that.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_TIMEOUT}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE})
+   *
+   * <p>Note {@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE} of the last attempt is getting
+   * effectively replaced in-place by {@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE}, it doesn't
+   * go into the cause chain.
+   */
   @Test
   @Parameters({"false"})
-  public void testActivityScheduleToCloseTimeout(boolean local) {
+  public void scheduleToCloseTimeout_startToCloseTimingOutActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Collections.singletonList(Outcome.SLEEP), 1, 100);
+
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
-    worker.registerActivitiesImplementations(new TimingOutActivityImpl());
+    worker.registerActivitiesImplementations(activity);
     testEnvironment.start();
 
     WorkflowClient client = testEnvironment.getWorkflowClient();
@@ -152,10 +343,13 @@ public class ActivityTimeoutTest {
         client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
 
     WorkflowException e =
-        assertThrows(WorkflowException.class, () -> workflow.workflow(2, 10, 1, false, local));
+        assertThrows(WorkflowException.class, () -> workflow.workflow(2, -1, 1, -1, local));
 
     assertTrue(e.getCause() instanceof ActivityFailure);
     ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
     assertEquals(RetryState.RETRY_STATE_TIMEOUT, activityFailure.getRetryState());
 
     assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
@@ -164,12 +358,220 @@ public class ActivityTimeoutTest {
         ((TimeoutFailure) activityFailure.getCause()).getTimeoutType());
 
     assertNull(activityFailure.getCause().getCause());
+
+    activity.verifyAttempts();
   }
 
-  // Heartbeats are currently not applicable to local activities
-  // Checks the behavior of heartbeat timeout activity failure in presence of schedule to close
+  /**
+   * This test hits a scenario when an activity reaches startToClose timeout twice and reaches
+   * scheduleToClose timeout after that.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_TIMEOUT}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE})
+   */
   @Test
-  public void testHeartbeatTimeoutDetails_scheduleToClose() {
+  @Parameters({"false"})
+  public void scheduleToCloseTimeout_twiceStartToCloseTimingOutActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Collections.singletonList(Outcome.SLEEP), 2, 100);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    testEnvironment.start();
+
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> workflow.workflow(4, -1, 1, -1, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
+    assertEquals(RetryState.RETRY_STATE_TIMEOUT, activityFailure.getRetryState());
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure scheduleToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, scheduleToClose.getTimeoutType());
+
+    assertTrue(scheduleToClose.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose = (TimeoutFailure) scheduleToClose.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose.getTimeoutType());
+
+    assertNull(startToClose.getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * This test hits a scenario when an activity:
+   *
+   * <ul>
+   *   <li>fails on the first attempt
+   *   <li>reaches startToClose on the second attempt
+   *   <li>reaches scheduleToClose on the third attempt
+   * </ul>
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_TIMEOUT}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_START_TO_CLOSE}) <br>
+   * an original first failure is not preserved in the chain
+   */
+  @Test
+  @Parameters({"false"})
+  public void scheduleToCloseTimeout_onceFailing_twiceStartToCloseTimingOut(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Arrays.asList(Outcome.FAIL, Outcome.SLEEP, Outcome.SLEEP), 3, 5);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> workflow.workflow(10, -1, 3, -1, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_TIMEOUT, activityFailure.getRetryState());
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure scheduleToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, scheduleToClose.getTimeoutType());
+
+    assertTrue(scheduleToClose.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToClose = (TimeoutFailure) scheduleToClose.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, startToClose.getTimeoutType());
+
+    assertNull(startToClose.getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * This test hits a scenario when an activity
+   *
+   * <ul>
+   *   <li>reaches startToClose on the first attempt
+   *   <li>fails on the second attempt
+   *   <li>reaches startToClose and scheduleToClose on the third attempt
+   * </ul>
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_TIMEOUT}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE}) -> <br>
+   * {@link ApplicationFailure}[from the second attempt]
+   */
+  @Test
+  @Parameters({"false"})
+  public void scheduleToCloseTimeout_startToClose_failing_startToCloseTimingOut(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Arrays.asList(Outcome.SLEEP, Outcome.FAIL, Outcome.SLEEP), 3, 5);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> workflow.workflow(10, -1, 3, -1, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_TIMEOUT, activityFailure.getRetryState());
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task timed out"));
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure scheduleToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, scheduleToClose.getTimeoutType());
+
+    assertTrue(scheduleToClose.getCause() instanceof ApplicationFailure);
+    ApplicationFailure applicationFailure = (ApplicationFailure) scheduleToClose.getCause();
+    assertEquals("intentional failure", applicationFailure.getOriginalMessage());
+
+    assertNull(applicationFailure.getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * This test verifies the behavior and observed result of a present scheduleToClose timeout ond an
+   * activity that retries and fails immediately every time.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_TIMEOUT}) -> <br>
+   * {@link ApplicationFailure}
+   */
+  @Test
+  @Parameters({"false"})
+  public void scheduleToCloseTimeout_failingActivity(boolean local) {
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(Collections.singletonList(Outcome.FAIL), 3, -1);
+
+    Worker worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(TestActivityTimeoutWorkflowImpl.class);
+    worker.registerActivitiesImplementations(activity);
+    testEnvironment.start();
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options = WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build();
+    TestActivityTimeoutWorkflow workflow =
+        client.newWorkflowStub(TestActivityTimeoutWorkflow.class, options);
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> workflow.workflow(5, -1, 1, -1, local));
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_TIMEOUT, activityFailure.getRetryState());
+    MatcherAssert.assertThat(
+        activityFailure.getMessage(), CoreMatchers.containsString("Activity task failed"));
+
+    assertTrue(activityFailure.getCause() instanceof ApplicationFailure);
+    ApplicationFailure applicationFailure = (ApplicationFailure) activityFailure.getCause();
+
+    assertEquals("intentional failure", applicationFailure.getOriginalMessage());
+
+    assertNull(applicationFailure.getCause());
+
+    activity.verifyAttempts();
+  }
+
+  /**
+   * Checks the behavior of heartbeat timeout activity failure in presence of scheduleToClose
+   * timeout.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_TIMEOUT}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_SCHEDULE_TO_CLOSE}, [last heartbeat
+   * details]) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_HEARTBEAT}, [no heartbeat details])
+   *
+   * <p>Heartbeats are currently not applicable to local activities.
+   */
+  @Test
+  public void scheduleToClose_heartbeatTimeoutDetails() {
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(TestHeartbeatTimeoutScheduleToClose.class);
     worker.registerActivitiesImplementations(new TestActivitiesImpl());
@@ -180,17 +582,39 @@ public class ActivityTimeoutTest {
 
     TestWorkflows.TestWorkflowReturnString workflowStub =
         client.newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class, options);
-    String result = workflowStub.execute();
-    Assert.assertEquals("heartbeatValue", result);
+    WorkflowException e = assertThrows(WorkflowException.class, workflowStub::execute);
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_TIMEOUT, activityFailure.getRetryState());
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure scheduleToClose = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, scheduleToClose.getTimeoutType());
+    assertEquals("heartbeatValue", scheduleToClose.getLastHeartbeatDetails().get(String.class));
+
+    assertTrue(scheduleToClose.getCause() instanceof TimeoutFailure);
+    TimeoutFailure heartbeat = (TimeoutFailure) scheduleToClose.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_HEARTBEAT, heartbeat.getTimeoutType());
+    assertEquals(0, heartbeat.getLastHeartbeatDetails().getSize());
+
+    assertNull(heartbeat.getCause());
   }
 
-  // Heartbeats are currently not applicable to local activities
-  // Checks the behavior of heartbeat timeout activity failure in presence of start to close and
-  // limited retries
+  /**
+   * Checks the behavior of heartbeat timeout activity failure in presence of limited retries.
+   *
+   * <p>The expected structure is <br>
+   * {@link ActivityFailure}({@link RetryState#RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED}) -> <br>
+   * {@link TimeoutFailure}({@link TimeoutType#TIMEOUT_TYPE_HEARTBEAT}, [last heartbeat details])
+   *
+   * <p>Heartbeats are currently not applicable to local activities.
+   */
   @Test
-  public void testHeartbeatTimeoutDetails_startToClose() {
+  public void maxRetries_heartbeatTimeoutDetails() {
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
-    worker.registerWorkflowImplementationTypes(TestHeartbeatTimeoutStartToClose.class);
+    worker.registerWorkflowImplementationTypes(TestHeartbeatTimeoutMaxAttempts.class);
     worker.registerActivitiesImplementations(new TestActivitiesImpl());
     testEnvironment.start();
 
@@ -199,18 +623,39 @@ public class ActivityTimeoutTest {
 
     TestWorkflows.TestWorkflowReturnString workflowStub =
         client.newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class, options);
-    String result = workflowStub.execute();
-    Assert.assertEquals("heartbeatValue", result);
+    WorkflowException e = assertThrows(WorkflowException.class, workflowStub::execute);
+
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+
+    assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, activityFailure.getRetryState());
+
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure startToCloseTimeout = (TimeoutFailure) activityFailure.getCause();
+    // Start to close timeout never fires here, because the heartbeat timeout is shorter and the
+    // activity doesn't heartbeat
+    assertEquals(TimeoutType.TIMEOUT_TYPE_HEARTBEAT, startToCloseTimeout.getTimeoutType());
+    assertEquals("heartbeatValue", startToCloseTimeout.getLastHeartbeatDetails().get(String.class));
+
+    assertNull(startToCloseTimeout.getCause());
   }
 
   @WorkflowInterface
   public interface TestActivityTimeoutWorkflow {
+    /**
+     * @param scheduleToCloseTimeoutSeconds -1 means not set
+     * @param scheduleToStartTimeoutSeconds -1 means not set
+     * @param startToCloseTimeoutSeconds -1 means not set
+     * @param attemptsAllowed how many attempts will be set in the activity RetryOptions, -1 means
+     *     not set (unlimited)
+     * @param local if the activity that workflow schedules should be local
+     */
     @WorkflowMethod
     void workflow(
         long scheduleToCloseTimeoutSeconds,
         long scheduleToStartTimeoutSeconds,
         long startToCloseTimeoutSeconds,
-        boolean disableRetries,
+        int attemptsAllowed,
         boolean local);
   }
 
@@ -221,7 +666,7 @@ public class ActivityTimeoutTest {
         long scheduleToCloseTimeoutSeconds,
         long scheduleToStartTimeoutSeconds,
         long startToCloseTimeoutSeconds,
-        boolean disableRetries,
+        int attemptsAllowed,
         boolean local) {
       TestActivities.TestActivity1 activity;
       if (local) {
@@ -234,8 +679,9 @@ public class ActivityTimeoutTest {
         }
         // TODO add scheduleToStart for local activities
         // .setScheduleToStartTimeout(Duration.ofSeconds(scheduleToStartTimeoutSeconds));
-        if (disableRetries) {
-          options.setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build());
+        if (attemptsAllowed > 0) {
+          options.setRetryOptions(
+              RetryOptions.newBuilder().setMaximumAttempts(attemptsAllowed).build());
         }
         activity =
             Workflow.newLocalActivityStub(TestActivities.TestActivity1.class, options.build());
@@ -250,8 +696,9 @@ public class ActivityTimeoutTest {
         if (scheduleToStartTimeoutSeconds >= 0) {
           options.setScheduleToStartTimeout(Duration.ofSeconds(scheduleToStartTimeoutSeconds));
         }
-        if (disableRetries) {
-          options.setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build());
+        if (attemptsAllowed > 0) {
+          options.setRetryOptions(
+              RetryOptions.newBuilder().setMaximumAttempts(attemptsAllowed).build());
         }
         activity = Workflow.newActivityStub(TestActivities.TestActivity1.class, options.build());
       }
@@ -260,18 +707,62 @@ public class ActivityTimeoutTest {
     }
   }
 
-  public static class TimingOutActivityImpl implements TestActivities.TestActivity1 {
+  public static class ControlledActivityImpl implements TestActivities.TestActivity1 {
+
+    enum Outcome {
+      FAIL,
+      SLEEP
+    }
+
+    private final List<Outcome> outcomes;
+    private final int expectedAttempts;
+    private final long secondsToSleep;
+
+    private int lastAttempt = 0;
+
+    public ControlledActivityImpl(
+        List<Outcome> outcomes, int expectedAttempts, long secondsToSleep) {
+      this.outcomes = outcomes;
+      this.expectedAttempts = expectedAttempts;
+      this.secondsToSleep = secondsToSleep;
+    }
 
     @Override
     public String execute(String input) {
-      while (true) {
-        try {
-          Thread.sleep(500);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new RuntimeException(e);
-        }
+      lastAttempt = Activity.getExecutionContext().getInfo().getAttempt();
+      if (lastAttempt > expectedAttempts) {
+        fail(
+            "Unexpected attempt '"
+                + lastAttempt
+                + "', over the expected '"
+                + expectedAttempts
+                + "'");
       }
+
+      Outcome outcome =
+          outcomes.get(
+              (Activity.getExecutionContext().getInfo().getAttempt() - 1) % outcomes.size());
+      switch (outcome) {
+        case FAIL:
+          throw new RuntimeException("intentional failure");
+        case SLEEP:
+          try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(secondsToSleep));
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+          return "done";
+        default:
+          throw new IllegalArgumentException("Unexpected outcome: " + outcome);
+      }
+    }
+
+    public void verifyAttempts() {
+      assertEquals(
+          "Amount of attempts performed is different from the expected",
+          expectedAttempts,
+          lastAttempt);
     }
   }
 
@@ -290,32 +781,22 @@ public class ActivityTimeoutTest {
           Workflow.newActivityStub(TestActivities.VariousTestActivities.class, options);
 
       // false for second argument means to heartbeat once to set details and then stop.
-      ActivityFailure e =
-          assertThrows(ActivityFailure.class, () -> activities.heartbeatAndWait(5000, false));
-      assertEquals(RetryState.RETRY_STATE_TIMEOUT, e.getRetryState());
+      activities.heartbeatAndWait(5000, false);
 
-      assertTrue(e.getCause() instanceof TimeoutFailure);
-      TimeoutFailure scheduleToCloseTimeout = (TimeoutFailure) e.getCause();
-      assertEquals(
-          TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, scheduleToCloseTimeout.getTimeoutType());
-
-      assertTrue(scheduleToCloseTimeout.getCause() instanceof TimeoutFailure);
-      TimeoutFailure heartbeatTimeout = (TimeoutFailure) scheduleToCloseTimeout.getCause();
-
-      assertEquals(TimeoutType.TIMEOUT_TYPE_HEARTBEAT, heartbeatTimeout.getTimeoutType());
-      assertEquals(0, heartbeatTimeout.getLastHeartbeatDetails().getSize());
-      return (scheduleToCloseTimeout.getLastHeartbeatDetails().get(String.class));
+      fail();
+      return "unexpected completion";
     }
   }
 
-  public static class TestHeartbeatTimeoutStartToClose
+  public static class TestHeartbeatTimeoutMaxAttempts
       implements TestWorkflows.TestWorkflowReturnString {
 
     @Override
     public String execute() {
       ActivityOptions options =
           ActivityOptions.newBuilder()
-              .setHeartbeatTimeout(Duration.ofSeconds(1)) // short heartbeat timeout;
+              .setHeartbeatTimeout(Duration.ofSeconds(1)) // short heartbeat timeout
+              // never fires (heartbeat timeout is shorter), but needed for correct ActivityOptions
               .setStartToCloseTimeout(Duration.ofSeconds(5))
               .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
               .build();
@@ -324,17 +805,10 @@ public class ActivityTimeoutTest {
           Workflow.newActivityStub(TestActivities.VariousTestActivities.class, options);
 
       // false for second argument means to heartbeat once to set details and then stop.
-      ActivityFailure e =
-          assertThrows(ActivityFailure.class, () -> activities.heartbeatAndWait(5000, false));
-      assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, e.getRetryState());
+      activities.heartbeatAndWait(5000, false);
 
-      assertTrue(e.getCause() instanceof TimeoutFailure);
-      TimeoutFailure startToCloseTimeout = (TimeoutFailure) e.getCause();
-      assertEquals(TimeoutType.TIMEOUT_TYPE_HEARTBEAT, startToCloseTimeout.getTimeoutType());
-
-      assertNull(startToCloseTimeout.getCause());
-
-      return (startToCloseTimeout.getLastHeartbeatDetails().get(String.class));
+      fail();
+      return "unexpected completion";
     }
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,7 +1,7 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    otelVersion = '1.20.0'
+    otelVersion = '1.20.1'
     otShimVersion = "${otelVersion}-alpha"
 }
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1614,9 +1614,10 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             int attempt = data.getAttempt();
             ctx.addTimer(
                 startToCloseTimeout,
-                () ->
-                    timeoutActivity(
-                        scheduledEventId, TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, attempt),
+                () -> {
+                  timeoutActivity(
+                      scheduledEventId, TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, attempt);
+                },
                 "Activity StartToCloseTimeout");
           }
           updateHeartbeatTimer(


### PR DESCRIPTION
This PR adds more test cases verifying the behavior across TestServer and a real Temporal Server for Activity Timeout Failures.

One of the tests shows strange behavior of the real server, which was mimicked in the Test Server with a TODO, showing that this behavior is inconsistent and looks like a bug. This needs further investigation and maybe more tests to be sure what happens there.

This PR is a continuation of the work started in #1514
Depends on #1524 to be merged first
Prerequisite for: #1004 #1507