### PR TITLE
Add TemporalOptionsCustomizer to allow users to modify the options constructed by Spring Boot Auto Configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.13.0' apply false
+    id 'com.diffplug.spotless' version '6.14.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -31,7 +31,7 @@ allprojects {
 ext {
     // Platforms
     grpcVersion = '1.52.1' // [1.34.0,)
-    jacksonVersion = '2.14.1' // [2.9.0,)
+    jacksonVersion = '2.14.2' // [2.9.0,)
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.3' : '1.9.7' // [1.0.0,)
 
@@ -54,7 +54,7 @@ ext {
     // test scoped
     // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
     logbackVersion = project.hasProperty("edgeDepsTest") ? '1.3.5' : '1.2.11'
-    mockitoVersion = '5.0.0'
+    mockitoVersion = '5.1.0'
     junitVersion = '4.13.2'
 }
 

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id 'org.jlleitschuh.gradle.ktlint' version '11.0.0'
+    id 'org.jlleitschuh.gradle.ktlint' version '11.1.0'
 }
 
 apply plugin: 'org.jetbrains.kotlin.jvm'

--- a/temporal-spring-boot-autoconfigure-alpha/README.md
+++ b/temporal-spring-boot-autoconfigure-alpha/README.md
@@ -116,6 +116,22 @@ Task Queue names directly for simplicity.
 
 Note: Worker whose name is not explicitly specified is named after it's Task Queue.
 
