### PR TITLE
Disable eager start by default

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
@@ -105,7 +105,7 @@ public final class WorkflowOptions {
 
     private List<ContextPropagator> contextPropagators;
 
-    private boolean disableEagerExecution;
+    private boolean disableEagerExecution = true;
 
     private Builder() {}
 
@@ -330,6 +330,11 @@ public final class WorkflowOptions {
      * and such a {@link WorkflowClient} is used to start a workflow, then the first workflow task
      * could be dispatched on this local worker with the response to the start call if Server
      * supports it. This option can be used to disable this mechanism.
+     *
+     * <p>Default is true
+     *
+     * <p>WARNING: Eager start does not respect worker versioning. An eagerly started workflow may
+     * run on any available local worker even if that worker is not in the default build ID set.
      *
      * @param disableEagerExecution if true, an eager local execution of the workflow task will
      *     never be requested even if it is possible.

--- a/temporal-sdk/src/test/java/io/temporal/workflow/EagerWorkflowTaskDispatchTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/EagerWorkflowTaskDispatchTest.java
@@ -98,7 +98,10 @@ public class EagerWorkflowTaskDispatchTest {
             .getWorkflowClient()
             .newWorkflowStub(
                 TestWorkflows.NoArgsWorkflow.class,
-                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setDisableEagerExecution(false)
+                    .build());
     workflowStub1.execute();
     assertTrue(START_CALL_INTERCEPTOR.wasLastStartEager);
     TestWorkflows.NoArgsWorkflow workflowStub2 =
@@ -106,7 +109,10 @@ public class EagerWorkflowTaskDispatchTest {
             .getWorkflowClient()
             .newWorkflowStub(
                 TestWorkflows.NoArgsWorkflow.class,
-                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setDisableEagerExecution(false)
+                    .build());
     workflowStub2.execute();
     assertTrue(START_CALL_INTERCEPTOR.wasLastStartEager);
 
@@ -151,7 +157,10 @@ public class EagerWorkflowTaskDispatchTest {
             .getWorkflowClient()
             .newWorkflowStub(
                 TestWorkflows.NoArgsWorkflow.class,
-                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setDisableEagerExecution(false)
+                    .build());
     workflowStub.execute();
     assertFalse(
         "Eager dispatch shouldn't be requested for activity-only worker",
@@ -181,7 +190,10 @@ public class EagerWorkflowTaskDispatchTest {
             .getWorkflowClient()
             .newWorkflowStub(
                 TestWorkflows.NoArgsWorkflow.class,
-                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setDisableEagerExecution(false)
+                    .build());
     workflowStub.execute();
     assertFalse(
         "Eager dispatch shouldn't be requested for a not started worker",
@@ -212,7 +224,10 @@ public class EagerWorkflowTaskDispatchTest {
             .getWorkflowClient()
             .newWorkflowStub(
                 TestWorkflows.NoArgsWorkflow.class,
-                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setDisableEagerExecution(false)
+                    .build());
     workflowStub.execute();
     assertFalse(
         "Eager dispatch shouldn't be requested for a suspended worker",
@@ -233,10 +248,7 @@ public class EagerWorkflowTaskDispatchTest {
             .getWorkflowClient()
             .newWorkflowStub(
                 TestWorkflows.NoArgsWorkflow.class,
-                WorkflowOptions.newBuilder()
-                    .setTaskQueue(testWorkflowRule.getTaskQueue())
-                    .setDisableEagerExecution(true)
-                    .build());
+                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
     workflowStub.execute();
     assertFalse(START_CALL_INTERCEPTOR.wasLastStartEager);
 


### PR DESCRIPTION
Disable eager start by default because it does not interact with worker versioning well.