### PR TITLE
Enable TCP keep alive by default

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -329,10 +329,10 @@ public class ServiceStubsOptions {
     private Consumer<ManagedChannelBuilder<?>> channelInitializer;
     private Duration healthCheckAttemptTimeout;
     private Duration healthCheckTimeout;
-    private boolean enableKeepAlive;
-    private Duration keepAliveTime;
-    private Duration keepAliveTimeout;
-    private boolean keepAlivePermitWithoutStream;
+    private boolean enableKeepAlive = true;
+    private Duration keepAliveTime = Duration.ofSeconds(30);
+    private Duration keepAliveTimeout = Duration.ofSeconds(15);
+    private boolean keepAlivePermitWithoutStream = true;
     private Duration rpcTimeout = DEFAULT_RPC_TIMEOUT;
     private Duration connectionBackoffResetFrequency = DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY;
     private Duration grpcReconnectFrequency = DEFAULT_GRPC_RECONNECT_FREQUENCY;
@@ -607,6 +607,8 @@ public class ServiceStubsOptions {
      * Enables keep alive ping from client to the server, which can help drop abruptly closed
      * connections faster.
      *
+     * <p>Default is true
+     *
      * @return {@code this}
      */
     public T setEnableKeepAlive(boolean enableKeepAlive) {
@@ -619,6 +621,8 @@ public class ServiceStubsOptions {
      * see if the transport is still alive. If set below 10s, a minimum value of 10s will be used
      * instead.
      *
+     * <p>Default is 30s
+     *
      * @return {@code this}
      */
     public T setKeepAliveTime(Duration keepAliveTime) {
@@ -630,6 +634,8 @@ public class ServiceStubsOptions {
      * After having pinged for keepalive check, the client waits for a duration of Timeout and if no
      * activity is seen even after that the connection is closed.
      *
+     * <p>Default is 15s
+     *
      * @return {@code this}
      */
     public T setKeepAliveTimeout(Duration keepAliveTimeout) {
@@ -640,6 +646,8 @@ public class ServiceStubsOptions {
     /**
      * If true, client sends keepalive pings even with no active RPCs. If false, when there are no
      * active RPCs, Time and Timeout will be ignored and no keepalive pings will be sent. * @return
+     *
+     * <p>Default is true
      *
      * @return {@code this}
      */

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/KeepAliveTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/KeepAliveTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.serviceclient.functional;
 
 import static org.junit.Assert.assertEquals;

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/KeepAliveTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/functional/KeepAliveTest.java
@@ -1,0 +1,22 @@
+package io.temporal.serviceclient.functional;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class KeepAliveTest {
+  @Rule public SDKTestWorkflowRule testWorkflowRule = SDKTestWorkflowRule.newBuilder().build();
+
+  @Test
+  public void testKeepAliveOnByDefault() {
+    WorkflowServiceStubsOptions options = testWorkflowRule.getWorkflowServiceStubs().getOptions();
+    assertEquals(true, options.getEnableKeepAlive());
+    assertEquals(true, options.getKeepAlivePermitWithoutStream());
+    assertEquals(Duration.ofSeconds(30), options.getKeepAliveTime());
+    assertEquals(Duration.ofSeconds(15), options.getKeepAliveTimeout());
+  }
+}


### PR DESCRIPTION
Enable TCP keep alive by default. Settings take from https://github.com/temporalio/features/issues/123

closes https://github.com/temporalio/sdk-java/issues/1872
