### PR TITLE
Add support for async update

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/CompletedUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/CompletedUpdateHandleImpl.java
@@ -23,18 +23,19 @@ package io.temporal.client;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.common.Experimental;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 @Experimental
-final class UpdateHandleImpl<T> implements UpdateHandle<T> {
+final class CompletedUpdateHandleImpl<T> implements UpdateHandle<T> {
 
   private final String id;
   private final WorkflowExecution execution;
-  private final CompletableFuture<T> future;
+  private final T result;
 
-  UpdateHandleImpl(String id, WorkflowExecution execution, CompletableFuture<T> future) {
+  CompletedUpdateHandleImpl(String id, WorkflowExecution execution, T result) {
     this.id = id;
     this.execution = execution;
-    this.future = future;
+    this.result = result;
   }
 
   @Override
@@ -49,6 +50,11 @@ final class UpdateHandleImpl<T> implements UpdateHandle<T> {
 
   @Override
   public CompletableFuture<T> getResultAsync() {
-    return future;
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit) {
+    return CompletableFuture.completedFuture(result);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.common.Experimental;
+import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
+import io.temporal.serviceclient.CheckedExceptionWrapper;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Experimental
+final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
+
+  private final WorkflowClientCallsInterceptor workflowClientInvoker;
+  private final String workflowType;
+  private final String updateName;
+  private final String id;
+  private final WorkflowExecution execution;
+  private final Class<T> resultClass;
+  private final Type resultType;
+
+  LazyUpdateHandleImpl(
+      WorkflowClientCallsInterceptor workflowClientInvoker,
+      String workflowType,
+      String updateName,
+      String id,
+      WorkflowExecution execution,
+      Class<T> resultClass,
+      Type resultType) {
+    this.workflowClientInvoker = workflowClientInvoker;
+    this.workflowType = workflowType;
+    this.updateName = updateName;
+    this.id = id;
+    this.execution = execution;
+    this.resultClass = resultClass;
+    this.resultType = resultType;
+  }
+
+  @Override
+  public WorkflowExecution getExecution() {
+    return execution;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit) {
+    WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput output =
+        workflowClientInvoker.pollWorkflowUpdate(
+            new WorkflowClientCallsInterceptor.PollWorkflowUpdateInput<>(
+                execution, updateName, id, resultClass, resultType, timeout, unit));
+
+    return output
+        .getResult()
+        .exceptionally(
+            failure -> {
+              if (failure instanceof CompletionException) {
+                // unwrap the CompletionException
+                failure = ((Throwable) failure).getCause();
+              }
+              failure = CheckedExceptionWrapper.unwrap((Throwable) failure);
+              if (failure instanceof Error) {
+                throw (Error) failure;
+              }
+              if (failure instanceof StatusRuntimeException) {
+                StatusRuntimeException sre = (StatusRuntimeException) failure;
+                if (Status.Code.NOT_FOUND.equals(sre.getStatus().getCode())) {
+                  // Currently no way to tell if the NOT_FOUND was because the workflow ID
+                  // does not exist or because the update ID does not exist.
+                  throw sre;
+                }
+              } else if (failure instanceof WorkflowException) {
+                throw (WorkflowException) failure;
+              } else if (failure instanceof TimeoutException) {
+                throw new CompletionException((TimeoutException) failure);
+              }
+              throw new WorkflowServiceException(execution, workflowType, (Throwable) failure);
+            });
+  }
+
+  @Override
+  public CompletableFuture<T> getResultAsync() {
+    return this.getResultAsync(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/client/UpdateHandle.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/UpdateHandle.java
@@ -23,6 +23,7 @@ package io.temporal.client;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.common.Experimental;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * UpdateHandle is a handle to an update workflow execution request that can be used to get the
@@ -51,4 +52,14 @@ public interface UpdateHandle<T> {
    * @return future completed with the result of the update or an exception
    */
   CompletableFuture<T> getResultAsync();
+
+  /**
+   * Returns a {@link CompletableFuture} with the update workflow execution request result
+   * potentially waiting for the update to complete.
+   *
+   * @param timeout maximum time to wait and perform the background long polling
+   * @param unit unit of timeout
+   * @return future completed with the result of the update or an exception
+   */
+  CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit);
 }

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -22,6 +22,7 @@ package io.temporal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.QueryRejectCondition;
+import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 import io.temporal.common.Experimental;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.TerminatedFailure;
@@ -103,8 +104,7 @@ public interface WorkflowStub {
    *     the update request with an error.
    * @param resultClass class of the update return value.
    * @param <R> type of the update return value.
-   * @param resultType type of the workflow return value. Differs from resultClass for generic
-   *     types.
+   * @param resultType type of the update return value. Differs from resultClass for generic types.
    * @param args update method arguments
    * @return update result
    * @throws WorkflowNotFoundException if the workflow execution doesn't exist or completed and
@@ -130,7 +130,7 @@ public interface WorkflowStub {
    * @param resultClass class of the update return value
    * @param <R> type of the update return value
    * @param args update method arguments
-   * @return update reference that can be used to get the result of the update.
+   * @return update handle that can be used to get the result of the update.
    */
   @Experimental
   <R> UpdateHandle<R> startUpdate(String updateName, Class<R> resultClass, Object... args);
@@ -145,21 +145,49 @@ public interface WorkflowStub {
    * @param firstExecutionRunId specifies the RunID expected to identify the first run in the
    *     workflow execution chain. If this expectation does not match then the server will reject
    *     the update request with an error.
+   * @param waitPolicy specifies at what point in the update request life cycles this request should
+   *     return.
    * @param resultClass class of the update return value.
    * @param <R> type of the update return value.
-   * @param resultType type of the workflow return value. Differs from resultClass for generic
-   *     types.
+   * @param resultType type of the update return value. Differs from resultClass for generic types.
    * @param args update method arguments
-   * @return update reference that can be used to get the result of the update.
+   * @return update handle that can be used to get the result of the update.
    */
   @Experimental
   <R> UpdateHandle<R> startUpdate(
       String updateName,
       String updateId,
       String firstExecutionRunId,
+      UpdateWorkflowExecutionLifecycleStage waitPolicy,
       Class<R> resultClass,
       Type resultType,
       Object... args);
+
+  /**
+   * Get an update handle to an update request previously started. Getting an update handle does not
+   * guarantee the update ID exists.
+   *
+   * @param updateId the identifier for the requested update.
+   * @param resultClass class of the update return value.
+   * @param <R> type of the update return value.
+   * @return update handle that can be used to get the result of the update.
+   */
+  @Experimental
+  <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass);
+
+  /**
+   * Get an update handle to an update request previously started.Getting an update handle does not
+   * guarantee the update ID exists.
+   *
+   * @param updateId is an application-layer identifier for the requested update. It must be unique
+   *     within the scope of a workflow execution.
+   * @param resultClass class of the update return value.
+   * @param <R> type of the update return value.
+   * @param resultType type of the update return value. Differs from resultClass for generic types.
+   * @return update handle that can be used to get the result of the update.
+   */
+  @Experimental
+  <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass, Type resultType);
 
   WorkflowExecution start(Object... args);
 

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptorBase.java
@@ -62,13 +62,13 @@ public class WorkflowClientCallsInterceptorBase implements WorkflowClientCallsIn
   }
 
   @Override
-  public <R> UpdateOutput<R> update(UpdateInput<R> input) {
-    return next.update(input);
+  public <R> StartUpdateOutput<R> startUpdate(StartUpdateInput<R> input) {
+    return next.startUpdate(input);
   }
 
   @Override
-  public <R> UpdateAsyncOutput<R> updateAsync(UpdateInput<R> input) {
-    return next.updateAsync(input);
+  public <R> PollWorkflowUpdateOutput<R> pollWorkflowUpdate(PollWorkflowUpdateInput<R> input) {
+    return next.pollWorkflowUpdate(input);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
@@ -42,6 +42,10 @@ public interface GenericWorkflowClient {
   @Experimental
   UpdateWorkflowExecutionResponse update(UpdateWorkflowExecutionRequest updateParameters);
 
+  @Experimental
+  CompletableFuture<PollWorkflowExecutionUpdateResponse> pollUpdateAsync(
+      @Nonnull PollWorkflowExecutionUpdateRequest request, @Nonnull Deadline deadline);
+
   void terminate(TerminateWorkflowExecutionRequest request);
 
   GetWorkflowExecutionHistoryResponse longPollHistory(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
@@ -265,4 +265,19 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
                 .updateWorkflowExecution(updateParameters),
         grpcRetryerOptions);
   }
+
+  @Override
+  public CompletableFuture<PollWorkflowExecutionUpdateResponse> pollUpdateAsync(
+      @Nonnull PollWorkflowExecutionUpdateRequest request, @Nonnull Deadline deadline) {
+    return grpcRetryer.retryWithResultAsync(
+        asyncThrottlerExecutor,
+        () ->
+            toCompletableFuture(
+                service
+                    .futureStub()
+                    .withDeadline(deadline)
+                    .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
+                    .pollWorkflowExecutionUpdate(request)),
+        new GrpcRetryer.GrpcRetryerOptions(DefaultStubLongPollRpcRetryOptions.INSTANCE, deadline));
+  }
 }

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTestTimeout.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTestTimeout.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client.functional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.base.Stopwatch;
+import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
+import io.temporal.client.UpdateHandle;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UpdateTestTimeout {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setUseTimeskipping(false)
+          .setWorkflowTypes(UpdateTestTimeout.BlockingWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void closeWorkflowWhileUpdateIsRunning() throws ExecutionException, InterruptedException {
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    String workflowType = BlockingWorkflow.class.getSimpleName();
+    WorkflowStub workflowStub =
+        workflowClient.newUntypedWorkflowStub(
+            workflowType,
+            SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+
+    workflowStub.start();
+    SDKTestWorkflowRule.waitForOKQuery(workflowStub);
+    // Send an update that is accepted, but will not complete.
+    UpdateHandle<String> handle =
+        workflowStub.startUpdate(
+            "update",
+            "update-id",
+            "",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            String.class,
+            String.class,
+            10_000,
+            "some-value");
+
+    // Complete workflow, since the update is accepted it will not block completion
+    workflowStub.update("complete", void.class);
+    assertEquals("complete", workflowStub.getResult(String.class));
+  }
+
+  @Test(timeout = 70_000)
+  public void LongRunningWorkflowUpdateId() throws ExecutionException, InterruptedException {
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    String workflowType = BlockingWorkflow.class.getSimpleName();
+    WorkflowStub workflowStub =
+        workflowClient.newUntypedWorkflowStub(
+            workflowType,
+            SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+
+    workflowStub.start();
+    SDKTestWorkflowRule.waitForOKQuery(workflowStub);
+    UpdateHandle<String> handle =
+        workflowStub.startUpdate(
+            "update",
+            "update-id",
+            "",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            String.class,
+            String.class,
+            65_000,
+            "some-value");
+
+    assertEquals("some-value", handle.getResultAsync().get());
+    workflowStub.update("complete", void.class);
+    assertEquals("complete", workflowStub.getResult(String.class));
+  }
+
+  @Test
+  public void WorkflowUpdateGetResultTimeout() throws ExecutionException, InterruptedException {
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    String workflowType = BlockingWorkflow.class.getSimpleName();
+    WorkflowStub workflowStub =
+        workflowClient.newUntypedWorkflowStub(
+            workflowType,
+            SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+
+    workflowStub.start();
+    SDKTestWorkflowRule.waitForOKQuery(workflowStub);
+
+    UpdateHandle<String> handle =
+        workflowStub.startUpdate(
+            "update",
+            "update-id",
+            "",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            String.class,
+            String.class,
+            10_000,
+            "some-value");
+
+    CompletableFuture<String> result = handle.getResultAsync(2, TimeUnit.SECONDS);
+    // Verify get throws the correct exception in around the right amount of time
+    Stopwatch stopWatch = Stopwatch.createStarted();
+    ExecutionException executionException = assertThrows(ExecutionException.class, result::get);
+    assertThat(executionException.getCause(), is(instanceOf(TimeoutException.class)));
+    stopWatch.stop();
+    long elapsedSeconds = stopWatch.elapsed(TimeUnit.SECONDS);
+    assertTrue(
+        "We shouldn't return too early or too late by the timeout, took "
+            + elapsedSeconds
+            + " seconds",
+        elapsedSeconds >= 1 && elapsedSeconds <= 3);
+
+    // Complete workflow, since the update is accepted it will not block completion
+    workflowStub.update("complete", void.class);
+    assertEquals("complete", workflowStub.getResult(String.class));
+  }
+
+  @WorkflowInterface
+  public interface BlockingWorkflow {
+    @WorkflowMethod
+    String execute();
+
+    @QueryMethod
+    String getState();
+
+    @UpdateMethod(name = "update")
+    String update(long sleep, String value);
+
+    @UpdateMethod
+    void complete();
+  }
+
+  public static class BlockingWorkflowImpl implements UpdateTestTimeout.BlockingWorkflow {
+    CompletablePromise<Void> promise = Workflow.newPromise();
+    CompletablePromise<Void> updateExecutePromise = Workflow.newPromise();
+
+    @Override
+    public String execute() {
+      promise.get();
+      return "complete";
+    }
+
+    @Override
+    public String getState() {
+      return "running";
+    }
+
+    @Override
+    public String update(long sleep, String value) {
+      Workflow.sleep(sleep);
+      return value;
+    }
+
+    @Override
+    public void complete() {
+      promise.complete(null);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -127,10 +127,10 @@ public class UpdateTest {
         WorkflowUpdateException.class,
         () -> workflowStub.update("bad_update_name", String.class, 0, "Bad Update"));
 
-    // send a bad update that will be rejected through the async path
-    UpdateHandle badUpdateRef = workflowStub.startUpdate("update", String.class, 0, "Bad Update");
     // send a bad update that will be rejected through the sync path
-    assertThrows(ExecutionException.class, () -> badUpdateRef.getResultAsync().get());
+    assertThrows(
+        WorkflowUpdateException.class,
+        () -> workflowStub.startUpdate("update", String.class, 0, "Bad Update"));
 
     workflowStub.update("complete", void.class);
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/LongPollUtil.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/LongPollUtil.java
@@ -29,7 +29,8 @@ class LongPollUtil {
   static <ReqT, RespT> boolean isLongPoll(
       MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
     if (method == WorkflowServiceGrpc.getPollWorkflowTaskQueueMethod()
-        || method == WorkflowServiceGrpc.getPollActivityTaskQueueMethod()) {
+        || method == WorkflowServiceGrpc.getPollActivityTaskQueueMethod()
+        || method == WorkflowServiceGrpc.getPollWorkflowExecutionUpdateMethod()) {
       return true;
     }
     if (method == WorkflowServiceGrpc.getGetWorkflowExecutionHistoryMethod()) {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1793,7 +1793,6 @@ class StateMachines {
                   UpdateRef.newBuilder()
                       .setWorkflowExecution(ctx.getExecution())
                       .setUpdateId(data.id))
-              .setOutcome(Outcome.getDefaultInstance())
               .build();
 
       data.acceptance.complete(response);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
@@ -116,6 +116,9 @@ interface TestWorkflowMutableState {
   UpdateWorkflowExecutionResponse updateWorkflowExecution(
       UpdateWorkflowExecutionRequest request, Deadline deadline);
 
+  PollWorkflowExecutionUpdateResponse pollUpdateWorkflowExecution(
+      PollWorkflowExecutionUpdateRequest request, Deadline deadline);
+
   DescribeWorkflowExecutionResponse describeWorkflowExecution();
 
   void completeQuery(QueryId queryId, RespondQueryTaskCompletedRequest completeRequest);

--- a/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
@@ -21,6 +21,7 @@
 package io.temporal.testing;
 
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 import io.temporal.client.UpdateHandle;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
@@ -259,11 +260,23 @@ class TimeLockingInterceptor extends WorkflowClientInterceptorBase {
         String updateName,
         String updateId,
         String firstExecutionRunId,
+        UpdateWorkflowExecutionLifecycleStage waitPolicy,
         Class<R> resultClass,
         Type resultType,
         Object... args) {
       return next.startUpdate(
-          updateName, updateId, firstExecutionRunId, resultClass, resultType, args);
+          updateName, updateId, firstExecutionRunId, waitPolicy, resultClass, resultType, args);
+    }
+
+    @Override
+    public <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass) {
+      return next.getUpdateHandle(updateId, resultClass);
+    }
+
+    @Override
+    public <R> UpdateHandle<R> getUpdateHandle(
+        String updateId, Class<R> resultClass, Type resultType) {
+      return next.getUpdateHandle(updateId, resultClass, resultType);
     }
   }
 }


### PR DESCRIPTION
Add support for async update to test server and client.

Includes some breaking changes to interceptors and where exceptions are returned. This should be fine as all the APIs are marked experimental and never released.



