### PR TITLE
Replace interpolated variables

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -50,7 +50,7 @@ jobs:
         if: steps.check_release.outputs.already_exists == 'false'
         uses: actions/checkout@v3
         with:
-          ref: $INPUT_REF
+          ref: ${{ env.INPUT_REF }}
 
       - name: Create release
         if: steps.check_release.outputs.already_exists == 'false'
@@ -61,7 +61,7 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
           --title "$INPUT_TAG"
           --target "$INPUT_REF"
-          --notes-file 'releases/$INPUT_TAG'
+          --notes-file releases/"$INPUT_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: $INPUT_REF
+          ref: ${{ env.INPUT_REF }}
           
       # Our custom gradle version sniffing builds the maven release artifact
       # names out of the git tag ... but the repo isn't tagged (yet) so add a
@@ -141,7 +141,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: $INPUT_REF
+          ref: ${{ env.INPUT_REF }}
 
       # See comment on temporary tag above. tldr: this is a local tag; never
       # gets pushed


### PR DESCRIPTION
## What was changed
Set a different variable to the interpolated inputs, and enclose them in quotes.

## Why?
This is to prevent bash injections in our runners.

## Checklist
How was this tested:
Ran this workflow on my fork and read the logs, I did get 403ed at the "Create release" step.