### PR TITLE
Reset lastHandledEventId on speculative WFT

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -202,7 +202,16 @@ public final class WorkflowStateMachines {
   }
 
   public void setCurrentStartedEventId(long eventId) {
+    // We have to drop any state machines (which should only be one workflow task machine)
+    // created when handling the speculative workflow task
+    for (long i = this.lastHandledEventId; i > eventId; i--) {
+      stateMachines.remove(i);
+    }
     this.currentStartedEventId = eventId;
+    // When we reset the event ID on a speculative WFT we need to move this counter back
+    // to the last WFT completed to allow new tasks to be processed. Assume the WFT complete
+    // always follows the WFT started.
+    this.lastHandledEventId = eventId + 1;
   }
 
   public long getCurrentStartedEventId() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
@@ -214,6 +214,9 @@ public class TestWorkflows {
     @UpdateMethod()
     String update(String value);
 
+    @UpdateValidatorMethod(updateName = "update")
+    void validator(String value);
+
     @UpdateMethod
     void complete();
   }


### PR DESCRIPTION
On a rejected speculative WFT we also need to reset `lastHandledEventId` so we don't accidentally skip new workflow tasks.

```
  public void handleEvent(HistoryEvent event, boolean hasNextEvent) {
    long eventId = event.getEventId();
    if (eventId <= lastHandledEventId) {
      // already handled
      return;
    }
...
``` 

We also should delete any new state machines created by the speculative task

closes https://github.com/temporalio/sdk-java/issues/1880
