### PR TITLE
fix(schedule): try catch clause and rethrow StatusRuntimeException that does not match status c…

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client.schedules;
+
+import io.temporal.failure.TemporalException;
+
+/** Exception thrown by client when attempting to create a schedule. */
+public final class ScheduleException extends TemporalException {
+  public ScheduleException(Throwable cause) {
+    super("Schedule exception", cause);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
@@ -105,7 +105,7 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
       if (Status.Code.ALREADY_EXISTS.equals(e.getStatus().getCode())) {
         throw new ScheduleAlreadyRunningException(e);
       } else {
-        throw e;
+        throw new ScheduleException(e);
       }
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
@@ -102,8 +102,8 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
     try {
       genericClient.createSchedule(request.build());
     } catch (StatusRuntimeException e) {
-      if (Status.Code.ALREADY_EXISTS.equals(sre.getStatus().getCode())) {
-        throw new ScheduleAlreadyRunningException(sre);
+      if (Status.Code.ALREADY_EXISTS.equals(e.getStatus().getCode())) {
+        throw new ScheduleAlreadyRunningException(e);
       } else {
         throw e;
       }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
@@ -101,12 +101,11 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
 
     try {
       genericClient.createSchedule(request.build());
-    } catch (Exception e) {
-      if (e instanceof StatusRuntimeException) {
-        StatusRuntimeException sre = (StatusRuntimeException) e;
-        if (Status.Code.ALREADY_EXISTS.equals(sre.getStatus().getCode())) {
-          throw new ScheduleAlreadyRunningException(sre);
-        }
+    } catch (StatusRuntimeException e) {
+      if (Status.Code.ALREADY_EXISTS.equals(sre.getStatus().getCode())) {
+        throw new ScheduleAlreadyRunningException(sre);
+      } else {
+        throw e;
       }
     }
   }


### PR DESCRIPTION
…ode ALREADY_EXISTS

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Should resolve #1817
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
