### PR TITLE
Fix getOriginalExecutionRunId return value and add explicit @NonNull annotations

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/BasicWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/BasicWorkflowContext.java
@@ -72,7 +72,8 @@ final class BasicWorkflowContext {
     return startedAttributes.getWorkflowType();
   }
 
-  public String getFirstExecutionRunId() {
+  @Nonnull
+  String getFirstExecutionRunId() {
     return startedAttributes.getFirstExecutionRunId();
   }
 
@@ -81,9 +82,9 @@ final class BasicWorkflowContext {
     return runId.isEmpty() ? Optional.empty() : Optional.of(runId);
   }
 
-  Optional<String> getOriginalExecutionRunId() {
-    String runId = startedAttributes.getOriginalExecutionRunId();
-    return runId.isEmpty() ? Optional.empty() : Optional.of(runId);
+  @Nonnull
+  String getOriginalExecutionRunId() {
+    return startedAttributes.getOriginalExecutionRunId();
   }
 
   WorkflowExecution getParentWorkflowExecution() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -84,6 +84,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
    * @see #getFirstExecutionRunId() for the very first RunId that is preserved along the whole
    *     Workflow Execution chain, including ContinueAsNew, Retry, Cron and Reset.
    */
+  @Nonnull
   String getRunId();
 
   /**
@@ -91,6 +92,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
    *     chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow
    *     Execution.
    */
+  @Nonnull
   String getFirstExecutionRunId();
 
   /**
@@ -108,7 +110,8 @@ public interface ReplayWorkflowContext extends ReplayAware {
    * @see #getFirstExecutionRunId() for the very first RunId that is preserved along the whole
    *     Workflow Execution chain, including ContinueAsNew, Retry, Cron and Reset.
    */
-  Optional<String> getOriginalExecutionRunId();
+  @Nonnull
+  String getOriginalExecutionRunId();
 
   /** Workflow task queue name. */
   String getTaskQueue();

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -120,7 +120,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
   }
 
   @Override
-  public Optional<String> getOriginalExecutionRunId() {
+  public String getOriginalExecutionRunId() {
     return basicWorkflowContext.getOriginalExecutionRunId();
   }
 
@@ -150,6 +150,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
     return basicWorkflowContext.getWorkflowExecution().getWorkflowId();
   }
 
+  @Nonnull
   @Override
   public String getRunId() {
     String result = basicWorkflowContext.getWorkflowExecution().getRunId();

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
@@ -26,6 +26,7 @@ import io.temporal.internal.replay.ReplayWorkflowContext;
 import io.temporal.workflow.WorkflowInfo;
 import java.time.Duration;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 final class WorkflowInfoImpl implements WorkflowInfo {
@@ -51,11 +52,13 @@ final class WorkflowInfoImpl implements WorkflowInfo {
     return context.getWorkflowType().getName();
   }
 
+  @Nonnull
   @Override
   public String getRunId() {
     return context.getRunId();
   }
 
+  @Nonnull
   @Override
   public String getFirstExecutionRunId() {
     return context.getFirstExecutionRunId();
@@ -66,8 +69,9 @@ final class WorkflowInfoImpl implements WorkflowInfo {
     return context.getContinuedExecutionRunId();
   }
 
+  @Nonnull
   @Override
-  public Optional<String> getOriginalExecutionRunId() {
+  public String getOriginalExecutionRunId() {
     return context.getOriginalExecutionRunId();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -23,6 +23,7 @@ package io.temporal.workflow;
 import io.temporal.api.common.v1.SearchAttributes;
 import java.time.Duration;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -54,6 +55,7 @@ public interface WorkflowInfo {
    * @see #getFirstExecutionRunId() for the very first RunId that is preserved along the whole
    *     Workflow Execution chain, including ContinueAsNew, Retry, Cron and Reset.
    */
+  @Nonnull
   String getRunId();
 
   /**
@@ -61,6 +63,7 @@ public interface WorkflowInfo {
    *     chain of ContinueAsNew, Retry, Cron and Reset. Identifies the whole Runs chain of Workflow
    *     Execution.
    */
+  @Nonnull
   String getFirstExecutionRunId();
 
   /**
@@ -78,7 +81,8 @@ public interface WorkflowInfo {
    * @see #getFirstExecutionRunId() for the very first RunId that is preserved along the whole
    *     Workflow Execution chain, including ContinueAsNew, Retry, Cron and Reset.
    */
-  Optional<String> getOriginalExecutionRunId();
+  @Nonnull
+  String getOriginalExecutionRunId();
 
   /**
    * @return Workflow Task Queue name

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -126,14 +126,16 @@ public class DummySyncWorkflowContext {
       return "dummy-workflow-id";
     }
 
+    @Nonnull
     @Override
     public String getRunId() {
       return "dummy-run-id";
     }
 
+    @Nonnull
     @Override
     public String getFirstExecutionRunId() {
-      return null;
+      throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
@@ -141,9 +143,10 @@ public class DummySyncWorkflowContext {
       throw new UnsupportedOperationException("not implemented");
     }
 
+    @Nonnull
     @Override
-    public Optional<String> getOriginalExecutionRunId() {
-      return Optional.empty();
+    public String getOriginalExecutionRunId() {
+      throw new UnsupportedOperationException("not implemented");
     }
 
     @Override


### PR DESCRIPTION
# Why

While adding `getOriginalExecutionRunId` method in the previous release I made a mistake by copying `getContinuedExecutionRunId` signature and made the return value `Optional<String>`.
This is an incorrect type and makes users think that they should account for situations when this value is not present.

This change is backward incompatible for users of `getOriginalExecutionRunId` method and will require a trivial refactoring. I expect the number of users to be affected as close to 0, because this method is not just very new and silently added for a specific user, but also most users should never use it and go for `getFirstExecutionRunId` instead.