### PR TITLE
Release WF slot on UnableToAcquireLockException

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -189,7 +189,7 @@ public class WorkflowWorkerTest {
         ImmutableMap.of("worker_type", "WorkflowWorker"),
         100.0);
     // Cleanup
-    worker.shutdown(new ShutdownManager(), true).get();
+    worker.shutdown(new ShutdownManager(), false).get();
     // Verify we only handled two tasks
     verify(taskHandler, times(2)).handleWorkflowTask(any());
   }


### PR DESCRIPTION
A user noticed that if their workflow task failed with `UnableToAcquireLockException` their worker would not be able to shutdown. Root cause was on `UnableToAcquireLockException` we didn't call `task.getCompletionCallback().apply();` because the exception was outside the `finally` block. 

Note: this will change the timing of `WORKFLOW_TASK_EXECUTION_TOTAL_LATENCY` to include the time waiting for the run lock, but this metric is java specific and is undocumented, and arguably should include the run lock.

close https://github.com/temporalio/sdk-java/issues/1870