### PR TITLE
Now query on workflow stub that was was used for start follows runIds 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,11 @@ ext {
 
     jsonPathVersion = '2.7.0' // compileOnly
 
-    springBootVersion = '2.7.6'// [2.4.0,)
+    springBootVersion = '2.7.8'// [2.4.0,)
 
     // test scoped
     logbackVersion = '1.2.11' // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
-    mockitoVersion = '4.11.0'
+    mockitoVersion = '5.0.0'
     junitVersion = '4.13.2'
 }
 

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/QueryAfterStartFollowsRunsChainTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/QueryAfterStartFollowsRunsChainTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client.functional;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class QueryAfterStartFollowsRunsChainTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowImpl.class).build();
+
+  @Test
+  public void testQueryAfterStartFollowsRunsChain() {
+    TestWorkflows.TestWorkflowWithQuery workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowWithQuery.class);
+    assertEquals("done", workflow.execute());
+    assertEquals(
+        "We expect query call to use the last run of the workflow, not the first one that we started by this stub",
+        "2",
+        workflow.query());
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.TestWorkflowWithQuery {
+    private final String status =
+        Workflow.getInfo().getContinuedExecutionRunId().isPresent() ? "2" : "1";
+
+    @Override
+    public String execute() {
+      if (!Workflow.getInfo().getContinuedExecutionRunId().isPresent()) {
+        Workflow.continueAsNew();
+      }
+      return "done";
+    }
+
+    @Override
+    public String query() {
+      return status;
+    }
+  }
+}


### PR DESCRIPTION
## What was changed

Previously if workflow stub was created and used to start a workflow, query on this stub was targeting the specific runId that was created by this stub and didn't follow the chain of runs.
Now the workflow stub follows the chain of runIds until it is explicitly created for a specific runId.

This PR also cleans up the messy internals that provided potentially outdated runIds in logs of operations that were not targeting a specific runId.

Closes #1601