### PR TITLE
Fix temporal-shaded packaging type

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -16,7 +16,6 @@ subprojects {
         publications {
             mavenJava(MavenPublication) {
                 afterEvaluate {
-                    if (tasks.findByName("shadowJar") != null) artifact shadowJar
                     from components.java
                 }
             }

--- a/temporal-shaded/build.gradle
+++ b/temporal-shaded/build.gradle
@@ -61,9 +61,6 @@ configurations.shadow {
     transitive = false
 }
 
-// we are not interested in a regular jar from this build
-project.tasks.named("jar")configure { enabled = false}
-
 shadowJar {
     configurations = [project.configurations.shadow]
 
@@ -74,3 +71,5 @@ shadowJar {
     mergeServiceFiles()
     archiveClassifier.set("")
 }
+
+shadowJar.shouldRunAfter(jar)


### PR DESCRIPTION
temporal-shaded descriptor is getting published with `<packaging>pom</packaging>` which requires to include both the pom and the jar as a separate artifact. This PR fixes that.