### PR TITLE
Correctly resolve null workflow locals to Optionals

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -594,7 +594,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     if (!runnerLocalMap.containsKey(key)) {
       return Optional.empty();
     }
-    return Optional.of((T) runnerLocalMap.get(key));
+    return Optional.ofNullable((T) runnerLocalMap.get(key));
   }
 
   <T> void setRunnerLocal(RunnerLocalInternal<T> key, T value) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -890,4 +890,14 @@ public class DeterministicRunnerTest {
     d.close();
     assertTrue("Close should return only after the thread finished", threadFinished.get());
   }
+
+  @Test
+  public void testGetRunnerLocalOfNull() {
+    DeterministicRunnerImpl d =
+        new DeterministicRunnerImpl(
+            threadPool::submit, DummySyncWorkflowContext.newDummySyncWorkflowContext(), () -> {});
+    RunnerLocalInternal<String> runnerLocalInternal = new RunnerLocalInternal<>();
+    d.setRunnerLocal(runnerLocalInternal, null);
+    d.getRunnerLocal(runnerLocalInternal);
+  }
 }


### PR DESCRIPTION
Java optional can't itself contain null, so use `ofNullable` to flatten Optionality when retrieving null values from the map of runner locals. 

Closes #1761

## What was changed
Use `ofNullable` to construct Optionals from values that may be null.

## Why?
There are three cases when getting values from a map where nullity matters:
* it's absent
* it's null
* it's non-null

The code handled the first with `empty` and tried to combine the second and third with `of`, (probably) not realizing `of` would not handle the second case.

### But I Don't Want to Call the Supplier

As #1761 points out, calling `get` over and over with no `set` results in repeated supplier calls. That means the supplier must be cheap and ideally pure, or at least idempotent. To me, this means it's fine to call the supplier whenever the locals have a null value. We just can't crash. If the user wants to differentiate between "affirmative absence" and nullity, they can use whatever type they want.

If we want the supplier to be called at most once regardless of what it returns, we're making what could be seen as an API change, albeit a small one. This is just fixing an immediate bug. Does that make sense?

If we want to go that way, I have a [more ambitious](https://github.com/bbqbaron/sdk-java/compare/master...bbqbaron:sdk-java:issue-1761-supplier-reuse?expand=1) branch that tries to disambiguate the cases and invoke the supplier only when needed.

## Checklist

1. Closes #1761

2. How was this tested:

Added a unit test. This code seemed to be untested, so I wasn't sure if there was a preferred/better idiom, but it was incredibly cheap to write, so I did it.
