### PR TITLE
remove the explicit dependency upon ServiceStubsAutoConfiguration

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/RootNamespaceAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/RootNamespaceAutoConfiguration.java
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -59,7 +58,6 @@ import org.springframework.context.event.ContextStartedEvent;
 @Configuration
 @EnableConfigurationProperties(TemporalProperties.class)
 @AutoConfigureAfter({ServiceStubsAutoConfiguration.class, OpenTracingAutoConfiguration.class})
-@ConditionalOnBean(ServiceStubsAutoConfiguration.class)
 @ConditionalOnExpression(
     "${spring.temporal.test-server.enabled:false} || '${spring.temporal.connection.target:}'.length() > 0")
 public class RootNamespaceAutoConfiguration {


### PR DESCRIPTION
## What was changed
Modify the Spring AutoConfiguration to be conditional on what is actually required, the service stubs

## Why?
This allows users to potentially disable the `ServiceStubsAutoConfiguration` and build a `WorkflowServiceStubs` themselves while still using the rest of the library. This may be needed if, for instance, further customization of the gRPC connection is required.

## Checklist
This was tested by running the unit tests. They all pass. 