### PR TITLE
Issue 1761 fix supplier reuse

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -592,7 +592,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
   /**
    * Retrieve data from runner locals. Returns 1. not found (an empty Optional) 2. found but null
    * (an Optional of an empty Optional) 3. found and non-null (an Optional of an Optional of a
-   * value) The type nesting is because Java Optionals cannot understand "Some null" vs "None",
+   * value). The type nesting is because Java Optionals cannot understand "Some null" vs "None",
    * which is exactly what we need here.
    *
    * @param key

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -594,7 +594,7 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     if (!runnerLocalMap.containsKey(key)) {
       return Optional.empty();
     }
-    return Optional.of((T) runnerLocalMap.get(key));
+    return Optional.ofNullable((T) runnerLocalMap.get(key));
   }
 
   <T> void setRunnerLocal(RunnerLocalInternal<T> key, T value) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -589,12 +589,22 @@ class DeterministicRunnerImpl implements DeterministicRunner {
         || !toExecuteInWorkflowThread.isEmpty();
   }
 
+  /**
+   * Retrieve data from runner locals. Returns 1. not found (an empty Optional) 2. found but null
+   * (an Optional of an empty Optional) 3. found and non-null (an Optional of an Optional of a
+   * value) The type nesting is because Java Optionals cannot understand "Some null" vs "None",
+   * which is exactly what we need here.
+   *
+   * @param key
+   * @return one of three cases
+   * @param <T>
+   */
   @SuppressWarnings("unchecked")
