### PR TITLE
Properly wrap exceptions from schedule client

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
@@ -107,6 +107,8 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
       } else {
         throw new ScheduleException(e);
       }
+    } catch (Exception e) {
+      throw new ScheduleException(e);
     }
   }
 
@@ -153,7 +155,11 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setScheduleId(input.getScheduleId())
             .setPatch(patch)
             .build();
-    genericClient.patchSchedule(request);
+    try {
+      genericClient.patchSchedule(request);
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 
   @Override
@@ -164,7 +170,11 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setNamespace(clientOptions.getNamespace())
             .setScheduleId(input.getScheduleId())
             .build();
-    genericClient.deleteSchedule(request);
+    try {
+      genericClient.deleteSchedule(request);
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 
   @Override
@@ -175,16 +185,20 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setScheduleId(input.getScheduleId())
             .build();
 
-    DescribeScheduleResponse response = genericClient.describeSchedule(request);
-    return new DescribeScheduleOutput(
-        new ScheduleDescription(
-            input.getScheduleId(),
-            scheduleRequestHeader.protoToScheduleInfo(response.getInfo()),
-            scheduleRequestHeader.protoToSchedule(response.getSchedule()),
-            Collections.unmodifiableMap(
-                SearchAttributesUtil.decode(response.getSearchAttributes())),
-            response.getMemo().getFieldsMap(),
-            clientOptions.getDataConverter()));
+    try {
+      DescribeScheduleResponse response = genericClient.describeSchedule(request);
+      return new DescribeScheduleOutput(
+          new ScheduleDescription(
+              input.getScheduleId(),
+              scheduleRequestHeader.protoToScheduleInfo(response.getInfo()),
+              scheduleRequestHeader.protoToSchedule(response.getSchedule()),
+              Collections.unmodifiableMap(
+                  SearchAttributesUtil.decode(response.getSearchAttributes())),
+              response.getMemo().getFieldsMap(),
+              clientOptions.getDataConverter()));
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 
   @Override
@@ -198,8 +212,11 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setScheduleId(input.getScheduleId())
             .setPatch(patch)
             .build();
-
-    genericClient.patchSchedule(request);
+    try {
+      genericClient.patchSchedule(request);
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 
   @Override
@@ -216,7 +233,11 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setScheduleId(input.getScheduleId())
             .setPatch(patch)
             .build();
-    genericClient.patchSchedule(request);
+    try {
+      genericClient.patchSchedule(request);
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 
   @Override
@@ -230,7 +251,11 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setScheduleId(input.getScheduleId())
             .setPatch(patch)
             .build();
-    genericClient.patchSchedule(request);
+    try {
+      genericClient.patchSchedule(request);
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 
   @Override
@@ -249,6 +274,10 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setRequestId(UUID.randomUUID().toString())
             .setSchedule(scheduleRequestHeader.scheduleToProto(schedule.getSchedule()))
             .build();
-    genericClient.updateSchedule(request);
+    try {
+      genericClient.updateSchedule(request);
+    } catch (Exception e) {
+      throw new ScheduleException(e);
+    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -20,6 +20,8 @@
 
 package io.temporal.client.schedules;
 
+import static org.junit.Assume.assumeTrue;
+
 import io.temporal.api.enums.v1.ScheduleOverlapPolicy;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.converter.EncodedValues;
@@ -37,8 +39,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.junit.Assume.assumeTrue;
 
 public class ScheduleTest {
   @Rule
@@ -86,10 +86,10 @@ public class ScheduleTest {
                 .build());
   }
 
-    @Before
-    public void checkRealServer() {
-      assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
-    }
+  @Before
+  public void checkRealServer() {
+    assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
+  }
 
   @Test
   public void createSchedule() {

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -20,8 +20,6 @@
 
 package io.temporal.client.schedules;
 
-import static org.junit.Assume.assumeTrue;
-
 import io.temporal.api.enums.v1.ScheduleOverlapPolicy;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.converter.EncodedValues;
@@ -39,6 +37,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assume.assumeTrue;
 
 public class ScheduleTest {
   @Rule
@@ -86,10 +86,10 @@ public class ScheduleTest {
                 .build());
   }
 
-  @Before
-  public void checkRealServer() {
-    assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
-  }
+    @Before
+    public void checkRealServer() {
+      assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
+    }
 
   @Test
   public void createSchedule() {
@@ -111,7 +111,7 @@ public class ScheduleTest {
     try {
       handle.describe();
       Assert.fail();
-    } catch (Exception e) {
+    } catch (ScheduleException e) {
     }
     // Create a handle to a non-existent schedule, creating the handle should not throw
     // but any operations on it should.
@@ -119,7 +119,7 @@ public class ScheduleTest {
       ScheduleHandle badHandle = client.getHandle(UUID.randomUUID().toString());
       badHandle.delete();
       Assert.fail();
-    } catch (Exception e) {
+    } catch (ScheduleException e) {
     }
   }
 
@@ -167,6 +167,12 @@ public class ScheduleTest {
     Assert.assertEquals(false, description.getSchedule().getState().isPaused());
     // Cleanup schedule
     handle.delete();
+    // Try to unpause a deleted schedule
+    try {
+      handle.unpause("");
+      Assert.fail();
+    } catch (ScheduleException e) {
+    }
   }
 
   @Test
@@ -221,6 +227,12 @@ public class ScheduleTest {
     Assert.assertEquals(3, handle.describe().getInfo().getNumActions());
     // Cleanup schedule
     handle.delete();
+    // Try to trigger a deleted schedule
+    try {
+      handle.trigger();
+      Assert.fail();
+    } catch (ScheduleException e) {
+    }
   }
 
   @Test
@@ -253,6 +265,15 @@ public class ScheduleTest {
     waitForActions(handle, 15);
     // Cleanup schedule
     handle.delete();
+    // Try to backfill a deleted schedule
+    try {
+      handle.backfill(
+          Arrays.asList(
+              new ScheduleBackfill(now.minusMillis(5500), now.minusMillis(2500)),
+              new ScheduleBackfill(now.minusMillis(2500), now)));
+      Assert.fail();
+    } catch (ScheduleException e) {
+    }
   }
 
   @Test
@@ -356,6 +377,12 @@ public class ScheduleTest {
     Assert.assertEquals(schedule.getState(), description.getSchedule().getState());
     // Cleanup schedule
     handle.delete();
+    // Try to describe a deleted schedule
+    try {
+      handle.describe();
+      Assert.fail();
+    } catch (ScheduleException e) {
+    }
   }
 
   @Test


### PR DESCRIPTION
Wrap exceptions from the `ScheduleClient`. Add some tests to show the exception is wrapped