### PR TITLE
Expose started time in ActivityInfo

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityInfo.java
@@ -67,6 +67,13 @@ public interface ActivityInfo {
   long getScheduledTimestamp();
 
   /**
+   * Time when the Activity Task (current attempt) was started.
+   *
+   * @return Timestamp in milliseconds (UNIX Epoch time)
+   */
+  long getStartedTimestamp();
+
+  /**
    * Time when the Activity Task (current attempt) was scheduled by the Temporal Server.
    *
    * @return Timestamp in milliseconds (UNIX Epoch time)

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityInfoImpl.java
@@ -83,6 +83,11 @@ final class ActivityInfoImpl implements ActivityInfoInternal {
   }
 
   @Override
+  public long getStartedTimestamp() {
+    return Timestamps.toMillis(response.getStartedTime());
+  }
+
+  @Override
   public long getCurrentAttemptScheduledTimestamp() {
     return Timestamps.toMillis(response.getCurrentAttemptScheduledTime());
   }
@@ -183,6 +188,8 @@ final class ActivityInfoImpl implements ActivityInfoInternal {
         + getActivityType()
         + ", scheduledTimestamp="
         + getScheduledTimestamp()
+        + ", startedTimestamp="
+        + getStartedTimestamp()
         + ", currentAttemptScheduledTimestamp="
         + getCurrentAttemptScheduledTimestamp()
         + ", scheduleToCloseTimeout="


### PR DESCRIPTION
Expose started time in `ActivityInfo`

closes https://github.com/temporalio/sdk-java/issues/1797