-  <T> Optional<T> getRunnerLocal(RunnerLocalInternal<T> key) {
+  <T> Optional<Optional<T>> getRunnerLocal(RunnerLocalInternal<T> key) {
     if (!runnerLocalMap.containsKey(key)) {
       return Optional.empty();
     }
-    return Optional.ofNullable((T) runnerLocalMap.get(key));
+    return Optional.of(Optional.ofNullable((T) runnerLocalMap.get(key)));
   }
 
   <T> void setRunnerLocal(RunnerLocalInternal<T> key, T value) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/RunnerLocalInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/RunnerLocalInternal.java
@@ -24,11 +24,24 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class RunnerLocalInternal<T> {
+  private T supplierResult = null;
+  private boolean supplierCalled = false;
+
+  Optional<T> invokeSupplier(Supplier<? extends T> supplier) {
+    if (!supplierCalled) {
+      T result = supplier.get();
+      supplierCalled = true;
+      supplierResult = result;
+      return Optional.ofNullable(result);
+    } else {
+      return Optional.ofNullable(supplierResult);
+    }
+  }
 
   public T get(Supplier<? extends T> supplier) {
-    Optional<T> result =
+    Optional<Optional<T>> result =
         DeterministicRunnerImpl.currentThreadInternal().getRunner().getRunnerLocal(this);
-    return result.orElse(supplier.get());
+    return result.orElseGet(() -> invokeSupplier(supplier)).orElse(null);
   }
 
   public void set(T value) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThread.java
@@ -120,7 +120,7 @@ public interface WorkflowThread extends CancellationScope {
 
   <T> void setThreadLocal(WorkflowThreadLocalInternal<T> key, T value);
 
-  <T> Optional<T> getThreadLocal(WorkflowThreadLocalInternal<T> key);
+  <T> Optional<Optional<T>> getThreadLocal(WorkflowThreadLocalInternal<T> key);
 
   WorkflowThreadContext getWorkflowThreadContext();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -405,7 +405,7 @@ class WorkflowThreadImpl implements WorkflowThread {
   }
 
   /**
-   * Retrieve data from runner locals. Returns 1. not found (an empty Optional) 2. found but null
+   * Retrieve data from thread locals. Returns 1. not found (an empty Optional) 2. found but null
    * (an Optional of an empty Optional) 3. found and non-null (an Optional of an Optional of a
    * value) The type nesting is because Java Optionals cannot understand "Some null" vs "None",
    * which is exactly what we need here.

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -407,7 +407,7 @@ class WorkflowThreadImpl implements WorkflowThread {
   /**
    * Retrieve data from thread locals. Returns 1. not found (an empty Optional) 2. found but null
    * (an Optional of an empty Optional) 3. found and non-null (an Optional of an Optional of a
-   * value) The type nesting is because Java Optionals cannot understand "Some null" vs "None",
+   * value). The type nesting is because Java Optionals cannot understand "Some null" vs "None",
    * which is exactly what we need here.
    *
    * @param key

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -404,13 +404,22 @@ class WorkflowThreadImpl implements WorkflowThread {
     threadLocalMap.put(key, value);
   }
 
+  /**
+   * Retrieve data from runner locals. Returns 1. not found (an empty Optional) 2. found but null
+   * (an Optional of an empty Optional) 3. found and non-null (an Optional of an Optional of a
+   * value) The type nesting is because Java Optionals cannot understand "Some null" vs "None",
+   * which is exactly what we need here.
+   *
+   * @param key
+   * @return one of three cases
+   * @param <T>
+   */
   @SuppressWarnings("unchecked")
-  @Override
-  public <T> Optional<T> getThreadLocal(WorkflowThreadLocalInternal<T> key) {
+  public <T> Optional<Optional<T>> getThreadLocal(WorkflowThreadLocalInternal<T> key) {
     if (!threadLocalMap.containsKey(key)) {
       return Optional.empty();
     }
-    return Optional.of((T) threadLocalMap.get(key));
+    return Optional.of(Optional.ofNullable((T) threadLocalMap.get(key)));
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/DeterministicRunnerTest.java
@@ -890,4 +890,14 @@ public class DeterministicRunnerTest {
     d.close();
     assertTrue("Close should return only after the thread finished", threadFinished.get());
   }
+
+  @Test
+  public void testGetRunnerLocalOfNull() {
+    DeterministicRunnerImpl d =
+        new DeterministicRunnerImpl(
+            threadPool::submit, DummySyncWorkflowContext.newDummySyncWorkflowContext(), () -> {});
+    RunnerLocalInternal<String> runnerLocalInternal = new RunnerLocalInternal<>();
+    d.setRunnerLocal(runnerLocalInternal, null);
+    d.getRunnerLocal(runnerLocalInternal);
+  }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowLocalsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowLocalsTest.java
@@ -25,96 +25,110 @@ import static org.junit.Assert.assertNull;
 
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
-
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class WorkflowLocalsTest {
 
-    @Rule
-    public SDKTestWorkflowRule testWorkflowRule =
-            SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowLocals.class).build();
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowLocals.class).build();
 
-    @Test
-    public void testWorkflowLocals() {
-        TestWorkflow1 workflowStub =
-                testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
-        String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
-        Assert.assertEquals("result=2, 100", result);
+  @Test
+  public void testWorkflowLocals() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("result=2, 100", result);
+  }
+
+  public static class TestWorkflowLocals implements TestWorkflow1 {
+
+    private final WorkflowThreadLocal<Integer> threadLocal =
+        WorkflowThreadLocal.withInitial(() -> 2);
+
+    private final WorkflowLocal<Integer> workflowLocal = WorkflowLocal.withInitial(() -> 5);
+
+    @Override
+    public String execute(String taskQueue) {
+      assertEquals(2, (int) threadLocal.get());
+      assertEquals(5, (int) workflowLocal.get());
+      Promise<Void> p1 =
+          Async.procedure(
+              () -> {
+                assertEquals(2, (int) threadLocal.get());
+                threadLocal.set(10);
+                Workflow.sleep(Duration.ofSeconds(1));
+                assertEquals(10, (int) threadLocal.get());
+                assertEquals(100, (int) workflowLocal.get());
+              });
+      Promise<Void> p2 =
+          Async.procedure(
+              () -> {
+                assertEquals(2, (int) threadLocal.get());
+                threadLocal.set(22);
+                workflowLocal.set(100);
+                assertEquals(22, (int) threadLocal.get());
+              });
+      p1.get();
+      p2.get();
+      return "result=" + threadLocal.get() + ", " + workflowLocal.get();
     }
+  }
 
-    public static class TestWorkflowLocals implements TestWorkflow1 {
+  public static class TestWorkflowLocalsSupplierReuse implements TestWorkflow1 {
 
-        private final WorkflowThreadLocal<Integer> threadLocal =
-                WorkflowThreadLocal.withInitial(() -> 2);
+    private final AtomicInteger localCalls = new AtomicInteger(0);
+    private final AtomicInteger threadLocalCalls = new AtomicInteger(0);
 
-        private final WorkflowLocal<Integer> workflowLocal = WorkflowLocal.withInitial(() -> 5);
+    private final WorkflowThreadLocal<Integer> workflowThreadLocal =
+        WorkflowThreadLocal.withInitial(
+            () -> {
+              threadLocalCalls.addAndGet(1);
+              return null;
+            });
+    private final WorkflowLocal<Integer> workflowLocal =
+        WorkflowLocal.withInitial(
+            () -> {
+              localCalls.addAndGet(1);
+              return null;
+            });
 
-        @Override
-        public String execute(String taskQueue) {
-            assertEquals(2, (int) threadLocal.get());
-            assertEquals(5, (int) workflowLocal.get());
-            Promise<Void> p1 =
-                    Async.procedure(
-                            () -> {
-                                assertEquals(2, (int) threadLocal.get());
-                                threadLocal.set(10);
-                                Workflow.sleep(Duration.ofSeconds(1));
-                                assertEquals(10, (int) threadLocal.get());
-                                assertEquals(100, (int) workflowLocal.get());
-                            });
-            Promise<Void> p2 =
-                    Async.procedure(
-                            () -> {
-                                assertEquals(2, (int) threadLocal.get());
-                                threadLocal.set(22);
-                                workflowLocal.set(100);
-                                assertEquals(22, (int) threadLocal.get());
-                            });
-            p1.get();
-            p2.get();
-            return "result=" + threadLocal.get() + ", " + workflowLocal.get();
-        }
+    @Override
+    public String execute(String taskQueue) {
+      assertNull(workflowThreadLocal.get());
+      workflowThreadLocal.set(null);
+      assertNull(workflowThreadLocal.get());
+      assertNull(workflowThreadLocal.get());
+      workflowThreadLocal.set(55);
+      assertEquals((long) workflowThreadLocal.get(), 55);
+      assertEquals(threadLocalCalls.get(), 1);
+
+      assertNull(workflowLocal.get());
+      workflowLocal.set(null);
+      assertNull(workflowLocal.get());
+      assertNull(workflowLocal.get());
+      workflowLocal.set(58);
+      assertEquals((long) workflowLocal.get(), 58);
+      assertEquals(localCalls.get(), 1);
+      return "ok";
     }
+  }
 
-    public static class TestWorkflowLocalsNullIsNotAbsent implements TestWorkflow1 {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRuleSupplierReuse =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowLocalsSupplierReuse.class)
+          .build();
 
-        private final AtomicInteger localCalls = new AtomicInteger(0);
-        private final WorkflowLocal<Integer> workflowLocal =
-                WorkflowLocal.withInitial(
-                        () -> {
-                            localCalls.addAndGet(1);
-                            return null;
-                        });
-
-        @Override
-        public String execute(String taskQueue) {
-            assertNull(workflowLocal.get());
-            workflowLocal.set(null);
-            assertNull(workflowLocal.get());
-            assertNull(workflowLocal.get());
-            workflowLocal.set(58);
-            assertEquals((long) workflowLocal.get(), 58);
-            assertEquals(localCalls.get(), 1);
-            return "ok";
-        }
-    }
-
-    @Rule
-    public SDKTestWorkflowRule testWorkflowRuleNullIsNotAbsent =
-            SDKTestWorkflowRule.newBuilder()
-                    .setWorkflowTypes(TestWorkflowLocalsNullIsNotAbsent.class)
-                    .build();
-
-    @Test
-    public void testWorkflowLocalsNullIsNotAbsent() {
-        TestWorkflow1 workflowStub =
-                testWorkflowRuleNullIsNotAbsent.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
-        String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
-        Assert.assertEquals("ok", result);
-    }
+  @Test
+  public void testWorkflowLocalsSupplierReuse() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRuleSupplierReuse.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("ok", result);
+  }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowLocalsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowLocalsTest.java
@@ -21,59 +21,100 @@
 package io.temporal.workflow;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class WorkflowLocalsTest {
 
-  @Rule
-  public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowLocals.class).build();
+    @Rule
+    public SDKTestWorkflowRule testWorkflowRule =
+            SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowLocals.class).build();
 
-  @Test
-  public void testWorkflowLocals() {
-    TestWorkflow1 workflowStub =
-        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
-    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
-    Assert.assertEquals("result=2, 100", result);
-  }
-
-  public static class TestWorkflowLocals implements TestWorkflow1 {
-
-    private final WorkflowThreadLocal<Integer> threadLocal =
-        WorkflowThreadLocal.withInitial(() -> 2);
-
-    private final WorkflowLocal<Integer> workflowLocal = WorkflowLocal.withInitial(() -> 5);
-
-    @Override
-    public String execute(String taskQueue) {
-      assertEquals(2, (int) threadLocal.get());
-      assertEquals(5, (int) workflowLocal.get());
-      Promise<Void> p1 =
-          Async.procedure(
-              () -> {
-                assertEquals(2, (int) threadLocal.get());
-                threadLocal.set(10);
-                Workflow.sleep(Duration.ofSeconds(1));
-                assertEquals(10, (int) threadLocal.get());
-                assertEquals(100, (int) workflowLocal.get());
-              });
-      Promise<Void> p2 =
-          Async.procedure(
-              () -> {
-                assertEquals(2, (int) threadLocal.get());
-                threadLocal.set(22);
-                workflowLocal.set(100);
-                assertEquals(22, (int) threadLocal.get());
-              });
-      p1.get();
-      p2.get();
-      return "result=" + threadLocal.get() + ", " + workflowLocal.get();
+    @Test
+    public void testWorkflowLocals() {
+        TestWorkflow1 workflowStub =
+                testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+        String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+        Assert.assertEquals("result=2, 100", result);
     }
-  }
+
+    public static class TestWorkflowLocals implements TestWorkflow1 {
+
+        private final WorkflowThreadLocal<Integer> threadLocal =
+                WorkflowThreadLocal.withInitial(() -> 2);
+
+        private final WorkflowLocal<Integer> workflowLocal = WorkflowLocal.withInitial(() -> 5);
+
+        @Override
+        public String execute(String taskQueue) {
+            assertEquals(2, (int) threadLocal.get());
+            assertEquals(5, (int) workflowLocal.get());
+            Promise<Void> p1 =
+                    Async.procedure(
+                            () -> {
+                                assertEquals(2, (int) threadLocal.get());
+                                threadLocal.set(10);
+                                Workflow.sleep(Duration.ofSeconds(1));
+                                assertEquals(10, (int) threadLocal.get());
+                                assertEquals(100, (int) workflowLocal.get());
+                            });
+            Promise<Void> p2 =
+                    Async.procedure(
+                            () -> {
+                                assertEquals(2, (int) threadLocal.get());
+                                threadLocal.set(22);
+                                workflowLocal.set(100);
+                                assertEquals(22, (int) threadLocal.get());
+                            });
+            p1.get();
+            p2.get();
+            return "result=" + threadLocal.get() + ", " + workflowLocal.get();
+        }
+    }
+
+    public static class TestWorkflowLocalsNullIsNotAbsent implements TestWorkflow1 {
+
+        private final AtomicInteger localCalls = new AtomicInteger(0);
+        private final WorkflowLocal<Integer> workflowLocal =
+                WorkflowLocal.withInitial(
+                        () -> {
+                            localCalls.addAndGet(1);
+                            return null;
+                        });
+
+        @Override
+        public String execute(String taskQueue) {
+            assertNull(workflowLocal.get());
+            workflowLocal.set(null);
+            assertNull(workflowLocal.get());
+            assertNull(workflowLocal.get());
+            workflowLocal.set(58);
+            assertEquals((long) workflowLocal.get(), 58);
+            assertEquals(localCalls.get(), 1);
+            return "ok";
+        }
+    }
+
+    @Rule
+    public SDKTestWorkflowRule testWorkflowRuleNullIsNotAbsent =
+            SDKTestWorkflowRule.newBuilder()
+                    .setWorkflowTypes(TestWorkflowLocalsNullIsNotAbsent.class)
+                    .build();
+
+    @Test
+    public void testWorkflowLocalsNullIsNotAbsent() {
+        TestWorkflow1 workflowStub =
+                testWorkflowRuleNullIsNotAbsent.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+        String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+        Assert.assertEquals("ok", result);
+    }
 }


### PR DESCRIPTION
See https://github.com/temporalio/sdk-java/pull/1777 for background/most thoughts. This is the more ambitious fix that tries to resolve the "not set"/"null" ambiguity.

Closes #1761 

Nested `Optional` didn't feel great, but I preferred it over the other solutions like "an `Optional` that is also nullable".