### PR TITLE
Generate bom using java-platform plugin

### DIFF
--- a/gradle/dependencyManagement.gradle
+++ b/gradle/dependencyManagement.gradle
@@ -1,4 +1,7 @@
 subprojects {
+    if (name == 'temporal-bom') {
+        return
+    }
     configurations.implementation {
         // add global exclusions here if needed
     }

--- a/gradle/gatherDependencies.gradle
+++ b/gradle/gatherDependencies.gradle
@@ -1,4 +1,7 @@
 subprojects {
+    if (name == 'temporal-bom') {
+        return
+    }
     // Creates build/runtimeDeps folder in each module that contains all the dependencies
     // that need to be in the runtime classpath of the module
     task gatherRuntimeDeps(type: Copy) {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,4 +1,7 @@
 subprojects {
+    if (name == 'temporal-bom') {
+        return
+    }
     apply plugin: 'java-library'
 
     java {

--- a/gradle/licensing.gradle
+++ b/gradle/licensing.gradle
@@ -1,4 +1,7 @@
 subprojects {
+    if (name == 'temporal-bom') {
+        return
+    }
     apply plugin: 'org.cadixdev.licenser'
     license {
         header rootProject.file('LICENSE.header')

--- a/gradle/linting.gradle
+++ b/gradle/linting.gradle
@@ -1,4 +1,7 @@
 subprojects {
+    if (name == 'temporal-bom') {
+        return
+    }
     apply plugin: 'com.diffplug.spotless'
 
     spotless {

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -16,7 +16,12 @@ subprojects {
         publications {
             mavenJava(MavenPublication) {
                 afterEvaluate {
-                    from components.java
+                    plugins.withId('java-platform') {
+                        from components.javaPlatform
+                    }
+                    plugins.withId('java') {
+                        from components.java
+                    }
                 }
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name='temporal-java-sdk'
+include 'temporal-bom'
 include 'temporal-serviceclient'
 include 'temporal-sdk'
 include 'temporal-testing'

--- a/temporal-bom/build.gradle
+++ b/temporal-bom/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'java-platform'
+}
+
+dependencies {
+    constraints {
+        api project(':temporal-kotlin')
+        api project(':temporal-opentracing')
+        api project(':temporal-remote-data-encoder')
+        api project(':temporal-sdk')
+        api project(':temporal-serviceclient')
+        api project(':temporal-shaded')
+        api project(':temporal-spring-boot-autoconfigure-alpha')
+        api project(':temporal-spring-boot-starter-alpha')
+        api project(':temporal-test-server')
+        api project(':temporal-testing')
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added a `temporal-bom` subproject that publishes a bom using Gradle's [java-platform plugin](https://docs.gradle.org/current/userguide/java_platform_plugin.html).

Most of the script plugins (`dependencyManagement.gradle`, `java.gradle`, etc) are built around the assumption each module is a java module. I excluded this project by name for this change.

## Why?
BOMs are useful for keeping versions aligned, especially when they are brought in only as transitive dependencies.

Example without a bom:
```
runtimeClasspath
+--- org.example:some-library:1.0.0
|    +--- io.temporal:temporal-serviceclient:1.15 (misaligned)
\--- io.temporal:temporal-sdk:1.20
```

Other examples of java libraries producing similar boms: [junit-bom](https://repo1.maven.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom), [okhttp-bom](https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp-bom/4.11.0/okhttp-bom-4.11.0.pom)
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

How was this tested:

I ran `./gradlew :temporal-bom:generatePomFileForMavenJavaPublication` and viewed the generated pom was expected.

<!--- Please describe how you tested your changes/how we can test them -->

Any docs updates needed?

Possibly an example of usage:

```gradle
dependencies {
    implementation platform('io.temporal:temporal-bom:1.21.0-SNAPSHOT')
    implementation 'io.temporal:temporal-sdk' // no version necessary
    implementation 'io.temporal:temporal-remote-data-encoder'
    testImplementation 'io.temporal:temporal-testing'
}
```
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
