### PR TITLE
Reconcile typed search attributes with schedules

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleActionStartWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleActionStartWorkflow.java
@@ -72,8 +72,8 @@ public final class ScheduleActionStartWorkflow extends ScheduleAction {
      * Set the workflow options to use when starting a workflow action.
      *
      * @note ID and TaskQueue are required. Some options like ID reuse policy, cron schedule, and
-     *     start signal cannot be set or an error will occur. Schedules requires the use of typed search attributes
-     *     and untyped search attributes will be ignored.
+     *     start signal cannot be set or an error will occur. Schedules requires the use of typed
+     *     search attributes and untyped search attributes will be ignored.
      */
     public Builder setOptions(WorkflowOptions options) {
       this.options = options;

--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleActionStartWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleActionStartWorkflow.java
@@ -72,7 +72,8 @@ public final class ScheduleActionStartWorkflow extends ScheduleAction {
      * Set the workflow options to use when starting a workflow action.
      *
      * @note ID and TaskQueue are required. Some options like ID reuse policy, cron schedule, and
-     *     start signal cannot be set or an error will occur.
+     *     start signal cannot be set or an error will occur. Schedules requires the use of typed search attributes
+     *     and untyped search attributes will be ignored.
      */
     public Builder setOptions(WorkflowOptions options) {
       this.options = options;

--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleActionStartWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleActionStartWorkflow.java
@@ -100,7 +100,10 @@ public final class ScheduleActionStartWorkflow extends ScheduleAction {
 
     public ScheduleActionStartWorkflow build() {
       return new ScheduleActionStartWorkflow(
-          workflowType, options, header == null ? Header.empty() : header, arguments);
+          workflowType,
+          options,
+          header == null ? Header.empty() : header,
+          arguments == null ? new EncodedValues() : arguments);
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleDescription.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleDescription.java
@@ -21,6 +21,7 @@
 package io.temporal.client.schedules;
 
 import io.temporal.api.common.v1.Payload;
+import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.DataConverter;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -35,6 +36,7 @@ public final class ScheduleDescription {
   private final ScheduleInfo info;
   private final Schedule schedule;
   private final Map<String, List<?>> searchAttributes;
+  private final SearchAttributes typedSearchAttributes;
   private final Map<String, Payload> memo;
   private final DataConverter dataConverter;
 
@@ -43,12 +45,14 @@ public final class ScheduleDescription {
       ScheduleInfo info,
       Schedule schedule,
       Map<String, List<?>> searchAttributes,
+      SearchAttributes typedSearchAttributes,
       Map<String, Payload> memo,
       DataConverter dataConverter) {
     this.id = id;
     this.info = info;
     this.schedule = schedule;
     this.searchAttributes = searchAttributes;
+    this.typedSearchAttributes = typedSearchAttributes;
     this.memo = memo;
     this.dataConverter = dataConverter;
   }
@@ -84,10 +88,21 @@ public final class ScheduleDescription {
    * Gets the search attributes on the schedule.
    *
    * @return search attributes
+   * @deprecated use {@link ScheduleDescription#getTypedSearchAttributes} instead.
    */
   @Nonnull
   public Map<String, List<?>> getSearchAttributes() {
     return searchAttributes;
+  }
+
+  /**
+   * Gets the search attributes on the schedule.
+   *
+   * @return search attributes
+   */
+  @Nonnull
+  public SearchAttributes getTypedSearchAttributes() {
+    return typedSearchAttributes;
   }
 
   @Nullable
@@ -113,12 +128,13 @@ public final class ScheduleDescription {
         && Objects.equals(info, that.info)
         && Objects.equals(schedule, that.schedule)
         && Objects.equals(searchAttributes, that.searchAttributes)
+        && Objects.equals(typedSearchAttributes, that.typedSearchAttributes)
         && Objects.equals(memo, that.memo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, info, schedule, searchAttributes, memo);
+    return Objects.hash(id, info, schedule, searchAttributes, typedSearchAttributes, memo);
   }
 
   @Override
@@ -133,6 +149,8 @@ public final class ScheduleDescription {
         + schedule
         + ", searchAttributes="
         + searchAttributes
+        + ", typedSearchAttributes="
+        + typedSearchAttributes
         + ", memo="
         + memo
         + '}';

--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleOptions.java
@@ -20,6 +20,7 @@
 
 package io.temporal.client.schedules;
 
+import io.temporal.common.SearchAttributes;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ public final class ScheduleOptions {
     private List<ScheduleBackfill> backfills;
     private Map<String, Object> memo;
     private Map<String, ?> searchAttributes;
+    private SearchAttributes typedSearchAttributes;
 
     private Builder() {}
 
@@ -49,6 +51,7 @@ public final class ScheduleOptions {
       this.backfills = options.backfills;
       this.memo = options.memo;
       this.searchAttributes = options.searchAttributes;
+      this.typedSearchAttributes = options.typedSearchAttributes;
     }
 
     /** Set if the schedule will be triggered immediately upon creation. */
@@ -69,14 +72,25 @@ public final class ScheduleOptions {
       return this;
     }
 
-    /** Set the search attributes for the schedule. */
+    /**
+     * Set the search attributes for the schedule.
+     *
+     * @deprecated use {@link ScheduleOptions.Builder#setTypedSearchAttributes} instead.
+     */
     public Builder setSearchAttributes(Map<String, ?> searchAttributes) {
       this.searchAttributes = searchAttributes;
       return this;
     }
 
+    /** Set the search attributes for the schedule. */
+    public Builder setTypedSearchAttributes(SearchAttributes searchAttributes) {
+      this.typedSearchAttributes = searchAttributes;
+      return this;
+    }
+
     public ScheduleOptions build() {
-      return new ScheduleOptions(triggerImmediately, backfills, memo, searchAttributes);
+      return new ScheduleOptions(
+          triggerImmediately, backfills, memo, searchAttributes, typedSearchAttributes);
     }
   }
 
@@ -84,16 +98,19 @@ public final class ScheduleOptions {
   private final List<ScheduleBackfill> backfills;
   private final Map<String, Object> memo;
   private final Map<String, ?> searchAttributes;
+  private final SearchAttributes typedSearchAttributes;
 
   private ScheduleOptions(
       boolean triggerImmediately,
       List<ScheduleBackfill> backfills,
       Map<String, Object> memo,
-      Map<String, ?> searchAttributes) {
+      Map<String, ?> searchAttributes,
+      SearchAttributes typedSearchAttributes) {
     this.triggerImmediately = triggerImmediately;
     this.backfills = backfills;
     this.memo = memo;
     this.searchAttributes = searchAttributes;
+    this.typedSearchAttributes = typedSearchAttributes;
   }
 
   /**
@@ -127,8 +144,18 @@ public final class ScheduleOptions {
    * Get the search attributes for the schedule.
    *
    * @return search attributes for the schedule
+   * @deprecated use {@link ScheduleOptions#getTypedSearchAttributes()} instead.
    */
   public Map<String, ?> getSearchAttributes() {
     return searchAttributes;
+  }
+
+  /**
+   * Get the search attributes for the schedule.
+   *
+   * @return search attributes for the schedule
+   */
+  public SearchAttributes getTypedSearchAttributes() {
+    return typedSearchAttributes;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/SearchAttributeKey.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/SearchAttributeKey.java
@@ -21,6 +21,7 @@
 package io.temporal.common;
 
 import com.google.common.reflect.TypeToken;
+import io.temporal.api.common.v1.Payload;
 import io.temporal.api.enums.v1.IndexedValueType;
 import java.lang.reflect.Type;
 import java.time.OffsetDateTime;
@@ -71,6 +72,17 @@ public class SearchAttributeKey<T> implements Comparable<SearchAttributeKey<T>> 
         IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST,
         List.class,
         KEYWORD_LIST_REFLECT_TYPE);
+  }
+
+  /**
+   * Create a search attribute key for an untyped attribute type.
+   *
+   * <p>This should only be used when the server can return untyped search attributes, for example,
+   * when describing a schedule workflow action.
+   */
+  public static SearchAttributeKey<Payload> forUntyped(String name) {
+    return new SearchAttributeKey<>(
+        name, IndexedValueType.INDEXED_VALUE_TYPE_UNSPECIFIED, Payload.class);
   }
 
   private final String name;

--- a/temporal-sdk/src/main/java/io/temporal/common/SearchAttributeKey.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/SearchAttributeKey.java
@@ -127,11 +127,17 @@ public class SearchAttributeKey<T> implements Comparable<SearchAttributeKey<T>> 
 
   /** Create an update that sets a value for this key. */
   public SearchAttributeUpdate<T> valueSet(@Nonnull T value) {
+    if (valueType == IndexedValueType.INDEXED_VALUE_TYPE_UNSPECIFIED) {
+      throw new IllegalStateException("untyped keys should not be used in workflows");
+    }
     return SearchAttributeUpdate.valueSet(this, value);
   }
 
   /** Create an update that unsets a value for this key. */
   public SearchAttributeUpdate<T> valueUnset() {
+    if (valueType == IndexedValueType.INDEXED_VALUE_TYPE_UNSPECIFIED) {
+      throw new IllegalStateException("untyped keys should not be used in workflows");
+    }
     return SearchAttributeUpdate.valueUnset(this);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
@@ -56,6 +56,7 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void createSchedule(CreateScheduleInput input) {
 
     CreateScheduleRequest.Builder request =
@@ -75,8 +76,15 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
 
     if (input.getOptions().getSearchAttributes() != null
         && !input.getOptions().getSearchAttributes().isEmpty()) {
+      if (input.getOptions().getTypedSearchAttributes() != null) {
+        throw new IllegalArgumentException(
+            "Cannot have search attributes and typed search attributes");
+      }
       request.setSearchAttributes(
           SearchAttributesUtil.encode(input.getOptions().getSearchAttributes()));
+    } else if (input.getOptions().getTypedSearchAttributes() != null) {
+      request.setSearchAttributes(
+          SearchAttributesUtil.encodeTyped(input.getOptions().getTypedSearchAttributes()));
     }
 
     if (input.getOptions().isTriggerImmediately()
@@ -194,6 +202,7 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
               scheduleRequestHeader.protoToSchedule(response.getSchedule()),
               Collections.unmodifiableMap(
                   SearchAttributesUtil.decode(response.getSearchAttributes())),
+              SearchAttributesUtil.decodeTyped(response.getSearchAttributes()),
               response.getMemo().getFieldsMap(),
               clientOptions.getDataConverter()));
     } catch (Exception e) {

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client.schedules;
+
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.WorkflowType;
+import io.temporal.api.schedule.v1.ScheduleAction;
+import io.temporal.api.taskqueue.v1.TaskQueue;
+import io.temporal.api.workflow.v1.NewWorkflowExecutionInfo;
+import io.temporal.api.workflowservice.v1.CreateScheduleRequest;
+import io.temporal.api.workflowservice.v1.DeleteScheduleRequest;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.SearchAttributeKey;
+import io.temporal.common.SearchAttributes;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ScheduleWithTypedSearchAttributesTest {
+  static final SearchAttributeKey<String> CUSTOM_KEYWORD_SA =
+      SearchAttributeKey.forKeyword("CustomKeywordField");
+  static final SearchAttributeKey<String> CUSTOM_STRING_SA =
+      SearchAttributeKey.forText("CustomStringField");
+  static final SearchAttributeKey<Double> CUSTOM_DOUBLE_SA =
+      SearchAttributeKey.forDouble("CustomDoubleField");
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ScheduleWithTypedSearchAttributesTest.QuickWorkflowImpl.class)
+          .setUseExternalService(true)
+          .build();
+
+  private ScheduleClient createScheduleClient() {
+    return new ScheduleClientImpl(
+        testWorkflowRule.getWorkflowServiceStubs(),
+        ScheduleClientOptions.newBuilder()
+            .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+            .setIdentity(testWorkflowRule.getWorkflowClient().getOptions().getIdentity())
+            .setDataConverter(testWorkflowRule.getWorkflowClient().getOptions().getDataConverter())
+            .build());
+  }
+
+  private Schedule.Builder createTestSchedule() {
+    SearchAttributes searchAttributes =
+        SearchAttributes.newBuilder()
+            .set(CUSTOM_KEYWORD_SA, "keyword")
+            .set(CUSTOM_STRING_SA, "string")
+            .set(CUSTOM_DOUBLE_SA, 0.1)
+            .build();
+
+    WorkflowOptions wfOptions =
+        WorkflowOptions.newBuilder()
+            .setWorkflowId("test-schedule-id")
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .setMemo(Collections.singletonMap("memokey1", "memoval1"))
+            .setTypedSearchAttributes(searchAttributes)
+            .build();
+
+    return Schedule.newBuilder()
+        .setAction(
+            ScheduleActionStartWorkflow.newBuilder()
+                .setWorkflowType("TestWorkflowReturnString")
+                .setOptions(wfOptions)
+                .build())
+        .setSpec(
+            ScheduleSpec.newBuilder()
+                .setIntervals(Arrays.asList(new ScheduleIntervalSpec(Duration.ofSeconds(1))))
+                .build());
+  }
+
+  //  @Before
+  //  public void checkRealServer() {
+  //    assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
+  //  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void createScheduleWithTypedSearchAttributes() {
+    ScheduleClient client = createScheduleClient();
+    // Create typed search attributes
+    SearchAttributes searchAttributes =
+        SearchAttributes.newBuilder().set(CUSTOM_KEYWORD_SA, "keyword").build();
+    // Create schedule with typed search attributes
+    ScheduleOptions options =
+        ScheduleOptions.newBuilder().setTypedSearchAttributes(searchAttributes).build();
+    String scheduleId = UUID.randomUUID().toString();
+    Schedule schedule = createTestSchedule().build();
+    ScheduleHandle handle = client.createSchedule(scheduleId, schedule, options);
+    // Verify schedules search attribute
+    ScheduleDescription description = handle.describe();
+    Assert.assertEquals(scheduleId, description.getId());
+    Assert.assertEquals("keyword", description.getTypedSearchAttributes().get(CUSTOM_KEYWORD_SA));
+    // Verify the actions search attributes
+    ScheduleActionStartWorkflow action =
+        (ScheduleActionStartWorkflow) description.getSchedule().getAction();
+    Assert.assertEquals(null, action.getOptions().getSearchAttributes());
+    Assert.assertEquals(3, action.getOptions().getTypedSearchAttributes().size());
+    Assert.assertEquals(
+        true, action.getOptions().getTypedSearchAttributes().containsKey(CUSTOM_DOUBLE_SA));
+    // Clean up schedule
+    handle.delete();
+  }
+
+  public void verifyTypedSearchAttributes(
+      ScheduleDescription description,
+      String customKeywordFieldValue,
+      String customStringFieldValue) {
+    ScheduleActionStartWorkflow readAction =
+        (ScheduleActionStartWorkflow) description.getSchedule().getAction();
+    Assert.assertEquals(2, readAction.getOptions().getTypedSearchAttributes().size());
+
+    Payload keywordPayload =
+        readAction
+            .getOptions()
+            .getTypedSearchAttributes()
+            .get(SearchAttributeKey.forUntyped("CustomKeywordField"));
+    Assert.assertEquals(
+        customKeywordFieldValue,
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            keywordPayload, String.class, String.class));
+
+    Payload textPayload =
+        readAction
+            .getOptions()
+            .getTypedSearchAttributes()
+            .get(SearchAttributeKey.forUntyped("CustomStringField"));
+    Assert.assertEquals(
+        customStringFieldValue,
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            textPayload, String.class, String.class));
+  }
+
+  @Test
+  public void updateExternalSchedule() {
+    // Create schedule using raw GRPC api to simulate one created from a different SDK
+    io.temporal.api.common.v1.SearchAttributes searchAttributes =
+        io.temporal.api.common.v1.SearchAttributes.newBuilder()
+            .putIndexedFields(
+                "CustomKeywordField",
+                DefaultDataConverter.STANDARD_INSTANCE.toPayload("keyword").get())
+            .putIndexedFields(
+                "CustomStringField", DefaultDataConverter.STANDARD_INSTANCE.toPayload("text").get())
+            .build();
+
+    String scheduleId = UUID.randomUUID().toString();
+    String workflowId = UUID.randomUUID().toString();
+    NewWorkflowExecutionInfo startWorkflow =
+        NewWorkflowExecutionInfo.newBuilder()
+            .setWorkflowId(workflowId)
+            .setTaskQueue(TaskQueue.newBuilder().setName(testWorkflowRule.getTaskQueue()).build())
+            .setWorkflowType(WorkflowType.newBuilder().setName("TestWorkflowReturnString").build())
+            .setSearchAttributes(searchAttributes)
+            .build();
+    ScheduleAction action = ScheduleAction.newBuilder().setStartWorkflow(startWorkflow).build();
+    io.temporal.api.schedule.v1.Schedule schedule =
+        io.temporal.api.schedule.v1.Schedule.newBuilder()
+            .setAction(action)
+            .setSpec(io.temporal.api.schedule.v1.ScheduleSpec.newBuilder().build())
+            .build();
+    CreateScheduleRequest request =
+        CreateScheduleRequest.newBuilder()
+            .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+            .setIdentity(testWorkflowRule.getWorkflowClient().getOptions().getIdentity())
+            .setRequestId(UUID.randomUUID().toString())
+            .setScheduleId(scheduleId)
+            .setSchedule(schedule)
+            .build();
+    testWorkflowRule.getWorkflowServiceStubs().blockingStub().createSchedule(request);
+    // Describe the schedule in the Java SDK
+    ScheduleClient client = createScheduleClient();
+    ScheduleHandle externalSchedule = client.getHandle(scheduleId);
+    ScheduleDescription description = externalSchedule.describe();
+    Assert.assertEquals(scheduleId, description.getId());
+    verifyTypedSearchAttributes(description, "keyword", "text");
+    // Update the schedule in the Java SDK
+    externalSchedule.update(
+        (ScheduleUpdateInput input) -> {
+          Schedule.Builder builder = Schedule.newBuilder(input.getDescription().getSchedule());
+          ScheduleActionStartWorkflow wfAction =
+              ((ScheduleActionStartWorkflow) input.getDescription().getSchedule().getAction());
+          WorkflowOptions wfOptions =
+              WorkflowOptions.newBuilder(wfAction.getOptions())
+                  .setWorkflowTaskTimeout(Duration.ofMinutes(7))
+                  .setMemo(Collections.singletonMap("memokey3", "memoval3"))
+                  .build();
+          builder.setAction(
+              ScheduleActionStartWorkflow.newBuilder(wfAction).setOptions(wfOptions).build());
+          return new ScheduleUpdate(builder.build());
+        });
+    // Verify the search attributes stayed the same
+    description = externalSchedule.describe();
+    Assert.assertEquals(scheduleId, description.getId());
+    verifyTypedSearchAttributes(description, "keyword", "text");
+    // Update the search attributes in the Java SDK
+    externalSchedule.update(
+        (ScheduleUpdateInput input) -> {
+          Schedule.Builder builder = Schedule.newBuilder(input.getDescription().getSchedule());
+          ScheduleActionStartWorkflow wfAction =
+              ((ScheduleActionStartWorkflow) input.getDescription().getSchedule().getAction());
+          WorkflowOptions wfOptions =
+              WorkflowOptions.newBuilder(wfAction.getOptions())
+                  .setTypedSearchAttributes(
+                      SearchAttributes.newBuilder()
+                          .set(
+                              SearchAttributeKey.forUntyped("CustomKeywordField"),
+                              DefaultDataConverter.STANDARD_INSTANCE.toPayload("new value").get())
+                          .set(
+                              SearchAttributeKey.forUntyped("CustomStringField"),
+                              DefaultDataConverter.STANDARD_INSTANCE
+                                  .toPayload("another new value")
+                                  .get())
+                          .build())
+                  .build();
+          builder.setAction(
+              ScheduleActionStartWorkflow.newBuilder(wfAction).setOptions(wfOptions).build());
+          return new ScheduleUpdate(builder.build());
+        });
+    description = externalSchedule.describe();
+    Assert.assertEquals(scheduleId, description.getId());
+    verifyTypedSearchAttributes(description, "new value", "another new value");
+    // Clean up out manually created schedule
+    testWorkflowRule
+        .getWorkflowServiceStubs()
+        .blockingStub()
+        .deleteSchedule(
+            DeleteScheduleRequest.newBuilder()
+                .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+                .setIdentity(testWorkflowRule.getWorkflowClient().getOptions().getIdentity())
+                .setScheduleId(scheduleId)
+                .build());
+  }
+
+  public static class QuickWorkflowImpl implements TestWorkflows.TestWorkflowReturnString {
+    @Override
+    public String execute() {
+      return null;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
@@ -20,6 +20,8 @@
 
 package io.temporal.client.schedules;
 
+import static org.junit.Assume.assumeTrue;
+
 import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.schedule.v1.ScheduleAction;
@@ -38,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -53,7 +56,6 @@ public class ScheduleWithTypedSearchAttributesTest {
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(ScheduleWithTypedSearchAttributesTest.QuickWorkflowImpl.class)
-          .setUseExternalService(true)
           .build();
 
   private ScheduleClient createScheduleClient() {
@@ -94,10 +96,10 @@ public class ScheduleWithTypedSearchAttributesTest {
                 .build());
   }
 
-  //  @Before
-  //  public void checkRealServer() {
-  //    assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
-  //  }
+  @Before
+  public void checkRealServer() {
+    assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
+  }
 
   @Test
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
Fix typed search attributes in java schedules by:
* Adding typed search attributes to `ScheduleOptions`
* Documenting old `SearchAttributes` do not work when creating a schedule
* Allow for untyped search attributes in the `SearchAttributes` container through a special key type

closes https://github.com/temporalio/sdk-java/issues/1847