### PR TITLE
Allow task queue names to use property placeholders

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/ActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/ActivityImpl.java
@@ -42,7 +42,7 @@ public @interface ActivityImpl {
   /**
    * @return Worker Task Queues to register this activity bean with. If Worker with the specified
    *     Task Queue is not present in the application config, it will be created with a default
-   *     config.
+   *     config. Can be specified as a property key, e.g.: ${propertyKey}.
    */
   String[] taskQueues() default {};
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/WorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/WorkflowImpl.java
@@ -42,7 +42,7 @@ public @interface WorkflowImpl {
   /**
    * @return Worker Task Queues to register this workflow implementation with. If Worker with the
    *     specified Task Queue is not defined in the application config, it will be created with a
-   *     default config.
+   *     default config. Can be specified by a property key, e.g.: ${propertyKey}.
    */
   String[] taskQueues() default {};
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByTaskQueueResolverTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByTaskQueueResolverTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
+import io.temporal.worker.WorkerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = AutoDiscoveryByTaskQueueResolverTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue-dynamic-suffix")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryByTaskQueueResolverTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired WorkflowClient workflowClient;
+
+  @Autowired WorkerFactory workerFactory;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testAutoDiscovery() {
+    TestWorkflow testWorkflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflow.class,
+            WorkflowOptions.newBuilder().setTaskQueue("PropertyResolverTest").build());
+    testWorkflow.execute("input");
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestActivityImpl.java
@@ -24,7 +24,7 @@ import io.temporal.spring.boot.ActivityImpl;
 import org.springframework.stereotype.Component;
 
 @Component("TestActivityImpl")
-@ActivityImpl(taskQueues = "UnitTest")
+@ActivityImpl(taskQueues = "${default-queue.name:UnitTest}")
 public class TestActivityImpl implements TestActivity {
   @Override
   public String execute(String input) {

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/bytaskqueue/TestWorkflowImpl.java
@@ -25,7 +25,7 @@ import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
 
-@WorkflowImpl(taskQueues = "UnitTest")
+@WorkflowImpl(taskQueues = {"${default-queue.name:UnitTest}"})
 public class TestWorkflowImpl implements TestWorkflow {
   @Override
   public String execute(String input) {

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
@@ -41,6 +41,18 @@ spring:
 spring:
   config:
     activate:
+      on-profile: auto-discovery-by-task-queue-dynamic-suffix
+  temporal:
+    workers-auto-discovery:
+      packages:
+        - io.temporal.spring.boot.autoconfigure.bytaskqueue
+default-queue:
+  name: PropertyResolverTest
+
+---
+spring:
+  config:
+    activate:
       on-profile: auto-discovery-by-worker-name
   temporal:
     workers:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make WorkerTemplate implement `EnvironmentAware` so that it can use the Spring environment to resolve property placeholders in task queue names to allow more dynamic naming while utilizing the `workers-auto-discovery`

## Why?
To enable more dynamic usage when utilizing the @WorkflowImpl and @ActivityImpl annotations, along with the workers-auto-discovery feature, this allows the task queue name values to be Spring property placeholder that will be resolved and populated by Spring at runtime.

## Checklist
<!--- add/delete as needed --->

1. Closes #1759 

2. How was this tested:
Added additional integration tests checking both for when the property value exists in the configuration and when the value does not exist

3. Any docs updates needed?
Javadoc was updated to indicate that the values can utilize the property placeholder syntax but no other documentation updates were required
