### PR TITLE
Treat UpdateWorkflowExecution as a long poll

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClient.java
@@ -40,7 +40,8 @@ public interface GenericWorkflowClient {
   QueryWorkflowResponse query(QueryWorkflowRequest queryParameters);
 
   @Experimental
-  UpdateWorkflowExecutionResponse update(UpdateWorkflowExecutionRequest updateParameters);
+  UpdateWorkflowExecutionResponse update(
+      @Nonnull UpdateWorkflowExecutionRequest updateParameters, @Nonnull Deadline deadline);
 
   @Experimental
   CompletableFuture<PollWorkflowExecutionUpdateResponse> pollUpdateAsync(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
@@ -318,7 +318,8 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
   }
 
   @Override
-  public UpdateWorkflowExecutionResponse update(UpdateWorkflowExecutionRequest updateParameters) {
+  public UpdateWorkflowExecutionResponse update(
+      @Nonnull UpdateWorkflowExecutionRequest updateParameters, @Nonnull Deadline deadline) {
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(1)
             .put(MetricsTag.UPDATE_NAME, updateParameters.getRequest().getInput().getName())
@@ -329,9 +330,10 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
         () ->
             service
                 .blockingStub()
+                .withDeadline(deadline)
                 .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, scope)
                 .updateWorkflowExecution(updateParameters),
-        grpcRetryerOptions);
+        new GrpcRetryer.GrpcRetryerOptions(DefaultStubLongPollRpcRetryOptions.INSTANCE, deadline));
   }
 
   @Override

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/LongPollUtil.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/LongPollUtil.java
@@ -30,6 +30,7 @@ class LongPollUtil {
       MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
     if (method == WorkflowServiceGrpc.getPollWorkflowTaskQueueMethod()
         || method == WorkflowServiceGrpc.getPollActivityTaskQueueMethod()
+        || method == WorkflowServiceGrpc.getUpdateWorkflowExecutionMethod()
         || method == WorkflowServiceGrpc.getPollWorkflowExecutionUpdateMethod()) {
       return true;
     }


### PR DESCRIPTION
Treat `UpdateWorkflowExecution` as a long poll.

See also https://github.com/temporalio/sdk-go/pull/1123