### PR TITLE
Remove unbound variable

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Upload
         run: |
           until gh release upload --clobber --repo $GITHUB_REPOSITORY "$INPUT_TAG" *.zip *.tar.gz; do
-            echo "Attempt $((++attempts)) to upload release artifacts failed. Will retry in 20s"
+            echo "Failed to upload release artifacts. Will retry in 20s"
             sleep 20
           done
         timeout-minutes: 10


### PR DESCRIPTION
When we updated our build runner, github started complaining about unbound variable `attempts `. Removing it because it doesn't provide much value.

The reason this code retries at all is because there is a human in the loop to publish the release.