### PR TITLE
Added ActivityOutput.activityId

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -108,10 +108,16 @@ public interface WorkflowOutboundCallsInterceptor {
   }
 
   final class ActivityOutput<R> {
+    private final String activityId;
     private final Promise<R> result;
 
-    public ActivityOutput(Promise<R> result) {
+    public ActivityOutput(String activityId, Promise<R> result) {
+      this.activityId = activityId;
       this.result = result;
+    }
+
+    public String getActivityId() {
+      return activityId;
     }
 
     public Promise<R> getResult() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -51,6 +51,25 @@ import javax.annotation.Nullable;
  */
 public interface ReplayWorkflowContext extends ReplayAware {
 
+  class ScheduleActivityTaskOutput {
+    private final String activityId;
+    private final Functions.Proc1<Exception> cancellationHandle;
+
+    public ScheduleActivityTaskOutput(
+        String activityId, Functions.Proc1<Exception> cancllationHandle) {
+      this.activityId = activityId;
+      this.cancellationHandle = cancllationHandle;
+    }
+
+    public String getActivityId() {
+      return activityId;
+    }
+
+    public Functions.Proc1<Exception> getCancellationHandle() {
+      return cancellationHandle;
+    }
+  }
+
   WorkflowExecution getWorkflowExecution();
 
   WorkflowExecution getParentWorkflowExecution();
@@ -93,7 +112,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
    * @return cancellation handle. Invoke {@link io.temporal.workflow.Functions.Proc1#apply(Object)}
    *     to cancel activity task.
    */
-  Functions.Proc1<Exception> scheduleActivityTask(
+  ScheduleActivityTaskOutput scheduleActivityTask(
       ExecuteActivityParameters parameters, Functions.Proc2<Optional<Payloads>, Failure> callback);
 
   Functions.Proc scheduleLocalActivityTask(

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -176,7 +176,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
   }
 
   @Override
-  public Functions.Proc1<Exception> scheduleActivityTask(
+  public ScheduleActivityTaskOutput scheduleActivityTask(
       ExecuteActivityParameters parameters, Functions.Proc2<Optional<Payloads>, Failure> callback) {
     ScheduleActivityTaskCommandAttributes.Builder attributes = parameters.getAttributes();
     if (attributes.getActivityId().isEmpty()) {
@@ -184,7 +184,8 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
     }
     Functions.Proc cancellationHandler =
         workflowStateMachines.scheduleActivityTask(parameters, callback);
-    return (exception) -> cancellationHandler.apply();
+    return new ScheduleActivityTaskOutput(
+        attributes.getActivityId(), (exception) -> cancellationHandler.apply());
   }
 
   @Override

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -162,7 +162,7 @@ public class DummySyncWorkflowContext {
     }
 
     @Override
-    public Functions.Proc1<Exception> scheduleActivityTask(
+    public ScheduleActivityTaskOutput scheduleActivityTask(
         ExecuteActivityParameters parameters,
         Functions.Proc2<Optional<Payloads>, Failure> callback) {
       throw new UnsupportedOperationException("not implemented");

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -302,6 +302,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
       heartbeatPayload.ifPresent(taskBuilder::setHeartbeatDetails);
       PollActivityTaskQueueResponse task = taskBuilder.build();
       return new ActivityOutput<>(
+          task.getActivityId(),
           Workflow.newPromise(
               getReply(task, executeActivity(task, false), i.getResultClass(), i.getResultType())));
     }


### PR DESCRIPTION
## What was changed
Added ActivityOutput.activityId. 

## Why?
The ActivityOutput is used by interceptors, and knowing `activityId` is important for some use cases.
The change is not backward compatible if an interceptor uses ActivityOutput constructor. I believe that there are very few (if any) interceptors that create ActivityOutput explicitly. 