### PR TITLE
Throw on heartbeat when activity task times out

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -67,6 +67,13 @@ public interface ActivityInfo {
   long getScheduledTimestamp();
 
   /**
+   * Time when the activity task (this attempt) was started
+   *
+   * @return Timestamp in milliseconds (UNIX Epoch time)
+   */
+  long getStartedTimestamp();
+
+  /**
    * Time when the Activity Task (current attempt) was scheduled by the Temporal Server.
    *
    * @return Timestamp in milliseconds (UNIX Epoch time)

--- a/temporal-sdk/src/main/java/io/temporal/client/ActivityTaskTimedOutException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/ActivityTaskTimedOutException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client;
+
+import io.temporal.activity.ActivityInfo;
+import io.temporal.api.enums.v1.TimeoutType;
+
+/**
+ * Indicates that the activity task has timed out while executing.
+ *
+ * <p>Catching this exception directly is discouraged and catching the parent class {@link
+ * ActivityCompletionException} is recommended instead.<br>
+ */
+public final class ActivityTaskTimedOutException extends ActivityCompletionException {
+  private final TimeoutType timeoutType;
+  private final long timeoutDeadline;
+
+  public ActivityTaskTimedOutException(
+      ActivityInfo info, TimeoutType timeoutType, long timeoutDeadline) {
+    super(info);
+    this.timeoutType = timeoutType;
+    this.timeoutDeadline = timeoutDeadline;
+  }
+
+  /**
+   * Gets the type of timeout that was exceeded during activity execution
+   *
+   * @return only TIMEOUT_TYPE_START_TO_CLOSE or TIMEOUT_TYPE_SCHEDULE_TO_CLOSE
+   */
+  public TimeoutType getTimeoutType() {
+    return timeoutType;
+  }
+
+  /**
+   * Gets the timeout deadline that was exceeded during activity execution
+   *
+   * @return Timestamp in milliseconds (UNIX Epoch time)
+   */
+  public long getTimeoutDeadline() {
+    return timeoutDeadline;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
@@ -88,6 +88,11 @@ final class ActivityInfoImpl implements ActivityInfoInternal {
   }
 
   @Override
+  public long getStartedTimestamp() {
+    return Timestamps.toMillis(response.getStartedTime());
+  }
+
+  @Override
   public Duration getScheduleToCloseTimeout() {
     return ProtobufTimeUtils.toJavaDuration(response.getScheduleToCloseTimeout());
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
@@ -100,9 +100,11 @@ public class WorkflowClosedRunningActivityTest {
         untyped.terminate("test termination");
         break;
       case EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
-        assertTrue(activityCancelled.waitForSignal(7, TimeUnit.SECONDS));
         break;
     }
+
+    // Wait for workflow failure before checking activity cancellation or workflow history
+    assertThrows(WorkflowFailedException.class, () -> untyped.getResult(String.class));
 
     assertTrue(activityCancelled.waitForSignal(1, TimeUnit.SECONDS));
 
@@ -125,9 +127,9 @@ public class WorkflowClosedRunningActivityTest {
       while (true) {
         try {
           Activity.getExecutionContext().heartbeat(System.currentTimeMillis() - start);
-        } catch (ActivityNotExistsException e) {
+        } catch (ActivityCompletionException e) {
           // in case of the whole workflow gets cancelled, we are getting
-          // ActivityNotExistsException
+          // some type of ActivityCompletionException
           activityCancelled.signal();
         }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Adds a new `ActivityTaskTimedOutException` subclassed from `ActivityCompletionException`
- This exception is now thrown on heartbeating when the activity task has exceeded the start-to-close or schedule-to-close timeout
- Adds a `getStartedTimestamp`  method to `ActivityInfo` for the `started_time` field from `PollActivityTaskQueueResponse`. This is needed to calculate if the start-to-close timeout has been exceeded.
- Added two new test cases in `ActivityTimeoutTest` and updated an existing test case in `WorkflowClosedRunningActivityTest`

## Why?
<!-- Tell your future self why have you made these changes -->

Because of heartbeat throttling, an activity task can keep running even though it has exceeded its timeouts and is heartbeating. This change moves these failures up in time, for more efficient activity processing and to reduce cases where multiple attempts of the same activity are executing simultaneously.

## Checklist
<!--- add/delete as needed --->

1. Closes #1770 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Ran above unit tests using gradle:
```
./gradlew :temporal-sdk:test --tests "io.temporal.workflow.activityTests.ActivityTimeoutTest"
./gradlew :temporal-sdk:test --tests "io.temporal.workflow.activityTests.cancellation.WorkflowClosedRunningActivityTest.activitySeesActivityNotExistException[*]"

```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

https://docs.temporal.io/dev-guide/java/features#activity-heartbeats