### PR TITLE
Add history fetching API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.12.1' apply false
+    id 'com.diffplug.spotless' version '6.13.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -29,7 +29,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.51.1' // [1.34.0,)
+    grpcVersion = '1.52.1' // [1.34.0,)
     jacksonVersion = '2.14.1' // [2.9.0,)
     micrometerVersion = '1.9.6' // [1.0.0,) // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
 

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -5,7 +5,7 @@ subprojects {
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
         if (JavaVersion.current().isJava11Compatible()) {
-            errorprone('com.google.errorprone:error_prone_core:2.17.0')
+            errorprone('com.google.errorprone:error_prone_core:2.18.0')
         } else {
             errorprone('com.google.errorprone:error_prone_core:2.10.0')
         }

--- a/temporal-sdk/src/main/java/io/temporal/client/EagerPaginator.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/EagerPaginator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client;
+
+import com.google.protobuf.ByteString;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The main goal for this Iterator implementation is to abstract the functionality of "eager
+ * pagination". This implementation requests the next page when we start iterating through the
+ * previous page. The main goal of this approach is to reduce a synchronous wait that would
+ * otherwise happen when a first element of the next page is requested.
+ */
+abstract class EagerPaginator<Resp, T> implements Iterator<T> {
+  private List<T> activeResponse;
+  private int nextActiveResponseIndex;
+  private CompletableFuture<Resp> nextResponse;
+
+  @Override
+  public boolean hasNext() {
+    if (nextActiveResponseIndex < activeResponse.size()) {
+      return true;
+    }
+    fetch();
+    return nextActiveResponseIndex < activeResponse.size();
+  }
+
+  @Override
+  public T next() {
+    if (hasNext()) {
+      return activeResponse.get(nextActiveResponseIndex++);
+    } else {
+      throw new NoSuchElementException();
+    }
+  }
+
+  void fetch() {
+    if (nextResponse == null) {
+      // if nextResponse is null, it's the end of the iteration through the pages
+      return;
+    }
+
+    Resp response = waitAndGetNextResponse();
+
+    ByteString nextPageToken = getNextPageToken(response);
+    if (nextPageToken != null && !nextPageToken.isEmpty()) {
+      this.nextResponse = performRequest(nextPageToken);
+    } else {
+      this.nextResponse = null;
+    }
+
+    List<T> responseElements = toElements(response);
+
+    if (responseElements.size() == 0 && nextResponse != null) {
+      LoggerFactory.getLogger(this.getClass())
+          .warn("[BUG] iterator received an empty collection with a non-empty nextPageToken");
+      // shouldn't be happening, but we want to tolerate it if it does, so we just effectively
+      // skip the empty response and wait for the next one in a blocking manner.
+      // If this actually ever happens as a normal scenario, this skipping should be reworked to
+      // be done asynchronously on a completion of nextResponse future.
+      fetch();
+      return;
+    }
+
+    activeResponse = responseElements;
+    nextActiveResponseIndex = 0;
+  }
+
+  public void init() {
+    nextResponse = performRequest(ByteString.empty());
+    waitAndGetNextResponse();
+    fetch();
+  }
+
+  private Resp waitAndGetNextResponse() {
+    Resp response;
+    try {
+      response = this.nextResponse.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      throw (cause instanceof RuntimeException
+          ? (RuntimeException) cause
+          : new RuntimeException(cause));
+    }
+    return response;
+  }
+
+  abstract CompletableFuture<Resp> performRequest(@Nonnull ByteString nextPageToken);
+
+  abstract ByteString getNextPageToken(Resp response);
+
+  abstract List<T> toElements(Resp response);
+}

--- a/temporal-sdk/src/main/java/io/temporal/client/GetWorkflowExecutionHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/GetWorkflowExecutionHistoryIterator.java
@@ -21,60 +21,57 @@
 package io.temporal.client;
 
 import com.google.protobuf.ByteString;
-import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsRequest;
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.internal.client.external.GenericWorkflowClient;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-class ListWorkflowExecutionIterator
-    extends EagerPaginator<ListWorkflowExecutionsResponse, WorkflowExecutionInfo> {
-  private final @Nullable String query;
+class GetWorkflowExecutionHistoryIterator
+    extends EagerPaginator<GetWorkflowExecutionHistoryResponse, HistoryEvent> {
   private final @Nonnull String namespace;
-  private final @Nullable Integer pageSize;
+  private final @Nonnull WorkflowExecution workflowExecution;
+  private final Integer pageSize;
   private final @Nonnull GenericWorkflowClient genericClient;
 
-  ListWorkflowExecutionIterator(
-      @Nullable String query,
+  public GetWorkflowExecutionHistoryIterator(
       @Nonnull String namespace,
+      @Nonnull WorkflowExecution workflowExecution,
       @Nullable Integer pageSize,
       @Nonnull GenericWorkflowClient genericClient) {
-    this.query = query;
-    this.namespace = Objects.requireNonNull(namespace, "namespace");
+    this.namespace = namespace;
+    this.workflowExecution = workflowExecution;
     this.pageSize = pageSize;
-    this.genericClient = Objects.requireNonNull(genericClient, "genericClient");
+    this.genericClient = genericClient;
   }
 
   @Override
-  CompletableFuture<ListWorkflowExecutionsResponse> performRequest(
+  CompletableFuture<GetWorkflowExecutionHistoryResponse> performRequest(
       @Nonnull ByteString nextPageToken) {
-    ListWorkflowExecutionsRequest.Builder request =
-        ListWorkflowExecutionsRequest.newBuilder()
+    GetWorkflowExecutionHistoryRequest.Builder requestBuilder =
+        GetWorkflowExecutionHistoryRequest.newBuilder()
             .setNamespace(namespace)
+            .setExecution(workflowExecution)
             .setNextPageToken(nextPageToken);
 
-    if (query != null) {
-      request.setQuery(query);
-    }
-
     if (pageSize != null) {
-      request.setPageSize(pageSize);
+      requestBuilder.setMaximumPageSize(pageSize);
     }
 
-    return genericClient.listWorkflowExecutionsAsync(request.build());
+    return genericClient.getWorkflowExecutionHistoryAsync(requestBuilder.build());
   }
 
   @Override
-  ByteString getNextPageToken(ListWorkflowExecutionsResponse response) {
+  ByteString getNextPageToken(GetWorkflowExecutionHistoryResponse response) {
     return response.getNextPageToken();
   }
 
   @Override
-  List<WorkflowExecutionInfo> toElements(ListWorkflowExecutionsResponse response) {
-    return response.getExecutionsList();
+  List<HistoryEvent> toElements(GetWorkflowExecutionHistoryResponse response) {
+    return response.getHistory().getEventsList();
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
@@ -46,6 +46,12 @@ public interface GenericWorkflowClient {
   CompletableFuture<GetWorkflowExecutionHistoryResponse> longPollHistoryAsync(
       @Nonnull GetWorkflowExecutionHistoryRequest request, @Nonnull Deadline deadline);
 
+  GetWorkflowExecutionHistoryResponse getWorkflowExecutionHistory(
+      @Nonnull GetWorkflowExecutionHistoryRequest request);
+
+  CompletableFuture<GetWorkflowExecutionHistoryResponse> getWorkflowExecutionHistoryAsync(
+      @Nonnull GetWorkflowExecutionHistoryRequest request);
+
   ListWorkflowExecutionsResponse listWorkflowExecutions(ListWorkflowExecutionsRequest listRequest);
 
   CompletableFuture<ListWorkflowExecutionsResponse> listWorkflowExecutionsAsync(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
@@ -177,6 +177,32 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
   }
 
   @Override
+  public GetWorkflowExecutionHistoryResponse getWorkflowExecutionHistory(
+      @Nonnull GetWorkflowExecutionHistoryRequest request) {
+    return grpcRetryer.retryWithResult(
+        () ->
+            service
+                .blockingStub()
+                .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
+                .getWorkflowExecutionHistory(request),
+        grpcRetryerOptions);
+  }
+
+  @Override
+  public CompletableFuture<GetWorkflowExecutionHistoryResponse> getWorkflowExecutionHistoryAsync(
+      @Nonnull GetWorkflowExecutionHistoryRequest request) {
+    return grpcRetryer.retryWithResultAsync(
+        asyncThrottlerExecutor,
+        () ->
+            toCompletableFuture(
+                service
+                    .futureStub()
+                    .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
+                    .getWorkflowExecutionHistory(request)),
+        grpcRetryerOptions);
+  }
+
+  @Override
   public QueryWorkflowResponse query(QueryWorkflowRequest queryParameters) {
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(1)

--- a/temporal-sdk/src/test/java/io/temporal/client/ListWorkflowExecutionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/ListWorkflowExecutionsTest.java
@@ -18,13 +18,11 @@
  * limitations under the License.
  */
 
-package io.temporal.client.functional;
+package io.temporal.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
-import io.temporal.client.WorkflowExecutionMetadata;
-import io.temporal.client.WorkflowStub;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.util.List;
@@ -55,8 +53,8 @@ public class ListWorkflowExecutionsTest {
     }
 
     // listWorkflowExecutions is Visibility API
-    // Temporal Visibility has latency and is not transactional
-    Thread.sleep(3_000);
+    // Temporal Visibility has latency and is not transactional with the Server API call
+    Thread.sleep(4_000);
 
     List<WorkflowExecutionMetadata> executions =
         testWorkflowRule.getWorkflowClient().listExecutions(QUERY).collect(Collectors.toList());
@@ -70,15 +68,40 @@ public class ListWorkflowExecutionsTest {
         "Each of the returned workflowIds should be different",
         EXECUTIONS_COUNT,
         workflowIds.size());
+  }
 
-    executions =
-        testWorkflowRule.getWorkflowClient().listExecutions(QUERY, 5).collect(Collectors.toList());
+  @Test
+  public void listWorkflowExecutions_returnsAllExecutions_pagination() throws InterruptedException {
+    final int EXECUTIONS_COUNT = 30;
+    final String QUERY = "TaskQueue='" + testWorkflowRule.getTaskQueue() + "'";
+
+    assumeTrue(
+        "Test Server doesn't support listWorkflowExecutions endpoint yet",
+        SDKTestWorkflowRule.useExternalService);
+
+    for (int i = 0; i < EXECUTIONS_COUNT; i++) {
+      WorkflowStub.fromTyped(testWorkflowRule.newWorkflowStub(TestWorkflows.NoArgsWorkflow.class))
+          .start();
+    }
+
+    // listWorkflowExecutions is Visibility API
+    // Temporal Visibility has latency and is not transactional with the Server API call
+    Thread.sleep(4_000);
+
+    WorkflowClientInternal workflowClientInternal =
+        new WorkflowClientInternal(
+            testWorkflowRule.getWorkflowServiceStubs(),
+            testWorkflowRule.getWorkflowClient().getOptions());
+
+    List<WorkflowExecutionMetadata> executions =
+        workflowClientInternal.listExecutions(QUERY, 5).collect(Collectors.toList());
     assertEquals(
         "Should return the original amount of the workflows", EXECUTIONS_COUNT, executions.size());
-    workflowIds =
+    Set<String> workflowIds =
         executions.stream()
             .map(meta -> meta.getExecution().getWorkflowId())
             .collect(Collectors.toSet());
+
     assertEquals(
         "Each of the returned workflowIds should be different",
         EXECUTIONS_COUNT,

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
@@ -80,7 +80,7 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
     WorkflowExecution workflowExecution = WorkflowStub.fromTyped(noArgsWorkflow).getExecution();
 
     WorkflowExecutionHistory workflowExecutionHistory =
-        testWorkflowRule.getExecutionHistory(workflowExecution);
+        testWorkflowRule.getWorkflowClient().fetchHistory(workflowExecution.getWorkflowId());
 
     PollWorkflowTaskQueueResponseOrBuilder wft =
         PollWorkflowTaskQueueResponse.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -484,7 +484,7 @@ public class StickyWorkerTest {
     // Assert
     assertEquals(workflow.getProgress(), GreetingSignalWorkflow.Status.WAITING_FOR_NAME);
     SDKTestWorkflowRule.assertNoHistoryEvent(
-        wrapper.testEnv.getWorkflowExecutionHistory(execution).getHistory(),
+        wrapper.testEnv.getWorkflowClient().fetchHistory(execution.getWorkflowId()).getHistory(),
         EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
 
     wrapper.close();
@@ -535,7 +535,7 @@ public class StickyWorkerTest {
     // Query after completion
     assertEquals(workflow.getProgress(), GreetingSignalWorkflow.Status.GREETING_GENERATED);
     SDKTestWorkflowRule.assertNoHistoryEvent(
-        wrapper.testEnv.getWorkflowExecutionHistory(execution).getHistory(),
+        wrapper.testEnv.getWorkflowClient().fetchHistory(execution.getWorkflowId()).getHistory(),
         EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
 
     wrapper.close();

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownHeartBeatingActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownHeartBeatingActivityTest.java
@@ -72,7 +72,11 @@ public class CleanWorkerShutdownHeartBeatingActivityTest {
     started.get();
     testWorkflowRule.getTestEnvironment().shutdown();
     testWorkflowRule.getTestEnvironment().awaitTermination(10, TimeUnit.MINUTES);
-    List<HistoryEvent> events = testWorkflowRule.getHistory(execution).getEventsList();
+    List<HistoryEvent> events =
+        testWorkflowRule
+            .getExecutionHistory(execution.getWorkflowId())
+            .getHistory()
+            .getEventsList();
     boolean found = false;
     for (HistoryEvent e : events) {
       if (e.getEventType() == EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED) {

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanWorkerShutdownTest.java
@@ -65,7 +65,11 @@ public class CleanWorkerShutdownTest {
     shutdownLatch.await();
     testWorkflowRule.getTestEnvironment().shutdown();
     testWorkflowRule.getTestEnvironment().awaitTermination(10, TimeUnit.MINUTES);
-    List<HistoryEvent> events = testWorkflowRule.getHistory(execution).getEventsList();
+    List<HistoryEvent> events =
+        testWorkflowRule
+            .getExecutionHistory(execution.getWorkflowId())
+            .getHistory()
+            .getEventsList();
     boolean found = false;
     for (HistoryEvent e : events) {
       if (e.getEventType() == EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED) {
@@ -87,7 +91,11 @@ public class CleanWorkerShutdownTest {
     shutdownNowLatch.await();
     testWorkflowRule.getTestEnvironment().shutdownNow();
     testWorkflowRule.getTestEnvironment().awaitTermination(10, TimeUnit.MINUTES);
-    List<HistoryEvent> events = testWorkflowRule.getHistory(execution).getEventsList();
+    List<HistoryEvent> events =
+        testWorkflowRule
+            .getExecutionHistory(execution.getWorkflowId())
+            .getHistory()
+            .getEventsList();
     events.forEach(System.out::println);
     boolean found = false;
     for (HistoryEvent e : events) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BinaryChecksumSetWhenTaskCompletedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BinaryChecksumSetWhenTaskCompletedTest.java
@@ -57,7 +57,8 @@ public class BinaryChecksumSetWhenTaskCompletedTest {
     SDKTestWorkflowRule.waitForOKQuery(stub);
 
     HistoryEvent completionEvent =
-        testWorkflowRule.getHistoryEvent(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED);
+        testWorkflowRule.getHistoryEvent(
+            execution.getWorkflowId(), EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED);
     assertNotNull(completionEvent);
     assertEquals(
         BINARY_CHECKSUM,

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetHistoryLengthTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetHistoryLengthTest.java
@@ -53,7 +53,7 @@ public class GetHistoryLengthTest {
     assertEquals("done", workflowStub.execute());
 
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    testWorkflowRule.regenerateHistoryForReplay(execution, "testGetHistoryLength");
+    testWorkflowRule.regenerateHistoryForReplay(execution.getWorkflowId(), "testGetHistoryLength");
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
@@ -78,7 +78,7 @@ public class WorkflowTaskFailureBackoffTest {
     Assert.assertEquals(
         1,
         testWorkflowRule
-            .getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .getHistoryEvents(execution.getWorkflowId(), EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
             .size());
     Map<String, String> tags =
         ImmutableMap.<String, String>builder()

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskNPEBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskNPEBackoffTest.java
@@ -60,7 +60,7 @@ public class WorkflowTaskNPEBackoffTest {
     Assert.assertEquals(
         1,
         testWorkflowRule
-            .getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .getHistoryEvents(execution.getWorkflowId(), EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
             .size());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/AsyncActivityRetryTest.java
@@ -65,7 +65,8 @@ public class AsyncActivityRetryTest {
     }
     Assert.assertEquals(activitiesImpl.toString(), 3, activitiesImpl.invocations.size());
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    testWorkflowRule.regenerateHistoryForReplay(execution, "testAsyncActivityRetryHistory");
+    testWorkflowRule.regenerateHistoryForReplay(
+        execution.getWorkflowId(), "testAsyncActivityRetryHistory");
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/EagerActivityDispatchingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/EagerActivityDispatchingTest.java
@@ -116,7 +116,8 @@ public class EagerActivityDispatchingTest {
     workflowStub.execute(true);
 
     WorkflowExecutionHistory history =
-        env.getWorkflowExecutionHistory(WorkflowStub.fromTyped(workflowStub).getExecution());
+        env.getWorkflowClient()
+            .fetchHistory(WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId());
     Set<String> activityTaskStartedEventIdentity =
         history.getEvents().stream()
             .filter(HistoryEvent::hasActivityTaskStartedEventAttributes)
@@ -155,7 +156,8 @@ public class EagerActivityDispatchingTest {
     workflowStub.execute(true);
 
     WorkflowExecutionHistory history =
-        env.getWorkflowExecutionHistory(WorkflowStub.fromTyped(workflowStub).getExecution());
+        env.getWorkflowClient()
+            .fetchHistory(WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId());
     Set<String> activityTaskStartedEventIdentity =
         history.getEvents().stream()
             .filter(HistoryEvent::hasActivityTaskStartedEventAttributes)
@@ -194,7 +196,8 @@ public class EagerActivityDispatchingTest {
     workflowStub.execute(false);
 
     WorkflowExecutionHistory history =
-        env.getWorkflowExecutionHistory(WorkflowStub.fromTyped(workflowStub).getExecution());
+        env.getWorkflowClient()
+            .fetchHistory(WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId());
     Set<String> activityTaskStartedEventIdentity =
         history.getEvents().stream()
             .filter(HistoryEvent::hasActivityTaskStartedEventAttributes)

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetriesAndFailsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetriesAndFailsTest.java
@@ -68,7 +68,8 @@ public class LocalActivityRetriesAndFailsTest {
     Assert.assertEquals("last attempt", 5, activitiesImpl.getLastAttempt());
 
     testWorkflowRule.regenerateHistoryForReplay(
-        WorkflowStub.fromTyped(workflowStub).getExecution(), "laRetriesAndFails_1_xx");
+        WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId(),
+        "laRetriesAndFails_1_xx");
   }
 
   /** History from 1.17 before we changed LA marker structure in 1.18 */

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
@@ -72,7 +72,7 @@ public class LocalActivityRetryOverLocalBackoffThresholdTest {
 
     List<HistoryEvent> historyEvents =
         testWorkflowRule.getHistoryEvents(
-            WorkflowStub.fromTyped(workflowStub).getExecution(),
+            WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId(),
             EventType.EVENT_TYPE_TIMER_STARTED);
     // attempt retry periods will be
     assertEquals(
@@ -104,7 +104,7 @@ public class LocalActivityRetryOverLocalBackoffThresholdTest {
     WorkflowStub untypedStub = WorkflowStub.fromTyped(workflowStub);
     WorkflowExecution execution = untypedStub.start(testWorkflowRule.getTaskQueue());
 
-    testWorkflowRule.waitForTheEndOfWFT(execution);
+    testWorkflowRule.waitForTheEndOfWFT(execution.getWorkflowId());
     testWorkflowRule.invalidateWorkflowCache();
 
     WorkflowException e =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivitySuccessfulCompletionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivitySuccessfulCompletionTest.java
@@ -50,7 +50,8 @@ public class LocalActivitySuccessfulCompletionTest {
     Assert.assertEquals("input1", result);
     Assert.assertEquals(activitiesImpl.toString(), 1, activitiesImpl.invocations.size());
     testWorkflowRule.regenerateHistoryForReplay(
-        WorkflowStub.fromTyped(workflowStub).getExecution(), "laSuccessfulCompletion_1_xx");
+        WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId(),
+        "laSuccessfulCompletion_1_xx");
   }
 
   /** History from 1.17 before we changed LA marker structure in 1.18 */

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityThrowingErrorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityThrowingErrorTest.java
@@ -59,9 +59,10 @@ public class LocalActivityThrowingErrorTest {
     WorkflowStub workflowStub = WorkflowStub.fromTyped(workflow);
     workflowStub.start();
     WorkflowExecution execution = workflowStub.getExecution();
-    testWorkflowRule.waitForTheEndOfWFT(execution);
+    testWorkflowRule.waitForTheEndOfWFT(execution.getWorkflowId());
     List<HistoryEvent> historyEvents =
-        testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
+        testWorkflowRule.getHistoryEvents(
+            execution.getWorkflowId(), EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
     assertTrue(historyEvents.size() > 0);
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/TestLocalActivity.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/TestLocalActivity.java
@@ -82,7 +82,8 @@ public class TestLocalActivity {
             "activity Activity2");
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
     List<HistoryEvent> markers =
-        testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+        testWorkflowRule.getHistoryEvents(
+            execution.getWorkflowId(), EventType.EVENT_TYPE_MARKER_RECORDED);
     for (HistoryEvent marker : markers) {
       String activityType =
           DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(
@@ -125,7 +126,8 @@ public class TestLocalActivity {
             "activity Activity2");
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
     List<HistoryEvent> markers =
-        testWorkflowRule.getHistoryEvents(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+        testWorkflowRule.getHistoryEvents(
+            execution.getWorkflowId(), EventType.EVENT_TYPE_MARKER_RECORDED);
     for (HistoryEvent marker : markers) {
       String activityType =
           DefaultDataConverter.STANDARD_INSTANCE.fromPayloads(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/AbandonOnCancelActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/AbandonOnCancelActivityTest.java
@@ -83,7 +83,8 @@ public class AbandonOnCancelActivityTest {
     assertTrue(
         "Activity with CancellationType=ABANDON should never have a requested cancellation in history",
         testWorkflowRule
-            .getHistoryEvents(execution, EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED)
+            .getHistoryEvents(
+                execution.getWorkflowId(), EventType.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED)
             .isEmpty());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
@@ -106,7 +106,8 @@ public class WorkflowClosedRunningActivityTest {
 
     assertTrue(activityCancelled.waitForSignal(1, TimeUnit.SECONDS));
 
-    WorkflowExecutionHistory history = testWorkflowRule.getExecutionHistory(execution);
+    WorkflowExecutionHistory history =
+        testWorkflowRule.getWorkflowClient().fetchHistory(execution.getWorkflowId());
     assertEquals(eventType, history.getLastEvent().getEventType());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitCancellationTest.java
@@ -46,15 +46,16 @@ public class WorkflowAwaitCancellationTest {
     TestWorkflows.TestWorkflow1 workflow =
         testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflow1.class);
     WorkflowExecution execution = null;
+    execution = WorkflowClient.start(workflow::execute, "input1");
     try {
-      execution = WorkflowClient.start(workflow::execute, "input1");
       WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
       untyped.cancel();
       untyped.getResult(String.class);
       fail("unreacheable");
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof CanceledFailure);
-      History history = testWorkflowRule.getHistory(execution);
+      History history =
+          testWorkflowRule.getExecutionHistory(execution.getWorkflowId()).getHistory();
 
       HistoryEvent lastEvent = history.getEvents(history.getEventsCount() - 1);
       assertEquals(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitWithDurationCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitWithDurationCancellationTest.java
@@ -51,8 +51,8 @@ public class WorkflowAwaitWithDurationCancellationTest {
     TestWorkflows.TestWorkflow1 workflow =
         testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflow1.class);
     WorkflowExecution execution = null;
+    execution = WorkflowClient.start(workflow::execute, "input1");
     try {
-      execution = WorkflowClient.start(workflow::execute, "input1");
       WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
       workflowStarted.waitForSignal();
       untyped.cancel();
@@ -60,7 +60,8 @@ public class WorkflowAwaitWithDurationCancellationTest {
       fail("unreacheable");
     } catch (WorkflowFailedException e) {
       assertTrue(e.getCause() instanceof CanceledFailure);
-      History history = testWorkflowRule.getHistory(execution);
+      History history =
+          testWorkflowRule.getExecutionHistory(execution.getWorkflowId()).getHistory();
 
       HistoryEvent lastEvent = history.getEvents(history.getEventsCount() - 1);
       assertEquals(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowCancellationTest.java
@@ -75,9 +75,10 @@ public class ChildWorkflowCancellationTest {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
     testWorkflowRule.assertHistoryEvent(
-        execution, EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
+        execution.getWorkflowId(),
+        EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
     testWorkflowRule.assertNoHistoryEvent(
-        execution, EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
+        execution.getWorkflowId(), EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
     assertFalse(
         "We should not have wait till the finish of detached scope in WAIT_CANCELLATION_REQUESTED mode",
         detachedScopeFinished.isSignalled());
@@ -98,7 +99,7 @@ public class ChildWorkflowCancellationTest {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
     testWorkflowRule.assertHistoryEvent(
-        execution, EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
+        execution.getWorkflowId(), EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED);
     assertTrue(
         "We should be here after the full finish of the detached scope in WAIT_CANCELLATION_COMPLETED mode",
         detachedScopeFinished.isSignalled());
@@ -118,7 +119,8 @@ public class ChildWorkflowCancellationTest {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
     testWorkflowRule.assertNoHistoryEvent(
-        execution, EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
+        execution.getWorkflowId(),
+        EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
     assertFalse(
         "We should not have wait till the finish of detached scope in ABANDON mode",
         detachedScopeFinished.isSignalled());
@@ -138,9 +140,11 @@ public class ChildWorkflowCancellationTest {
       assertTrue(e.getCause() instanceof CanceledFailure);
     }
     testWorkflowRule.assertHistoryEvent(
-        execution, EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
+        execution.getWorkflowId(),
+        EventType.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED);
     testWorkflowRule.assertNoHistoryEvent(
-        execution, EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
+        execution.getWorkflowId(),
+        EventType.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED);
     assertFalse(
         "We should not have wait till the finish of detached scope in TRY_CANCEL mode",
         detachedScopeFinished.isSignalled());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
@@ -115,7 +115,8 @@ public class ChildWorkflowRetryTest {
     assertEquals("TestWorkflow1", lastStartedWorkflowType.get());
     assertEquals(3, angryChildActivity.getInvocationCount());
     WorkflowExecution execution = WorkflowStub.fromTyped(client).getExecution();
-    testWorkflowRule.regenerateHistoryForReplay(execution, "testChildWorkflowRetryHistory");
+    testWorkflowRule.regenerateHistoryForReplay(
+        execution.getWorkflowId(), "testChildWorkflowRetryHistory");
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyBlockWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyBlockWorkflowTest.java
@@ -78,7 +78,7 @@ public class NonDeterministicWorkflowPolicyBlockWorkflowTest {
     // other WFTs after it should end with WORKFLOW_TASK_TIMED_OUT
     HistoryEvent nonDeterministicExceptionHistoryEvent =
         testWorkflowRule.getHistoryEvent(
-            WorkflowStub.fromTyped(workflowStub).getExecution(),
+            WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId(),
             EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
     WorkflowTaskFailedEventAttributes failedWFTEventAttributes =
         nonDeterministicExceptionHistoryEvent.getWorkflowTaskFailedEventAttributes();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/LocalActivityAndQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/LocalActivityAndQueryTest.java
@@ -90,7 +90,8 @@ public class LocalActivityAndQueryTest {
     activitiesImpl.assertInvocations(
         "sleepActivity", "sleepActivity", "sleepActivity", "sleepActivity", "sleepActivity");
     HistoryEvent marker =
-        testWorkflowRule.getHistoryEvent(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+        testWorkflowRule.getHistoryEvent(
+            execution.getWorkflowId(), EventType.EVENT_TYPE_MARKER_RECORDED);
     Optional<Payloads> input =
         Optional.of(marker.getMarkerRecordedEventAttributes().getDetailsMap().get("input"));
     long arg0 =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/QueryCausingReplayWithLocalActivityInLastWFTTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/QueryCausingReplayWithLocalActivityInLastWFTTest.java
@@ -58,7 +58,7 @@ public class QueryCausingReplayWithLocalActivityInLastWFTTest {
     WorkflowExecution execution = WorkflowClient.start(workflowStub::execute);
     // Don't do waitForOKQuery wait here, it changes the structure of history events in a way that
     // doesn't reproduce the problem
-    testWorkflowRule.waitForTheEndOfWFT(execution);
+    testWorkflowRule.waitForTheEndOfWFT(execution.getWorkflowId());
 
     testWorkflowRule.invalidateWorkflowCache();
     assertEquals("updated", workflowStub.query());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/UpsertSearchAttributeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/UpsertSearchAttributeTest.java
@@ -71,7 +71,7 @@ public class UpsertSearchAttributeTest {
             "executeActivity Activity",
             "activity Activity");
     testWorkflowRule.assertHistoryEvent(
-        execution, EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES);
+        execution.getWorkflowId(), EventType.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES);
   }
 
   public static class TestUpsertSearchAttributesImpl implements TestWorkflowStringArg {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAfterScopeCancellationInMainWorkflowMethodTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAfterScopeCancellationInMainWorkflowMethodTest.java
@@ -78,7 +78,7 @@ public class GetVersionAfterScopeCancellationInMainWorkflowMethodTest {
     untypedWorkflowStub.getResult(Void.TYPE);
 
     testWorkflowRule.assertNoHistoryEvent(
-        untypedWorkflowStub.getExecution(), EVENT_TYPE_WORKFLOW_TASK_FAILED);
+        untypedWorkflowStub.getExecution().getWorkflowId(), EVENT_TYPE_WORKFLOW_TASK_FAILED);
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAfterScopeCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAfterScopeCancellationTest.java
@@ -63,7 +63,7 @@ public class GetVersionAfterScopeCancellationTest {
     untypedWorkflowStub.getResult(Void.TYPE);
 
     testWorkflowRule.assertNoHistoryEvent(
-        untypedWorkflowStub.getExecution(), EVENT_TYPE_WORKFLOW_TASK_FAILED);
+        untypedWorkflowStub.getExecution().getWorkflowId(), EVENT_TYPE_WORKFLOW_TASK_FAILED);
   }
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
@@ -59,7 +59,8 @@ public class GetVersionSameIdOnReplayTest {
     workflowStub.execute();
     assertTrue(hasReplayed);
     WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
-    testWorkflowRule.assertNoHistoryEvent(execution, EventType.EVENT_TYPE_MARKER_RECORDED);
+    testWorkflowRule.assertNoHistoryEvent(
+        execution.getWorkflowId(), EventType.EVENT_TYPE_MARKER_RECORDED);
   }
 
   public static class TestGetVersionSameIdOnReplay implements NoArgsWorkflow {

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/RepeatedWorkflowTaskFailuresTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/RepeatedWorkflowTaskFailuresTest.java
@@ -65,7 +65,7 @@ public class RepeatedWorkflowTaskFailuresTest {
         "Out of three failed retries only the first one should be FAILED, other 2 should be dropped, allowed to time out and not being recorded at all",
         1,
         testWorkflowRule
-            .getHistoryEvents(execution, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .getHistoryEvents(execution.getWorkflowId(), EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
             .size());
   }
 

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/searchattributes/IncorrectUpsertSearchAttributesTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/searchattributes/IncorrectUpsertSearchAttributesTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 import com.google.common.collect.ImmutableMap;
-import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.enums.v1.WorkflowTaskFailedCause;
 import io.temporal.api.history.v1.History;
@@ -79,9 +78,7 @@ public class IncorrectUpsertSearchAttributesTest {
             .newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class, options);
     stubF.execute();
 
-    History history =
-        testWorkflowRule.getHistory(
-            WorkflowExecution.newBuilder().setWorkflowId(WORKFLOW_ID).build());
+    History history = testWorkflowRule.getExecutionHistory(WORKFLOW_ID).getHistory();
     Optional<HistoryEvent> wftFailedEvent =
         history.getEventsList().stream()
             .filter(event -> event.getEventType().equals(EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED))
@@ -115,9 +112,7 @@ public class IncorrectUpsertSearchAttributesTest {
             .newWorkflowStub(TestWorkflows.PrimitiveWorkflow.class, options);
     stubF.execute();
 
-    History history =
-        testWorkflowRule.getHistory(
-            WorkflowExecution.newBuilder().setWorkflowId(WORKFLOW_ID).build());
+    History history = testWorkflowRule.getExecutionHistory(WORKFLOW_ID).getHistory();
     Optional<HistoryEvent> wftFailedEvent =
         history.getEventsList().stream()
             .filter(event -> event.getEventType().equals(EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED))

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     junit4Api 'junit:junit:4.13.2'
 
-    junit5Api platform('org.junit:junit-bom:5.9.1')
+    junit5Api platform('org.junit:junit-bom:5.9.2')
     junit5Api 'org.junit.jupiter:junit-jupiter-api'
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter'

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -196,7 +196,9 @@ public interface TestWorkflowEnvironment extends Closeable {
   /**
    * @param execution identifies the workflowId and runId (optionally) to reach the history for
    * @return history of the execution
+   * @deprecated use {@link WorkflowClient#fetchHistory(String, String)}
    */
+  @Deprecated
   WorkflowExecutionHistory getWorkflowExecutionHistory(@Nonnull WorkflowExecution execution);
 
   /** Calls {@link #shutdownNow()} and {@link #awaitTermination(long, TimeUnit)}. */

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -31,7 +31,6 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.IndexedValueType;
 import io.temporal.api.operatorservice.v1.AddSearchAttributesRequest;
 import io.temporal.api.testservice.v1.SleepRequest;
-import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.WorkflowExecutionHistory;
@@ -242,16 +241,11 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
   }
 
   @Override
+  @Deprecated
   public WorkflowExecutionHistory getWorkflowExecutionHistory(
       @Nonnull WorkflowExecution execution) {
     Preconditions.checkNotNull(execution, "execution is required");
-    GetWorkflowExecutionHistoryRequest request =
-        GetWorkflowExecutionHistoryRequest.newBuilder()
-            .setNamespace(getNamespace())
-            .setExecution(execution)
-            .build();
-    return new WorkflowExecutionHistory(
-        workflowServiceStubs.blockingStub().getWorkflowExecutionHistory(request).getHistory());
+    return getWorkflowClient().fetchHistory(execution.getWorkflowId(), execution.getRunId());
   }
 
   @Override

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -29,7 +29,6 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
-import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.internal.common.env.DebugModeUtils;
 import io.temporal.internal.docker.RegisterTestNamespace;
@@ -441,15 +440,18 @@ public class TestWorkflowRule implements TestRule {
 
   /**
    * @return workflow execution history
+   * @deprecated use {@link WorkflowClient#fetchHistory(String, String)}. To obtain a WorkflowClient
+   *     use {@link #getWorkflowClient()}
    */
+  @Deprecated
   public History getHistory(@Nonnull WorkflowExecution execution) {
     return testEnvironment.getWorkflowExecutionHistory(execution).getHistory();
   }
 
   /**
    * @return name of the task queue that test worker is polling.
-   * @deprecated use {@link #getHistory}, this method will be reworked to return {@link
-   *     WorkflowExecutionHistory} in the upcoming releases
+   * @deprecated use {@link WorkflowClient#fetchHistory(String, String)}. To obtain a WorkflowClient
+   *     use {@link #getWorkflowClient()}
    */
   @Deprecated
   public History getWorkflowExecutionHistory(WorkflowExecution execution) {


### PR DESCRIPTION
## What was changed

This PR exposes `WorkflowClient#fetchHistory` and `WorkflowClient#streamHistory` APIs that export histories of the workflow executions and runs.

Closes #1552