### PR TITLE
Fix Eager Activity Dispatch Worker state check, rework states of internal Workers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'com.diffplug.spotless' version '6.14.1' apply false
+    id 'com.diffplug.spotless' version '6.15.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -30,7 +30,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.52.1' // [1.34.0,)
+    grpcVersion = '1.53.0' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.3' : '1.9.7' // [1.0.0,)
@@ -38,7 +38,7 @@ ext {
     // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which still stay on 1.x
     // also slf4j 2.x is not compatible with spring boot 2.x
     slf4jVersion = project.hasProperty("edgeDepsTest") ? '2.0.6' : '1.7.36' // [1.4.0,)
-    protoVersion = '3.21.12' // [3.10.0,)
+    protoVersion = '3.21.12' // [3.12.0,) 3.12 is brought by min gRPC 1.38
     annotationApiVersion = '1.3.2'
     guavaVersion = '31.1-jre' // [10.0,)
     tallyVersion = '0.12.0' // [0.4.0,)

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -207,13 +207,18 @@ final class LocalActivityWorker implements Startable, Shutdownable {
         @Nonnull ExecuteLocalActivityParameters params,
         @Nonnull Functions.Proc1<LocalActivityResult> resultCallback,
         @Nullable Deadline acceptanceDeadline) {
-      if (!isStarted()) {
-        if (isShutdown()) {
-          throw new IllegalStateException("Local Activity Worker is shutdown");
-        } else {
+      WorkerLifecycleState lifecycleState = getLifecycleState();
+      switch (lifecycleState) {
+        case NOT_STARTED:
           throw new IllegalStateException(
               "Local Activity Worker is not started, no activities were registered");
-        }
+        case SHUTDOWN:
+          throw new IllegalStateException("Local Activity Worker is shutdown");
+        case TERMINATED:
+          throw new IllegalStateException("Local Activity Worker is terminated");
+        case SUSPENDED:
+          throw new IllegalStateException(
+              "[BUG] Local Activity Worker is suspended. Suspension is not supported for Local Activity Worker");
       }
 
       Preconditions.checkArgument(
@@ -650,12 +655,8 @@ final class LocalActivityWorker implements Startable, Shutdownable {
     }
   }
 
-  public boolean isAnyTypeSupported() {
-    return handler.isAnyTypeSupported();
-  }
-
   @Override
-  public void start() {
+  public boolean start() {
     if (handler.isAnyTypeSupported()) {
       this.scheduledExecutor =
           Executors.newSingleThreadScheduledExecutor(
@@ -679,27 +680,15 @@ final class LocalActivityWorker implements Startable, Shutdownable {
               false);
 
       this.workerMetricsScope.counter(MetricsType.WORKER_START_COUNTER).inc(1);
+      return true;
+    } else {
+      return false;
     }
   }
 
   @Override
-  public boolean isStarted() {
-    return scheduledExecutor != null && !scheduledExecutor.isShutdown();
-  }
-
-  @Override
-  public boolean isShutdown() {
-    return scheduledExecutor != null && scheduledExecutor.isShutdown();
-  }
-
-  @Override
-  public boolean isTerminated() {
-    return scheduledExecutor != null && scheduledExecutor.isTerminated();
-  }
-
-  @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
-    if (isStarted()) {
+    if (activityAttemptTaskExecutor != null && !activityAttemptTaskExecutor.isShutdown()) {
       return activityAttemptTaskExecutor
           .shutdown(shutdownManager, interruptTasks)
           .thenCompose(
@@ -720,6 +709,34 @@ final class LocalActivityWorker implements Startable, Shutdownable {
   public void awaitTermination(long timeout, TimeUnit unit) {
     long timeoutMillis = unit.toMillis(timeout);
     ShutdownManager.awaitTermination(scheduledExecutor, timeoutMillis);
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return activityAttemptTaskExecutor != null && activityAttemptTaskExecutor.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return activityAttemptTaskExecutor != null
+        && activityAttemptTaskExecutor.isTerminated()
+        && scheduledExecutor.isTerminated();
+  }
+
+  @Override
+  public WorkerLifecycleState getLifecycleState() {
+    if (activityAttemptTaskExecutor == null) {
+      return WorkerLifecycleState.NOT_STARTED;
+    }
+    if (activityAttemptTaskExecutor.isShutdown()) {
+      // return TERMINATED only if both pollExecutor and taskExecutor are terminated
+      if (activityAttemptTaskExecutor.isTerminated() && scheduledExecutor.isTerminated()) {
+        return WorkerLifecycleState.TERMINATED;
+      } else {
+        return WorkerLifecycleState.SHUTDOWN;
+      }
+    }
+    return WorkerLifecycleState.ACTIVE;
   }
 
   private PollerOptions getPollerOptions(SingleWorkerOptions options) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NoopWorker.java
@@ -28,18 +28,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Helper class that is used instead of null for non initialized worker. This eliminates needs for
  * null checks when calling into it.
  */
-class NoopSuspendableWorker implements SuspendableWorker {
+class NoopWorker implements SuspendableWorker {
 
   private final AtomicBoolean shutdown = new AtomicBoolean();
 
   @Override
-  public boolean isShutdown() {
-    return shutdown.get();
-  }
-
-  @Override
-  public boolean isTerminated() {
-    return shutdown.get();
+  public boolean start() {
+    throw new IllegalStateException("Non startable");
   }
 
   @Override
@@ -52,16 +47,6 @@ class NoopSuspendableWorker implements SuspendableWorker {
   public void awaitTermination(long timeout, TimeUnit unit) {}
 
   @Override
-  public void start() {
-    throw new IllegalStateException("Non startable");
-  }
-
-  @Override
-  public boolean isStarted() {
-    return false;
-  }
-
-  @Override
   public void suspendPolling() {}
 
   @Override
@@ -70,5 +55,20 @@ class NoopSuspendableWorker implements SuspendableWorker {
   @Override
   public boolean isSuspended() {
     return true;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return shutdown.get();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return shutdown.get();
+  }
+
+  @Override
+  public WorkerLifecycleState getLifecycleState() {
+    return WorkerLifecycleState.NOT_STARTED;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -87,7 +87,7 @@ final class Poller<T> implements SuspendableWorker {
   }
 
   @Override
-  public void start() {
+  public boolean start() {
     log.info("start: {}", this);
 
     if (pollerOptions.getMaximumPollRatePerSecond() > 0.0) {
@@ -116,29 +116,20 @@ final class Poller<T> implements SuspendableWorker {
       pollExecutor.execute(new PollLoopTask(new PollExecutionTask()));
       workerMetricsScope.counter(MetricsType.POLLER_START_COUNTER).inc(1);
     }
-  }
 
-  @Override
-  public boolean isStarted() {
-    return pollExecutor != null;
-  }
-
-  @Override
-  public boolean isShutdown() {
-    return pollExecutor.isShutdown();
-  }
-
-  @Override
-  public boolean isTerminated() {
-    return pollExecutor.isTerminated() && taskExecutor.isTerminated();
+    return true;
   }
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
     log.info("shutdown: {}", this);
-    if (!isStarted()) {
-      return CompletableFuture.completedFuture(null);
+    WorkerLifecycleState lifecycleState = getLifecycleState();
+    switch (lifecycleState) {
+      case NOT_STARTED:
+      case TERMINATED:
+        return CompletableFuture.completedFuture(null);
     }
+
     return shutdownManager
         // it's ok to forcefully shutdown pollers, especially because they stuck in a long poll call
         // we don't lose any progress doing that
@@ -156,9 +147,13 @@ final class Poller<T> implements SuspendableWorker {
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    if (!isStarted()) {
-      return;
+    WorkerLifecycleState lifecycleState = getLifecycleState();
+    switch (lifecycleState) {
+      case NOT_STARTED:
+      case TERMINATED:
+        return;
     }
+
     long timeoutMillis = unit.toMillis(timeout);
     timeoutMillis = ShutdownManager.awaitTermination(pollExecutor, timeoutMillis);
     ShutdownManager.awaitTermination(taskExecutor, timeoutMillis);
@@ -185,6 +180,35 @@ final class Poller<T> implements SuspendableWorker {
   @Override
   public boolean isSuspended() {
     return suspendLatch.get() != null;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return pollExecutor.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return pollExecutor.isTerminated() && taskExecutor.isTerminated();
+  }
+
+  @Override
+  public WorkerLifecycleState getLifecycleState() {
+    if (pollExecutor == null) {
+      return WorkerLifecycleState.NOT_STARTED;
+    }
+    if (suspendLatch.get() != null) {
+      return WorkerLifecycleState.SUSPENDED;
+    }
+    if (pollExecutor.isShutdown()) {
+      // return TERMINATED only if both pollExecutor and taskExecutor are terminated
+      if (pollExecutor.isTerminated() && taskExecutor.isTerminated()) {
+        return WorkerLifecycleState.TERMINATED;
+      } else {
+        return WorkerLifecycleState.SHUTDOWN;
+      }
+    }
+    return WorkerLifecycleState.ACTIVE;
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Startable.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Startable.java
@@ -20,9 +20,12 @@
 
 package io.temporal.internal.worker;
 
-public interface Startable {
-
-  void start();
-
-  boolean isStarted();
+public interface Startable extends WorkerWithLifecycle {
+  /**
+   * This method is not required to be idempotent. It is expected to be called only once.
+   *
+   * @return true if the start was successful, false if the worker configuration renders the start
+   *     obsolete (like no types are registered)
+   */
+  boolean start();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Suspendable.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Suspendable.java
@@ -20,7 +20,7 @@
 
 package io.temporal.internal.worker;
 
-public interface Suspendable {
+public interface Suspendable extends WorkerWithLifecycle {
 
   /**
    * Do not make new poll requests. Outstanding long polls still can return tasks after this method

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncActivityWorker.java
@@ -90,23 +90,8 @@ public class SyncActivityWorker implements SuspendableWorker {
   }
 
   @Override
-  public void start() {
-    worker.start();
-  }
-
-  @Override
-  public boolean isStarted() {
-    return worker.isStarted();
-  }
-
-  @Override
-  public boolean isShutdown() {
-    return worker.isShutdown();
-  }
-
-  @Override
-  public boolean isTerminated() {
-    return worker.isTerminated() && heartbeatExecutor.isTerminated();
+  public boolean start() {
+    return worker.start();
   }
 
   @Override
@@ -143,6 +128,29 @@ public class SyncActivityWorker implements SuspendableWorker {
   @Override
   public boolean isSuspended() {
     return worker.isSuspended();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return worker.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return worker.isTerminated() && heartbeatExecutor.isTerminated();
+  }
+
+  @Override
+  public WorkerLifecycleState getLifecycleState() {
+    WorkerLifecycleState lifecycleState = worker.getLifecycleState();
+    if (WorkerLifecycleState.TERMINATED.equals(lifecycleState)) {
+      // return TERMINATED only if both worker and heartbeatExecutor are terminated
+      return heartbeatExecutor.isTerminated()
+          ? WorkerLifecycleState.TERMINATED
+          : WorkerLifecycleState.SHUTDOWN;
+    } else {
+      return lifecycleState;
+    }
   }
 
   public EagerActivityDispatcher getEagerActivityDispatcher() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -154,27 +154,13 @@ public class SyncWorkflowWorker implements SuspendableWorker {
   }
 
   @Override
-  public void start() {
-    workflowWorker.start();
+  public boolean start() {
+    boolean started = workflowWorker.start();
     // It doesn't start if no types are registered with it.
-    if (workflowWorker.isStarted()) {
+    if (started) {
       laWorker.start();
     }
-  }
-
-  @Override
-  public boolean isStarted() {
-    return workflowWorker.isStarted() && (laWorker.isStarted() || !laWorker.isAnyTypeSupported());
-  }
-
-  @Override
-  public boolean isShutdown() {
-    return workflowWorker.isShutdown() || laWorker.isShutdown();
-  }
-
-  @Override
-  public boolean isTerminated() {
-    return workflowWorker.isTerminated() && laWorker.isTerminated();
+    return started;
   }
 
   @Override
@@ -205,11 +191,6 @@ public class SyncWorkflowWorker implements SuspendableWorker {
     workflowWorker.resumePolling();
   }
 
-  @Override
-  public boolean isSuspended() {
-    return workflowWorker.isSuspended();
-  }
-
   @SuppressWarnings("deprecation")
   public <R> R queryWorkflowExecution(
       io.temporal.internal.common.WorkflowExecutionHistory history,
@@ -222,6 +203,26 @@ public class SyncWorkflowWorker implements SuspendableWorker {
     Optional<Payloads> result =
         queryReplayHelper.queryWorkflowExecution(history, queryType, serializedArgs);
     return dataConverter.fromPayloads(0, result, resultClass, resultType);
+  }
+
+  @Override
+  public boolean isSuspended() {
+    return workflowWorker.isSuspended();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return workflowWorker.isShutdown() || laWorker.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return workflowWorker.isTerminated() && laWorker.isTerminated();
+  }
+
+  @Override
+  public WorkerLifecycleState getLifecycleState() {
+    return null;
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerLifecycleState.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerLifecycleState.java
@@ -20,4 +20,22 @@
 
 package io.temporal.internal.worker;
 
-public interface SuspendableWorker extends Suspendable, Startable, Shutdownable {}
+public enum WorkerLifecycleState {
+  /** The worker was created but never started */
+  NOT_STARTED,
+  /** Ready to accept and process tasks */
+  ACTIVE,
+  /** May be absent from a worker state machine is the worker is not {@link Suspendable} */
+  SUSPENDED,
+  /**
+   * Shutdown is requested on the worker, and it is completing with the outstanding tasks before
+   * being {@link #TERMINATED}. The worker MAY reject new tasks to be processed if any internals are
+   * already being released.
+   */
+  SHUTDOWN,
+  /**
+   * The final state of the worker, all internal resources are released, the worker SHOULD reject
+   * any new tasks to be processed
+   */
+  TERMINATED
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerWithLifecycle.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkerWithLifecycle.java
@@ -20,4 +20,6 @@
 
 package io.temporal.internal.worker;
 
-public interface SuspendableWorker extends Suspendable, Startable, Shutdownable {}
+public interface WorkerWithLifecycle {
+  WorkerLifecycleState getLifecycleState();
+}

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,7 +1,7 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    otelVersion = '1.22.0'
+    otelVersion = '1.23.0'
     otShimVersion = "${otelVersion}-alpha"
 }
 


### PR DESCRIPTION
## What was changed
`isStarted` method was removed from internal Workers because of the potential duality of its meaning.
Internal SDK workers got explicit states in addition to `isX` methods.
Eager Activity Dispatch was fixed to be requested if Activity Worker is in an ACTIVE state.

## Why
Needed to correctly implement #1646 and #1230 
The current `isStarted` method already caused at least one potentially incorrect usage that may lead an eager dispatch to be requested for a suspended worker.