### PR TITLE
Wait for worker slots to be fully released in the graceful worker shutdown

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -62,6 +62,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFactory {
+  private static final Logger log =
+      LoggerFactory.getLogger(POJOWorkflowImplementationFactory.class);
+
   public static final ImmutableSet<String> WORKFLOW_HANDLER_STACKTRACE_CUTOFF =
       ImmutableSet.<String>builder()
           // POJO
@@ -71,13 +74,8 @@ public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFa
           // Dynamic
           .add(
               ReflectionUtils.getMethodNameForStackTraceCutoff(
-                  DynamicSyncWorkflowDefinition.RootWorkflowInboundCallsInterceptor.class,
-                  "execute",
-                  WorkflowInboundCallsInterceptor.WorkflowInput.class))
+                  DynamicSyncWorkflowDefinition.class, "execute", Header.class, Optional.class))
           .build();
-
-  private static final Logger log =
-      LoggerFactory.getLogger(POJOWorkflowImplementationFactory.class);
   private final WorkerInterceptor[] workerInterceptors;
 
   private final DataConverter dataConverter;

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -134,9 +134,6 @@ final class Poller<T> implements SuspendableWorker {
         // it's ok to forcefully shutdown pollers, especially because they stuck in a long poll call
         // we don't lose any progress doing that
         .shutdownExecutorNow(pollExecutor, this + "#pollExecutor", Duration.ofSeconds(1))
-        // TODO Poller shouldn't shutdown taskExecutor, because it gets it already created
-        //  externally. Creator of taskExecutor should be responsible for it's shutdown.
-        .thenCompose(ignore -> taskExecutor.shutdown(shutdownManager, interruptTasks))
         .exceptionally(
             e -> {
               log.error("Unexpected exception during shutdown", e);
@@ -154,8 +151,7 @@ final class Poller<T> implements SuspendableWorker {
     }
 
     long timeoutMillis = unit.toMillis(timeout);
-    timeoutMillis = ShutdownManager.awaitTermination(pollExecutor, timeoutMillis);
-    ShutdownManager.awaitTermination(taskExecutor, timeoutMillis);
+    ShutdownManager.awaitTermination(pollExecutor, timeoutMillis);
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
@@ -79,7 +79,7 @@ public class ActivityTimeoutTest {
   public @Rule Timeout timeout = Timeout.seconds(15);
 
   /**
-   * An activity reaches startToClose timeout once, max retries are set to 1.
+   * An activity reaches startToClose timeout once, max retries are set to 1. o
    *
    * <p>The expected structure is <br>
    * {@link ActivityFailure}({@link RetryState#RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED}) -> <br>


### PR DESCRIPTION
## What was changed

Now Workflow and Activity workers will wait for the release of all worker slots during a graceful shutdown.

## Why?

This improvement allows graceful shutdown to respect all existing eager dispatch handles, so it doesn't happen that a WorkflowClient gets an eager task from the Server, but there is nowhere to dispatch it already.

An added beneficial side effect: this allows us to detect and make sure in our testing framework that there are no executor slot leaks happening. Leaking executor slots will lead to long / unlimited graceful shutdowns.