### PR TITLE
Data Converters now have method deserializing all the Payloads at once

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         palantirGitVersionVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '0.15.0' : '0.13.0'}"
-        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.8.10' : (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) ? '1.5.32' : '1.4.32')}"
+        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.8.20' : (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) ? '1.5.32' : '1.4.32')}"
     }
 }
 
@@ -10,14 +10,14 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
-    id 'com.diffplug.spotless' version '6.17.0' apply false
+    id 'com.diffplug.spotless' version '6.18.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
     //    id 'org.jetbrains.kotlin.jvm' version '1.5.32'
     //    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
     //    id 'org.jetbrains.kotlin.jvm' version '1.7.22'
-    //    id 'org.jetbrains.kotlin.jvm' version '1.8.10'
+    //    id 'org.jetbrains.kotlin.jvm' version '1.8.20'
     id 'org.jetbrains.kotlin.jvm' version "${kotlinVersion}" apply false
     id 'base'
 }
@@ -30,7 +30,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.54.0' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.54.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.5' : '1.9.9' // [1.0.0,)
@@ -50,7 +50,7 @@ ext {
 
     gsonVersion = '2.10.1' // [2.0,)
 
-    jsonPathVersion = '2.7.0' // compileOnly
+    jsonPathVersion = '2.8.0' // compileOnly
 
     cronUtilsVersion = '9.2.1' // for test server only
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -51,7 +51,7 @@ subprojects {
     apply plugin: 'jacoco'
 
     jacoco {
-        toolVersion = "0.8.8"
+        toolVersion = "0.8.9"
     }
 
     jacocoTestReport {

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/CodecDataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/CodecDataConverter.java
@@ -176,6 +176,17 @@ public class CodecDataConverter implements DataConverter, PayloadCodec {
   }
 
   @Override
+  public Object[] fromPayloads(
+      Optional<Payloads> content, Class<?>[] parameterTypes, Type[] genericParameterTypes)
+      throws DataConverterException {
+    if (content.isPresent()) {
+      content = Optional.of(decodePayloads(content.get()));
+    }
+    return ConverterUtils.withContext(dataConverter, serializationContext)
+        .fromPayloads(content, parameterTypes, genericParameterTypes);
+  }
+
+  @Override
   @Nonnull
   public Failure exceptionToFailure(@Nonnull Throwable throwable) {
     Preconditions.checkNotNull(throwable, "throwable");

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
@@ -99,13 +99,12 @@ public interface DataConverter {
   Optional<Payloads> toPayloads(Object... values) throws DataConverterException;
 
   /**
-   * Implements conversion of an array of values of different types. Useful for deserializing
-   * arguments of function invocations.
+   * Implements conversion of a single {@link Payload} from the serialized {@link Payloads}.
    *
    * @param index index of the value in the payloads
    * @param content serialized value to convert to Java objects.
-   * @param valueType type of the value stored in the content
-   * @param valueGenericType generic type of the value stored in the content
+   * @param valueType type of the value stored in the {@code content}
+   * @param valueGenericType generic type of the value stored in the {@code content}
    * @return converted Java object
    * @throws DataConverterException if conversion of the data passed as parameter failed for any
    *     reason.
@@ -113,6 +112,58 @@ public interface DataConverter {
   <T> T fromPayloads(
       int index, Optional<Payloads> content, Class<T> valueType, Type valueGenericType)
       throws DataConverterException;
+
+  /**
+   * Implements conversion of the whole {@code content} {@link Payloads} into an array of values of
+   * different types.
+   *
+   * <p>Implementation note<br>
+   * This method is expected to return an array of the same length as {@code parameterTypes}. If
+   * {@code content} has not enough {@link Payload} elements, this method provides default
+   * instances.
+   *
+   * @param content serialized value to convert to Java objects.
+   * @param parameterTypes types of the values stored in the @code content}
+   * @param genericParameterTypes generic types of the values stored in the {@code content}
+   * @return array if converted Java objects
+   * @throws DataConverterException if conversion of the data passed as parameter failed for any
+   *     reason.
+   */
+  default Object[] fromPayloads(
+      Optional<Payloads> content, Class<?>[] parameterTypes, Type[] genericParameterTypes)
+      throws DataConverterException {
+    if (parameterTypes != null
+        && (genericParameterTypes == null
+            || parameterTypes.length != genericParameterTypes.length)) {
+      throw new IllegalArgumentException(
+          "parameterTypes don't match length of valueTypes: "
+              + Arrays.toString(parameterTypes)
+              + "<>"
+              + Arrays.toString(genericParameterTypes));
+    }
+
+    int totalLength = parameterTypes.length;
+    Object[] result = new Object[totalLength];
+    if (!content.isPresent()) {
+      // Return defaults for all the parameters
+      for (int i = 0; i < parameterTypes.length; i++) {
+        result[i] = Defaults.defaultValue((Class<?>) genericParameterTypes[i]);
+      }
+      return result;
+    }
+    Payloads payloads = content.get();
+    int count = payloads.getPayloadsCount();
+    for (int i = 0; i < parameterTypes.length; i++) {
+      Class<?> pt = parameterTypes[i];
+      Type gt = genericParameterTypes[i];
+      if (i >= count) {
+        result[i] = Defaults.defaultValue((Class<?>) gt);
+      } else {
+        result[i] = this.fromPayload(payloads.getPayloads(i), pt, gt);
+      }
+    }
+    return result;
+  }
 
   /**
    * Instantiate an appropriate Java Exception from a serialized Failure object. The default
@@ -136,45 +187,6 @@ public interface DataConverter {
   @Nonnull
   Failure exceptionToFailure(@Nonnull Throwable throwable);
 
-  static Object[] arrayFromPayloads(
-      DataConverter converter,
-      Optional<Payloads> content,
-      Class<?>[] parameterTypes,
-      Type[] genericParameterTypes)
-      throws DataConverterException {
-    if (parameterTypes != null
-        && (genericParameterTypes == null
-            || parameterTypes.length != genericParameterTypes.length)) {
-      throw new IllegalArgumentException(
-          "parameterTypes don't match length of valueTypes: "
-              + Arrays.toString(parameterTypes)
-              + "<>"
-              + Arrays.toString(genericParameterTypes));
-    }
-
-    int length = parameterTypes.length;
-    Object[] result = new Object[length];
-    if (!content.isPresent()) {
-      // Return defaults for all the parameters
-      for (int i = 0; i < parameterTypes.length; i++) {
-        result[i] = Defaults.defaultValue((Class<?>) genericParameterTypes[i]);
-      }
-      return result;
-    }
-    Payloads payloads = content.get();
-    int count = payloads.getPayloadsCount();
-    for (int i = 0; i < parameterTypes.length; i++) {
-      Class<?> pt = parameterTypes[i];
-      Type gt = genericParameterTypes[i];
-      if (i >= count) {
-        result[i] = Defaults.defaultValue((Class<?>) gt);
-      } else {
-        result[i] = converter.fromPayload(payloads.getPayloads(i), pt, gt);
-      }
-    }
-    return result;
-  }
-
   /**
    * A correct implementation of this interface should have a fully functional "contextless"
    * implementation. Temporal SDK will call this method when a knowledge of the context exists, but
@@ -196,5 +208,19 @@ public interface DataConverter {
   @Nonnull
   default DataConverter withContext(@Nonnull SerializationContext context) {
     return this;
+  }
+
+  /**
+   * @deprecated use {@link DataConverter#fromPayloads(int, Optional, Class, Type)}. This is an SDK
+   *     implementation detail and never was expected to be exposed to users.
+   */
+  @Deprecated
+  static Object[] arrayFromPayloads(
+      DataConverter converter,
+      Optional<Payloads> content,
+      Class<?>[] parameterTypes,
+      Type[] genericParameterTypes)
+      throws DataConverterException {
+    return converter.fromPayloads(content, parameterTypes, genericParameterTypes);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
@@ -200,11 +200,8 @@ final class ActivityTaskExecutors {
 
     @Override
     Object[] provideArgs(Optional<Payloads> input, DataConverter dataConverterWithActivityContext) {
-      return DataConverter.arrayFromPayloads(
-          dataConverterWithActivityContext,
-          input,
-          method.getParameterTypes(),
-          method.getGenericParameterTypes());
+      return dataConverterWithActivityContext.fromPayloads(
+          input, method.getParameterTypes(), method.getGenericParameterTypes());
     }
 
     @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -306,11 +306,8 @@ public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFa
         throws CanceledFailure, WorkflowExecutionException {
 
       Object[] args =
-          DataConverter.arrayFromPayloads(
-              dataConverterWithWorkflowContext,
-              input,
-              workflowMethod.getParameterTypes(),
-              workflowMethod.getGenericParameterTypes());
+          dataConverterWithWorkflowContext.fromPayloads(
+              input, workflowMethod.getParameterTypes(), workflowMethod.getGenericParameterTypes());
       Preconditions.checkNotNull(workflowInvoker, "initialize not called");
       WorkflowInboundCallsInterceptor.WorkflowOutput result =
           workflowInvoker.execute(new WorkflowInboundCallsInterceptor.WorkflowInput(header, args));

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/QueryDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/QueryDispatcher.java
@@ -80,11 +80,8 @@ class QueryDispatcher {
       args = new Object[] {new EncodedValues(input, dataConverterWithWorkflowContext)};
     } else {
       args =
-          DataConverter.arrayFromPayloads(
-              dataConverterWithWorkflowContext,
-              input,
-              handler.getArgTypes(),
-              handler.getGenericArgTypes());
+          dataConverterWithWorkflowContext.fromPayloads(
+              input, handler.getArgTypes(), handler.getGenericArgTypes());
     }
     Object result =
         inboundCallsInterceptor

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SignalDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SignalDispatcher.java
@@ -89,11 +89,8 @@ class SignalDispatcher {
     } else {
       try {
         args =
-            DataConverter.arrayFromPayloads(
-                dataConverterWithWorkflowContext,
-                input,
-                handler.getArgTypes(),
-                handler.getGenericArgTypes());
+            dataConverterWithWorkflowContext.fromPayloads(
+                input, handler.getArgTypes(), handler.getGenericArgTypes());
       } catch (DataConverterException e) {
         logSerializationException(signalName, eventId, e);
         return;

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/JsonDataConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/JsonDataConverterTest.java
@@ -117,8 +117,7 @@ public class JsonDataConverterTest {
     Optional<Payloads> data =
         converter.toPayloads(1234, struct1, "a string", list, "an extra string :o!!!");
     Object[] deserializedArguments =
-        DataConverter.arrayFromPayloads(
-            converter, data, m.getParameterTypes(), m.getGenericParameterTypes());
+        converter.fromPayloads(data, m.getParameterTypes(), m.getGenericParameterTypes());
     assertEquals(4, deserializedArguments.length);
     assertEquals(1234, (int) deserializedArguments[0]);
     assertEquals(struct1, deserializedArguments[1]);
@@ -136,8 +135,7 @@ public class JsonDataConverterTest {
     Optional<Payloads> data = converter.toPayloads(1);
     @SuppressWarnings("unchecked")
     Object[] deserializedArguments =
-        DataConverter.arrayFromPayloads(
-            converter, data, m.getParameterTypes(), m.getGenericParameterTypes());
+        converter.fromPayloads(data, m.getParameterTypes(), m.getGenericParameterTypes());
     assertEquals(5, deserializedArguments.length);
     assertEquals(1, (int) deserializedArguments[0]);
     assertEquals(null, deserializedArguments[1]);

--- a/temporal-spring-boot-autoconfigure-alpha/build.gradle
+++ b/temporal-spring-boot-autoconfigure-alpha/build.gradle
@@ -1,7 +1,7 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    otelVersion = '1.24.0'
+    otelVersion = '1.25.0'
     otShimVersion = "${otelVersion}-alpha"
 }
 


### PR DESCRIPTION
## What was changed

`DataConverter` interface got a new method `fromPayloads` that convert all the payloads at once with default implementations that uses one-by-one conversion.
`CodecDataConverter` implements the new method in a way that avoids calling the codec several times for each Payload.

## Why?

Closes #1345
