### PR TITLE
Use ByteString.EMPTY in EagerPaginator

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/EagerPaginator.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/EagerPaginator.java
@@ -91,7 +91,7 @@ abstract class EagerPaginator<Resp, T> implements Iterator<T> {
   }
 
   public void init() {
-    nextResponse = performRequest(ByteString.empty());
+    nextResponse = performRequest(ByteString.EMPTY);
     waitAndGetNextResponse();
     fetch();
   }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Use `ByteString.EMPTY` instead of `ByteString.empty()` in `EagerPaginator`

## Why?
<!-- Tell your future self why have you made these changes -->
The `empty()` method appears to have been introduced in protobuf 3.20.0-rc1 ([blame](https://github.com/protocolbuffers/protobuf/blame/b1109ff985b4f6382981a16cc6e46a5fb4704800/java/core/src/main/java/com/google/protobuf/ByteString.java#L241)). Using `EMPTY` instead allows the Temporal SDK to work with older versions of the protobuf library, going back to the minimum supported 3.10.0.

Moreover, this method does not seem to be listed in the [proto Javadoc](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/ByteString.html).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
n/a

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- Existing tests run with `./gradlew test` continue to pass
- Used this change in a Java workflow worker service running against protobuf 3.19.2 successfully

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->