### PR TITLE
Enable Infinitely Retrying Local Activity

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -140,6 +140,10 @@ final class LocalActivityWorker implements Startable, Shutdownable {
       throw (Error) attemptThrowable;
     }
 
+    if (isRetryPolicyNotSet(activityTask)) {
+      return new RetryDecision(RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET, null);
+    }
+
     RetryOptions retryOptions = RetryOptionsUtils.toRetryOptions(activityTask.getRetryPolicy());
 
     if (RetryOptionsUtils.isNotRetryable(retryOptions, attemptThrowable)) {
@@ -370,6 +374,10 @@ final class LocalActivityWorker implements Startable, Shutdownable {
         PollActivityTaskQueueResponseOrBuilder activityTask,
         @Nullable Failure previousLocalExecutionFailure) {
       int currentAttempt = activityTask.getAttempt();
+
+      if (isRetryPolicyNotSet(activityTask)) {
+        return RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET;
+      }
 
       RetryOptions retryOptions = RetryOptionsUtils.toRetryOptions(activityTask.getRetryPolicy());
 
@@ -754,6 +762,14 @@ final class LocalActivityWorker implements Startable, Shutdownable {
       result.setCause(cause);
     }
     return result.build();
+  }
+
+  private static boolean isRetryPolicyNotSet(
+      PollActivityTaskQueueResponseOrBuilder pollActivityTask) {
+    return !pollActivityTask.hasScheduleToCloseTimeout()
+        && !pollActivityTask.hasStartToCloseTimeout()
+        && (!pollActivityTask.hasRetryPolicy()
+            || pollActivityTask.getRetryPolicy().getMaximumAttempts() <= 0);
   }
 
   private static boolean isNonRetryableApplicationFailure(@Nullable Throwable executionThrowable) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -140,10 +140,6 @@ final class LocalActivityWorker implements Startable, Shutdownable {
       throw (Error) attemptThrowable;
     }
 
-    if (isRetryPolicyNotSet(activityTask)) {
-      return new RetryDecision(RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET, null);
-    }
-
     RetryOptions retryOptions = RetryOptionsUtils.toRetryOptions(activityTask.getRetryPolicy());
 
     if (RetryOptionsUtils.isNotRetryable(retryOptions, attemptThrowable)) {
@@ -374,10 +370,6 @@ final class LocalActivityWorker implements Startable, Shutdownable {
         PollActivityTaskQueueResponseOrBuilder activityTask,
         @Nullable Failure previousLocalExecutionFailure) {
       int currentAttempt = activityTask.getAttempt();
-
-      if (isRetryPolicyNotSet(activityTask)) {
-        return RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET;
-      }
 
       RetryOptions retryOptions = RetryOptionsUtils.toRetryOptions(activityTask.getRetryPolicy());
 
@@ -762,13 +754,6 @@ final class LocalActivityWorker implements Startable, Shutdownable {
       result.setCause(cause);
     }
     return result.build();
-  }
-
-  private static boolean isRetryPolicyNotSet(
-      PollActivityTaskQueueResponseOrBuilder pollActivityTask) {
-    return !pollActivityTask.hasScheduleToCloseTimeout()
-        && (!pollActivityTask.hasRetryPolicy()
-            || pollActivityTask.getRetryPolicy().getMaximumAttempts() <= 0);
   }
 
   private static boolean isNonRetryableApplicationFailure(@Nullable Throwable executionThrowable) {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServiceRetryState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServiceRetryState.java
@@ -109,6 +109,10 @@ final class TestServiceRetryState {
         }
       }
     }
+    Timestamp expirationTime = getExpirationTime();
+    if (retryPolicy.getMaximumAttempts() == 0 && Timestamps.toMillis(expirationTime) == 0) {
+      return new BackoffInterval(RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET);
+    }
 
     if (retryPolicy.getMaximumAttempts() > 0 && getAttempt() >= retryPolicy.getMaximumAttempts()) {
       // currAttempt starts from 1.
@@ -133,7 +137,6 @@ final class TestServiceRetryState {
       nextInterval = maxInterval;
     }
 
-    Timestamp expirationTime = getExpirationTime();
     long backoffInterval = nextInterval;
     Timestamp nextScheduleTime = Timestamps.add(currentTime, Durations.fromMillis(backoffInterval));
     if (expirationTime.getNanos() != 0

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServiceRetryState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServiceRetryState.java
@@ -109,10 +109,6 @@ final class TestServiceRetryState {
         }
       }
     }
-    Timestamp expirationTime = getExpirationTime();
-    if (retryPolicy.getMaximumAttempts() == 0 && Timestamps.toMillis(expirationTime) == 0) {
-      return new BackoffInterval(RetryState.RETRY_STATE_RETRY_POLICY_NOT_SET);
-    }
 
     if (retryPolicy.getMaximumAttempts() > 0 && getAttempt() >= retryPolicy.getMaximumAttempts()) {
       // currAttempt starts from 1.
@@ -137,6 +133,7 @@ final class TestServiceRetryState {
       nextInterval = maxInterval;
     }
 
+    Timestamp expirationTime = getExpirationTime();
     long backoffInterval = nextInterval;
     Timestamp nextScheduleTime = Timestamps.add(currentTime, Durations.fromMillis(backoffInterval));
     if (expirationTime.getNanos() != 0


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->
Setting setMaximumAttempts=0 (or not setting any value, default = 0) for local activities make the activity not retry at all. 

There is no way to enable infinite retries for local activities 

This is inconsistent with non-local/normal activity retry behavior  

https://github.com/temporalio/sdk-java/issues/1727

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
https://github.com/temporalio/sdk-java/issues/1727

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Tested by running java samples with this change  https://github.com/temporalio/samples-java 

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Nope
