### PR TITLE
Fail WFT if Local Activity execution experienced an Error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.12.0' apply false
+    id 'com.diffplug.spotless' version '6.12.1' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -39,7 +39,7 @@ ext {
     guavaVersion = '31.1-jre' // [10.0,)
     tallyVersion = '0.11.1' // [0.4.0,)
 
-    gsonVersion = '2.10' // [2.0,)
+    gsonVersion = '2.10.1' // [2.0,)
 
     jsonPathVersion = '2.7.0' // compileOnly
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -125,7 +125,7 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
   @Override
   public WorkflowTaskResult handleWorkflowTask(
       PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowHistoryIterator historyIterator)
-      throws InterruptedException {
+      throws InterruptedException, Throwable {
     lock.lock();
     try {
       Deadline wftHearbeatDeadline =
@@ -273,7 +273,7 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
   }
 
   private void processLocalActivityRequests(Deadline wftHeartbeatDeadline)
-      throws InterruptedException {
+      throws InterruptedException, Throwable {
 
     while (true) {
       List<ExecuteLocalActivityParameters> laRequests =
@@ -307,6 +307,11 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
       }
 
       localActivityTaskCount--;
+
+      if (laCompletion.getProcessingError() != null) {
+        throw laCompletion.getProcessingError().getThrowable();
+      }
+
       workflowStateMachines.handleLocalActivityCompletion(laCompletion);
       // handleLocalActivityCompletion triggers eventLoop.
       // After this call, there may be new local activity requests available in

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowRunTaskHandler.java
@@ -21,6 +21,7 @@
 package io.temporal.internal.replay;
 
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
+import io.temporal.worker.NonDeterministicException;
 
 /**
  * Task handler that encapsulates a cached workflow and can handle multiple calls to
@@ -35,10 +36,12 @@ public interface WorkflowRunTaskHandler {
    *
    * @param workflowTask task to handle
    * @return an object that can be used to build workflow task completion or failure response
+   * @throws Throwable if processing experienced issues that are considered unrecoverable inside the
+   *     current workflow task. {@link NonDeterministicException} or {@link Error} are such cases.
    */
   WorkflowTaskResult handleWorkflowTask(
       PollWorkflowTaskQueueResponseOrBuilder workflowTask, WorkflowHistoryIterator historyIterator)
-      throws InterruptedException;
+      throws Throwable;
 
   /**
    * Handles a Direct Query (or Legacy Query) scenario. In this case, it's not a real workflow task

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -197,6 +197,7 @@ public class LocalActivityStateMachineTest {
               1,
               RespondActivityTaskCompletedRequest.newBuilder().setResult(result2).build(),
               null,
+              null,
               null);
       stateMachines.handleLocalActivityCompletion(completionActivity2);
       requests = stateMachines.takeLocalActivityRequests();
@@ -209,6 +210,7 @@ public class LocalActivityStateMachineTest {
               "id3",
               1,
               RespondActivityTaskCompletedRequest.newBuilder().setResult(result3).build(),
+              null,
               null,
               null);
       stateMachines.handleLocalActivityCompletion(completionActivity3);
@@ -247,6 +249,7 @@ public class LocalActivityStateMachineTest {
               "id1",
               1,
               RespondActivityTaskCompletedRequest.newBuilder().setResult(result).build(),
+              null,
               null,
               null);
       stateMachines.handleLocalActivityCompletion(completionActivity1);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityThrowingApplicationFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityThrowingApplicationFailureTest.java
@@ -42,7 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-public class LocalActivityThrowingpplicationFailureTest {
+public class LocalActivityThrowingApplicationFailureTest {
 
   private static WorkflowOptions options;
 
@@ -69,7 +69,7 @@ public class LocalActivityThrowingpplicationFailureTest {
   }
 
   @Test
-  public void localActivityThrowsError() {
+  public void retryable() {
     String name = testName.getMethodName();
     WorkflowClient client = testWorkflowRule.getWorkflowClient();
     TestWorkflow4 workflow = client.newWorkflowStub(TestWorkflow4.class, options);
@@ -84,7 +84,7 @@ public class LocalActivityThrowingpplicationFailureTest {
   }
 
   @Test
-  public void localActivityNonRetryableThrowsError() {
+  public void nonRetryable() {
     String name = testName.getMethodName();
     WorkflowClient client = testWorkflowRule.getWorkflowClient();
     TestWorkflow4 workflow = client.newWorkflowStub(TestWorkflow4.class, options);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityThrowingErrorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityThrowingErrorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.activityTests;
+
+import static org.junit.Assert.*;
+
+import io.temporal.activity.LocalActivityOptions;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * If Local Activity throws an {@link Error}, it should immediately fail Workflow Task. Java Error
+ * signals a problem with the Worker and shouldn't lead to a failure of a Local Activity execution
+ * or a Workflow.
+ */
+public class LocalActivityThrowingErrorTest {
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(LocalActivityThrowsErrorWorkflow.class)
+          .setActivityImplementations(new ApplicationFailureActivity())
+          .build();
+
+  @Test
+  public void throwsError() {
+    NoArgsWorkflow workflow = testWorkflowRule.newWorkflowStub(NoArgsWorkflow.class);
+    WorkflowStub workflowStub = WorkflowStub.fromTyped(workflow);
+    workflowStub.start();
+    WorkflowExecution execution = workflowStub.getExecution();
+    testWorkflowRule.waitForTheEndOfWFT(execution);
+    List<HistoryEvent> historyEvents =
+        testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
+    assertTrue(historyEvents.size() > 0);
+  }
+
+  public static class LocalActivityThrowsErrorWorkflow implements NoArgsWorkflow {
+
+    private final TestActivities.NoArgsActivity activity1 =
+        Workflow.newLocalActivityStub(
+            TestActivities.NoArgsActivity.class,
+            LocalActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofMinutes(2))
+                .build());
+
+    @Override
+    public void execute() {
+      activity1.execute();
+    }
+  }
+
+  public static class ApplicationFailureActivity implements TestActivities.NoArgsActivity {
+    @Override
+    public void execute() {
+      throw new Error("test");
+    }
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,7 +1,7 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    otelVersion = '1.21.0'
+    otelVersion = '1.22.0'
     otShimVersion = "${otelVersion}-alpha"
 }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -31,6 +31,7 @@ import io.temporal.worker.WorkerOptions;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * TestWorkflowEnvironment provides workflow unit testing capabilities.
@@ -196,7 +197,7 @@ public interface TestWorkflowEnvironment extends Closeable {
    * @param execution identifies the workflowId and runId (optionally) to reach the history for
    * @return history of the execution
    */
-  WorkflowExecutionHistory getWorkflowExecutionHistory(WorkflowExecution execution);
+  WorkflowExecutionHistory getWorkflowExecutionHistory(@Nonnull WorkflowExecution execution);
 
   /** Calls {@link #shutdownNow()} and {@link #awaitTermination(long, TimeUnit)}. */
   @Override

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -44,6 +44,7 @@ import io.temporal.worker.WorkerFactory;
 import io.temporal.worker.WorkerOptions;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnvironment {
@@ -241,7 +242,9 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
   }
 
   @Override
-  public WorkflowExecutionHistory getWorkflowExecutionHistory(WorkflowExecution execution) {
+  public WorkflowExecutionHistory getWorkflowExecutionHistory(
+      @Nonnull WorkflowExecution execution) {
+    Preconditions.checkNotNull(execution, "execution is required");
     GetWorkflowExecutionHistoryRequest request =
         GetWorkflowExecutionHistoryRequest.newBuilder()
             .setNamespace(getNamespace())

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -442,7 +442,7 @@ public class TestWorkflowRule implements TestRule {
   /**
    * @return workflow execution history
    */
-  public History getHistory(WorkflowExecution execution) {
+  public History getHistory(@Nonnull WorkflowExecution execution) {
     return testEnvironment.getWorkflowExecutionHistory(execution).getHistory();
   }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -53,7 +53,6 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -310,16 +309,11 @@ public class SDKTestWorkflowRule implements TestRule {
       // wait for completion of a workflow task in progress
       long startEventId = lastEvent.getEventId();
       while (true) {
-        History history = getHistory(execution);
-        ListIterator<HistoryEvent> historyEventListIterator =
-            history.getEventsList().listIterator(history.getEventsList().size());
-        HistoryEvent previous;
-        for (previous = historyEventListIterator.previous();
-            historyEventListIterator.hasPrevious() && previous.getEventId() > startEventId;
-            previous = historyEventListIterator.previous()) {
-          if (!isWFTInProgress(historyEventListIterator.previous())) {
-            return;
-          }
+        List<HistoryEvent> historyEvents = getHistory(execution).getEventsList();
+        if (historyEvents.stream()
+            .filter(e -> e.getEventId() > startEventId)
+            .anyMatch(e -> !isWFTInProgress(e))) {
+          return;
         }
         busyWaitSleep();
       }


### PR DESCRIPTION
## What was changed
Now if a Local Activity throws an `Error`, it will lead to WFT failure, not a failure of activity execution.

Closes #1533