### PR TITLE
Add support for SDK metadata to test server

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1405,6 +1405,7 @@ class StateMachines {
             .setIdentity(request.getIdentity())
             .setBinaryChecksum(request.getBinaryChecksum())
             .setMeteringMetadata(request.getMeteringMetadata())
+            .setSdkMetadata(request.getSdkMetadata())
             .setScheduledEventId(data.scheduledEventId);
     HistoryEvent event =
         HistoryEvent.newBuilder()

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -509,6 +509,23 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     }
   }
 
+  @Override
+  public void getSystemInfo(
+      GetSystemInfoRequest request, StreamObserver<GetSystemInfoResponse> responseObserver) {
+    responseObserver.onNext(
+        GetSystemInfoResponse.newBuilder()
+            .setCapabilities(
+                // These are the capabilities I could verify the test server supports
+                GetSystemInfoResponse.Capabilities.newBuilder()
+                    .setSdkMetadata(true)
+                    .setSignalAndQueryHeader(true)
+                    .setEncodedFailureAttributes(true)
+                    .setEagerWorkflowStart(true)
+                    .build())
+            .build());
+    responseObserver.onCompleted();
+  }
+
   private Context.CancellableContext deadlineCtx(Deadline deadline) {
     return Context.current().withDeadline(deadline, this.backgroundScheduler);
   }


### PR DESCRIPTION
Add support for SDK metadata to the test server and reflect that in system info. Needed to implement SDKFlags

close https://github.com/temporalio/sdk-java/issues/1746