### PR TITLE
Set heartbeat details for TestActivityEnvironment

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironment.java
@@ -141,10 +141,11 @@ public interface TestActivityEnvironment {
       Class<T> detailsClass, Type detailsType, Functions.Proc1<T> listener);
 
   /**
-   * Sets heartbeat details for the next activity execution. The next activity
-   * called from this TestActivityEnvironment will be able to access this value
-   * using {@link io.temporal.activity.ActivityExecutionContext#getHeartbeatDetails(Class)}.
-   * This value is cleared upon execution.
+   * Sets heartbeat details for the next activity execution. The next activity called from this
+   * TestActivityEnvironment will be able to access this value using {@link
+   * io.temporal.activity.ActivityExecutionContext#getHeartbeatDetails(Class)}. This value is
+   * cleared upon execution.
+   *
    * @param details The details object to make available to the next activity call.
    * @param <T> Type of the heartbeat details.
    */

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironment.java
@@ -141,6 +141,16 @@ public interface TestActivityEnvironment {
       Class<T> detailsClass, Type detailsType, Functions.Proc1<T> listener);
 
   /**
+   * Sets heartbeat details for the next activity execution. The next activity
+   * called from this TestActivityEnvironment will be able to access this value
+   * using {@link io.temporal.activity.ActivityExecutionContext#getHeartbeatDetails(Class)}.
+   * This value is cleared upon execution.
+   * @param details The details object to make available to the next activity call.
+   * @param <T> Type of the heartbeat details.
+   */
+  <T> void setHeartbeatDetails(T details);
+
+  /**
    * Requests activity cancellation. The cancellation is going to be delivered to the activity on
    * the next heartbeat.
    */

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -272,10 +272,12 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
               .toPayloads(i.getArgs());
       Optional<Payloads> heartbeatPayload =
           Optional.ofNullable(heartbeatDetails)
-                .flatMap(obj -> testEnvironmentOptions
-                    .getWorkflowClientOptions()
-                    .getDataConverter()
-                    .toPayloads(obj));
+              .flatMap(
+                  obj ->
+                      testEnvironmentOptions
+                          .getWorkflowClientOptions()
+                          .getDataConverter()
+                          .toPayloads(obj));
       heartbeatDetails = null;
 
       ActivityOptions options = i.getOptions();

--- a/temporal-testing/src/test/java/io/temporal/testing/TestActivityEnvironmentHeartbeat.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestActivityEnvironmentHeartbeat.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.testing;
 
 import io.temporal.activity.Activity;
@@ -16,7 +36,8 @@ class TestActivityEnvironmentHeartbeat {
     String detailString = "details";
     testActivityEnvironment.registerActivitiesImplementations(new HeartbeatingActivityImpl());
     testActivityEnvironment.setHeartbeatDetails(detailString);
-    HearbeatingActivity heartbeatActivityStub = testActivityEnvironment.newActivityStub(HearbeatingActivity.class);
+    HearbeatingActivity heartbeatActivityStub =
+        testActivityEnvironment.newActivityStub(HearbeatingActivity.class);
 
     String result = heartbeatActivityStub.heartbeatMethod();
     Assertions.assertEquals(detailString, result);
@@ -28,7 +49,8 @@ class TestActivityEnvironmentHeartbeat {
   @Test
   void testHeartbeatNullWithoutSetting() {
     testActivityEnvironment.registerActivitiesImplementations(new HeartbeatingActivityImpl());
-    HearbeatingActivity heartbeatActivityStub = testActivityEnvironment.newActivityStub(HearbeatingActivity.class);
+    HearbeatingActivity heartbeatActivityStub =
+        testActivityEnvironment.newActivityStub(HearbeatingActivity.class);
 
     String result = heartbeatActivityStub.heartbeatMethod();
     Assertions.assertNull(result);
@@ -39,16 +61,15 @@ class TestActivityEnvironmentHeartbeat {
 
     @ActivityMethod
     String heartbeatMethod();
-
   }
 
   static class HeartbeatingActivityImpl implements HearbeatingActivity {
 
     @Override
     public String heartbeatMethod() {
-      Optional<String> maybeDetails = Activity.getExecutionContext().getHeartbeatDetails(String.class);
+      Optional<String> maybeDetails =
+          Activity.getExecutionContext().getHeartbeatDetails(String.class);
       return maybeDetails.orElse(null);
     }
   }
-
 }

--- a/temporal-testing/src/test/java/io/temporal/testing/TestActivityEnvironmentHeartbeat.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestActivityEnvironmentHeartbeat.java
@@ -1,0 +1,54 @@
+package io.temporal.testing;
+
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestActivityEnvironmentHeartbeat {
+
+  TestActivityEnvironment testActivityEnvironment = TestActivityEnvironment.newInstance();
+
+  @Test
+  void testHeartbeat() {
+    String detailString = "details";
+    testActivityEnvironment.registerActivitiesImplementations(new HeartbeatingActivityImpl());
+    testActivityEnvironment.setHeartbeatDetails(detailString);
+    HearbeatingActivity heartbeatActivityStub = testActivityEnvironment.newActivityStub(HearbeatingActivity.class);
+
+    String result = heartbeatActivityStub.heartbeatMethod();
+    Assertions.assertEquals(detailString, result);
+
+    String secondResult = heartbeatActivityStub.heartbeatMethod();
+    Assertions.assertNull(secondResult);
+  }
+
+  @Test
+  void testHeartbeatNullWithoutSetting() {
+    testActivityEnvironment.registerActivitiesImplementations(new HeartbeatingActivityImpl());
+    HearbeatingActivity heartbeatActivityStub = testActivityEnvironment.newActivityStub(HearbeatingActivity.class);
+
+    String result = heartbeatActivityStub.heartbeatMethod();
+    Assertions.assertNull(result);
+  }
+
+  @ActivityInterface
+  public interface HearbeatingActivity {
+
+    @ActivityMethod
+    String heartbeatMethod();
+
+  }
+
+  static class HeartbeatingActivityImpl implements HearbeatingActivity {
+
+    @Override
+    public String heartbeatMethod() {
+      Optional<String> maybeDetails = Activity.getExecutionContext().getHeartbeatDetails(String.class);
+      return maybeDetails.orElse(null);
+    }
+  }
+
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds a `setHeartbeatDetails` method to `TestActivityEnvironment`. This will make the provided details object available with the next activity execution's call to `ActivityExecutionContext#getHeartbeatDetails`. The details object is cleared when it is applied to an activity execution.

As written this only applies to Activity Executions, not Local Activity Executions. My understanding is that Local Activities do not support heartbeating; if I'm wrong here it is trivial to extend support.

## Why?
Activities can send a "details" object when heartbeating, and that details object is made available to the next run of that activity, should it need to be retried. One of the obvious applications of this as a progress marker; e.g., an activity which is performing a number of tasks can potentially use the details marker to resume partway after being interrupted and retried.

However, there is currently no way to test this functionality within the `TestActivityEnvironment`, since the execution contexts it creates never include heartbeat details. This PR addresses this gap and makes resumption logic and other applications of heartbeat details testable. 

## Checklist
<!--- add/delete as needed --->

1. Closes #1310 

2. How was this tested:
New set of unit tests

3. Any docs updates needed?
Javadoc is included. I don't believe `TestActivityEnvironment` is documented outside of the Javadoc
