### PR TITLE
Wire some WorkerFactoryOptions and WorkerOptions properties to Spring Boot Configuration

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -198,7 +198,7 @@ public final class WorkerOptions {
      * workflow tasks will be using host local task queue due to caching. So try incrementing {@link
      * WorkerFactoryOptions.Builder#setWorkflowHostLocalPollThreadCount(int)} before this one.
      *
-     * <p>Default is 2.
+     * <p>Default is 5.
      *
      * @deprecated Use {@link #setMaxConcurrentWorkflowTaskPollers}
      */

--- a/temporal-spring-boot-autoconfigure-alpha/README.md
+++ b/temporal-spring-boot-autoconfigure-alpha/README.md
@@ -72,13 +72,40 @@ Follow the pattern to explicitly configure the workers:
 spring.temporal:
   workers:
     - task-queue: your-task-queue-name
-      # name: your-worker-name # unique name of the Worker. If not specified, Task Queue is used as a Worker name.
+      name: your-worker-name # unique name of the Worker. If not specified, Task Queue is used as the Worker name.
       workflow-classes:
         - your.package.YouWorkflowImpl
       activity-beans:
         - activity-bean-name1
-  # start-workers: false # disable auto-start of WorkersFactory and Workers if you want to make any custom changes before the start
 ```
+
+<details>
+  <summary>Extended Workers configuration example</summary>
+
+  ```yml
+  spring.temporal:
+    workers:
+      - task-queue: your-task-queue-name
+        # name: your-worker-name # unique name of the Worker. If not specified, Task Queue is used as the Worker name.
+        workflow-classes:
+          - your.package.YouWorkflowImpl
+        activity-beans:
+          - activity-bean-name1
+        # capacity:
+          # max-concurrent-workflow-task-executors: 200
+          # max-concurrent-activity-executors: 200
+          # max-concurrent-local-activity-executors: 200
+          # max-concurrent-workflow-task-pollers: 5
+          # max-concurrent-activity-task-pollers: 5
+        # rate-limits:
+          # max-worker-activities-per-second: 5.0
+          # max-task-queue-activities-per-second: 5.0
+    # workflow-cache:
+      # max-instances: 600
+      # max-threads: 600
+    # start-workers: false # disable auto-start of WorkersFactory and Workers if you want to make any custom changes before the start
+```
+</details>
 
 ## Auto-discovery
 
@@ -93,7 +120,6 @@ spring.temporal:
   workers-auto-discovery:
     packages:
       - your.package # enumerate all the packages that contain your workflow and activity implementations
-  # start-workers: false # disable starting WorkersFactory if you want to make any custom changes before the start
 ```
 
 What is auto-discovered:
@@ -103,7 +129,7 @@ What is auto-discovered:
 
 Auto-discovered workflow implementation classes and activity beans will be registered with the configured workers if not already registered.
 
-### Referencing worker names vs task queues
+### Referencing Worker names vs Task Queues
 
 Application that incorporates
 [Task Queue based Versioning strategy](https://community.temporal.io/t/workflow-versioning-strategies/6911)

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestServerAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/TestServerAutoConfiguration.java
@@ -102,7 +102,7 @@ public class TestServerAutoConfiguration {
     }
 
     options.setWorkerFactoryOptions(
-        new WorkerFactoryOptionsTemplate(otTracer, workerFactoryCustomizer)
+        new WorkerFactoryOptionsTemplate(properties, otTracer, workerFactoryCustomizer)
             .createWorkerFactoryOptions());
 
     if (testEnvOptionsCustomizer != null) {

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
@@ -34,15 +34,18 @@ public class NamespaceProperties {
       workersAutoDiscovery;
   private final @Nullable List<WorkerProperties> workers;
   private final @Nonnull String namespace;
+  private final @Nullable WorkflowCacheProperties workflowCache;
 
   @ConstructorBinding
   public NamespaceProperties(
       @Nullable String namespace,
       @Nullable WorkersAutoDiscoveryProperties workersAutoDiscovery,
-      @Nullable List<WorkerProperties> workers) {
+      @Nullable List<WorkerProperties> workers,
+      @Nullable WorkflowCacheProperties workflowCache) {
     this.workersAutoDiscovery = workersAutoDiscovery;
     this.workers = workers;
     this.namespace = MoreObjects.firstNonNull(namespace, NAMESPACE_DEFAULT);
+    this.workflowCache = workflowCache;
   }
 
   @Nullable
@@ -61,5 +64,37 @@ public class NamespaceProperties {
   @Nonnull
   public String getNamespace() {
     return namespace;
+  }
+
+  @Nullable
+  public WorkflowCacheProperties getWorkflowCache() {
+    return workflowCache;
+  }
+
+  public static class WorkflowCacheProperties {
+    private final @Nullable Integer maxInstances;
+    private final @Nullable Integer maxThreads;
+
+    /**
+     * @param maxInstances max number of workflow instances in the cache. Defines {@link
+     *     io.temporal.worker.WorkerFactoryOptions.Builder#setWorkflowCacheSize(int)}
+     * @param maxThreads max number of workflow threads in the cache. Defines {@link
+     *     io.temporal.worker.WorkerFactoryOptions.Builder#setMaxWorkflowThreadCount(int)}
+     */
+    @ConstructorBinding
+    public WorkflowCacheProperties(@Nullable Integer maxInstances, @Nullable Integer maxThreads) {
+      this.maxInstances = maxInstances;
+      this.maxThreads = maxThreads;
+    }
+
+    @Nullable
+    public Integer getMaxInstances() {
+      return maxInstances;
+    }
+
+    @Nullable
+    public Integer getMaxThreads() {
+      return maxThreads;
+    }
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TemporalProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TemporalProperties.java
@@ -38,10 +38,11 @@ public class TemporalProperties extends NamespaceProperties {
       @Nullable String namespace,
       @Nullable WorkersAutoDiscoveryProperties workersAutoDiscovery,
       @Nullable List<WorkerProperties> workers,
+      @Nullable WorkflowCacheProperties workflowCache,
       @Nonnull ConnectionProperties connection,
       @Nullable TestServerProperties testServer,
       @Nullable Boolean startWorkers) {
-    super(namespace, workersAutoDiscovery, workers);
+    super(namespace, workersAutoDiscovery, workers, workflowCache);
     this.connection = connection;
     this.testServer = testServer;
     this.startWorkers = startWorkers;

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
@@ -26,23 +26,27 @@ import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 public class WorkerProperties {
-  private @Nonnull String taskQueue;
-  private @Nullable String name;
-
-  private @Nullable Collection<Class<?>> workflowClasses;
-
-  private @Nullable Collection<String> activityBeans;
+  private final @Nonnull String taskQueue;
+  private final @Nullable String name;
+  private final @Nullable Collection<Class<?>> workflowClasses;
+  private final @Nullable Collection<String> activityBeans;
+  private final @Nullable CapacityConfigurationProperties capacity;
+  private final @Nullable RateLimitsConfigurationProperties rateLimits;
 
   @ConstructorBinding
   public WorkerProperties(
       @Nonnull String taskQueue,
       @Nullable String name,
       @Nullable Collection<Class<?>> workflowClasses,
-      @Nullable Collection<String> activityBeans) {
+      @Nullable Collection<String> activityBeans,
+      @Nullable CapacityConfigurationProperties capacity,
+      @Nullable RateLimitsConfigurationProperties rateLimits) {
     this.name = name;
     this.taskQueue = taskQueue;
     this.workflowClasses = workflowClasses;
     this.activityBeans = activityBeans;
+    this.capacity = capacity;
+    this.rateLimits = rateLimits;
   }
 
   @Nonnull
@@ -50,17 +54,9 @@ public class WorkerProperties {
     return taskQueue;
   }
 
-  public void setTaskQueue(@Nonnull String taskQueue) {
-    this.taskQueue = taskQueue;
-  }
-
   @Nullable
   public String getName() {
     return name;
-  }
-
-  public void setName(@Nullable String name) {
-    this.name = name;
   }
 
   @Nullable
@@ -68,16 +64,106 @@ public class WorkerProperties {
     return workflowClasses;
   }
 
-  public void setWorkflowClasses(@Nullable Collection<Class<?>> workflowClasses) {
-    this.workflowClasses = workflowClasses;
-  }
-
   @Nullable
   public Collection<String> getActivityBeans() {
     return activityBeans;
   }
 
-  public void setActivityBeans(@Nullable Collection<String> activityBeans) {
-    this.activityBeans = activityBeans;
+  @Nullable
+  public CapacityConfigurationProperties getCapacity() {
+    return capacity;
+  }
+
+  @Nullable
+  public RateLimitsConfigurationProperties getRateLimits() {
+    return rateLimits;
+  }
+
+  public static class CapacityConfigurationProperties {
+    private final @Nullable Integer maxConcurrentWorkflowTaskExecutors;
+    private final @Nullable Integer maxConcurrentActivityExecutors;
+    private final @Nullable Integer maxConcurrentLocalActivityExecutors;
+    private final @Nullable Integer maxConcurrentWorkflowTaskPollers;
+    private final @Nullable Integer maxConcurrentActivityTaskPollers;
+
+    /**
+     * @param maxConcurrentWorkflowTaskExecutors defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers(int)}
+     * @param maxConcurrentActivityExecutors defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentActivityExecutionSize(int)}
+     * @param maxConcurrentLocalActivityExecutors defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentLocalActivityExecutionSize(int)}
+     * @param maxConcurrentWorkflowTaskPollers defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers(int)}
+     * @param maxConcurrentActivityTaskPollers defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentActivityTaskPollers(int)}
+     */
+    @ConstructorBinding
+    public CapacityConfigurationProperties(
+        @Nullable Integer maxConcurrentWorkflowTaskExecutors,
+        @Nullable Integer maxConcurrentActivityExecutors,
+        @Nullable Integer maxConcurrentLocalActivityExecutors,
+        @Nullable Integer maxConcurrentWorkflowTaskPollers,
+        @Nullable Integer maxConcurrentActivityTaskPollers) {
+      this.maxConcurrentWorkflowTaskExecutors = maxConcurrentWorkflowTaskExecutors;
+      this.maxConcurrentActivityExecutors = maxConcurrentActivityExecutors;
+      this.maxConcurrentLocalActivityExecutors = maxConcurrentLocalActivityExecutors;
+      this.maxConcurrentWorkflowTaskPollers = maxConcurrentWorkflowTaskPollers;
+      this.maxConcurrentActivityTaskPollers = maxConcurrentActivityTaskPollers;
+    }
+
+    @Nullable
+    public Integer getMaxConcurrentWorkflowTaskExecutors() {
+      return maxConcurrentWorkflowTaskExecutors;
+    }
+
+    @Nullable
+    public Integer getMaxConcurrentActivityExecutors() {
+      return maxConcurrentActivityExecutors;
+    }
+
+    @Nullable
+    public Integer getMaxConcurrentLocalActivityExecutors() {
+      return maxConcurrentLocalActivityExecutors;
+    }
+
+    @Nullable
+    public Integer getMaxConcurrentWorkflowTaskPollers() {
+      return maxConcurrentWorkflowTaskPollers;
+    }
+
+    @Nullable
+    public Integer getMaxConcurrentActivityTaskPollers() {
+      return maxConcurrentActivityTaskPollers;
+    }
+  }
+
+  public static class RateLimitsConfigurationProperties {
+    private final @Nullable Double maxWorkerActivitiesPerSecond;
+    private final @Nullable Double maxTaskQueueActivitiesPerSecond;
+
+    /**
+     * @param maxTaskQueueActivitiesPerSecond defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxTaskQueueActivitiesPerSecond(double)}}
+     * @param maxWorkerActivitiesPerSecond defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentActivityExecutionSize(int)}
+     */
+    @ConstructorBinding
+    public RateLimitsConfigurationProperties(
+        @Nullable Double maxWorkerActivitiesPerSecond,
+        @Nullable Double maxTaskQueueActivitiesPerSecond) {
+      this.maxWorkerActivitiesPerSecond = maxWorkerActivitiesPerSecond;
+      this.maxTaskQueueActivitiesPerSecond = maxTaskQueueActivitiesPerSecond;
+    }
+
+    @Nullable
+    public Double getMaxWorkerActivitiesPerSecond() {
+      return maxWorkerActivitiesPerSecond;
+    }
+
+    @Nullable
+    public Double getMaxTaskQueueActivitiesPerSecond() {
+      return maxTaskQueueActivitiesPerSecond;
+    }
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
@@ -20,6 +20,7 @@
 
 package io.temporal.spring.boot.autoconfigure.template;
 
+import com.google.common.base.Preconditions;
 import com.uber.m3.tally.Scope;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.temporal.serviceclient.SimpleSslContextBuilder;
@@ -59,9 +60,8 @@ public class ServiceStubOptionsTemplate {
     WorkflowServiceStubsOptions.Builder stubsOptionsBuilder =
         WorkflowServiceStubsOptions.newBuilder();
 
-    if (connectionProperties.getTarget() != null) {
-      stubsOptionsBuilder.setTarget(connectionProperties.getTarget());
-    }
+    Preconditions.checkNotNull(connectionProperties.getTarget(), "target");
+    stubsOptionsBuilder.setTarget(connectionProperties.getTarget());
 
     stubsOptionsBuilder.setEnableHttps(Boolean.TRUE.equals(connectionProperties.isEnableHttps()));
 

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -107,7 +107,7 @@ public class WorkersTemplate implements BeanFactoryAware {
       return testWorkflowEnvironment.getWorkerFactory();
     } else {
       WorkerFactoryOptions workerFactoryOptions =
-          new WorkerFactoryOptionsTemplate(tracer, workerFactoryCustomizer)
+          new WorkerFactoryOptionsTemplate(namespaceProperties, tracer, workerFactoryCustomizer)
               .createWorkerFactoryOptions();
       return WorkerFactory.newInstance(workflowClient, workerFactoryOptions);
     }
@@ -371,7 +371,8 @@ public class WorkersTemplate implements BeanFactoryAware {
     this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
   }
 
-  private Worker createNewWorker(String taskQueue, WorkerProperties properties, Workers workers) {
+  private Worker createNewWorker(
+      @Nonnull String taskQueue, @Nullable WorkerProperties properties, @Nonnull Workers workers) {
     Preconditions.checkState(
         workerFactory.tryGetWorker(taskQueue) == null,
         "[BUG] This method should never be called twice for the same Task Queue='%s'",
@@ -381,7 +382,8 @@ public class WorkersTemplate implements BeanFactoryAware {
         properties != null && properties.getName() != null ? properties.getName() : taskQueue;
 
     WorkerOptions workerOptions =
-        new WorkerOptionsTemplate(workerName, taskQueue, workerCustomizer).createWorkerOptions();
+        new WorkerOptionsTemplate(workerName, taskQueue, properties, workerCustomizer)
+            .createWorkerOptions();
     Worker worker = workerFactory.newWorker(taskQueue, workerOptions);
     workers.addWorker(workerName, worker);
     return worker;

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
@@ -26,6 +26,7 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.opentracing.OpenTracingClientInterceptor;
 import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -48,12 +49,8 @@ public class WorkflowClientOptionsTemplate {
 
   public WorkflowClientOptions createWorkflowClientOptions() {
     WorkflowClientOptions.Builder options = WorkflowClientOptions.newBuilder();
-
     options.setNamespace(namespace);
-
-    if (dataConverter != null) {
-      options.setDataConverter(dataConverter);
-    }
+    Optional.ofNullable(dataConverter).ifPresent(options::setDataConverter);
 
     if (tracer != null) {
       OpenTracingClientInterceptor openTracingClientInterceptor =

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/OptionalWorkerOptionsTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/OptionalWorkerOptionsTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.worker.WorkerOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = OptionalWorkerOptionsTest.Configuration.class)
+@ActiveProfiles(profiles = {"optional-workers-options"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OptionalWorkerOptionsTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+  @Autowired TestWorkflowEnvironment testWorkflowEnvironment;
+  @Autowired WorkflowClient workflowClient;
+
+  @Autowired TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer;
+  @Autowired TemporalOptionsCustomizer<WorkerOptions.Builder> workerCustomizer;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testOptionalVariablesFromTheConfigAreRespected() {
+    // Checking that customizers were called, the actual value checks are located in these
+    // customizers
+    verify(workerFactoryCustomizer).customize(any());
+    verify(workerCustomizer).customize(any());
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer() {
+      TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> customizer =
+          optionsBuilder -> {
+            WorkerFactoryOptions options = optionsBuilder.build();
+
+            assertEquals(
+                10,
+                options.getMaxWorkflowThreadCount(),
+                "Values from the Spring Config should be respected");
+            assertEquals(
+                10,
+                options.getWorkflowCacheSize(),
+                "Values from the Spring Config should be respected");
+            return optionsBuilder;
+          };
+      return mock(TemporalOptionsCustomizer.class, delegatesTo(customizer));
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public TemporalOptionsCustomizer<WorkerOptions.Builder> workerCustomizer() {
+      TemporalOptionsCustomizer<WorkerOptions.Builder> customizer =
+          optionsBuilder -> {
+            WorkerOptions options = optionsBuilder.build();
+
+            assertEquals(
+                1,
+                options.getMaxConcurrentWorkflowTaskExecutionSize(),
+                "Values from the Spring Config should be respected");
+            assertEquals(
+                1,
+                options.getMaxConcurrentActivityExecutionSize(),
+                "Values from the Spring Config should be respected");
+            assertEquals(
+                1,
+                options.getMaxConcurrentLocalActivityExecutionSize(),
+                "Values from the Spring Config should be respected");
+
+            assertEquals(
+                1,
+                options.getMaxConcurrentWorkflowTaskPollers(),
+                "Values from the Spring Config should be respected");
+            assertEquals(
+                1,
+                options.getMaxConcurrentActivityTaskPollers(),
+                "Values from the Spring Config should be respected");
+
+            assertEquals(
+                1.0,
+                options.getMaxWorkerActivitiesPerSecond(),
+                "Values from the Spring Config should be respected");
+            assertEquals(
+                1.0,
+                options.getMaxTaskQueueActivitiesPerSecond(),
+                "Values from the Spring Config should be respected");
+            return optionsBuilder;
+          };
+      return mock(TemporalOptionsCustomizer.class, delegatesTo(customizer));
+    }
+  }
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
@@ -22,7 +22,7 @@ spring.temporal:
   connection:
     mtls:
       key-file: /path/to/key.key
-      cert-file: /path/to/cert.pem
+      cert-chain-file: /path/to/cert.pem
     target: local
   test-server:
     enabled: true
@@ -62,3 +62,25 @@ spring:
           - io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflowImpl
         activity-beans:
           - TestActivityImpl
+
+---
+spring:
+  config:
+    activate:
+      on-profile: optional-workers-options
+  temporal:
+    workers:
+      - task-queue: UnitTest
+        capacity:
+          max-concurrent-workflow-task-executors: 1
+          max-concurrent-activity-executors: 1
+          max-concurrent-local-activity-executors: 1
+          max-concurrent-workflow-task-pollers: 1
+          max-concurrent-activity-task-pollers: 1
+        rate-limits:
+          max-worker-activities-per-second: 1.0
+          max-task-queue-activities-per-second: 1.0
+    workflow-cache:
+      max-instances: 10
+      max-threads: 10
+


### PR DESCRIPTION
Wire into Spring Boot Configuration:

- workflow cache size
- worker executors
- worker pollers
- worker rate limiting properties

Closes #1488