### PR TITLE
Replace interpolated variables

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,10 @@ on:
         description: 'Publish Java Artifacts'
         required: true
         default: 'true'
-
+env:
+  INPUT_REF: ${{ github.event.inputs.ref }}
+  INPUT_TAG: ${{ github.event.inputs.tag }}
+  
 jobs:
   create_draft_release:
     name: Create Github draft release
@@ -37,7 +40,7 @@ jobs:
         id: check_release
         run: |
           echo "::echo::on"
-          gh release view --repo '${{ github.repository }}' '${{ github.event.inputs.tag }}' \
+          gh release view --repo "$GITHUB_REPOSITORY" "$INPUT_TAG" \
             && echo "::set-output name=already_exists::true" \
             || echo "::set-output name=already_exists::false"
         env:
@@ -47,18 +50,18 @@ jobs:
         if: steps.check_release.outputs.already_exists == 'false'
         uses: actions/checkout@v3
         with:
-          ref: '${{ github.event.inputs.ref }}'
+          ref: ${{ env.INPUT_REF }}
 
       - name: Create release
         if: steps.check_release.outputs.already_exists == 'false'
         run: >
           gh release create
-          '${{ github.event.inputs.tag }}'
+          "$INPUT_REF"
           --draft
-          --repo '${{ github.repository }}'
-          --title '${{ github.event.inputs.tag }}'
-          --target '${{ github.event.inputs.ref }}'
-          --notes-file 'releases/${{ github.event.inputs.tag }}'
+          --repo "$GITHUB_REPOSITORY"
+          --title "$INPUT_TAG"
+          --target "$INPUT_REF"
+          --notes-file releases/"$INPUT_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
@@ -71,7 +74,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: '${{ github.event.inputs.ref }}'
+          ref: ${{ env.INPUT_REF }}
           
       # Our custom gradle version sniffing builds the maven release artifact
       # names out of the git tag ... but the repo isn't tagged (yet) so add a
@@ -80,7 +83,7 @@ jobs:
       # inspected and verified, the manual act of publishing the draft GH
       # release creates the tag.
       - name: Temporary tag
-        run: git tag '${{ github.event.inputs.tag }}'
+        run: git tag "$INPUT_TAG"
         
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -138,12 +141,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: '${{ github.event.inputs.ref }}'
+          ref: ${{ env.INPUT_REF }}
 
       # See comment on temporary tag above. tldr: this is a local tag; never
       # gets pushed
       - name: Temporary tag
-        run: git tag '${{ github.event.inputs.tag }}'
+        run: git tag "$INPUT_TAG"
         
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -186,7 +189,7 @@ jobs:
       # the root directory of the contents of the archive.
       - name: Rename dirs
         run: |
-          version="$(sed 's/^v//'<<<'${{ github.event.inputs.tag }}')"
+          version="$(sed 's/^v//'<<<"$INPUT_TAG")"
           for dir in *; do mv "$dir" "temporal-test-server_${version}_${dir}"; done        
       
       - name: Tar (linux, macOS)
@@ -207,7 +210,7 @@ jobs:
 
       - name: Upload
         run: |
-         until gh release upload --clobber --repo ${{ github.repository }} ${{ github.event.inputs.tag }} *.zip *.tar.gz; do
+         until gh release upload --clobber --repo $GITHUB_REPOSITORY "$INPUT_TAG" *.zip *.tar.gz; do
            echo "Attempt $((++attempts)) to upload release artifacts failed. Will retry in 20s"
            sleep 20
          done


### PR DESCRIPTION
## What was changed
Set a different variable to the interpolated inputs, and enclose them in quotes.

## Why?
This is to prevent bash injections in our runners.

## Checklist
How was this tested:
Ran this workflow on my fork and read the logs, I did get 403ed at the "Create release" step.