### PR TITLE
Spring Boot 3 support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply -x spotlessJava"
+    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply -x spotlessJava -P edgeDepsTest"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:
@@ -14,7 +14,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses"
+    command: "./gradlew --no-daemon test -x checkLicenseMain -x checkLicenses -x spotlessCheck -x spotlessApply -x spotlessJava"
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         palantirGitVersionVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '0.15.0' : '0.13.0'}"
-        kotlinVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) ? '1.5.32' : '1.4.32'}"
+        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.8.0' : (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) ? '1.5.32' : '1.4.32')}"
     }
 }
 
@@ -16,7 +16,8 @@ plugins {
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
     //    id 'org.jetbrains.kotlin.jvm' version '1.5.32'
     //    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
-    //    id 'org.jetbrains.kotlin.jvm' version '1.7.20'
+    //    id 'org.jetbrains.kotlin.jvm' version '1.7.22'
+    //    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
     id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}" apply false
     id 'base'
 }
@@ -31,9 +32,12 @@ ext {
     // Platforms
     grpcVersion = '1.52.1' // [1.34.0,)
     jacksonVersion = '2.14.1' // [2.9.0,)
-    micrometerVersion = '1.9.6' // [1.0.0,) // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
+    // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
+    micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.3' : '1.9.7' // [1.0.0,)
 
-    slf4jVersion = '1.7.36' // [1.4.0,) // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which stay on 1.x
+    // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which still stay on 1.x
+    // also slf4j 2.x is not compatible with spring boot 2.x
+    slf4jVersion = project.hasProperty("edgeDepsTest") ? '2.0.6' : '1.7.36' // [1.4.0,)
     protoVersion = '3.21.12' // [3.10.0,)
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
@@ -43,10 +47,13 @@ ext {
 
     jsonPathVersion = '2.7.0' // compileOnly
 
-    springBootVersion = '2.7.8'// [2.4.0,)
+    // Spring Boot 3 requires Java 17, java-sdk builds against 2.x version because we support Java 8.
+    // We do test compatibility with Spring Boot 3 in integration tests.
+    springBootVersion = project.hasProperty("edgeDepsTest") ? '3.0.2' : '2.7.8'// [2.4.0,)
 
     // test scoped
-    logbackVersion = '1.2.11' // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
+    // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
+    logbackVersion = project.hasProperty("edgeDepsTest") ? '1.3.5' : '1.2.11'
     mockitoVersion = '5.0.0'
     junitVersion = '4.13.2'
 }

--- a/docker/buildkite/Dockerfile-JDK18
+++ b/docker/buildkite/Dockerfile-JDK18
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-focal
+FROM eclipse-temurin:18-focal
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y protobuf-compiler git

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -2,8 +2,9 @@ subprojects {
     apply plugin: 'java-library'
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        // graal only supports java 8, 11, 16, 17
+        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
+        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
         withJavadocJar()
         withSourcesJar()
     }
@@ -11,7 +12,7 @@ subprojects {
     compileJava {
         options.encoding = 'UTF-8'
         options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror'
-        if (JavaVersion.current().isJava9Compatible()) {
+        if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
             // https://stackoverflow.com/a/43103115/525203
             options.compilerArgs.addAll(['--release', '8'])
         }
@@ -20,7 +21,7 @@ subprojects {
     compileTestJava {
         options.encoding = 'UTF-8'
         options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror'
-        if (JavaVersion.current().isJava9Compatible()) {
+        if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
             // https://stackoverflow.com/a/43103115/525203
             options.compilerArgs.addAll(['--release', '8'])
         }

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id 'org.jlleitschuh.gradle.ktlint' version '11.0.0'
 }
@@ -6,17 +8,10 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 
 description = '''Temporal Workflow Java SDK Kotlin'''
 
-compileKotlin {
+tasks.withType(KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        jvmTarget = JavaVersion.VERSION_1_8
-    }
-}
-
-compileTestKotlin {
-    kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
     }
 }
 

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/ConnectionProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/ConnectionProperties.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 /** These properties are significantly mirroring {@link WorkflowServiceStubsOptions} */
-@ConstructorBinding
 public class ConnectionProperties {
   public static final String TARGET_LOCAL_SERVICE = "local";
 
@@ -43,6 +42,7 @@ public class ConnectionProperties {
    * @param enableHttps {@link WorkflowServiceStubsOptions.Builder#setEnableHttps(boolean)}
    *     (String)}
    */
+  @ConstructorBinding
   public ConnectionProperties(
       @Nonnull String target, @Nullable Boolean enableHttps, @Nullable MTLSProperties mtls) {
     this.target = target;
@@ -65,7 +65,6 @@ public class ConnectionProperties {
     return mtls;
   }
 
-  @ConstructorBinding
   public static class MTLSProperties {
     private final @Nullable Integer pkcs;
 
@@ -89,6 +88,7 @@ public class ConnectionProperties {
      * @param insecureTrustManager see {@link
      *     SimpleSslContextBuilder#setUseInsecureTrustManager(boolean)}
      */
+    @ConstructorBinding
     public MTLSProperties(
         @Nullable Integer pkcs,
         @Nullable String key,

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-@ConstructorBinding
 public class NamespaceProperties {
   public static final String NAMESPACE_DEFAULT = "default";
 
@@ -36,6 +35,7 @@ public class NamespaceProperties {
   private final @Nullable List<WorkerProperties> workers;
   private final @Nonnull String namespace;
 
+  @ConstructorBinding
   public NamespaceProperties(
       @Nullable String namespace,
       @Nullable WorkersAutoDiscoveryProperties workersAutoDiscovery,

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TemporalProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TemporalProperties.java
@@ -28,12 +28,12 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @ConfigurationProperties(prefix = "spring.temporal")
-@ConstructorBinding
 public class TemporalProperties extends NamespaceProperties {
   private final @NestedConfigurationProperty @Nonnull ConnectionProperties connection;
   private final @NestedConfigurationProperty @Nullable TestServerProperties testServer;
   private final @Nullable Boolean startWorkers;
 
+  @ConstructorBinding
   public TemporalProperties(
       @Nullable String namespace,
       @Nullable WorkersAutoDiscoveryProperties workersAutoDiscovery,

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TestServerProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TestServerProperties.java
@@ -23,10 +23,10 @@ package io.temporal.spring.boot.autoconfigure.properties;
 import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-@ConstructorBinding
 public class TestServerProperties {
   private final @Nullable Boolean enabled;
 
+  @ConstructorBinding
   public TestServerProperties(@Nullable Boolean enabled) {
     this.enabled = enabled;
   }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-@ConstructorBinding
 public class WorkerProperties {
   private @Nonnull String taskQueue;
 
@@ -33,6 +32,7 @@ public class WorkerProperties {
 
   private @Nullable Collection<String> activityBeans;
 
+  @ConstructorBinding
   public WorkerProperties(
       @Nonnull String taskQueue,
       @Nullable Collection<Class<?>> workflowClasses,

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkersAutoDiscoveryProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkersAutoDiscoveryProperties.java
@@ -24,10 +24,10 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-@ConstructorBinding
 public class WorkersAutoDiscoveryProperties {
   private final @Nullable List<String> packages;
 
+  @ConstructorBinding
   public WorkersAutoDiscoveryProperties(@Nullable List<String> packages) {
     this.packages = packages;
   }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,5 @@
+io.temporal.spring.boot.autoconfigure.MetricsScopeAutoConfiguration
+io.temporal.spring.boot.autoconfigure.OpenTracingAutoConfiguration
+io.temporal.spring.boot.autoconfigure.TestServerAutoConfiguration
+io.temporal.spring.boot.autoconfigure.ServiceStubsAutoConfiguration
+io.temporal.spring.boot.autoconfigure.RootNamespaceAutoConfiguration


### PR DESCRIPTION
Fix incompatibilities with Sprint Boot 3.
Add `edgeDepsTest` profile that is going to use the latest dependencies versions for compatibility testing.

Closes #1619