### PR TITLE
Release v1.19.1

### DIFF
--- a/releases/v1.19.1
+++ b/releases/v1.19.1
@@ -1,0 +1,8 @@
+# Highlights
+
+Fixes native test server distribution not working correctly if search attributes are used.
+JavaSDK users don't need to upgrade to this release until they build their own native test server distribution.
+
+# Changeset
+
+2023-03-23 - 5d980b3b - Fix location of graal descriptors and a missing reflection reference for temporal-sdk module (#1713)


### PR DESCRIPTION
# Highlights

Fixes native test server distribution not working correctly if search attributes are used.
JavaSDK users don't need to upgrade to this release until they build their own native test server distribution.

# Changeset

2023-03-23 - 5d980b3b - Fix location of graal descriptors and a missing reflection reference for temporal-sdk module (#1713)