### PR TITLE
Remove usage of Workflow time from tracing spans

### DIFF
--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -70,7 +70,6 @@ public class OpenTracingActivityInboundCallsInterceptor
             .createActivityRunSpan(
                 tracer,
                 activityInfo.getActivityType(),
-                System.currentTimeMillis(),
                 activityInfo.getWorkflowId(),
                 activityInfo.getRunId(),
                 rootSpanContext)

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
@@ -79,10 +79,6 @@ public class OpenTracingWorkflowClientCallsInterceptor extends WorkflowClientCal
   private Tracer.SpanBuilder createWorkflowStartSpanBuilder(
       WorkflowStartInput input, SpanOperationType operationType) {
     return spanFactory.createWorkflowStartSpan(
-        tracer,
-        operationType,
-        input.getWorkflowType(),
-        System.currentTimeMillis(),
-        input.getWorkflowId());
+        tracer, operationType, input.getWorkflowType(), input.getWorkflowId());
   }
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowInboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowInboundCallsInterceptor.java
@@ -65,7 +65,6 @@ public class OpenTracingWorkflowInboundCallsInterceptor
             .createWorkflowRunSpan(
                 tracer,
                 Workflow.getInfo().getWorkflowType(),
-                Workflow.currentTimeMillis(),
                 Workflow.getInfo().getWorkflowId(),
                 Workflow.getInfo().getRunId(),
                 rootSpanContext)

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowOutboundCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowOutboundCallsInterceptor.java
@@ -136,11 +136,7 @@ public class OpenTracingWorkflowOutboundCallsInterceptor
   private Tracer.SpanBuilder createActivityStartSpanBuilder(String activityName) {
     WorkflowInfo workflowInfo = Workflow.getInfo();
     return spanFactory.createActivityStartSpan(
-        tracer,
-        activityName,
-        Workflow.currentTimeMillis(),
-        workflowInfo.getWorkflowId(),
-        workflowInfo.getRunId());
+        tracer, activityName, workflowInfo.getWorkflowId(), workflowInfo.getRunId());
   }
 
   private <R> Tracer.SpanBuilder createChildWorkflowStartSpanBuilder(ChildWorkflowInput<R> input) {
@@ -160,7 +156,6 @@ public class OpenTracingWorkflowOutboundCallsInterceptor
         tracer,
         MoreObjects.firstNonNull(input.getWorkflowType(), parentWorkflowInfo.getWorkflowType()),
         parentWorkflowInfo.getWorkflowId(),
-        Workflow.currentTimeMillis(),
         parentWorkflowInfo.getRunId());
   }
 }

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -35,7 +35,6 @@ import io.temporal.opentracing.SpanOperationType;
 import io.temporal.opentracing.StandardTagNames;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 public class SpanFactory {
@@ -48,11 +47,7 @@ public class SpanFactory {
   }
 
   public Tracer.SpanBuilder createWorkflowStartSpan(
-      Tracer tracer,
-      SpanOperationType operationType,
-      String workflowType,
-      long startTimeMs,
-      String workflowId) {
+      Tracer tracer, SpanOperationType operationType, String workflowType, String workflowId) {
 
     SpanCreationContext context =
         SpanCreationContext.newBuilder()
@@ -61,7 +56,7 @@ public class SpanFactory {
             .setWorkflowId(workflowId)
             .build();
 
-    return createSpan(context, tracer, startTimeMs, null, References.FOLLOWS_FROM);
+    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
   }
 
   public Tracer.SpanBuilder createChildWorkflowStartSpan(
@@ -79,15 +74,11 @@ public class SpanFactory {
             .setParentWorkflowId(parentWorkflowId)
             .setParentRunId(parentRunId)
             .build();
-    return createSpan(context, tracer, startTimeMs, null, References.CHILD_OF);
+    return createSpan(context, tracer, null, References.CHILD_OF);
   }
 
   public Tracer.SpanBuilder createContinueAsNewWorkflowStartSpan(
-      Tracer tracer,
-      String continueAsNewWorkflowType,
-      String workflowId,
-      long startTimeMs,
-      String parentRunId) {
+      Tracer tracer, String continueAsNewWorkflowType, String workflowId, String parentRunId) {
     SpanCreationContext context =
         SpanCreationContext.newBuilder()
             .setSpanOperationType(SpanOperationType.START_CONTINUE_AS_NEW_WORKFLOW)
@@ -95,13 +86,12 @@ public class SpanFactory {
             .setWorkflowId(workflowId)
             .setParentRunId(parentRunId)
             .build();
-    return createSpan(context, tracer, startTimeMs, null, References.FOLLOWS_FROM);
+    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
   }
 
   public Tracer.SpanBuilder createWorkflowRunSpan(
       Tracer tracer,
       String workflowType,
-      long startTimeMs,
       String workflowId,
       String runId,
       SpanContext workflowStartSpanContext) {
@@ -112,12 +102,11 @@ public class SpanFactory {
             .setWorkflowId(workflowId)
             .setRunId(runId)
             .build();
-    return createSpan(
-        context, tracer, startTimeMs, workflowStartSpanContext, References.FOLLOWS_FROM);
+    return createSpan(context, tracer, workflowStartSpanContext, References.FOLLOWS_FROM);
   }
 
   public Tracer.SpanBuilder createActivityStartSpan(
-      Tracer tracer, String activityType, long startTimeMs, String workflowId, String runId) {
+      Tracer tracer, String activityType, String workflowId, String runId) {
     SpanCreationContext context =
         SpanCreationContext.newBuilder()
             .setSpanOperationType(SpanOperationType.START_ACTIVITY)
@@ -125,13 +114,12 @@ public class SpanFactory {
             .setWorkflowId(workflowId)
             .setRunId(runId)
             .build();
-    return createSpan(context, tracer, startTimeMs, null, References.CHILD_OF);
+    return createSpan(context, tracer, null, References.CHILD_OF);
   }
 
   public Tracer.SpanBuilder createActivityRunSpan(
       Tracer tracer,
       String activityType,
-      long startTimeMs,
       String workflowId,
       String runId,
       SpanContext activityStartSpanContext) {
@@ -142,8 +130,7 @@ public class SpanFactory {
             .setWorkflowId(workflowId)
             .setRunId(runId)
             .build();
-    return createSpan(
-        context, tracer, startTimeMs, activityStartSpanContext, References.FOLLOWS_FROM);
+    return createSpan(context, tracer, activityStartSpanContext, References.FOLLOWS_FROM);
   }
 
   @SuppressWarnings("deprecation")
@@ -172,7 +159,6 @@ public class SpanFactory {
   private Tracer.SpanBuilder createSpan(
       SpanCreationContext context,
       Tracer tracer,
-      long startTimeMs,
       @Nullable SpanContext parentSpanContext,
       @Nullable String parentReferenceType) {
     SpanContext parent;
@@ -187,9 +173,6 @@ public class SpanFactory {
     }
 
     SpanBuilder builder = options.getSpanBuilderProvider().createSpanBuilder(tracer, context);
-
-    long startTimeMc = TimeUnit.MILLISECONDS.toMicros(startTimeMs);
-    builder.withStartTimestamp(startTimeMc);
 
     if (parent != null) {
       builder.addReference(


### PR DESCRIPTION
## Why?
There is no big reason to use workflow time in spans. It actually may be confusing even during replay to get spans "started in the past".
Usage of Workflow Time creates problems for users that attempt to use span structures and data for profiling, especially on the milliseconds level.