### PR TITLE
Avoid incrementing WFT failure metric on respond failure

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -360,7 +360,6 @@ final class WorkflowWorker implements SuspendableWorker {
             }
           } catch (Exception e) {
             logExceptionDuringResultReporting(e, currentTask, result);
-            workflowTypeScope.counter(MetricsType.WORKFLOW_TASK_EXECUTION_FAILURE_COUNTER).inc(1);
             // if we failed to report the workflow task completion back to the server,
             // our cached version of the workflow may be more advanced than the server is aware of.
             // We should discard this execution and perform a clean replay based on what server
@@ -370,8 +369,6 @@ final class WorkflowWorker implements SuspendableWorker {
             throw e;
           }
 
-          // this should be after sendReply, otherwise we may log
-          // WORKFLOW_TASK_EXECUTION_FAILURE_COUNTER twice if sendReply throws
           if (result.getTaskFailed() != null) {
             // we don't trigger the counter in case of the legacy query
             // (which never has taskFailed set)

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -196,8 +196,8 @@ public class WorkflowWorkerTest {
 
   @Test
   public void respondWorkflowTaskFailureMetricTest() throws Exception {
-    // Test that if the server sends multiple concurrent workflow tasks for the same workflow the
-    // SDK holds the lock during all processing.
+    // Test that if the SDK gets a failure on RespondWorkflowTaskCompleted it does not increment
+    // workflow_task_execution_failed.
     WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
     when(client.getServerCapabilities())
         .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());


### PR DESCRIPTION
Avoid incrementing WFT failure metric on respond failure. This aligns Java with other SDKs.

closes https://github.com/temporalio/sdk-java/issues/1885