### PR TITLE
Add labels to WORKFLOW_TASK_EXECUTION_FAILURE

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -26,6 +26,13 @@ public final class MetricsType {
   public static final String TEMPORAL_METRICS_PREFIX = "temporal_";
 
   //
+  // Labels
+  //
+  public static final String TEMPORAL_METRICS_LABEL_EXCEPTION = "exception";
+  public static final String TEMPORAL_METRICS_LABEL_EXCEPTION_MESSAGE = "exception_message";
+  public static final String TEMPORAL_METRICS_LABEL_REASON = "reason";
+
+  //
   // Workflow
   //
   public static final String WORKFLOW_COMPLETED_COUNTER =


### PR DESCRIPTION
This is needed to be able to differentiate on the different causes for this metric to increase as the cause currently is only present in the logs preventing good alarms to be made

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Labels has been added to the WORKFLOW_TASK_EXECUTION_FAILURE_COUNTER metrics showing the cause of the counter increasing

## Why?
The current implementation of the counter just tells us that a workflow has failed during its execution, without giving any details. This prevents us from using the metrics in a meaningful alarm as different causes should have different responses.

## Checklist

2. How was this tested:
Tested in our local deployment of temporal running our workflows by forcing the workflow to experience a failure

4. Any docs updates needed?
The CONTRIBUTING.md doc should be updated informing on how the process of filling out the 
Temporal Contributor License Agreement works, as it is currently unclear on how to do this for new developers

5. Further enchantments suggested
Most other metrics should be reviewed for the usefulness of labels to enhance them further
