### PR TITLE
Release 1.20.1

### DIFF
--- a/releases/v1.20.1
+++ b/releases/v1.20.1
@@ -1,0 +1,12 @@
+# Highlights
+
+Default implementation for exceptionToFailure and failureToException to fix an unintentional breaking change
+in the DataConverter interface.
+
+# Changeset
+
+2023-06-27 - 57cb086f - Add support for SDK metadata to test server (#1800)
+2023-06-27 - c6aadda8 - Expose started time in ActivityInfo (#1798)
+2023-06-29 - 9a457157 - Generate bom using java-platform plugin (#1796)
+2023-07-03 - 15337d9a - Add Semgrep scanning (#1775)
+2023-07-10 - 25387be8 - Add default methods for exceptionToFailure and failureToException (#1809)


### PR DESCRIPTION
# Highlights

Default implementation for exceptionToFailure and failureToException to fix an unintentional breaking change
in the DataConverter interface.

# Changeset

2023-06-27 - 57cb086f - Add support for SDK metadata to test server (#1800)
2023-06-27 - c6aadda8 - Expose started time in ActivityInfo (#1798)
2023-06-29 - 9a457157 - Generate bom using java-platform plugin (#1796)
2023-07-03 - 15337d9a - Add Semgrep scanning (#1775)
2023-07-10 - 25387be8 - Add default methods for exceptionToFailure and failureToException (#1809)
