### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,13 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @temporalio/sdk will be requested for review when
+# someone opens a pull request.
 * @temporalio/sdk
+
+# Security team must approve exceptions to static analysis
+# scans, and any custom rules.
+
+.semgrepignore @temporalio/security
+.semgrep/ @temporalio/security


### PR DESCRIPTION
## What was changed
Update CODEOWNERS so that Security can own the Semgrep rules files and paths.

## Why?
We are adding Semgrep for static analysis to this repository, and only the security team should be able to approve exclusions from the policy.

## Checklist

How was this tested:
We ran this scanner on internal repos with this CODEOWNERS file and it worked as expected.