+## Customization of `*Options`
+
+To provide freedom in customization of `*Options` instances that are created by this module,
+beans that implement `io.temporal.spring.boot.TemporalOptionsCustomizer<OptionsBuilderType>`
+interface may be added to the Spring context.
+
+Where `OptionsType` may be one of:
+- `WorkflowServiceStubsOptions.Builder`
+- `WorkflowClientOption.Builder`
+- `WorkerFactoryOptions.Builder`
+- `WorkerOptions.Builder`
+- `TestEnvironmentOptions.Builder`
+
+`io.temporal.spring.boot.WorkerOptionsCustomizer` may be used instead of `TemporalOptionsCustomizer<WorkerOptions.Builder>`
+if `WorkerOptions` needs to be modified differently depending on the Task Queue or Worker name.
+
 # Integrations
 
 ## Metrics

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/TemporalOptionsCustomizer.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/TemporalOptionsCustomizer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot;
+
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.TestEnvironmentOptions;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.worker.WorkerOptions;
+import javax.annotation.Nonnull;
+
+/**
+ * Beans of this class can be added to Spring context to get a fine control over *Options objects
+ * that are created by Temporal Spring Boot Autoconfigure module.
+ *
+ * <p>Only one bean of each generic type can be added to Spring context.
+ *
+ * @param <T> Temporal Options Builder to customize. Respected types: {@link
+ *     WorkflowServiceStubsOptions.Builder}, {@link WorkflowClientOptions.Builder}, {@link
+ *     TestEnvironmentOptions.Builder}, {@link WorkerOptions.Builder}, {@link
+ *     WorkerFactoryOptions.Builder}
+ * @see WorkerOptionsCustomizer to get access to a name and task queue of a worker that's being
+ *     customized
+ */
+public interface TemporalOptionsCustomizer<T> {
+  /**
+   * This method can modify some fields of the provided builder or create a new builder altogether
+   * and return it back to be used. This method is called after the {@code *Options.Builder} is
+   * initialized by the Temporal Spring Boot module, so changes done by this method will override
+   * Spring Boot configuration values.
+   *
+   * @param optionsBuilder {@code *Options.Builder} to customize
+   * @return modified {@code optionsBuilder} or a new builder to be used by the caller code.
+   */
+  @Nonnull
+  T customize(@Nonnull T optionsBuilder);
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/WorkerOptionsCustomizer.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/WorkerOptionsCustomizer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot;
+
+import io.temporal.worker.WorkerOptions;
+import javax.annotation.Nonnull;
+
+/**
+ * Bean of this class can be added to Spring context to get a fine control over WorkerOptions
+ * objects that are created by Temporal Spring Boot Autoconfigure module.
+ *
+ * <p>Only one bean of this or {@code TemporalOptionsCustomizer<WorkerOptions.Builder>} type can be
+ * added to Spring context.
+ */
+public interface WorkerOptionsCustomizer extends TemporalOptionsCustomizer<WorkerOptions.Builder> {
+  @Nonnull
+  @Override
+  default WorkerOptions.Builder customize(@Nonnull WorkerOptions.Builder optionsBuilder) {
+    return optionsBuilder;
+  }
+
+  /**
+   * This method can modify some fields of the provided {@code WorkerOptions.Builder} or create a
+   * new builder altogether and return it back to be used. This method is called after the {@code
+   * WorkerOptions.Builder} is initialized by the Temporal Spring Boot module, so changes done by
+   * this method will override Spring Boot configuration values.
+   *
+   * @param optionsBuilder {@code *Options.Builder} to customize
+   * @param workerName name of a Worker that will be created using the {@link WorkerOptions}
+   *     produced by this call
+   * @param taskQueue Task Queue of a Worker that will be created using the {@link WorkerOptions}
+   *     produced by this call
+   * @return modified {@code optionsBuilder} or a new builder instance to be used by the caller code
+   */
+  @Nonnull
+  WorkerOptions.Builder customize(
+      @Nonnull WorkerOptions.Builder optionsBuilder,
+      @Nonnull String workerName,
+      @Nonnull String taskQueue);
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/RootNamespaceAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/RootNamespaceAutoConfiguration.java
@@ -22,8 +22,10 @@ package io.temporal.spring.boot.autoconfigure;
 
 import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import io.temporal.spring.boot.autoconfigure.template.ClientTemplate;
 import io.temporal.spring.boot.autoconfigure.template.NamespaceTemplate;
@@ -31,6 +33,8 @@ import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAda
 import io.temporal.spring.boot.autoconfigure.template.WorkersTemplate;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.worker.WorkerOptions;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -76,7 +80,13 @@ public class RootNamespaceAutoConfiguration {
           DataConverter mainDataConverter,
       @Autowired(required = false) @Nullable Tracer otTracer,
       @Qualifier("temporalTestWorkflowEnvironmentAdapter") @Autowired(required = false) @Nullable
-          TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
+          TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkerOptions.Builder> workerCustomizer,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer) {
     DataConverter chosenDataConverter =
         AutoConfigurationUtils.choseDataConverter(dataConverters, mainDataConverter);
     return new NamespaceTemplate(
@@ -85,7 +95,10 @@ public class RootNamespaceAutoConfiguration {
         workflowServiceStubs,
         chosenDataConverter,
         otTracer,
-        testWorkflowEnvironment);
+        testWorkflowEnvironment,
+        workerFactoryCustomizer,
+        workerCustomizer,
+        clientCustomizer);
   }
 
   /** Client */

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/ServiceStubsAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/ServiceStubsAutoConfiguration.java
@@ -22,6 +22,8 @@ package io.temporal.spring.boot.autoconfigure;
 
 import com.uber.m3.tally.Scope;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import io.temporal.spring.boot.autoconfigure.template.ServiceStubsTemplate;
 import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAdapter;
@@ -46,9 +48,15 @@ public class ServiceStubsAutoConfiguration {
       TemporalProperties properties,
       @Qualifier("temporalMetricsScope") @Autowired(required = false) @Nullable Scope metricsScope,
       @Qualifier("temporalTestWorkflowEnvironmentAdapter") @Autowired(required = false) @Nullable
-          TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
+          TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>
+              workflowServiceStubsCustomizer) {
     return new ServiceStubsTemplate(
-        properties.getConnection(), metricsScope, testWorkflowEnvironment);
+        properties.getConnection(),
+        metricsScope,
+        testWorkflowEnvironment,
+        workflowServiceStubsCustomizer);
   }
 
   @Bean(name = "temporalWorkflowServiceStubs")

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestServerAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestServerAutoConfiguration.java
@@ -22,14 +22,21 @@ package io.temporal.spring.boot.autoconfigure;
 
 import com.uber.m3.tally.Scope;
 import io.opentracing.Tracer;
+import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
-import io.temporal.spring.boot.autoconfigure.template.ClientTemplate;
 import io.temporal.spring.boot.autoconfigure.template.TestWorkflowEnvironmentAdapter;
+import io.temporal.spring.boot.autoconfigure.template.WorkerFactoryOptionsTemplate;
+import io.temporal.spring.boot.autoconfigure.template.WorkflowClientOptionsTemplate;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.WorkerFactoryOptions;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -49,6 +56,8 @@ import org.springframework.context.annotation.Configuration;
     havingValue = "true")
 @AutoConfigureAfter({OpenTracingAutoConfiguration.class, MetricsScopeAutoConfiguration.class})
 public class TestServerAutoConfiguration {
+  private static final Logger log = LoggerFactory.getLogger(TestServerAutoConfiguration.class);
+
   @Bean(name = "temporalTestWorkflowEnvironmentAdapter")
   public TestWorkflowEnvironmentAdapter testTestWorkflowEnvironmentAdapter(
       @Qualifier("temporalTestWorkflowEnvironment")
@@ -63,17 +72,41 @@ public class TestServerAutoConfiguration {
       @Autowired List<DataConverter> dataConverters,
       @Qualifier("mainDataConverter") @Autowired(required = false) @Nullable
           DataConverter mainDataConverter,
-      @Autowired(required = false) @Nullable Tracer otTracer) {
+      @Autowired(required = false) @Nullable Tracer otTracer,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<TestEnvironmentOptions.Builder> testEnvOptionsCustomizer,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer,
+      @Autowired(required = false) @Nullable
+          TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>
+              workflowServiceStubsCustomizer) {
     DataConverter chosenDataConverter =
         AutoConfigurationUtils.choseDataConverter(dataConverters, mainDataConverter);
-    ClientTemplate clientTemplate =
-        new ClientTemplate(properties.getNamespace(), chosenDataConverter, otTracer, null, null);
+
+    if (workflowServiceStubsCustomizer != null) {
+      log.info(
+          "`TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>` bean is ignored for test environment");
+    }
 
     TestEnvironmentOptions.Builder options =
         TestEnvironmentOptions.newBuilder()
-            .setWorkflowClientOptions(clientTemplate.getWorkflowClientOptions());
+            .setWorkflowClientOptions(
+                new WorkflowClientOptionsTemplate(
+                        properties.getNamespace(), chosenDataConverter, otTracer, clientCustomizer)
+                    .createWorkflowClientOptions());
+
     if (metricsScope != null) {
       options.setMetricsScope(metricsScope);
+    }
+
+    options.setWorkerFactoryOptions(
+        new WorkerFactoryOptionsTemplate(otTracer, workerFactoryCustomizer)
+            .createWorkerFactoryOptions());
+
+    if (testEnvOptionsCustomizer != null) {
+      options = testEnvOptionsCustomizer.customize(options);
     }
 
     return TestWorkflowEnvironment.newInstance(options.build());

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ClientTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ClientTemplate.java
@@ -25,17 +25,13 @@ import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.converter.DataConverter;
-import io.temporal.opentracing.OpenTracingClientInterceptor;
-import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
-import java.util.Objects;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ClientTemplate {
-  private final @Nonnull String namespace;
-  private final @Nullable DataConverter dataConverter;
-  private final @Nullable Tracer tracer;
+  private final @Nonnull WorkflowClientOptionsTemplate optionsTemplate;
   private final @Nullable WorkflowServiceStubs workflowServiceStubs;
   // if not null, we work with an environment with defined test server
   private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
@@ -47,10 +43,10 @@ public class ClientTemplate {
       @Nullable DataConverter dataConverter,
       @Nullable Tracer tracer,
       @Nullable WorkflowServiceStubs workflowServiceStubs,
-      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
-    this.namespace = Objects.requireNonNull(namespace);
-    this.dataConverter = dataConverter;
-    this.tracer = tracer;
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
+      @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> customizer) {
+    this.optionsTemplate =
+        new WorkflowClientOptionsTemplate(namespace, dataConverter, tracer, customizer);
     this.workflowServiceStubs = workflowServiceStubs;
     this.testWorkflowEnvironment = testWorkflowEnvironment;
   }
@@ -68,25 +64,8 @@ public class ClientTemplate {
     } else {
       Preconditions.checkState(
           workflowServiceStubs != null, "ClientTemplate was created without workflowServiceStubs");
-      return WorkflowClient.newInstance(workflowServiceStubs, getWorkflowClientOptions());
+      return WorkflowClient.newInstance(
+          workflowServiceStubs, optionsTemplate.createWorkflowClientOptions());
     }
-  }
-
-  public WorkflowClientOptions getWorkflowClientOptions() {
-    WorkflowClientOptions.Builder clientOptionsBuilder = WorkflowClientOptions.newBuilder();
-
-    clientOptionsBuilder.setNamespace(namespace);
-
-    if (dataConverter != null) {
-      clientOptionsBuilder.setDataConverter(dataConverter);
-    }
-
-    if (tracer != null) {
-      OpenTracingClientInterceptor openTracingClientInterceptor =
-          new OpenTracingClientInterceptor(
-              OpenTracingOptions.newBuilder().setTracer(tracer).build());
-      clientOptionsBuilder.setInterceptors(openTracingClientInterceptor);
-    }
-    return clientOptionsBuilder.build();
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/NamespaceTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/NamespaceTemplate.java
@@ -21,10 +21,14 @@
 package io.temporal.spring.boot.autoconfigure.template;
 
 import io.opentracing.Tracer;
+import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.worker.WorkerOptions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -36,6 +40,11 @@ public class NamespaceTemplate {
   private final @Nullable Tracer tracer;
   private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
 
+  private final @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder>
+      workerFactoryCustomizer;
+  private final @Nullable TemporalOptionsCustomizer<WorkerOptions.Builder> workerCustomizer;
+  private final @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer;
+
   private ClientTemplate clientTemplate;
   private WorkersTemplate workersTemplate;
 
@@ -45,13 +54,20 @@ public class NamespaceTemplate {
       @Nonnull WorkflowServiceStubs workflowServiceStubs,
       @Nullable DataConverter dataConverter,
       @Nullable Tracer tracer,
-      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
+      @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer,
+      @Nullable TemporalOptionsCustomizer<WorkerOptions.Builder> workerCustomizer,
+      @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer) {
     this.properties = properties;
     this.namespaceProperties = namespaceProperties;
     this.workflowServiceStubs = workflowServiceStubs;
     this.dataConverter = dataConverter;
     this.tracer = tracer;
     this.testWorkflowEnvironment = testWorkflowEnvironment;
+
+    this.workerFactoryCustomizer = workerFactoryCustomizer;
+    this.workerCustomizer = workerCustomizer;
+    this.clientCustomizer = clientCustomizer;
   }
 
   public ClientTemplate getClientTemplate() {
@@ -62,7 +78,8 @@ public class NamespaceTemplate {
               dataConverter,
               tracer,
               workflowServiceStubs,
-              testWorkflowEnvironment);
+              testWorkflowEnvironment,
+              clientCustomizer);
     }
     return clientTemplate;
   }
@@ -75,7 +92,9 @@ public class NamespaceTemplate {
               namespaceProperties,
               getClientTemplate(),
               tracer,
-              testWorkflowEnvironment);
+              testWorkflowEnvironment,
+              workerFactoryCustomizer,
+              workerCustomizer);
     }
     return this.workersTemplate;
   }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.template;
