### PR TITLE
Add comment on Workflow#newQueue

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -473,6 +473,10 @@ public final class Workflow {
     return WorkflowInternal.newTimer(delay);
   }
 
+  /**
+   * @deprecated use {@link #newWorkflowQueue(int)} instead. An implementation returned by this
+   *     method has a bug.
+   */
   @Deprecated
   public static <E> WorkflowQueue<E> newQueue(int capacity) {
     return WorkflowInternal.newQueue(capacity);


### PR DESCRIPTION
## Why?
User-facing method was deprecated without an appropriate explanatory and replace-with comment.