### PR TITLE
Block mutating workflow state in a read only context

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandler.java
@@ -25,6 +25,7 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.common.MethodRetry;
 import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
 import io.temporal.workflow.ActivityStub;
+import io.temporal.workflow.Functions;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -36,26 +37,30 @@ public class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
   private final ActivityOptions options;
   private final Map<String, ActivityOptions> activityMethodOptions;
   private final WorkflowOutboundCallsInterceptor activityExecutor;
+  private final Functions.Proc assertReadOnly;
 
   @VisibleForTesting
   public static InvocationHandler newInstance(
       Class<?> activityInterface,
       ActivityOptions options,
       Map<String, ActivityOptions> methodOptions,
-      WorkflowOutboundCallsInterceptor activityExecutor) {
+      WorkflowOutboundCallsInterceptor activityExecutor,
+      Functions.Proc assertReadOnly) {
     return new ActivityInvocationHandler(
-        activityInterface, activityExecutor, options, methodOptions);
+        activityInterface, activityExecutor, options, methodOptions, assertReadOnly);
   }
 
   private ActivityInvocationHandler(
       Class<?> activityInterface,
       WorkflowOutboundCallsInterceptor activityExecutor,
       ActivityOptions options,
-      Map<String, ActivityOptions> methodOptions) {
+      Map<String, ActivityOptions> methodOptions,
+      Functions.Proc assertReadOnly) {
     super(activityInterface);
     this.options = options;
     this.activityMethodOptions = (methodOptions == null) ? new HashMap<>() : methodOptions;
     this.activityExecutor = activityExecutor;
+    this.assertReadOnly = assertReadOnly;
   }
 
   @Override
@@ -73,7 +78,7 @@ public class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
               + activityName
               + " activity. Please set at least one of the above through the ActivityStub or WorkflowImplementationOptions.");
     }
-    ActivityStub stub = ActivityStubImpl.newInstance(merged, activityExecutor);
+    ActivityStub stub = ActivityStubImpl.newInstance(merged, activityExecutor, assertReadOnly);
     function =
         (a) -> stub.execute(activityName, method.getReturnType(), method.getGenericReturnType(), a);
     return function;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityStubImpl.java
@@ -24,28 +24,37 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.common.interceptors.Header;
 import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
 import io.temporal.workflow.ActivityStub;