+
+import com.uber.m3.tally.Scope;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.temporal.serviceclient.SimpleSslContextBuilder;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import io.temporal.spring.boot.autoconfigure.properties.ConnectionProperties;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.support.BeanDefinitionValidationException;
+import org.springframework.util.ResourceUtils;
+
+public class ServiceStubOptionsTemplate {
+  private final @Nonnull ConnectionProperties connectionProperties;
+  private final @Nullable Scope metricsScope;
+  private final @Nullable TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>
+      workflowServiceStubsCustomizer;
+
+  public ServiceStubOptionsTemplate(
+      @Nonnull ConnectionProperties connectionProperties,
+      @Nullable Scope metricsScope,
+      @Nullable
+          TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>
+              workflowServiceStubsCustomizer) {
+    this.connectionProperties = connectionProperties;
+    this.metricsScope = metricsScope;
+    this.workflowServiceStubsCustomizer = workflowServiceStubsCustomizer;
+  }
+
+  public WorkflowServiceStubsOptions createServiceStubOptions() {
+    WorkflowServiceStubsOptions.Builder stubsOptionsBuilder =
+        WorkflowServiceStubsOptions.newBuilder();
+
+    if (connectionProperties.getTarget() != null) {
+      stubsOptionsBuilder.setTarget(connectionProperties.getTarget());
+    }
+
+    stubsOptionsBuilder.setEnableHttps(Boolean.TRUE.equals(connectionProperties.isEnableHttps()));
+
+    configureMTLS(connectionProperties.getMTLS(), stubsOptionsBuilder);
+
+    if (metricsScope != null) {
+      stubsOptionsBuilder.setMetricsScope(metricsScope);
+    }
+
+    if (workflowServiceStubsCustomizer != null) {
+      stubsOptionsBuilder = workflowServiceStubsCustomizer.customize(stubsOptionsBuilder);
+    }
+
+    return stubsOptionsBuilder.build();
+  }
+
+  private void configureMTLS(
+      @Nullable ConnectionProperties.MTLSProperties mtlsProperties,
+      WorkflowServiceStubsOptions.Builder stubsOptionsBuilder) {
+    if (mtlsProperties == null
+        || (mtlsProperties.getKeyFile() == null
+            && mtlsProperties.getCertChainFile() == null
+            && mtlsProperties.getKey() == null
+            && mtlsProperties.getCertChain() == null)) {
+      return;
+    }
+
+    Integer pkcs = mtlsProperties.getPKCS();
+    if (pkcs != null && pkcs != 8 && pkcs != 12) {
+      throw new BeanDefinitionValidationException("Invalid PKCS: " + pkcs);
+    }
+
+    String keyFile = mtlsProperties.getKeyFile();
+    String key = mtlsProperties.getKey();
+    if (keyFile == null && key == null) {
+      throw new BeanDefinitionValidationException("key-file or key has to be specified");
+    } else if (keyFile != null && key != null) {
+      throw new BeanDefinitionValidationException(
+          "Both key-file and key can't be specified at the same time");
+    }
+
+    String certChainFile = mtlsProperties.getCertChainFile();
+    String certChain = mtlsProperties.getCertChain();
+
+    if (pkcs == null) {
+      pkcs = certChainFile != null || certChain != null ? 8 : 12;
+    }
+
+    SimpleSslContextBuilder sslBuilder;
+    SslContext sslContext;
+    if (pkcs == 8) {
+      if (certChainFile == null && certChain == null) {
+        throw new BeanDefinitionValidationException(
+            "cert-chain-file or cert-chain has to be specified for PKCS8");
+      }
+      if (certChainFile != null && certChain != null) {
+        throw new BeanDefinitionValidationException(
+            "Both cert-chain-file or cert-chain can't be set at the same time");
+      }
+      try (InputStream certInputStream =
+              certChainFile != null
+                  ? Files.newInputStream(ResourceUtils.getFile(certChainFile).toPath())
+                  : new ByteArrayInputStream(certChain.getBytes(StandardCharsets.UTF_8));
+          InputStream keyInputStream =
+              keyFile != null
+                  ? Files.newInputStream(ResourceUtils.getFile(keyFile).toPath())
+                  : new ByteArrayInputStream(key.getBytes(StandardCharsets.UTF_8)); ) {
+        sslBuilder = SimpleSslContextBuilder.forPKCS8(certInputStream, keyInputStream);
+        sslContext = applyMTLSPropertiesAndBuildSslContext(mtlsProperties, sslBuilder);
+      } catch (IOException e) {
+        throw new BeanCreationException("Failure reading PKCS8 mTLS key or cert chain file", e);
+      }
+    } else {
+      if (certChainFile != null || certChain != null) {
+        throw new BeanDefinitionValidationException(
+            "cert-chain-file or cert-chain can't be specified for PKCS12, cert chain is bundled into the key file");
+      }
+      if (key != null) {
+        throw new BeanDefinitionValidationException(
+            "key can't be specified for PKCS12, use key-file");
+      }
+      try (InputStream keyInputStream =
+          Files.newInputStream(ResourceUtils.getFile(keyFile).toPath())) {
+        sslBuilder = SimpleSslContextBuilder.forPKCS12(keyInputStream);
+        sslContext = applyMTLSPropertiesAndBuildSslContext(mtlsProperties, sslBuilder);
+
+      } catch (IOException e) {
+        throw new BeanCreationException("Failure reading PKCS12 mTLS cert key file", e);
+      }
+    }
+
+    stubsOptionsBuilder.setSslContext(sslContext);
+  }
+
+  private SslContext applyMTLSPropertiesAndBuildSslContext(
+      ConnectionProperties.MTLSProperties mtlsProperties, SimpleSslContextBuilder sslBuilder) {
+    if (mtlsProperties.getKeyPassword() != null) {
+      sslBuilder.setKeyPassword(mtlsProperties.getKeyPassword());
+    }
+
+    if (Boolean.TRUE.equals(mtlsProperties.getInsecureTrustManager())) {
+      sslBuilder.setUseInsecureTrustManager(true);
+    }
+
+    try {
+      return sslBuilder.build();
+    } catch (SSLException e) {
+      throw new BeanCreationException("Failure building SSLContext", e);
+    }
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubsTemplate.java
@@ -21,43 +21,36 @@
 package io.temporal.spring.boot.autoconfigure.template;
 
 import com.uber.m3.tally.Scope;
-import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
-import io.temporal.serviceclient.SimpleSslContextBuilder;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.ConnectionProperties;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLException;
-import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.support.BeanDefinitionValidationException;
-import org.springframework.util.ResourceUtils;
 
 public class ServiceStubsTemplate {
-  public static final com.uber.m3.util.Duration DEFAULT_SCOPE_REPORT_INTERVAL =
-      com.uber.m3.util.Duration.ofSeconds(1);
-
   private final @Nonnull ConnectionProperties connectionProperties;
-
   private final @Nullable Scope metricsScope;
 
   // if not null, we work with an environment with defined test server
   private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
+
+  private final @Nullable TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>
+      workflowServiceStubsCustomizer;
 
   private WorkflowServiceStubs workflowServiceStubs;
 
   public ServiceStubsTemplate(
       @Nonnull ConnectionProperties connectionProperties,
       @Nullable Scope metricsScope,
-      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment) {
+      @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
+      @Nullable
+          TemporalOptionsCustomizer<WorkflowServiceStubsOptions.Builder>
+              workflowServiceStubsCustomizer) {
     this.connectionProperties = connectionProperties;
     this.metricsScope = metricsScope;
     this.testWorkflowEnvironment = testWorkflowEnvironment;
+    this.workflowServiceStubsCustomizer = workflowServiceStubsCustomizer;
   }
 
   public WorkflowServiceStubs getWorkflowServiceStubs() {
@@ -77,123 +70,14 @@ public class ServiceStubsTemplate {
           workflowServiceStubs = WorkflowServiceStubs.newLocalServiceStubs();
           break;
         default:
-          WorkflowServiceStubsOptions.Builder stubsOptionsBuilder =
-              WorkflowServiceStubsOptions.newBuilder();
-
-          if (connectionProperties.getTarget() != null) {
-            stubsOptionsBuilder.setTarget(connectionProperties.getTarget());
-          }
-
-          stubsOptionsBuilder.setEnableHttps(
-              Boolean.TRUE.equals(connectionProperties.isEnableHttps()));
-
-          configureMTLS(connectionProperties.getMTLS(), stubsOptionsBuilder);
-
-          if (metricsScope != null) {
-            stubsOptionsBuilder.setMetricsScope(metricsScope);
-          }
-
           workflowServiceStubs =
               WorkflowServiceStubs.newServiceStubs(
-                  stubsOptionsBuilder.validateAndBuildWithDefaults());
+                  new ServiceStubOptionsTemplate(
+                          connectionProperties, metricsScope, workflowServiceStubsCustomizer)
+                      .createServiceStubOptions());
       }
     }
 
     return workflowServiceStubs;
-  }
-
-  private void configureMTLS(
-      @Nullable ConnectionProperties.MTLSProperties mtlsProperties,
-      WorkflowServiceStubsOptions.Builder stubsOptionsBuilder) {
-    if (mtlsProperties == null
-        || (mtlsProperties.getKeyFile() == null
-            && mtlsProperties.getCertChainFile() == null
-            && mtlsProperties.getKey() == null
-            && mtlsProperties.getCertChain() == null)) {
-      return;
-    }
-
-    Integer pkcs = mtlsProperties.getPKCS();
-    if (pkcs != null && pkcs != 8 && pkcs != 12) {
-      throw new BeanDefinitionValidationException("Invalid PKCS: " + pkcs);
-    }
-
-    String keyFile = mtlsProperties.getKeyFile();
-    String key = mtlsProperties.getKey();
-    if (keyFile == null && key == null) {
-      throw new BeanDefinitionValidationException("key-file or key has to be specified");
-    } else if (keyFile != null && key != null) {
-      throw new BeanDefinitionValidationException(
-          "Both key-file and key can't be specified at the same time");
-    }
-
-    String certChainFile = mtlsProperties.getCertChainFile();
-    String certChain = mtlsProperties.getCertChain();
-
-    if (pkcs == null) {
-      pkcs = certChainFile != null || certChain != null ? 8 : 12;
-    }
-
-    SimpleSslContextBuilder sslBuilder;
-    SslContext sslContext;
-    if (pkcs == 8) {
-      if (certChainFile == null && certChain == null) {
-        throw new BeanDefinitionValidationException(
-            "cert-chain-file or cert-chain has to be specified for PKCS8");
-      }
-      if (certChainFile != null && certChain != null) {
-        throw new BeanDefinitionValidationException(
-            "Both cert-chain-file or cert-chain can't be set at the same time");
-      }
-      try (InputStream certInputStream =
-              certChainFile != null
-                  ? Files.newInputStream(ResourceUtils.getFile(certChainFile).toPath())
-                  : new ByteArrayInputStream(certChain.getBytes(StandardCharsets.UTF_8));
-          InputStream keyInputStream =
-              keyFile != null
-                  ? Files.newInputStream(ResourceUtils.getFile(keyFile).toPath())
-                  : new ByteArrayInputStream(key.getBytes(StandardCharsets.UTF_8)); ) {
-        sslBuilder = SimpleSslContextBuilder.forPKCS8(certInputStream, keyInputStream);
-        sslContext = applyMTLSPropertiesAndBuildSslContext(mtlsProperties, sslBuilder);
-      } catch (IOException e) {
-        throw new BeanCreationException("Failure reading PKCS8 mTLS key or cert chain file", e);
-      }
-    } else {
-      if (certChainFile != null || certChain != null) {
-        throw new BeanDefinitionValidationException(
-            "cert-chain-file or cert-chain can't be specified for PKCS12, cert chain is bundled into the key file");
-      }
-      if (key != null) {
-        throw new BeanDefinitionValidationException(
-            "key can't be specified for PKCS12, use key-file");
-      }
-      try (InputStream keyInputStream =
-          Files.newInputStream(ResourceUtils.getFile(keyFile).toPath())) {
-        sslBuilder = SimpleSslContextBuilder.forPKCS12(keyInputStream);
-        sslContext = applyMTLSPropertiesAndBuildSslContext(mtlsProperties, sslBuilder);
-
-      } catch (IOException e) {
-        throw new BeanCreationException("Failure reading PKCS12 mTLS cert key file", e);
-      }
-    }
-
-    stubsOptionsBuilder.setSslContext(sslContext);
-  }
-
-  private SslContext applyMTLSPropertiesAndBuildSslContext(
-      ConnectionProperties.MTLSProperties mtlsProperties, SimpleSslContextBuilder sslBuilder) {
-    if (mtlsProperties.getKeyPassword() != null) {
-      sslBuilder.setKeyPassword(mtlsProperties.getKeyPassword());
-    }
-
-    if (Boolean.TRUE.equals(mtlsProperties.getInsecureTrustManager())) {
-      sslBuilder.setUseInsecureTrustManager(true);
-    }
-
-    try {
-      return sslBuilder.build();
-    } catch (SSLException e) {
-      throw new BeanCreationException("Failure building SSLContext", e);
-    }
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerFactoryOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerFactoryOptionsTemplate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.template;
+
+import io.opentracing.Tracer;
+import io.temporal.opentracing.OpenTracingOptions;
+import io.temporal.opentracing.OpenTracingWorkerInterceptor;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import io.temporal.worker.WorkerFactoryOptions;
+import javax.annotation.Nullable;
+
+public class WorkerFactoryOptionsTemplate {
+  private final @Nullable Tracer tracer;
+  private final @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> customizer;
+
+  public WorkerFactoryOptionsTemplate(
+      @Nullable Tracer tracer,
+      @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> customizer) {
+    this.tracer = tracer;
+    this.customizer = customizer;
+  }
+
+  public WorkerFactoryOptions createWorkerFactoryOptions() {
+    WorkerFactoryOptions.Builder options = WorkerFactoryOptions.newBuilder();
+    if (tracer != null) {
+      OpenTracingWorkerInterceptor openTracingClientInterceptor =
+          new OpenTracingWorkerInterceptor(
+              OpenTracingOptions.newBuilder().setTracer(tracer).build());
+      options.setWorkerInterceptors(openTracingClientInterceptor);
+    }
+
+    if (customizer != null) {
+      options = customizer.customize(options);
+    }
+
+    return options.build();
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerOptionsTemplate.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.template;
+
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import io.temporal.spring.boot.WorkerOptionsCustomizer;
+import io.temporal.worker.WorkerOptions;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+class WorkerOptionsTemplate {
+  private final @Nullable TemporalOptionsCustomizer<WorkerOptions.Builder> customizer;
+  private final @Nonnull String taskQueue;
+  private final @Nonnull String workerName;
+
+  WorkerOptionsTemplate(
+      @Nonnull String workerName,
+      @Nonnull String taskQueue,
+      @Nullable TemporalOptionsCustomizer<WorkerOptions.Builder> customizer) {
+    this.workerName = workerName;
+    this.taskQueue = taskQueue;
+    this.customizer = customizer;
+  }
+
+  WorkerOptions createWorkerOptions() {
+    WorkerOptions.Builder options = WorkerOptions.newBuilder();
+
+    if (customizer != null) {
+      options = customizer.customize(options);
+      if (customizer instanceof WorkerOptionsCustomizer) {
+        options = ((WorkerOptionsCustomizer) customizer).customize(options, workerName, taskQueue);
+      }
+    }
+
+    return options.build();
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure.template;
+
+import io.opentracing.Tracer;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.opentracing.OpenTracingClientInterceptor;
+import io.temporal.opentracing.OpenTracingOptions;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class WorkflowClientOptionsTemplate {
+  private final @Nonnull String namespace;
+  private final @Nullable DataConverter dataConverter;
+  private final @Nullable Tracer tracer;
+  private final @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> customizer;
+
+  public WorkflowClientOptionsTemplate(
+      @Nonnull String namespace,
+      @Nullable DataConverter dataConverter,
+      @Nullable Tracer tracer,
+      @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> customizer) {
+    this.namespace = namespace;
+    this.dataConverter = dataConverter;
+    this.tracer = tracer;
+    this.customizer = customizer;
+  }
+
+  public WorkflowClientOptions createWorkflowClientOptions() {
+    WorkflowClientOptions.Builder options = WorkflowClientOptions.newBuilder();
+
+    options.setNamespace(namespace);
+
+    if (dataConverter != null) {
+      options.setDataConverter(dataConverter);
+    }
+
+    if (tracer != null) {
+      OpenTracingClientInterceptor openTracingClientInterceptor =
+          new OpenTracingClientInterceptor(
+              OpenTracingOptions.newBuilder().setTracer(tracer).build());
+      options.setInterceptors(openTracingClientInterceptor);
+    }
+
+    if (customizer != null) {
+      options = customizer.customize(options);
+    }
+
+    return options.build();
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/OptionsCustomizersTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/OptionsCustomizersTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import io.temporal.spring.boot.WorkerOptionsCustomizer;
+import io.temporal.testing.TestEnvironmentOptions;
+import io.temporal.worker.WorkerFactoryOptions;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = OptionsCustomizersTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OptionsCustomizersTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired List<TemporalOptionsCustomizer<?>> customizers;
+  @Autowired WorkerOptionsCustomizer workerCustomizer;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testCustomizersGotCalled() {
+    assertEquals(4, customizers.size());
+    customizers.forEach(c -> verify(c).customize(any()));
+    verify(workerCustomizer).customize(any(), eq("UnitTest"), eq("UnitTest"));
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {
+
+    @Bean
+    public TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer() {
+      return getReturningMock();
+    }
+
+    @Bean
+    public TemporalOptionsCustomizer<TestEnvironmentOptions.Builder> testEnvironmentCustomizer() {
+      return getReturningMock();
+    }
+
+    @Bean
+    public TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer() {
+      return getReturningMock();
+    }
+
+    @Bean
+    public WorkerOptionsCustomizer workerCustomizer() {
+      WorkerOptionsCustomizer mock = mock(WorkerOptionsCustomizer.class);
+      when(mock.customize(any())).thenAnswer(invocation -> invocation.getArgument(0)).getMock();
+      when(mock.customize(any(), any(), any()))
+          .thenAnswer(invocation -> invocation.getArgument(0))
+          .getMock();
+      return mock;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> TemporalOptionsCustomizer<T> getReturningMock() {
+      return when(mock(TemporalOptionsCustomizer.class).customize(any()))
+          .thenAnswer(invocation -> invocation.getArgument(0))
+          .getMock();
+    }
+  }
+}


### PR DESCRIPTION
# What

Add TemporalOptionsCustomizer to allow users to modify the options constructed by Spring Boot Auto Configuration
Supported `*Options.Builder` classes for customization:

- `WorkerOptions.Builder`
- `WorkerFactoryOptions.Builder`
- `WorkflowServiceStubsOptions.Builder`
- `WorkflowClientOptions.Builder`
- `TestEnvironmentOptions.Builder`

# Why

Closes #1394