### PR TITLE
Update protos, use #namespace in register SA request, use old protoc on M1 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: ":java: JDK18 Unit test with in-memory test service"
+  - label: ":java: [Edge] Unit test with in-memory test service"
     agents:
       queue: "default"
       docker: "*"
@@ -7,7 +7,7 @@ steps:
     timeout_in_minutes: 15
     plugins:
       - docker-compose#v3.8.0:
-          run: unit-test-test-service-jdk18
+          run: unit-test-test-service-edge
           config: docker/buildkite/docker-compose.yaml
 
   - label: ":docker: JDK8 Unit test with docker service"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.14.0' apply false
+    id 'com.diffplug.spotless' version '6.14.1' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -54,7 +54,7 @@ ext {
     // test scoped
     // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
     logbackVersion = project.hasProperty("edgeDepsTest") ? '1.3.5' : '1.2.11'
-    mockitoVersion = '5.1.0'
+    mockitoVersion = '5.1.1'
     junitVersion = '4.13.2'
 }
 

--- a/docker/buildkite/Dockerfile-JDK19
+++ b/docker/buildkite/Dockerfile-JDK19
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:18-focal
+FROM eclipse-temurin:19-jdk-focal
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y protobuf-compiler git

--- a/docker/buildkite/docker-compose.yaml
+++ b/docker/buildkite/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - 9042
 
   temporal:
-    image: temporaliotest/auto-setup:sha-cc2e0c0
+    image: temporaliotest/auto-setup:latest
     ports:
       - "7233:7233"
       - "7234:7234"
@@ -59,10 +59,10 @@ services:
     volumes:
       - "../../:/temporal-java-client"
 
-  unit-test-test-service-jdk18:
+  unit-test-test-service-edge:
     build:
       context: ../../
-      dockerfile: ./docker/buildkite/Dockerfile-JDK18
+      dockerfile: ./docker/buildkite/Dockerfile-JDK19
     environment:
       - "USER=unittest"
       - "USE_DOCKER_SERVICE=false"
@@ -73,15 +73,6 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile-JDK11
-    environment:
-      - "USER=unittest"
-    volumes:
-      - "../../:/temporal-java-client"
-
-  jdk18:
-    build:
-      context: ../../
-      dockerfile: ./docker/buildkite/Dockerfile-JDK18
     environment:
       - "USER=unittest"
     volumes:

--- a/gradle/linting.gradle
+++ b/gradle/linting.gradle
@@ -10,12 +10,7 @@ subprojects {
         }
 
         kotlin {
-            ktlint('0.47.1')
-                    .setUseExperimental(true)
-                    // needs to be aligned with .editorconfig
-                    // https://github.com/diffplug/spotless/tree/main/plugin-gradle#ktlint
-                    // reenable filename rule after https://github.com/pinterest/ktlint/issues/1521
-                    .editorConfigOverride(['indent_size': '2', 'ktlint_disabled_rules': 'filename'])
+            ktlint('0.48.2')
         }
     }
 

--- a/temporal-kotlin/.editorconfig
+++ b/temporal-kotlin/.editorconfig
@@ -1,4 +1,7 @@
+root = true
+
 [*.{kt,kts}]
 indent_size = 2
-# reenable filename rule after https://github.com/pinterest/ktlint/issues/1521
-ktlint_disabled_rules = filename
+
+ij_kotlin_allow_trailing_comma = false
+ij_kotlin_allow_trailing_comma_on_call_site = false

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -63,27 +63,14 @@ protobuf {
     // version/variables substitution is not supported in protobuf section.
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
     // with the oldest supported versions of protoc and grpc artifacts.
-    // For aarch64 (M1) using oldest version with binary available for this platform
-    if (System.getProperty("os.arch") == 'aarch64') {
-        protoc {
-            artifact = 'com.google.protobuf:protoc:3.21.12'
-        }
-        plugins {
-            grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.2'
-            }
-        }
-    } else {
-        protoc {
-            artifact = 'com.google.protobuf:protoc:3.10.1'
-        }
-        plugins {
-            grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
-            }
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.10.1' + (System.getProperty("os.arch") == 'aarch64' ? ':osx-x86_64' : '')
+    }
+    plugins {
+        grpc {
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1' + (System.getProperty("os.arch") == 'aarch64' ? ':osx-x86_64' : '')
         }
     }
-
     generateProtoTasks {
         all().each { task -> task.dependsOn updateSubmodules }
         all()*.plugins {

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -67,24 +67,12 @@ protobuf {
     // version/variables substitution is not supported in protobuf section.
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
     // with the oldest supported versions of protoc and grpc artifacts.
-    // For aarch64 (M1) using oldest version with binary available for this platform
-    if (System.getProperty("os.arch") == 'aarch64') {
-        protoc {
-            artifact = 'com.google.protobuf:protoc:3.21.12'
-        }
-        plugins {
-            grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.48.2'
-            }
-        }
-    } else {
-        protoc {
-            artifact = 'com.google.protobuf:protoc:3.10.1'
-        }
-        plugins {
-            grpc {
-                artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
-            }
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.10.1' + (System.getProperty("os.arch") == 'aarch64' ? ':osx-x86_64' : '')
+    }
+    plugins {
+        grpc {
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1' + (System.getProperty("os.arch") == 'aarch64' ? ':osx-x86_64' : '')
         }
     }
     generateProtoTasks {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -204,7 +204,10 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
           "Class " + type + " can't be used as a search attribute type");
     }
     AddSearchAttributesRequest request =
-        AddSearchAttributesRequest.newBuilder().putSearchAttributes(name, type).build();
+        AddSearchAttributesRequest.newBuilder()
+            .setNamespace(getNamespace())
+            .putSearchAttributes(name, type)
+            .build();
     try {
       operatorServiceStubs.blockingStub().addSearchAttributes(request);
       return true;


### PR DESCRIPTION
Make Apple Silicone build to use the same protoc and protoc-gen-grpc-java versions as Temporal JavaSDK uses for publishing release artifacts
Update temporal/api protos
Move Edge build profile onto Java 19
Use new #namespace on AddSearchAttributes request