### PR TITLE
Implement retries of local activities that break local retry threshold

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.11.0' apply false
+    id 'com.diffplug.spotless' version '6.12.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -30,11 +30,11 @@ allprojects {
 ext {
     // Platforms
     grpcVersion = '1.51.0' // [1.34.0,)
-    jacksonVersion = '2.14.0' // [2.9.0,)
+    jacksonVersion = '2.14.1' // [2.9.0,)
     micrometerVersion = '1.9.6' // [1.0.0,) // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
 
     slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which stay on 1.x
-    protoVersion = '3.21.9' // [3.10.0,)
+    protoVersion = '3.21.10' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
     tallyVersion = '0.11.1' // [0.4.0,)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -81,8 +81,9 @@ public final class LocalActivityOptions {
     }
 
     /**
-     * Maximum time to retry locally, while keeping the Workflow Task open via a Heartbeat. Default
-     * value is Workflow Task timeout multiplied by 6.
+     * Maximum time to wait between retries locally, while keeping the Workflow Task open via a
+     * Heartbeat. If the delay between the attempts becomes larger that this threshold, a Workflow
+     * Timer will be scheduled. Default value is Workflow Task Timeout multiplied by 3.
      */
     public Builder setLocalRetryThreshold(Duration localRetryThreshold) {
       if (localRetryThreshold.isZero() || localRetryThreshold.isNegative()) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
@@ -23,22 +23,23 @@ package io.temporal.internal.activity;
 import com.google.protobuf.util.Timestamps;
 import io.temporal.api.common.v1.Header;
 import io.temporal.api.common.v1.Payloads;
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponseOrBuilder;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 final class ActivityInfoImpl implements ActivityInfoInternal {
-  private final PollActivityTaskQueueResponse response;
+  private final PollActivityTaskQueueResponseOrBuilder response;
   private final String activityNamespace;
   private final boolean local;
   private final Functions.Proc completionHandle;
 
   ActivityInfoImpl(
-      PollActivityTaskQueueResponse response,
+      PollActivityTaskQueueResponseOrBuilder response,
       String activityNamespace,
       boolean local,
       Functions.Proc completionHandle) {
@@ -93,6 +94,7 @@ final class ActivityInfoImpl implements ActivityInfoInternal {
     return ProtobufTimeUtils.toJavaDuration(response.getStartToCloseTimeout());
   }
 
+  @Nonnull
   @Override
   public Duration getHeartbeatTimeout() {
     return ProtobufTimeUtils.toJavaDuration(response.getHeartbeatTimeout());

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskHandlerImpl.java
@@ -25,7 +25,7 @@ import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
 import io.temporal.activity.DynamicActivity;
 import io.temporal.api.failure.v1.Failure;
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponseOrBuilder;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequest;
 import io.temporal.api.workflowservice.v1.RespondActivityTaskFailedRequest;
 import io.temporal.client.ActivityCanceledException;
@@ -82,7 +82,7 @@ public final class ActivityTaskHandlerImpl implements ActivityTaskHandler {
 
   @Override
   public Result handle(ActivityTask activityTask, Scope metricsScope, boolean localActivity) {
-    PollActivityTaskQueueResponse pollResponse = activityTask.getResponse();
+    PollActivityTaskQueueResponseOrBuilder pollResponse = activityTask.getResponse();
     String activityType = pollResponse.getActivityType().getName();
     ActivityInfoInternal activityInfo =
         new ActivityInfoImpl(

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/ProtobufTimeUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/ProtobufTimeUtils.java
@@ -25,9 +25,11 @@ import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
 import java.time.Instant;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ProtobufTimeUtils {
+  @Nonnull
   public static Duration toJavaDuration(com.google.protobuf.Duration d) {
     // TODO we should refactor an implicit conversion of empty values into ZERO and rename the
     // current method into toJavaDurationSafe, toJavaDurationOrDefault or something like that

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/RetryOptionsUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/RetryOptionsUtils.java
@@ -42,6 +42,13 @@ public class RetryOptionsUtils {
         e instanceof ApplicationFailure
             ? ((ApplicationFailure) e).getType()
             : e.getClass().getName();
+    return isNotRetryable(o, type);
+  }
+
+  public static boolean isNotRetryable(RetryOptions o, @Nullable String type) {
+    if (type == null) {
+      return false;
+    }
     if (o.getDoNotRetry() != null) {
       for (String doNotRetry : o.getDoNotRetry()) {
         if (doNotRetry.equals(type)) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/history/LocalActivityMarkerMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/history/LocalActivityMarkerMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.history;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import javax.annotation.Nullable;
+
+/**
+ * See <a
+ * href="https://github.com/temporalio/sdk-core/blob/master/protos/local/temporal/sdk/core/external_data/external_data.proto#L12">Core
+ * Data Structure</a>
+ */
+public class LocalActivityMarkerMetadata {
+  // The time the LA was originally scheduled (wall clock time). This is used to track
+  // schedule-to-close timeouts when timer-based backoffs are used.
+  @JsonProperty(value = "firstSkd")
+  private long originalScheduledTimestamp;
+
+  // The number of attempts at execution before we recorded this result. Typically starts at 1,
+  // but it is possible to start at a higher number when backing off using a timer.
+  @JsonProperty(value = "atpt")
+  private int attempt;
+
+  // If set, this local activity conceptually is retrying after the specified backoff.
+  // Implementation wise, they are really two different LA machines, but with the same type & input.
+  // The retry starts with an attempt number > 1.
+  @Nullable
+  @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT)
+  @JsonProperty(value = "backoff")
+  private Duration backoff;
+
+  public LocalActivityMarkerMetadata() {}
+
+  public LocalActivityMarkerMetadata(int attempt, long originalScheduledTimestamp) {
+    this.attempt = attempt;
+    this.originalScheduledTimestamp = originalScheduledTimestamp;
+  }
+
+  public long getOriginalScheduledTimestamp() {
+    return originalScheduledTimestamp;
+  }
+
+  public void setOriginalScheduledTimestamp(long originalScheduledTimestamp) {
+    this.originalScheduledTimestamp = originalScheduledTimestamp;
+  }
+
+  public int getAttempt() {
+    return attempt;
+  }
+
+  public void setAttempt(int attempt) {
+    this.attempt = attempt;
+  }
+
+  @Nullable
+  public Duration getBackoff() {
+    return backoff;
+  }
+
+  public void setBackoff(@Nullable Duration backoff) {
+    this.backoff = backoff;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/history/LocalActivityMarkerUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/history/LocalActivityMarkerUtils.java
@@ -20,25 +20,29 @@
 
 package io.temporal.internal.history;
 
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 public class LocalActivityMarkerUtils {
+  public static final String MARKER_NAME = "LocalActivity";
   public static final String MARKER_ACTIVITY_ID_KEY = "activityId";
   public static final String MARKER_ACTIVITY_TYPE_KEY = "type";
   public static final String MARKER_ACTIVITY_RESULT_KEY = "result";
   public static final String MARKER_ACTIVITY_INPUT_KEY = "input";
   public static final String MARKER_TIME_KEY = "time";
+  public static final String MARKER_METADATA_KEY = "meta";
   // Deprecated in favor of result. Still present for backwards compatibility.
-  public static final String MARKER_DATA_KEY = "data";
+  private static final String MARKER_DATA_KEY = "data";
 
   /**
    * @param event {@code HistoryEvent} to inspect
    * @return true if the event has a correct structure for a local activity
    */
   public static boolean hasLocalActivityStructure(HistoryEvent event) {
-    return MarkerUtils.verifyMarkerName(event, MarkerUtils.LOCAL_ACTIVITY_MARKER_NAME);
+    return MarkerUtils.verifyMarkerName(event, MARKER_NAME);
   }
 
   @Nullable
@@ -49,5 +53,28 @@ public class LocalActivityMarkerUtils {
   @Nullable
   public static String getActivityTypeName(MarkerRecordedEventAttributes markerAttributes) {
     return MarkerUtils.getValueFromMarker(markerAttributes, MARKER_ACTIVITY_TYPE_KEY, String.class);
+  }
+
+  @Nullable
+  public static Payloads getResult(MarkerRecordedEventAttributes markerAttributes) {
+    Map<String, Payloads> detailsMap = markerAttributes.getDetailsMap();
+    Payloads result = detailsMap.get(LocalActivityMarkerUtils.MARKER_ACTIVITY_RESULT_KEY);
+    if (result == null) {
+      // Support old histories that used "data" as a key for "result".
+      result = detailsMap.get(LocalActivityMarkerUtils.MARKER_DATA_KEY);
+    }
+    return result;
+  }
+
+  @Nullable
+  public static Long getTime(MarkerRecordedEventAttributes markerAttributes) {
+    return MarkerUtils.getValueFromMarker(markerAttributes, MARKER_TIME_KEY, Long.class);
+  }
+
+  @Nullable
+  public static LocalActivityMarkerMetadata getMetadata(
+      MarkerRecordedEventAttributes markerAttributes) {
+    return MarkerUtils.getValueFromMarker(
+        markerAttributes, MARKER_METADATA_KEY, LocalActivityMarkerMetadata.class);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/history/MarkerUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/history/MarkerUtils.java
@@ -28,9 +28,6 @@ import io.temporal.common.converter.StdConverterBackwardsCompatAdapter;
 import java.util.Optional;
 
 public class MarkerUtils {
-  public static final String VERSION_MARKER_NAME = "Version";
-
-  public static final String LOCAL_ACTIVITY_MARKER_NAME = "LocalActivity";
 
   /**
    * @param event {@code HistoryEvent} to inspect

--- a/temporal-sdk/src/main/java/io/temporal/internal/history/VersionMarkerUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/history/VersionMarkerUtils.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 public class VersionMarkerUtils {
+  public static final String MARKER_NAME = "Version";
   public static final String MARKER_CHANGE_ID_KEY = "changeId";
   public static final String MARKER_VERSION_KEY = "version";
 
@@ -52,7 +53,7 @@ public class VersionMarkerUtils {
    * @return true if the event has a correct structure for a version marker
    */
   public static boolean hasVersionMarkerStructure(HistoryEvent event) {
-    return MarkerUtils.verifyMarkerName(event, MarkerUtils.VERSION_MARKER_NAME);
+    return MarkerUtils.verifyMarkerName(event, MARKER_NAME);
   }
 
   @Nullable
@@ -74,7 +75,7 @@ public class VersionMarkerUtils {
     details.put(
         MARKER_VERSION_KEY, DefaultDataConverter.STANDARD_INSTANCE.toPayloads(version).get());
     return RecordMarkerCommandAttributes.newBuilder()
-        .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+        .setMarkerName(MARKER_NAME)
         .putAllDetails(details)
         .build();
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -32,6 +32,7 @@ import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.internal.statemachines.ExecuteActivityParameters;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
+import io.temporal.internal.statemachines.LocalActivityCallback;
 import io.temporal.internal.statemachines.StartChildWorkflowExecutionParameters;
 import io.temporal.workflow.Functions;
 import io.temporal.workflow.Functions.Func;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -92,6 +94,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
 
   long getRunStartedTimestampMillis();
 
+  @Nonnull
   Duration getWorkflowTaskTimeout();
 
   Payload getMemo(String key);
@@ -115,8 +118,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
       ExecuteActivityParameters parameters, Functions.Proc2<Optional<Payloads>, Failure> callback);
 
   Functions.Proc scheduleLocalActivityTask(
-      ExecuteLocalActivityParameters parameters,
-      Functions.Proc2<Optional<Payloads>, Failure> callback);
+      ExecuteLocalActivityParameters parameters, LocalActivityCallback callback);
 
   /**
    * Start child workflow.
@@ -181,8 +183,8 @@ public interface ReplayWorkflowContext extends ReplayAware {
    * getting random number or new UUID. The only way to fail SideEffect is to throw {@link Error}
    * which causes workflow task failure. The workflow task after timeout is rescheduled and
    * re-executed giving SideEffect another chance to succeed. Use {@link
-   * #scheduleLocalActivityTask(ExecuteLocalActivityParameters, Functions.Proc2)} for executing
-   * operations that rely on non-global dependencies and can fail.
+   * #scheduleLocalActivityTask(ExecuteLocalActivityParameters, LocalActivityCallback)} for
+   * executing operations that rely on non-global dependencies and can fail.
    *
    * @param func function that is called once to return a value.
    * @param callback function that accepts the result of the side effect.

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -32,10 +32,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.common.ProtobufTimeUtils;
-import io.temporal.internal.statemachines.ExecuteActivityParameters;
-import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
-import io.temporal.internal.statemachines.StartChildWorkflowExecutionParameters;
-import io.temporal.internal.statemachines.WorkflowStateMachines;
+import io.temporal.internal.statemachines.*;
 import io.temporal.internal.worker.SingleWorkerOptions;
 import io.temporal.workflow.Functions;
 import io.temporal.workflow.Functions.Func;
@@ -139,6 +136,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
     return basicWorkflowContext.getContinueAsNewOnCompletion();
   }
 
+  @Nonnull
   @Override
   public Duration getWorkflowTaskTimeout() {
     return basicWorkflowContext.getWorkflowTaskTimeout();
@@ -208,8 +206,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
 
   @Override
   public Functions.Proc scheduleLocalActivityTask(
-      ExecuteLocalActivityParameters parameters,
-      Functions.Proc2<Optional<Payloads>, Failure> callback) {
+      ExecuteLocalActivityParameters parameters, LocalActivityCallback callback) {
     return workflowStateMachines.scheduleLocalActivityTask(parameters, callback);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityCallback.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityCallback.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.statemachines;
+
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.workflow.Functions;
+import java.time.Duration;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@FunctionalInterface
+public interface LocalActivityCallback
+    extends Functions.Proc2<
+        Optional<Payloads>, LocalActivityCallback.LocalActivityFailedException> {
+
+  @Override
+  void apply(Optional<Payloads> successOutput, LocalActivityFailedException exception);
+
+  class LocalActivityFailedException extends RuntimeException {
+    private final @Nonnull Failure failure;
+    private final long originalScheduledTimestamp;
+    private final int lastAttempt;
+    /**
+     * If this is not null, code that processes this exception will schedule a workflow timer to
+     * continue retrying the execution
+     */
+    private final @Nullable Duration backoff;
+
+    public LocalActivityFailedException(
+        @Nonnull Failure failure,
+        long originalScheduledTimestamp,
+        int lastAttempt,
+        @Nullable Duration backoff) {
+      this.failure = failure;
+      this.originalScheduledTimestamp = originalScheduledTimestamp;
+      this.lastAttempt = lastAttempt;
+      this.backoff = backoff;
+    }
+
+    @Nonnull
+    public Failure getFailure() {
+      return failure;
+    }
+
+    public long getOriginalScheduledTimestamp() {
+      return originalScheduledTimestamp;
+    }
+
+    public int getLastAttempt() {
+      return lastAttempt;
+    }
+
+    @Nullable
+    public Duration getBackoff() {
+      return backoff;
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -799,7 +799,8 @@ public final class WorkflowStateMachines {
 
   public Functions.Proc scheduleLocalActivityTask(
       ExecuteLocalActivityParameters parameters,
-      Functions.Proc2<Optional<Payloads>, Failure> callback) {
+      Functions.Proc2<Optional<Payloads>, LocalActivityCallback.LocalActivityFailedException>
+          callback) {
     checkEventLoopExecuting();
     String activityId = parameters.getActivityId();
     if (Strings.isNullOrEmpty(activityId)) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -489,7 +489,8 @@ public final class WorkflowInternal {
 
   public static <R> R retry(
       RetryOptions options, Optional<Duration> expiration, Functions.Func<R> fn) {
-    return WorkflowRetryerInternal.validateOptionsAndRetry(options, expiration, fn);
+    return WorkflowRetryerInternal.retry(
+        options.toBuilder().validateBuildWithDefaults(), expiration, fn);
   }
 
   public static void continueAsNew(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowRetryerInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowRetryerInternal.java
@@ -100,11 +100,6 @@ final class WorkflowRetryerInternal {
         });
   }
 
-  public static <R> R validateOptionsAndRetry(
-      RetryOptions options, Optional<Duration> expiration, Functions.Func<R> func) {
-    return retry(options.toBuilder().validateBuildWithDefaults(), expiration, func);
-  }
-
   /**
    * Retry function synchronously.
    *
@@ -223,27 +218,6 @@ final class WorkflowRetryerInternal {
       result.setMaximumAttempts(sRetryOptions.getMaximumAttempts());
     }
     return result.build();
-  }
-
-  static <R> Promise<R> retryAsync(
-      Functions.Func2<Integer, Long, Promise<R>> func, int attempt, long startTime) {
-
-    CompletablePromise<R> funcResult = WorkflowInternal.newCompletablePromise();
-    try {
-      funcResult.completeFrom(func.apply(attempt, startTime));
-    } catch (RuntimeException e) {
-      funcResult.completeExceptionally(e);
-    }
-
-    return funcResult
-        .handle(
-            (r, e) -> {
-              if (e == null) {
-                return WorkflowInternal.newPromise(r);
-              }
-              throw e;
-            })
-        .thenCompose((r) -> r);
   }
 
   private WorkflowRetryerInternal() {}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityTask.java
@@ -20,22 +20,23 @@
 
 package io.temporal.internal.worker;
 
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponseOrBuilder;
 import io.temporal.workflow.Functions;
 import javax.annotation.Nonnull;
 
 public final class ActivityTask {
-  private final @Nonnull PollActivityTaskQueueResponse response;
+  private final @Nonnull PollActivityTaskQueueResponseOrBuilder response;
   private final @Nonnull Functions.Proc completionCallback;
 
   public ActivityTask(
-      @Nonnull PollActivityTaskQueueResponse response, @Nonnull Functions.Proc completionCallback) {
+      @Nonnull PollActivityTaskQueueResponseOrBuilder response,
+      @Nonnull Functions.Proc completionCallback) {
     this.response = response;
     this.completionCallback = completionCallback;
   }
 
   @Nonnull
-  public PollActivityTaskQueueResponse getResponse() {
+  public PollActivityTaskQueueResponseOrBuilder getResponse() {
     return response;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -186,7 +186,7 @@ final class ActivityWorker implements SuspendableWorker {
 
     @Override
     public void handle(ActivityTask task) throws Exception {
-      PollActivityTaskQueueResponse pollResponse = task.getResponse();
+      PollActivityTaskQueueResponseOrBuilder pollResponse = task.getResponse();
       Scope metricsScope =
           workerMetricsScope.tagged(
               ImmutableMap.of(
@@ -226,7 +226,7 @@ final class ActivityWorker implements SuspendableWorker {
     }
 
     private ActivityTaskHandler.Result handleActivity(ActivityTask task, Scope metricsScope) {
-      PollActivityTaskQueueResponse pollResponse = task.getResponse();
+      PollActivityTaskQueueResponseOrBuilder pollResponse = task.getResponse();
       ByteString taskToken = pollResponse.getTaskToken();
       metricsScope
           .timer(MetricsType.ACTIVITY_SCHEDULE_TO_START_LATENCY)
@@ -270,7 +270,7 @@ final class ActivityWorker implements SuspendableWorker {
 
     @Override
     public Throwable wrapFailure(ActivityTask t, Throwable failure) {
-      PollActivityTaskQueueResponse response = t.getResponse();
+      PollActivityTaskQueueResponseOrBuilder response = t.getResponse();
       WorkflowExecution execution = response.getWorkflowExecution();
       return new RuntimeException(
           "Failure processing activity response. WorkflowId="
@@ -344,7 +344,7 @@ final class ActivityWorker implements SuspendableWorker {
 
     private void logExceptionDuringResultReporting(
         Exception e,
-        PollActivityTaskQueueResponse pollResponse,
+        PollActivityTaskQueueResponseOrBuilder pollResponse,
         ActivityTaskHandler.Result result) {
       MDC.put(LoggerTag.ACTIVITY_ID, pollResponse.getActivityId());
       MDC.put(LoggerTag.ACTIVITY_TYPE, pollResponse.getActivityType().getName());

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityAttemptTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityAttemptTask.java
@@ -21,18 +21,17 @@
 package io.temporal.internal.worker;
 
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
-import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
 import javax.annotation.Nonnull;
 
 // TODO This class is an absolutely trivial wrapper and may go away with reworking of local activity
 //  scheduling from the generic poller classes.
 class LocalActivityAttemptTask {
   private final @Nonnull LocalActivityExecutionContext executionContext;
-  private final @Nonnull PollActivityTaskQueueResponse attemptTask;
+  private final @Nonnull PollActivityTaskQueueResponse.Builder attemptTask;
 
   public LocalActivityAttemptTask(
       @Nonnull LocalActivityExecutionContext executionContext,
-      @Nonnull PollActivityTaskQueueResponse attemptTask) {
+      @Nonnull PollActivityTaskQueueResponse.Builder attemptTask) {
     this.executionContext = executionContext;
     this.attemptTask = attemptTask;
   }
@@ -47,12 +46,7 @@ class LocalActivityAttemptTask {
   }
 
   @Nonnull
-  public ExecuteLocalActivityParameters getExecutionParams() {
-    return executionContext.getExecutionParams();
-  }
-
-  @Nonnull
-  public PollActivityTaskQueueResponse getAttemptTask() {
+  public PollActivityTaskQueueResponse.Builder getAttemptTask() {
     return attemptTask;
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
@@ -152,6 +152,8 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
                                               .getMarkerRecordedEventAttributes()))
                                   .build()),
                       null,
+                      System.currentTimeMillis(),
+                      null,
                       false,
                       null),
                   (r, e) -> {});

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
@@ -36,7 +36,6 @@ import io.temporal.api.history.v1.TimerFiredEventAttributes;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.FailureConverter;
-import io.temporal.internal.history.MarkerUtils;
 import io.temporal.internal.history.VersionMarkerUtils;
 import io.temporal.worker.NonDeterministicException;
 import io.temporal.workflow.Functions;
@@ -101,7 +100,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -175,7 +174,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -258,7 +257,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -542,7 +541,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -677,7 +676,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -771,7 +770,7 @@ public class VersionStateMachineTest {
             .add(
                 EventType.EVENT_TYPE_MARKER_RECORDED,
                 MarkerRecordedEventAttributes.newBuilder()
-                    .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+                    .setMarkerName(VersionMarkerUtils.MARKER_NAME)
                     .putDetails(
                         VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get())
                     .putDetails(
@@ -781,7 +780,7 @@ public class VersionStateMachineTest {
             .add(
                 EventType.EVENT_TYPE_MARKER_RECORDED,
                 MarkerRecordedEventAttributes.newBuilder()
-                    .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+                    .setMarkerName(VersionMarkerUtils.MARKER_NAME)
                     .putDetails(
                         VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id2").get())
                     .putDetails(
@@ -791,7 +790,7 @@ public class VersionStateMachineTest {
             .add(
                 EventType.EVENT_TYPE_MARKER_RECORDED,
                 MarkerRecordedEventAttributes.newBuilder()
-                    .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+                    .setMarkerName(VersionMarkerUtils.MARKER_NAME)
                     .putDetails(
                         VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id3").get())
                     .putDetails(
@@ -883,7 +882,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -968,7 +967,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -1033,7 +1032,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -1114,7 +1113,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -1210,7 +1209,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -1290,7 +1289,7 @@ public class VersionStateMachineTest {
     */
     MarkerRecordedEventAttributes.Builder markerBuilder =
         MarkerRecordedEventAttributes.newBuilder()
-            .setMarkerName(MarkerUtils.VERSION_MARKER_NAME)
+            .setMarkerName(VersionMarkerUtils.MARKER_NAME)
             .putDetails(VersionMarkerUtils.MARKER_CHANGE_ID_KEY, converter.toPayloads("id1").get());
     TestHistoryBuilder h =
         new TestHistoryBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetHistoryLengthTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetHistoryLengthTest.java
@@ -21,7 +21,6 @@
 package io.temporal.workflow;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -59,8 +58,6 @@ public class GetHistoryLengthTest {
 
   @Test
   public void replay() throws Exception {
-    // Avoid executing 4 times
-    assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
     WorkflowReplayer.replayWorkflowExecutionFromResource(
         "testGetHistoryLength.json", TestWorkflowImpl.class);
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityThrowingApplicationFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityThrowingApplicationFailureTest.java
@@ -20,103 +20,86 @@
 
 package io.temporal.workflow.activityTests;
 
-import static io.temporal.workflow.activityTests.ActivityThrowingErrorTest.FAILURE_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import io.temporal.activity.LocalActivityOptions;
-import io.temporal.client.WorkflowClient;
+import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowFailedException;
-import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.ApplicationFailureActivity;
 import io.temporal.workflow.shared.TestActivities.TestActivity4;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow4;
 import java.time.Duration;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-public class LocalActivityThrowingErrorTest {
+public class ActivityThrowingApplicationFailureTest {
 
-  private static WorkflowOptions options;
+  public static final String FAILURE_TYPE = "fail";
 
   @Rule public TestName testName = new TestName();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(LocalActivityThrowsErrorWorkflow.class)
-          .setActivityImplementations(new ActivityThrowingErrorTest.ApplicationFailureActivity())
+          .setWorkflowTypes(ActivityThrowsErrorWorkflow.class)
+          .setActivityImplementations(new ApplicationFailureActivity())
           .build();
 
-  @Before
-  public void setUp() {
-    options =
-        WorkflowOptions.newBuilder()
-            .setTaskQueue(testWorkflowRule.getTaskQueue())
-            .setRetryOptions(
-                RetryOptions.newBuilder()
-                    .setMaximumAttempts(1)
-                    .setInitialInterval(Duration.ofMinutes(2))
-                    .build())
-            .build();
-  }
-
   @Test
-  public void localActivityThrowsError() {
+  public void activityThrowsError() {
     String name = testName.getMethodName();
-    WorkflowClient client = testWorkflowRule.getWorkflowClient();
-    TestWorkflow4 workflow = client.newWorkflowStub(TestWorkflow4.class, options);
+    TestWorkflow4 workflow = testWorkflowRule.newWorkflowStub(TestWorkflow4.class);
+
     try {
       workflow.execute(name, true);
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof ActivityFailure);
       assertTrue(e.getCause().getCause() instanceof ApplicationFailure);
       assertEquals(FAILURE_TYPE, ((ApplicationFailure) e.getCause().getCause()).getType());
-      assertEquals(
-          3, ActivityThrowingErrorTest.ApplicationFailureActivity.invocations.get(name).get());
+      assertEquals(3, ApplicationFailureActivity.invocations.get(name).get());
     }
   }
 
   @Test
-  public void localActivityNonRetryableThrowsError() {
+  public void activityThrowsNonRetryableError() {
     String name = testName.getMethodName();
-    WorkflowClient client = testWorkflowRule.getWorkflowClient();
-    TestWorkflow4 workflow = client.newWorkflowStub(TestWorkflow4.class, options);
+    TestWorkflow4 workflow = testWorkflowRule.newWorkflowStub(TestWorkflow4.class);
+
     try {
       workflow.execute(name, false);
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof ActivityFailure);
       assertTrue(e.getCause().getCause() instanceof ApplicationFailure);
       assertEquals(FAILURE_TYPE, ((ApplicationFailure) e.getCause().getCause()).getType());
-      assertEquals(
-          1, ActivityThrowingErrorTest.ApplicationFailureActivity.invocations.get(name).get());
+      assertEquals(1, ApplicationFailureActivity.invocations.get(name).get());
     }
   }
 
-  public static class LocalActivityThrowsErrorWorkflow implements TestWorkflow4 {
+  public static class ActivityThrowsErrorWorkflow implements TestWorkflow4 {
 
-    private final TestActivity4 activity1 =
-        Workflow.newLocalActivityStub(
+    private final TestActivity4 activity =
+        Workflow.newActivityStub(
             TestActivity4.class,
-            LocalActivityOptions.newBuilder()
+            ActivityOptions.newBuilder()
                 .setRetryOptions(
                     RetryOptions.newBuilder()
                         .setMaximumAttempts(3)
-                        .setInitialInterval(Duration.ofSeconds(1))
-                        .setMaximumInterval(Duration.ofMinutes(2))
+                        .setInitialInterval(Duration.ofMillis(100))
+                        .setMaximumInterval(Duration.ofMillis(100))
+                        .setBackoffCoefficient(1.0)
                         .build())
                 .setStartToCloseTimeout(Duration.ofMinutes(2))
                 .build());
 
     @Override
     public String execute(String testName, boolean retryable) {
-      activity1.execute(testName, retryable);
+      activity.execute(testName, retryable);
       return testName;
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
@@ -20,8 +20,6 @@
 
 package io.temporal.workflow.activityTests;
 
-import static org.junit.Assume.assumeFalse;
-
 import io.temporal.activity.ActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowException;
@@ -71,9 +69,7 @@ public class AsyncActivityRetryTest {
   }
 
   @Test
-  public void testAsyncActivityRetryReplay() throws Exception {
-    // Avoid executing 4 times
-    assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
+  public void testAsyncActivityRetry_replay() throws Exception {
     WorkflowReplayer.replayWorkflowExecutionFromResource(
         "testAsyncActivityRetryHistory.json", TestAsyncActivityRetry.class);
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests;
+
+import static org.junit.Assert.*;
+
+import io.temporal.activity.LocalActivityOptions;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.enums.v1.RetryState;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.Worker;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.ControlledActivityImpl;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.*;
+
+public class LocalActivityRetryOverLocalBackoffThresholdTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setDoNotStart(true).build();
+
+  @Test(timeout = 20_000)
+  public void localActivityRetryOverTheThreshold() {
+    Worker worker = testWorkflowRule.getWorker();
+    ControlledActivityImpl controlledActivity =
+        new ControlledActivityImpl(
+            Collections.singletonList(ControlledActivityImpl.Outcome.FAIL), 7, -1);
+    worker.registerActivitiesImplementations(controlledActivity);
+    worker.registerWorkflowImplementationTypes(TestWorkflowImpl.class);
+    testWorkflowRule.getTestEnvironment().start();
+
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+
+    WorkflowException e =
+        assertThrows(
+            WorkflowException.class, () -> workflowStub.execute(testWorkflowRule.getTaskQueue()));
+    assertTrue(e.getCause() instanceof ActivityFailure);
+
+    controlledActivity.verifyAttempts();
+
+    List<HistoryEvent> historyEvents =
+        testWorkflowRule.getHistoryEvents(
+            WorkflowStub.fromTyped(workflowStub).getExecution(),
+            EventType.EVENT_TYPE_TIMER_STARTED);
+    // attempt retry periods will be
+    assertEquals(
+        "6 retry periods are expected: [1, 1.2, 1.44, 1.727, 2.073, 2.488] with 2 being larger than 2 (local retry threshold)",
+        2,
+        historyEvents.size());
+    historyEvents.forEach(
+        timerEvent ->
+            assertEquals(
+                2,
+                timerEvent.getTimerStartedEventAttributes().getStartToFireTimeout().getSeconds()));
+  }
+
+  @Test(timeout = 20_000)
+  public void maxAttemptDecreasedOnRetryWakeUp() {
+    Worker worker = testWorkflowRule.getWorker();
+    ControlledActivityImpl controlledActivity =
+        new ControlledActivityImpl(
+            Arrays.asList(
+                ControlledActivityImpl.Outcome.FAIL, ControlledActivityImpl.Outcome.COMPLETE),
+            1,
+            -1);
+    worker.registerActivitiesImplementations(controlledActivity);
+    worker.registerWorkflowImplementationTypes(WorkflowReducingAttemptsImpl.class);
+    testWorkflowRule.getTestEnvironment().start();
+
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    WorkflowStub untypedStub = WorkflowStub.fromTyped(workflowStub);
+    WorkflowExecution execution = untypedStub.start(testWorkflowRule.getTaskQueue());
+
+    testWorkflowRule.waitForTheEndOfWFT(execution);
+    testWorkflowRule.invalidateWorkflowCache();
+
+    WorkflowException e =
+        assertThrows(WorkflowException.class, () -> untypedStub.getResult(String.class));
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+    assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, activityFailure.getRetryState());
+
+    controlledActivity.verifyAttempts();
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      LocalActivityOptions options =
+          LocalActivityOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(100))
+              .setLocalRetryThreshold(Duration.ofSeconds(2))
+              .setRetryOptions(
+                  RetryOptions.newBuilder()
+                      .setInitialInterval(Duration.ofSeconds(1))
+                      .setBackoffCoefficient(1.2)
+                      .setMaximumAttempts(7)
+                      .setDoNotRetry(AssertionError.class.getName())
+                      .build())
+              .build();
+      TestActivities.TestActivity1 activities =
+          Workflow.newLocalActivityStub(TestActivities.TestActivity1.class, options);
+      activities.execute(taskQueue);
+
+      return "ignored";
+    }
+  }
+
+  public static class WorkflowReducingAttemptsImpl implements TestWorkflows.TestWorkflow1 {
+    private static final AtomicInteger maxAttempts = new AtomicInteger(2);
+
+    @Override
+    public String execute(String taskQueue) {
+      LocalActivityOptions options =
+          LocalActivityOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(100))
+              .setLocalRetryThreshold(Duration.ofSeconds(1))
+              .setRetryOptions(
+                  RetryOptions.newBuilder()
+                      .setInitialInterval(Duration.ofSeconds(2))
+                      .setBackoffCoefficient(1)
+                      .setMaximumAttempts(maxAttempts.getAndDecrement())
+                      .setDoNotRetry(AssertionError.class.getName())
+                      .build())
+              .build();
+      TestActivities.TestActivity1 activities =
+          Workflow.newLocalActivityStub(TestActivities.TestActivity1.class, options);
+      activities.execute(taskQueue);
+
+      return "ignored";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivitySuccessfulCompletionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivitySuccessfulCompletionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests;
+
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.WorkflowReplayer;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LocalActivitySuccessfulCompletionTest {
+  private final TestActivities.TestActivitiesImpl activitiesImpl =
+      new TestActivities.TestActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestLongLocalActivityWorkflowTaskHeartbeatWorkflowImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void testSuccessfulCompletion() {
+    TestWorkflows.TestWorkflowReturnString workflowStub =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class);
+    String result = workflowStub.execute();
+    Assert.assertEquals("input1", result);
+    Assert.assertEquals(activitiesImpl.toString(), 1, activitiesImpl.invocations.size());
+    testWorkflowRule.regenerateHistoryForReplay(
+        WorkflowStub.fromTyped(workflowStub).getExecution(), "laSuccessfulCompletion_1_xx");
+  }
+
+  /** History from 1.17 before we changed LA marker structure in 1.18 */
+  @Test
+  public void testSuccessfulCompletion_replay117() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "laSuccessfulCompletion_1_17.json",
+        TestLongLocalActivityWorkflowTaskHeartbeatWorkflowImpl.class);
+  }
+
+  public static class TestLongLocalActivityWorkflowTaskHeartbeatWorkflowImpl
+      implements TestWorkflows.TestWorkflowReturnString {
+    @Override
+    public String execute() {
+      TestActivities.VariousTestActivities localActivities =
+          Workflow.newLocalActivityStub(
+              TestActivities.VariousTestActivities.class,
+              SDKTestOptions.newLocalActivityOptions20sScheduleToClose());
+      return localActivities.activity2("input", 1);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowAsyncRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowAsyncRetryTest.java
@@ -21,7 +21,6 @@
 package io.temporal.workflow.childWorkflowTests;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
 
 import io.temporal.client.WorkflowException;
 import io.temporal.client.WorkflowOptions;
@@ -79,8 +78,6 @@ public class ChildWorkflowAsyncRetryTest {
   /** Tests that WorkflowReplayer fails if replay does not match workflow run. */
   @Test(expected = RuntimeException.class)
   public void testAlteredWorkflowReplayFailure() throws Exception {
-    assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
-
     WorkflowReplayer.replayWorkflowExecutionFromResource(
         "testChildWorkflowRetryHistory.json", AlteredTestChildWorkflowRetryWorkflow.class);
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
@@ -22,7 +22,6 @@ package io.temporal.workflow.childWorkflowTests;
 
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowClientOptions;
@@ -124,9 +123,7 @@ public class ChildWorkflowRetryTest {
    * compatible with the client that supports the server side retry.
    */
   @Test
-  public void testChildWorkflowRetryReplay() throws Exception {
-    assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
-
+  public void testChildWorkflowRetry_replay() throws Exception {
     WorkflowReplayer.replayWorkflowExecutionFromResource(
         "testChildWorkflowRetryHistory.json", TestChildWorkflowRetryWorkflow.class);
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/ApplicationFailureActivity.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/ApplicationFailureActivity.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.shared;
+
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.workflow.activityTests.ActivityThrowingApplicationFailureTest;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ApplicationFailureActivity implements TestActivities.TestActivity4 {
+  public static final Map<String, AtomicInteger> invocations = new ConcurrentHashMap<>();
+
+  @Override
+  public void execute(String testName, boolean retryable) {
+    invocations.computeIfAbsent(testName, k -> new AtomicInteger()).incrementAndGet();
+    if (retryable) {
+      throw ApplicationFailure.newFailure(
+          "Simulate retryable failure.",
+          ActivityThrowingApplicationFailureTest.FAILURE_TYPE,
+          ActivityThrowingApplicationFailureTest.FAILURE_TYPE);
+    }
+    throw ApplicationFailure.newNonRetryableFailure(
+        "Simulate non-retryable failure.",
+        ActivityThrowingApplicationFailureTest.FAILURE_TYPE,
+        ActivityThrowingApplicationFailureTest.FAILURE_TYPE);
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/ControlledActivityImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/ControlledActivityImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.shared;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.activity.Activity;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ControlledActivityImpl implements TestActivities.NoArgsReturnsStringActivity {
+
+  public enum Outcome {
+    FAIL,
+    SLEEP,
+    COMPLETE
+  }
+
+  private final List<Outcome> outcomes;
+  private final int expectedAttempts;
+  private final long secondsToSleep;
+
+  private int lastAttempt = 0;
+
+  public ControlledActivityImpl(List<Outcome> outcomes, int expectedAttempts, long secondsToSleep) {
+    this.outcomes = outcomes;
+    this.expectedAttempts = expectedAttempts;
+    this.secondsToSleep = secondsToSleep;
+  }
+
+  @Override
+  public String execute() {
+    lastAttempt = Activity.getExecutionContext().getInfo().getAttempt();
+    Outcome outcome = outcomes.get((lastAttempt - 1) % outcomes.size());
+    switch (outcome) {
+      case FAIL:
+        throw new RuntimeException("intentional failure");
+      case SLEEP:
+        try {
+          Thread.sleep(TimeUnit.SECONDS.toMillis(secondsToSleep));
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+        }
+        return "done";
+      case COMPLETE:
+        return "done";
+      default:
+        throw new IllegalArgumentException("Unexpected outcome: " + outcome);
+    }
+  }
+
+  public void verifyAttempts() {
+    assertEquals(
+        "Amount of attempts performed is different from the expected",
+        expectedAttempts,
+        lastAttempt);
+  }
+}

--- a/temporal-sdk/src/test/resources/laRetriesAndFails_1_17.json
+++ b/temporal-sdk/src/test/resources/laRetriesAndFails_1_17.json
@@ -1,0 +1,197 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2022-12-05T23:33:20.915Z",
+      "eventType": "WorkflowExecutionStarted",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "TestWorkflow1"
+        },
+        "taskQueue": {
+          "name": "WorkflowTest-testLocalActivityRetriesAndFails-3ce18680-be42-43d0-98e8-f6ae7da9056c"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+              },
+              "data": "IldvcmtmbG93VGVzdC10ZXN0TG9jYWxBY3Rpdml0eVJldHJpZXNBbmRGYWlscy0zY2UxODY4MC1iZTQyLTQzZDAtOThlOC1mNmFlN2RhOTA1NmMi"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "200s",
+        "workflowTaskTimeout": "5s",
+        "originalExecutionRunId": "36dbe72d-1f3a-4280-a2a1-3d42a70e67a4",
+        "identity": "9600@dmitrys-mini.lan",
+        "firstExecutionRunId": "36dbe72d-1f3a-4280-a2a1-3d42a70e67a4",
+        "attempt": 1,
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2022-12-05T23:33:20.915Z",
+      "eventType": "WorkflowTaskScheduled",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "WorkflowTest-testLocalActivityRetriesAndFails-3ce18680-be42-43d0-98e8-f6ae7da9056c"
+        },
+        "startToCloseTimeout": "5s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2022-12-05T23:33:20.930Z",
+      "eventType": "WorkflowTaskStarted",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "9600@dmitrys-mini.lan"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2022-12-05T23:33:25.035Z",
+      "eventType": "WorkflowTaskCompleted",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "9600@dmitrys-mini.lan"
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2022-12-05T23:33:25.035Z",
+      "eventType": "WorkflowTaskScheduled",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "WorkflowTest-testLocalActivityRetriesAndFails-3ce18680-be42-43d0-98e8-f6ae7da9056c"
+        },
+        "startToCloseTimeout": "5s",
+        "attempt": 2
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2022-12-05T23:33:25.035Z",
+      "eventType": "WorkflowTaskStarted",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "9600@dmitrys-mini.lan"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2022-12-05T23:33:25.136Z",
+      "eventType": "WorkflowTaskCompleted",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "9600@dmitrys-mini.lan"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2022-12-05T23:33:25.136Z",
+      "eventType": "MarkerRecorded",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "activityId": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "ImY0NzBiODExLThkNTYtMzNkMC04ZGExLWY3ODY3NTAwMzZkYyI\u003d"
+              }
+            ]
+          },
+          "input": {},
+          "time": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "MTY3MDI4MzIwNTAzNQ\u003d\u003d"
+              }
+            ]
+          },
+          "type": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IlRocm93SU8i"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "6",
+        "failure": {
+          "message": "Local Activity task failed",
+          "cause": {
+            "message": "simulated IO problem",
+            "source": "JavaSDK",
+            "stackTrace": "io.temporal.workflow.shared.TestActivities$TestActivitiesImpl.throwIO(TestActivities.java:379)\njava.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)\njava.base/java.lang.reflect.Method.invoke(Method.java:577)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)\nio.temporal.testing.internal.TracingWorkerInterceptor$TracingActivityInboundCallsInterceptor.execute(TracingWorkerInterceptor.java:404)\nio.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:95)\nio.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:92)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:330)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:282)\nio.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\njava.base/java.lang.Thread.run(Thread.java:833)\n",
+            "cause": {
+              "message": "test throwable wrapping",
+              "source": "JavaSDK",
+              "stackTrace": "io.temporal.workflow.shared.TestActivities$TestActivitiesImpl.throwIO(TestActivities.java:379)\njava.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)\njava.base/java.lang.reflect.Method.invoke(Method.java:577)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)\nio.temporal.testing.internal.TracingWorkerInterceptor$TracingActivityInboundCallsInterceptor.execute(TracingWorkerInterceptor.java:404)\nio.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:95)\nio.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:92)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:330)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:282)\nio.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\njava.base/java.lang.Thread.run(Thread.java:833)\n",
+              "applicationFailureInfo": {
+                "type": "java.lang.Throwable"
+              }
+            },
+            "applicationFailureInfo": {
+              "type": "java.io.IOException"
+            }
+          },
+          "activityFailureInfo": {
+            "activityType": {
+              "name": "ThrowIO"
+            },
+            "activityId": "f470b811-8d56-33d0-8da1-f786750036dc",
+            "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+          }
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2022-12-05T23:33:25.136Z",
+      "eventType": "WorkflowExecutionFailed",
+      "workflowExecutionFailedEventAttributes": {
+        "failure": {
+          "message": "Local Activity task failed",
+          "cause": {
+            "message": "simulated IO problem",
+            "source": "JavaSDK",
+            "stackTrace": "io.temporal.workflow.shared.TestActivities$TestActivitiesImpl.throwIO(TestActivities.java:379)\njava.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)\njava.base/java.lang.reflect.Method.invoke(Method.java:577)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)\nio.temporal.testing.internal.TracingWorkerInterceptor$TracingActivityInboundCallsInterceptor.execute(TracingWorkerInterceptor.java:404)\nio.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:95)\nio.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:92)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:330)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:282)\nio.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\njava.base/java.lang.Thread.run(Thread.java:833)\n",
+            "cause": {
+              "message": "test throwable wrapping",
+              "source": "JavaSDK",
+              "stackTrace": "io.temporal.workflow.shared.TestActivities$TestActivitiesImpl.throwIO(TestActivities.java:379)\njava.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)\njava.base/java.lang.reflect.Method.invoke(Method.java:577)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)\nio.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)\nio.temporal.testing.internal.TracingWorkerInterceptor$TracingActivityInboundCallsInterceptor.execute(TracingWorkerInterceptor.java:404)\nio.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:95)\nio.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:92)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:330)\nio.temporal.internal.worker.LocalActivityWorker$TaskHandlerImpl.handle(LocalActivityWorker.java:282)\nio.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)\njava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\njava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\njava.base/java.lang.Thread.run(Thread.java:833)\n",
+              "applicationFailureInfo": {
+                "type": "java.lang.Throwable"
+              }
+            },
+            "applicationFailureInfo": {
+              "type": "java.io.IOException"
+            }
+          },
+          "activityFailureInfo": {
+            "activityType": {
+              "name": "ThrowIO"
+            },
+            "activityId": "f470b811-8d56-33d0-8da1-f786750036dc",
+            "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
+          }
+        },
+        "workflowTaskCompletedEventId": "6"
+      }
+    }
+  ]
+}

--- a/temporal-sdk/src/test/resources/laSuccessfulCompletion_1_17.json
+++ b/temporal-sdk/src/test/resources/laSuccessfulCompletion_1_17.json
@@ -1,0 +1,141 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2022-12-05T23:15:57.982Z",
+      "eventType": "WorkflowExecutionStarted",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "TestWorkflowReturnString"
+        },
+        "taskQueue": {
+          "name": "WorkflowTest-testSuccessfulCompletion-4aaade89-17d4-44c2-933d-7859e1ab58f5"
+        },
+        "input": {},
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "286fef70-b0d5-4ebd-95d7-fa3df7ec3162",
+        "identity": "7790@dmitrys-mini.lan",
+        "firstExecutionRunId": "286fef70-b0d5-4ebd-95d7-fa3df7ec3162",
+        "attempt": 1,
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2022-12-05T23:15:57.982Z",
+      "eventType": "WorkflowTaskScheduled",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "WorkflowTest-testSuccessfulCompletion-4aaade89-17d4-44c2-933d-7859e1ab58f5"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2022-12-05T23:15:57.997Z",
+      "eventType": "WorkflowTaskStarted",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "7790@dmitrys-mini.lan"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2022-12-05T23:15:58.205Z",
+      "eventType": "WorkflowTaskCompleted",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "7790@dmitrys-mini.lan"
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2022-12-05T23:15:58.205Z",
+      "eventType": "MarkerRecorded",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "ImlucHV0MSI\u003d"
+              }
+            ]
+          },
+          "activityId": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "Ijc4OWRmYjEwLTgxMWYtM2NmMy1hY2IzLTBlMmVjZGE5YTRmNyI\u003d"
+              }
+            ]
+          },
+          "input": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "ImlucHV0Ig\u003d\u003d"
+              },
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "MQ\u003d\u003d"
+              }
+            ]
+          },
+          "time": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "MTY3MDI4MjE1ODAyNA\u003d\u003d"
+              }
+            ]
+          },
+          "type": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IkFjdGl2aXR5MiI\u003d"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2022-12-05T23:15:58.205Z",
+      "eventType": "WorkflowExecutionCompleted",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+              },
+              "data": "ImlucHV0MSI\u003d"
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    }
+  ]
+}

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api "io.grpc:grpc-api" //Classes like io.grpc.Metadata are used as a part of our API
     api "io.grpc:grpc-stub" //Part of WorkflowServiceStubs API
     api "io.grpc:grpc-netty-shaded" //Part of WorkflowServiceStubs API, specifically SslContext
-    api "io.grpc:grpc-services" //Stardard gRPC HealthCheck Response class
+    api "io.grpc:grpc-services" //Standard gRPC HealthCheck Response class
     api "com.google.protobuf:protobuf-java-util:$protoVersion" //proto request and response objects are a part of this module's API
     if (JavaVersion.current().isJava9Compatible()) {
         //needed for the generated grpc stubs and is not a part of JDK since java 9
@@ -57,7 +57,7 @@ protobuf {
     // For aarch64 (M1) using oldest version with binary available for this platform
     if (System.getProperty("os.arch") == 'aarch64') {
         protoc {
-            artifact = 'com.google.protobuf:protoc:3.21.9'
+            artifact = 'com.google.protobuf:protoc:3.21.10'
         }
         plugins {
             grpc {

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -61,7 +61,7 @@ protobuf {
     // For aarch64 (M1) using oldest version with binary available for this platform
     if (System.getProperty("os.arch") == 'aarch64') {
         protoc {
-            artifact = 'com.google.protobuf:protoc:3.21.9'
+            artifact = 'com.google.protobuf:protoc:3.21.10'
         }
         plugins {
             grpc {

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -35,10 +35,12 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.replay.ReplayWorkflowContext;
 import io.temporal.internal.statemachines.ExecuteActivityParameters;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
+import io.temporal.internal.statemachines.LocalActivityCallback;
 import io.temporal.internal.statemachines.StartChildWorkflowExecutionParameters;
 import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.*;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class DummySyncWorkflowContext {
@@ -127,6 +129,7 @@ public class DummySyncWorkflowContext {
       return 0;
     }
 
+    @Nonnull
     @Override
     public Duration getWorkflowTaskTimeout() {
       throw new UnsupportedOperationException("not implemented");
@@ -151,8 +154,7 @@ public class DummySyncWorkflowContext {
 
     @Override
     public Functions.Proc scheduleLocalActivityTask(
-        ExecuteLocalActivityParameters parameters,
-        Functions.Proc2<Optional<Payloads>, Failure> callback) {
+        ExecuteLocalActivityParameters parameters, LocalActivityCallback callback) {
       throw new UnsupportedOperationException("not implemented");
     }
 


### PR DESCRIPTION
Implemented retries of local activities that break the local retry threshold.
Local activities now persist additional information into local activities marker (original scheduled time, last attempt, backoff duration).
If activity execution kept failing, and has more retries to do according to LocalActivityOptions, but is over the Local Retry Threshold, now workflow code will schedule a timer and continues retrying the local activities after the timer is fired. This will be done transparently for users. The timer will be present in the workflow history but is not observable from the user workflow code.

TODO: backward compatibility tests with old histories that don't have new marker fields.

Closes #1261