### PR TITLE
Add auto discovery binding strategy by worker name to Spring Boot

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -188,7 +189,8 @@ public final class WorkerFactory {
    * @return a worker created previously through {@link #newWorker(String)} for the given task queue
    *     or null.
    */
-  public synchronized Worker tryGetWorker(String taskQueue) {
+  @Nullable
+  public synchronized Worker tryGetWorker(@Nonnull String taskQueue) {
     return workers.get(taskQueue);
   }
 

--- a/temporal-spring-boot-autoconfigure-alpha/README.md
+++ b/temporal-spring-boot-autoconfigure-alpha/README.md
@@ -72,6 +72,7 @@ Follow the pattern to explicitly configure the workers:
 spring.temporal:
   workers:
     - task-queue: your-task-queue-name
+      # name: your-worker-name # unique name of the Worker. If not specified, Task Queue is used as a Worker name.
       workflow-classes:
         - your.package.YouWorkflowImpl
       activity-beans:
@@ -81,8 +82,10 @@ spring.temporal:
 
 ## Auto-discovery
 
-Allows to skip specifying workflow and activity classes explicitly in the config 
-by providing worker task queue names on Workflow and Activity implementations.
+Allows to skip specifying Workflow classes and Activity beans explicitly in the config
+by referencing Worker Task Queue names or Worker Names on Workflow and Activity implementations.
+Auto-discovery is applied after and on top of an explicit configuration.
+
 Add the following to your `application.yml` to auto-discover workflows and activities from your classpath.
 
 ```yml
@@ -95,14 +98,23 @@ spring.temporal:
 
 What is auto-discovered:
 - Workflows implementation classes annotated with `io.temporal.spring.boot.WorkflowImpl`
-- Activity beans registered in Spring context which implementation classes are annotated with `io.temporal.spring.boot.ActivityImpl`
+- Activity beans present Spring context whose implementations are annotated with `io.temporal.spring.boot.ActivityImpl`
+- Workers if a Task Queue is referenced by the annotations but not explicitly configured. Default configuration will be used.
 
-Auto-discovered workflow implementation classes and activity beans will be registered with workers configured explicitly 
-or workers will be created for them if no explicit configuration is provided for a worker.
+Auto-discovered workflow implementation classes and activity beans will be registered with the configured workers if not already registered.
 
-## Note on mixing configuration styles
+### Referencing worker names vs task queues
 
-The behavior when both auto-discovery and explicit configuration is mixed is undefined and to be decided later.
+Application that incorporates
+[Task Queue based Versioning strategy](https://community.temporal.io/t/workflow-versioning-strategies/6911)
+may choose to use explicit Worker names to reference because it adds a level of indirection.
+This way Task Queue name is specified only once in the config and can be easily changed when needed,
+while all the auto-discovery annotations reference the Worker by its static name.
+
+An application whose lifecycle doesn't involve changing task queue names may prefer to reference
+Task Queue names directly for simplicity.
+
+Note: Worker whose name is not explicitly specified is named after it's Task Queue.
 
 # Integrations
 

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/ActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/ActivityImpl.java
@@ -25,8 +25,24 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Enables the Activity bean to be discovered by the Workers auto-discovery. This annotation is not
+ * needed if only an explicit config is used.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface ActivityImpl {
-  String[] taskQueues();
+  /**
+   * @return names of Workers to register this activity bean with. Workers with these names must be
+   *     present in the application config. Worker is named by its task queue if its name is not
+   *     specified.
+   */
+  String[] workers() default {};
+
+  /**
+   * @return Worker Task Queues to register this activity bean with. If Worker with the specified
+   *     Task Queue is not present in the application config, it will be created with a default
+   *     config.
+   */
+  String[] taskQueues() default {};
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/WorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/WorkflowImpl.java
@@ -25,8 +25,24 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Enables the Workflow implementation class to be discovered by the Workers auto-discovery. This
+ * annotation is not needed if only an explicit config is used.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface WorkflowImpl {
-  String[] taskQueues();
+  /**
+   * @return names of Workers to register this workflow implementation with. Workers with these
+   *     names must be present in the application config or auto-discovered from {@link
+   *     #taskQueues()}. Worker is named by its task queue if its name is not specified.
+   */
+  String[] workers() default {};
+
+  /**
+   * @return Worker Task Queues to register this workflow implementation with. If Worker with the
+   *     specified Task Queue is not defined in the application config, it will be created with a
+   *     default config.
+   */
+  String[] taskQueues() default {};
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 
 public class WorkerProperties {
   private @Nonnull String taskQueue;
+  private @Nullable String name;
 
   private @Nullable Collection<Class<?>> workflowClasses;
 
@@ -35,8 +36,10 @@ public class WorkerProperties {
   @ConstructorBinding
   public WorkerProperties(
       @Nonnull String taskQueue,
+      @Nullable String name,
       @Nullable Collection<Class<?>> workflowClasses,
       @Nullable Collection<String> activityBeans) {
+    this.name = name;
     this.taskQueue = taskQueue;
     this.workflowClasses = workflowClasses;
     this.activityBeans = activityBeans;
@@ -47,8 +50,17 @@ public class WorkerProperties {
     return taskQueue;
   }
 
-  public void setTaskQueue(String taskQueue) {
+  public void setTaskQueue(@Nonnull String taskQueue) {
     this.taskQueue = taskQueue;
+  }
+
+  @Nullable
+  public String getName() {
+    return name;
+  }
+
+  public void setName(@Nullable String name) {
+    this.name = name;
   }
 
   @Nullable
@@ -56,7 +68,7 @@ public class WorkerProperties {
     return workflowClasses;
   }
 
-  public void setWorkflowClasses(Collection<Class<?>> workflowClasses) {
+  public void setWorkflowClasses(@Nullable Collection<Class<?>> workflowClasses) {
     this.workflowClasses = workflowClasses;
   }
 
@@ -65,7 +77,7 @@ public class WorkerProperties {
     return activityBeans;
   }
 
-  public void setActivityBeans(Collection<String> activityBeans) {
+  public void setActivityBeans(@Nullable Collection<String> activityBeans) {
     this.activityBeans = activityBeans;
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByTaskQueueTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByTaskQueueTest.java
@@ -22,6 +22,7 @@ package io.temporal.spring.boot.autoconfigure;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
 import io.temporal.testing.TestWorkflowEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,12 +32,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = AutoDiscoveryTest.Configuration.class)
-@ActiveProfiles(profiles = "auto-discovery")
+@SpringBootTest(classes = AutoDiscoveryByTaskQueueTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AutoDiscoveryTest {
+public class AutoDiscoveryByTaskQueueTest {
   @Autowired ConfigurableApplicationContext applicationContext;
 
   @Autowired TestWorkflowEnvironment testWorkflowEnvironment;
@@ -57,6 +59,10 @@ public class AutoDiscoveryTest {
     testWorkflow.execute("input");
   }
 
-  @ComponentScan
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
   public static class Configuration {}
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/CustomDataConverterTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/CustomDataConverterTest.java
@@ -27,6 +27,7 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
 import io.temporal.testing.TestWorkflowEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,10 +38,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = CustomDataConverterTest.Configuration.class)
-@ActiveProfiles(profiles = "auto-discovery")
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CustomDataConverterTest {
   @Autowired ConfigurableApplicationContext applicationContext;
@@ -66,7 +68,11 @@ public class CustomDataConverterTest {
     verify(spyDataConverter, atLeastOnce()).toPayloads(any());
   }
 
-  @ComponentScan
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
   public static class Configuration {
     @Bean
     public DataConverter spyDataConverter() {

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/ExplicitConfigTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/ExplicitConfigTest.java
@@ -22,6 +22,7 @@ package io.temporal.spring.boot.autoconfigure;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
 import io.temporal.testing.TestWorkflowEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = ExplicitConfigTest.Configuration.class)
@@ -57,6 +59,10 @@ public class ExplicitConfigTest {
     testWorkflow.execute("input");
   }
 
-  @ComponentScan
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
   public static class Configuration {}
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/WorkersAreNotStartingBeforeContextTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/WorkersAreNotStartingBeforeContextTest.java
@@ -32,10 +32,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = AutoDiscoveryTest.Configuration.class)
-@ActiveProfiles(profiles = "auto-discovery")
+@SpringBootTest(classes = AutoDiscoveryByTaskQueueTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class WorkersAreNotStartingBeforeContextTest {
   @Autowired ConfigurableApplicationContext applicationContext;
@@ -54,6 +55,10 @@ public class WorkersAreNotStartingBeforeContextTest {
     assertTrue(workerFactory.isStarted());
   }
 
-  @ComponentScan
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
   public static class Configuration {}
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestActivity.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestActivity.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.bytaskqueue;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface TestActivity {
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestActivityImpl.java
@@ -18,11 +18,16 @@
  * limitations under the License.
  */
 
-package io.temporal.spring.boot.autoconfigure;
+package io.temporal.spring.boot.autoconfigure.bytaskqueue;
 
-import io.temporal.activity.ActivityInterface;
+import io.temporal.spring.boot.ActivityImpl;
+import org.springframework.stereotype.Component;
 
-@ActivityInterface
-public interface TestActivity {
-  String execute(String input);
+@Component("TestActivityImpl")
+@ActivityImpl(taskQueues = "UnitTest")
+public class TestActivityImpl implements TestActivity {
+  @Override
+  public String execute(String input) {
+    return input;
+  }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestWorkflow.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestWorkflow.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.bytaskqueue;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface TestWorkflow {
+
+  @WorkflowMethod(name = "testWorkflow1")
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestWorkflowImpl.java
@@ -18,16 +18,22 @@
  * limitations under the License.
  */
 
-package io.temporal.spring.boot.autoconfigure;
+package io.temporal.spring.boot.autoconfigure.bytaskqueue;
 
-import io.temporal.spring.boot.ActivityImpl;
-import org.springframework.stereotype.Component;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.spring.boot.WorkflowImpl;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
 
-@Component("TestActivityImpl")
-@ActivityImpl(taskQueues = "UnitTest")
-public class TestActivityImpl implements TestActivity {
+@WorkflowImpl(taskQueues = "UnitTest")
+public class TestWorkflowImpl implements TestWorkflow {
   @Override
   public String execute(String input) {
-    return input;
+    return Workflow.newActivityStub(
+            TestActivity.class,
+            ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(1))
+                .validateAndBuildWithDefaults())
+        .execute("done");
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestActivity.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestActivity.java
@@ -18,14 +18,11 @@
  * limitations under the License.
  */
 
-package io.temporal.spring.boot.autoconfigure;
+package io.temporal.spring.boot.autoconfigure.byworkername;
 
-import io.temporal.workflow.WorkflowInterface;
-import io.temporal.workflow.WorkflowMethod;
+import io.temporal.activity.ActivityInterface;
 
-@WorkflowInterface
-public interface TestWorkflow {
-
-  @WorkflowMethod(name = "testWorkflow1")
+@ActivityInterface
+public interface TestActivity {
   String execute(String input);
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestActivityImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.byworkername;
+
+import io.temporal.spring.boot.ActivityImpl;
+import org.springframework.stereotype.Component;
+
+@Component("TestActivityImpl")
+@ActivityImpl(workers = "mainWorker")
+public class TestActivityImpl implements TestActivity {
+  @Override
+  public String execute(String input) {
+    return input;
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestWorkflow.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestWorkflow.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.byworkername;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface TestWorkflow {
+
+  @WorkflowMethod(name = "testWorkflow1")
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/byworkername/TestWorkflowImpl.java
@@ -18,14 +18,14 @@
  * limitations under the License.
  */
 
-package io.temporal.spring.boot.autoconfigure;
+package io.temporal.spring.boot.autoconfigure.byworkername;
 
 import io.temporal.activity.ActivityOptions;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
 
-@WorkflowImpl(taskQueues = "UnitTest")
+@WorkflowImpl(workers = "mainWorker")
 public class TestWorkflowImpl implements TestWorkflow {
   @Override
   public String execute(String input) {

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
@@ -31,11 +31,24 @@ spring.temporal:
 spring:
   config:
     activate:
-      on-profile: auto-discovery
+      on-profile: auto-discovery-by-task-queue
   temporal:
     workers-auto-discovery:
       packages:
-        - io.temporal
+        - io.temporal.spring.boot.autoconfigure.bytaskqueue
+
+---
+spring:
+  config:
+    activate:
+      on-profile: auto-discovery-by-worker-name
+  temporal:
+    workers:
+      - task-queue: UnitTest
+        name: mainWorker
+    workers-auto-discovery:
+      packages:
+        - io.temporal.spring.boot.autoconfigure.byworkername
 
 ---
 spring:
@@ -46,6 +59,6 @@ spring:
     workers:
       - task-queue: UnitTest
         workflow-classes:
-          - io.temporal.spring.boot.autoconfigure.TestWorkflowImpl
+          - io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflowImpl
         activity-beans:
           - TestActivityImpl


### PR DESCRIPTION
## What?

Added a concept of Worker Name. Worker Name defaults to Worker Task Queue, but can be explicitly set. Worker Name can be used by auto-discovery annotations instead of Task Queues. 

## Why?

Application that incorporates [Task Queue based Versioning strategy](https://community.temporal.io/t/workflow-versioning-strategies/6911) may choose to use explicit Worker names to reference because it adds a level of indirection. 
This way Task Queue name is specified only once in the config and can be easily changed when needed, while all the auto-discovery annotations reference the Worker by its static name.