### PR TITLE
Remove use of deprecated API

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/UpdateDispatcher.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/UpdateDispatcher.java
@@ -65,11 +65,8 @@ class UpdateDispatcher {
       args = new Object[] {new EncodedValues(input, dataConverterWithWorkflowContext)};
     } else {
       args =
-          DataConverter.arrayFromPayloads(
-              dataConverterWithWorkflowContext,
-              input,
-              handler.getArgTypes(),
-              handler.getGenericArgTypes());
+          dataConverterWithWorkflowContext.fromPayloads(
+              input, handler.getArgTypes(), handler.getGenericArgTypes());
     }
 
     inboundCallsInterceptor.validateUpdate(
@@ -89,11 +86,8 @@ class UpdateDispatcher {
       args = new Object[] {new EncodedValues(input, dataConverterWithWorkflowContext)};
     } else {
       args =
-          DataConverter.arrayFromPayloads(
-              dataConverterWithWorkflowContext,
-              input,
-              handler.getArgTypes(),
-              handler.getGenericArgTypes());
+          dataConverterWithWorkflowContext.fromPayloads(
+              input, handler.getArgTypes(), handler.getGenericArgTypes());
     }
     Object result =
         inboundCallsInterceptor


### PR DESCRIPTION
`arrayFromPayloads` was deprecated between opening the original PR and merging it, but out CI build did not catch this on rebase.