### PR TITLE
Exposing an ability to fail WorkflowTask for any callback in executor code

### DIFF
--- a/gradle/licensing.gradle
+++ b/gradle/licensing.gradle
@@ -2,7 +2,8 @@ subprojects {
     apply plugin: 'org.cadixdev.licenser'
     license {
         header rootProject.file('LICENSE.header')
-        exclude '**/*.puml'
+        exclude '**/*.puml', 'io/temporal/api', 'gogoproto/Gogo.java'
+
     }
     tasks.check.dependsOn('checkLicenseMain')
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowMutableState.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowMutableState.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.replay;
+
+import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes;
+import io.temporal.api.common.v1.SearchAttributes;
+import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
+import javax.annotation.Nullable;
+
+class WorkflowMutableState {
+  private boolean cancelRequested;
+  private ContinueAsNewWorkflowExecutionCommandAttributes continueAsNewOnCompletion;
+  private boolean workflowMethodCompleted;
+  private Throwable workflowTaskFailureThrowable;
+  private SearchAttributes.Builder searchAttributes;
+
+  WorkflowMutableState(WorkflowExecutionStartedEventAttributes startedAttributes) {
+    if (startedAttributes.hasSearchAttributes()) {
+      this.searchAttributes = startedAttributes.getSearchAttributes().toBuilder();
+    }
+  }
+
+  boolean isCancelRequested() {
+    return cancelRequested;
+  }
+
+  void setCancelRequested() {
+    cancelRequested = true;
+  }
+
+  ContinueAsNewWorkflowExecutionCommandAttributes getContinueAsNewOnCompletion() {
+    return continueAsNewOnCompletion;
+  }
+
+  void continueAsNewOnCompletion(ContinueAsNewWorkflowExecutionCommandAttributes parameters) {
+    this.continueAsNewOnCompletion = parameters;
+  }
+
+  Throwable getWorkflowTaskFailure() {
+    return workflowTaskFailureThrowable;
+  }
+
+  void failWorkflowTask(Throwable failure) {
+    workflowTaskFailureThrowable = failure;
+  }
+
+  boolean isWorkflowMethodCompleted() {
+    return workflowMethodCompleted;
+  }
+
+  void setWorkflowMethodCompleted() {
+    this.workflowMethodCompleted = true;
+  }
+
+  SearchAttributes getSearchAttributes() {
+    return searchAttributes == null || searchAttributes.getIndexedFieldsCount() == 0
+        ? null
+        : searchAttributes.build();
+  }
+
+  void upsertSearchAttributes(@Nullable SearchAttributes searchAttributes) {
+    if (searchAttributes == null || searchAttributes.getIndexedFieldsCount() == 0) {
+      return;
+    }
+    if (this.searchAttributes == null) {
+      this.searchAttributes = SearchAttributes.newBuilder();
+    }
+    this.searchAttributes.putAllIndexedFields(searchAttributes.getIndexedFieldsMap());
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
@@ -49,9 +49,12 @@ public interface WorkflowRunTaskHandler {
    *
    * @param workflowTask task to handle
    * @return an object that can be used to build a legacy query response
+   * @throws Throwable if processing experienced issues that are considered unrecoverable inside the
+   *     current workflow task. {@link NonDeterministicException} or {@link Error} are such cases.
    */
   QueryResult handleDirectQueryWorkflowTask(
-      PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowHistoryIterator historyIterator);
+      PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowHistoryIterator historyIterator)
+      throws Throwable;
 
   void close();
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
@@ -71,7 +71,7 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
   private WorkflowStateMachines stateMachines;
 
   @Test
-  public void queryIsOutdated() {
+  public void queryIsOutdated() throws Throwable {
     TestWorkflows.TestWorkflowWithQuery noArgsWorkflow =
         testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowWithQuery.class);
     noArgsWorkflow.execute();

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowMutableStateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowMutableStateTest.java
@@ -24,30 +24,28 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import io.temporal.api.common.v1.SearchAttributes;
-import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
 import io.temporal.internal.common.SearchAttributesUtil;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
-public class BasicWorkflowContextTest {
+public class WorkflowMutableStateTest {
 
   @Test
-  public void testMergeSearchAttributes() {
+  public void testUpsertSearchAttributes() {
     WorkflowExecutionStartedEventAttributes startAttr =
         WorkflowExecutionStartedEventAttributes.getDefaultInstance();
-    BasicWorkflowContext basicWorkflowContext =
-        new BasicWorkflowContext("namespace", WorkflowExecution.getDefaultInstance(), startAttr, 0);
+    WorkflowMutableState workflowMutableState = new WorkflowMutableState(startAttr);
 
     Map<String, Object> indexedFields = new HashMap<>();
     indexedFields.put("CustomKeywordField", "key");
 
     SearchAttributes searchAttributes = SearchAttributesUtil.encode(indexedFields);
 
-    basicWorkflowContext.mergeSearchAttributes(searchAttributes);
+    workflowMutableState.upsertSearchAttributes(searchAttributes);
 
-    SearchAttributes decodedAttributes = basicWorkflowContext.getSearchAttributes();
+    SearchAttributes decodedAttributes = workflowMutableState.getSearchAttributes();
     assertNotNull(decodedAttributes);
 
     assertEquals(

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.google.protobuf' version '0.8.19'
+    id 'com.google.protobuf' version '0.9.2'
 }
 
 apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
@@ -50,6 +50,15 @@ jar {
     includeEmptyDirs false
 }
 
+// Needed to include generated files into the source jar
+sourcesJar {
+    dependsOn 'generateProto'
+    from(file("$buildDir/generated/main/java"))
+        // Solves: "Entry gogoproto/Gogo.java is a duplicate but no duplicate handling strategy has been set.
+        // Please refer to https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details."
+        .setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+}
+
 protobuf {
     // version/variables substitution is not supported in protobuf section.
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
@@ -91,12 +100,6 @@ clean {
 
 protobuf {
     generatedFilesBaseDir = "$buildDir/generated"
-}
-
-// Needed to include generated files into the source jar
-sourcesJar {
-    dependsOn 'generateProto'
-    from(file("$buildDir/generated/main/java"))
 }
 
 javadocJar {

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'application'
     id 'com.palantir.graal' version "${graalVersion}"
     id 'com.palantir.docker' version '0.34.0'
-    id 'com.google.protobuf' version '0.8.19'
+    id 'com.google.protobuf' version '0.9.2'
 }
 
 apply plugin: 'idea' // IntelliJ plugin to see files generated from protos
@@ -54,6 +54,15 @@ jar {
     }
 }
 
+// Needed to include generated files into the source jar
+sourcesJar {
+    dependsOn 'generateProto'
+    from(file("$buildDir/generated/main/java"))
+        // Solves: "Entry gogoproto/Gogo.java is a duplicate but no duplicate handling strategy has been set.
+        // Please refer to https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details."
+        .setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+}
+
 protobuf {
     // version/variables substitution is not supported in protobuf section.
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
@@ -93,12 +102,6 @@ clean {
 
 protobuf {
     generatedFilesBaseDir = "$buildDir/generated"
-}
-
-// Needed to include generated files into the source jar
-sourcesJar {
-    dependsOn 'generateProto'
-    from(file("$buildDir/generated/main/java"))
 }
 
 idea {

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -85,6 +85,21 @@ public class DummySyncWorkflowContext {
     }
 
     @Override
+    public void setCancelRequested() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public boolean isWorkflowMethodCompleted() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void setWorkflowMethodCompleted() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
     public ContinueAsNewWorkflowExecutionCommandAttributes getContinueAsNewOnCompletion() {
       throw new UnsupportedOperationException("not implemented");
     }
@@ -141,6 +156,7 @@ public class DummySyncWorkflowContext {
     }
 
     @Override
+    @Nullable
     public SearchAttributes getSearchAttributes() {
       throw new UnsupportedOperationException("not implemented");
     }
@@ -182,6 +198,16 @@ public class DummySyncWorkflowContext {
     @Override
     public void continueAsNewOnCompletion(
         ContinueAsNewWorkflowExecutionCommandAttributes attributes) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Throwable getWorkflowTaskFailure() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public void failWorkflowTask(Throwable failure) {
       throw new UnsupportedOperationException("not implemented");
     }
 
@@ -255,7 +281,7 @@ public class DummySyncWorkflowContext {
     }
 
     @Override
-    public void upsertSearchAttributes(SearchAttributes searchAttributes) {
+    public void upsertSearchAttributes(@Nonnull SearchAttributes searchAttributes) {
       throw new UnsupportedOperationException("not implemented");
     }
 


### PR DESCRIPTION
## What was changed
Exposing an ability to fail WorkflowTask for any callback in executor code
Refactored a clean separate WorkflowMutableState.
After this change, `ReplayWorkflowContext` has a clean logic over two complementary mutable entities - `WorkflowStateMachines` and `WorkflowMutableState`. Workflow mutable state fields are not scattered over the workflow control (executor) codebase anymore.

This also creates a solid ground to migrate `WorkflowMutableState` into states of state machines in `WorkflowStateMachines` (defining WorkflowStateMachine)