+import io.temporal.workflow.Functions;
 import io.temporal.workflow.Promise;
 import java.lang.reflect.Type;
 
 final class ActivityStubImpl extends ActivityStubBase {
   protected final ActivityOptions options;
   private final WorkflowOutboundCallsInterceptor activityExecutor;
+  private final Functions.Proc assertReadOnly;
 
   static ActivityStub newInstance(
-      ActivityOptions options, WorkflowOutboundCallsInterceptor activityExecutor) {
+      ActivityOptions options,
+      WorkflowOutboundCallsInterceptor activityExecutor,
+      Functions.Proc assertReadOnly) {
     ActivityOptions validatedOptions =
         ActivityOptions.newBuilder(options).validateAndBuildWithDefaults();
-    return new ActivityStubImpl(validatedOptions, activityExecutor);
+    return new ActivityStubImpl(validatedOptions, activityExecutor, assertReadOnly);
   }
 
-  ActivityStubImpl(ActivityOptions options, WorkflowOutboundCallsInterceptor activityExecutor) {
+  ActivityStubImpl(
+      ActivityOptions options,
+      WorkflowOutboundCallsInterceptor activityExecutor,
+      Functions.Proc assertReadOnly) {
     this.options = options;
     this.activityExecutor = activityExecutor;
+    this.assertReadOnly = assertReadOnly;
   }
 
   @Override
   public <R> Promise<R> executeAsync(
       String activityName, Class<R> resultClass, Type resultType, Object... args) {
+    this.assertReadOnly.apply();
     return activityExecutor
         .executeActivity(
             new WorkflowOutboundCallsInterceptor.ActivityInput<>(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowInvocationHandler.java
@@ -30,6 +30,7 @@ import io.temporal.common.metadata.POJOWorkflowMethodMetadata;
 import io.temporal.common.metadata.WorkflowMethodType;
 import io.temporal.workflow.ChildWorkflowOptions;
 import io.temporal.workflow.ChildWorkflowStub;
+import io.temporal.workflow.Functions;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -43,7 +44,8 @@ class ChildWorkflowInvocationHandler implements InvocationHandler {
   ChildWorkflowInvocationHandler(
       Class<?> workflowInterface,
       ChildWorkflowOptions options,
-      WorkflowOutboundCallsInterceptor outboundCallsInterceptor) {
+      WorkflowOutboundCallsInterceptor outboundCallsInterceptor,
+      Functions.Proc1<String> assertReadOnly) {
     workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowInterface);
     Optional<POJOWorkflowMethodMetadata> workflowMethodMetadata =
         workflowMetadata.getWorkflowMethod();
@@ -61,7 +63,10 @@ class ChildWorkflowInvocationHandler implements InvocationHandler {
             .validateAndBuildWithDefaults();
     this.stub =
         new ChildWorkflowStubImpl(
-            workflowMethodMetadata.get().getName(), merged, outboundCallsInterceptor);
+            workflowMethodMetadata.get().getName(),
+            merged,
+            outboundCallsInterceptor,
+            assertReadOnly);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowInvocationHandler.java
@@ -25,6 +25,7 @@ import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
 import io.temporal.common.metadata.POJOWorkflowInterfaceMetadata;
 import io.temporal.common.metadata.POJOWorkflowMethodMetadata;
 import io.temporal.workflow.ExternalWorkflowStub;
+import io.temporal.workflow.Functions;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
@@ -37,9 +38,11 @@ class ExternalWorkflowInvocationHandler implements InvocationHandler {
   public ExternalWorkflowInvocationHandler(
       Class<?> workflowInterface,
       WorkflowExecution execution,
-      WorkflowOutboundCallsInterceptor workflowOutboundCallsInterceptor) {
-    workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowInterface);
-    stub = new ExternalWorkflowStubImpl(execution, workflowOutboundCallsInterceptor);
+      WorkflowOutboundCallsInterceptor workflowOutboundCallsInterceptor,
+      Functions.Proc1<String> assertReadOnly) {
+    this.workflowMetadata = POJOWorkflowInterfaceMetadata.newInstance(workflowInterface);
+    this.stub =
+        new ExternalWorkflowStubImpl(execution, workflowOutboundCallsInterceptor, assertReadOnly);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowStubImpl.java
@@ -22,10 +22,7 @@ package io.temporal.internal.sync;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
-import io.temporal.workflow.CancelExternalWorkflowException;
-import io.temporal.workflow.ExternalWorkflowStub;
-import io.temporal.workflow.Promise;
-import io.temporal.workflow.SignalExternalWorkflowException;
+import io.temporal.workflow.*;
 import java.util.Objects;
 
 /** Dynamic implementation of a strongly typed child workflow interface. */
@@ -33,11 +30,15 @@ class ExternalWorkflowStubImpl implements ExternalWorkflowStub {
 
   private final WorkflowOutboundCallsInterceptor outboundCallsInterceptor;
   private final WorkflowExecution execution;
+  private Functions.Proc1<String> assertReadOnly;
 
   public ExternalWorkflowStubImpl(
-      WorkflowExecution execution, WorkflowOutboundCallsInterceptor outboundCallsInterceptor) {
+      WorkflowExecution execution,
+      WorkflowOutboundCallsInterceptor outboundCallsInterceptor,
+      Functions.Proc1<String> assertReadOnly) {
     this.outboundCallsInterceptor = Objects.requireNonNull(outboundCallsInterceptor);
     this.execution = Objects.requireNonNull(execution);
+    this.assertReadOnly = assertReadOnly;
   }
 
   @Override
@@ -47,6 +48,7 @@ class ExternalWorkflowStubImpl implements ExternalWorkflowStub {
 
   @Override
   public void signal(String signalName, Object... args) {
+    assertReadOnly.apply("signal external workflow");
     Promise<Void> signaled =
         outboundCallsInterceptor
             .signalExternalWorkflow(
@@ -69,6 +71,7 @@ class ExternalWorkflowStubImpl implements ExternalWorkflowStub {
 
   @Override
   public void cancel() {
+    assertReadOnly.apply("cancel external workflow");
     Promise<Void> cancelRequested =
         outboundCallsInterceptor
             .cancelWorkflow(new WorkflowOutboundCallsInterceptor.CancelWorkflowInput(execution))

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -157,10 +157,13 @@ class SyncWorkflow implements ReplayWorkflow {
               // TODO(https://github.com/temporalio/sdk-java/issues/1748) handleValidateUpdate
               // should not just be run
               // in a workflow thread
+              workflowContext.setReadOnly(true);
               workflowProc.handleValidateUpdate(updateName, input, eventId);
             } catch (Exception e) {
               callbacks.reject(this.dataConverter.exceptionToFailure(e));
               return;
+            } finally {
+              workflowContext.setReadOnly(false);
             }
           }
           callbacks.accept();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BadMutableSideEffectTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BadMutableSideEffectTest.java
@@ -1,0 +1,50 @@
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertThrows;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BadMutableSideEffectTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(Error.class)
+                  .build(),
+              TestSideEffectWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testBadMutableSideEffect() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    for (String testCase : TestWorkflows.illegalCallCases) {
+      assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(testCase));
+    }
+  }
+
+  public static class TestSideEffectWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String testCase) {
+      Workflow.mutableSideEffect(
+          "id",
+          int.class,
+          (Integer i, Integer j) -> {
+            return i.equals(j);
+          },
+          () -> {
+            TestWorkflows.illegalCalls(testCase);
+            return 0;
+          });
+      return "";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BadMutableSideEffectTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BadMutableSideEffectTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow;
 
 import static org.junit.Assert.assertThrows;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BadSideEffectTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BadSideEffectTest.java
@@ -1,0 +1,46 @@
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertThrows;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BadSideEffectTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(Error.class)
+                  .build(),
+              TestSideEffectWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testBadSideEffect() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    for (String testCase : TestWorkflows.illegalCallCases) {
+      assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(testCase));
+    }
+  }
+
+  public static class TestSideEffectWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String testCase) {
+      Workflow.sideEffect(
+          void.class,
+          () -> {
+            TestWorkflows.illegalCalls(testCase);
+            return null;
+          });
+      return "";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/BadSideEffectTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/BadSideEffectTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow;
 
 import static org.junit.Assert.assertThrows;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateBadValidator.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateBadValidator.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow.updateTest;
 
 import static org.junit.Assert.assertEquals;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateBadValidator.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateBadValidator.java
@@ -1,0 +1,114 @@
+package io.temporal.workflow.updateTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import io.temporal.activity.*;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.*;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.workflow.CompletablePromise;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpdateBadValidator {
+
+  private static final Logger log = LoggerFactory.getLogger(UpdateTest.class);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkerOptions(WorkerOptions.newBuilder().build())
+          .setWorkflowTypes(TestUpdateWithBadValidatorWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testBadUpdateValidator() {
+    String workflowId = UUID.randomUUID().toString();
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .setWorkflowId(workflowId)
+            .build();
+    TestWorkflows.WorkflowWithUpdate workflow =
+        workflowClient.newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    // To execute workflow client.execute() would do. But we want to start workflow and immediately
+    // return.
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+
+    SDKTestWorkflowRule.waitForOKQuery(workflow);
+    assertEquals("initial", workflow.getState());
+
+    assertEquals(workflowId, execution.getWorkflowId());
+
+    for (String testCase : TestWorkflows.illegalCallCases) {
+      assertThrows(WorkflowUpdateException.class, () -> workflow.update(0, testCase));
+    }
+
+    workflow.complete();
+
+    String result =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(execution, Optional.empty())
+            .getResult(String.class);
+    assertEquals("", result);
+  }
+
+  public static class TestUpdateWithBadValidatorWorkflowImpl
+      implements TestWorkflows.WorkflowWithUpdate {
+    String state = "initial";
+    CompletablePromise<Void> promise = Workflow.newPromise();
+
+    @Override
+    public String execute() {
+      promise.get();
+      return "";
+    }
+
+    @Override
+    public String getState() {
+      return state;
+    }
+
+    @Override
+    public String update(Integer index, String value) {
+      return "";
+    }
+
+    @Override
+    public void updateValidator(Integer index, String testCase) {
+      TestWorkflows.illegalCalls(testCase);
+    }
+
+    @Override
+    public void complete() {
+      promise.complete(null);
+    }
+
+    @Override
+    public void completeValidator() {}
+  }
+
+  @ActivityInterface
+  public interface GreetingActivities {
+    @ActivityMethod
+    String hello(String input);
+  }
+
+  public static class ActivityImpl implements TestActivities.TestActivity1 {
+    @Override
+    public String execute(String input) {
+      return Activity.getExecutionContext().getInfo().getActivityType() + "-" + input;
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -190,7 +190,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
             .build();
     InvocationHandler invocationHandler =
         ActivityInvocationHandler.newInstance(
-            activityInterface, options, null, new TestActivityExecutor());
+            activityInterface, options, null, new TestActivityExecutor(), () -> {});
     invocationHandler =
         new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor::submit);
     return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
@@ -206,7 +206,7 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
   public <T> T newActivityStub(Class<T> activityInterface, ActivityOptions options) {
     InvocationHandler invocationHandler =
         ActivityInvocationHandler.newInstance(
-            activityInterface, options, null, new TestActivityExecutor());
+            activityInterface, options, null, new TestActivityExecutor(), () -> {});
     invocationHandler =
         new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor::submit);
     return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);
@@ -226,7 +226,11 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
       Map<String, LocalActivityOptions> activityMethodOptions) {
     InvocationHandler invocationHandler =
         LocalActivityInvocationHandler.newInstance(
-            activityInterface, options, activityMethodOptions, new TestActivityExecutor());
+            activityInterface,
+            options,
+            activityMethodOptions,
+            new TestActivityExecutor(),
+            () -> {});
     invocationHandler =
         new DeterministicRunnerWrapper(invocationHandler, deterministicRunnerExecutor::submit);
     return ActivityInvocationHandlerBase.newProxy(activityInterface, invocationHandler);


### PR DESCRIPTION
Block calling most mutating workflow functions in read only context. This includes update validators and side effects.

Note: This does not include queries because queries are not run in a workflow thread