### PR TITLE
Add generated proto classes info into javadoc jar

### DIFF
--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -99,6 +99,11 @@ sourcesJar {
     from(file("$buildDir/generated/main/java"))
 }
 
+javadocJar {
+    dependsOn 'generateProto'
+    from(file("$buildDir/generated/main/java"))
+}
+
 idea {
     module {
         sourceDirs += file("$buildDir/generated/main/java")


### PR DESCRIPTION
Add generated proto classes info into javadoc jar, aligning it's content with sources jar.
This will add docs generated from api repo comments into javadocs.

Closes #1532