### PR TITLE
Apply data converter context in more places

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowExecutionMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowExecutionMetadata.java
@@ -29,6 +29,7 @@ import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.common.SearchAttributesUtil;
+import io.temporal.payload.context.WorkflowSerializationContext;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.Collections;
@@ -123,7 +124,11 @@ public class WorkflowExecutionMetadata {
     if (memo == null) {
       return null;
     }
-    return dataConverter.fromPayload(memo, valueClass, genericType);
+    return dataConverter
+        .withContext(
+            new WorkflowSerializationContext(
+                info.getParentNamespaceId(), info.getExecution().getWorkflowId()))
+        .fromPayload(memo, valueClass, genericType);
   }
 
   @Nonnull

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootScheduleClientInvoker.java
@@ -68,6 +68,7 @@ public class RootScheduleClientInvoker implements ScheduleClientCallsInterceptor
             .setSchedule(scheduleRequestHeader.scheduleToProto(input.getSchedule()));
 
     if (input.getOptions().getMemo() != null) {
+      // TODO we don't have a workflow context here, maybe we need a schedule context?
       request.setMemo(
           Memo.newBuilder()
               .putAllFields(

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -83,7 +83,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
         (input.getOptions().getMemo() != null)
             ? Memo.newBuilder()
                 .putAllFields(
-                    intoPayloadMap(clientOptions.getDataConverter(), input.getOptions().getMemo()))
+                    intoPayloadMap(dataConverterWithWorkflowContext, input.getOptions().getMemo()))
                 .build()
             : null;
 
@@ -169,7 +169,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
             ? Memo.newBuilder()
                 .putAllFields(
                     intoPayloadMap(
-                        clientOptions.getDataConverter(),
+                        dataConverterWithWorkflowContext,
                         workflowStartInput.getOptions().getMemo()))
                 .build()
             : null;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -1008,6 +1008,10 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
     return dataConverter;
   }
 
+  public DataConverter getDataConverterWithCurrentWorkflowContext() {
+    return dataConverterWithCurrentWorkflowContext;
+  }
+
   boolean isReplaying() {
     return replayContext.isReplaying();
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -555,7 +555,7 @@ public final class WorkflowInternal {
       return null;
     }
 
-    return getDataConverter().fromPayload(memo, valueClass, genericType);
+    return getDataConverterWithCurrentWorkflowContext().fromPayload(memo, valueClass, genericType);
   }
 
   public static <R> R retry(
@@ -693,18 +693,22 @@ public final class WorkflowInternal {
   }
 
   public static void upsertSearchAttributes(Map<String, ?> searchAttributes) {
-    assertNotReadOnly("upset search attribute");
+    assertNotReadOnly("upsert search attribute");
     getWorkflowOutboundInterceptor().upsertSearchAttributes(searchAttributes);
   }
 
   public static void upsertTypedSearchAttributes(
       SearchAttributeUpdate<?>... searchAttributeUpdates) {
-    assertNotReadOnly("upset search attribute");
+    assertNotReadOnly("upsert search attribute");
     getWorkflowOutboundInterceptor().upsertTypedSearchAttributes(searchAttributeUpdates);
   }
 
   public static DataConverter getDataConverter() {
     return getRootWorkflowContext().getDataConverter();
+  }
+
+  static DataConverter getDataConverterWithCurrentWorkflowContext() {
+    return getRootWorkflowContext().getDataConverterWithCurrentWorkflowContext();
   }
 
   /**
@@ -723,7 +727,7 @@ public final class WorkflowInternal {
     return Optional.ofNullable(getRootWorkflowContext().getReplayContext().getPreviousRunFailure())
         // Temporal Failure Values are additional user payload and serialized using user data
         // converter
-        .map(f -> getDataConverter().failureToException(f));
+        .map(f -> getDataConverterWithCurrentWorkflowContext().failureToException(f));
   }
 
   private static WorkflowOutboundCallsInterceptor getWorkflowOutboundInterceptor() {

--- a/temporal-sdk/src/main/java/io/temporal/payload/context/HasWorkflowSerializationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/payload/context/HasWorkflowSerializationContext.java
@@ -41,6 +41,8 @@ public interface HasWorkflowSerializationContext extends SerializationContext {
    * @return workflowId of the Workflow Execution the Serialization Target belongs to. If the Target
    *     is a Workflow itself, this method will return the Target's Workflow ID (not the ID of the
    *     parent workflow).
+   *     <p>WARNING: When used in the context of a schedule workflow the workflowId may differ on
+   *     serialization and deserialization.
    */
   String getWorkflowId();
 }

--- a/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
@@ -21,34 +21,39 @@
 package io.temporal.functional.serialization;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import io.temporal.activity.*;
 import io.temporal.api.common.v1.Payload;
-import io.temporal.client.WorkflowClientOptions;
-import io.temporal.common.converter.CodecDataConverter;
-import io.temporal.common.converter.DataConverter;
-import io.temporal.common.converter.DefaultDataConverter;
-import io.temporal.common.converter.EncodingKeys;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.*;
+import io.temporal.client.schedules.*;
+import io.temporal.common.converter.*;
+import io.temporal.failure.CanceledFailure;
 import io.temporal.payload.codec.PayloadCodec;
 import io.temporal.payload.codec.PayloadCodecException;
 import io.temporal.payload.context.ActivitySerializationContext;
 import io.temporal.payload.context.HasWorkflowSerializationContext;
 import io.temporal.payload.context.SerializationContext;
+import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.ChildWorkflowOptions;
+import io.temporal.workflow.ContinueAsNewOptions;
 import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflowWithCronScheduleImpl;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 /**
  * This test emulates a scenario when users may be using WorkflowId in their encoding to sign every
@@ -58,6 +63,9 @@ import org.junit.Test;
  * explode on decoding.
  */
 public class WorkflowIdSignedPayloadsTest {
+  private static final String MEMO_KEY = "testKey";
+  private static final String MEMO_VALUE = "testValue";
+  private static final Map<String, Object> MEMO = ImmutableMap.of(MEMO_KEY, MEMO_VALUE);
   private final SimpleActivity heartbeatingActivity = new HeartbeatingIfNotLocalActivityImpl();
   private final ManualCompletionActivity manualCompletionActivity =
       new ManualCompletionActivityImpl();
@@ -70,17 +78,88 @@ public class WorkflowIdSignedPayloadsTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(SimpleWorkflowWithAnActivity.class)
+          .setWorkflowTypes(
+              SimpleWorkflowWithAnActivity.class, TestWorkflowWithCronScheduleImpl.class)
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder().setDataConverter(codecDataConverter).build())
           .setActivityImplementations(heartbeatingActivity, manualCompletionActivity)
           .build();
+
+  @Rule public TestName testName = new TestName();
 
   @Test
   public void testSimpleWorkflowWithAnActivity() {
     TestWorkflows.TestWorkflow1 workflowStub =
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     assertEquals("result", workflowStub.execute("input"));
+  }
+
+  @Test
+  public void testSimpleWorkflowWithMemo() throws InterruptedException {
+    assumeTrue(
+        "skipping as test server does not support list", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue());
+    options = WorkflowOptions.newBuilder(options).setMemo(MEMO).build();
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflow1.class, options);
+    assertEquals("result", workflowStub.execute("input"));
+    WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
+    String workflowId = execution.getWorkflowId();
+    String runId = execution.getRunId();
+
+    // listWorkflowExecutions is Visibility API
+    // Temporal Visibility has latency and is not transactional with the Server API call
+    Thread.sleep(4_000);
+
+    List<WorkflowExecutionMetadata> executions =
+        testWorkflowRule
+            .getWorkflowClient()
+            .listExecutions("WorkflowId = '" + workflowId + "' AND " + " RunId = '" + runId + "'")
+            .collect(Collectors.toList());
+    assertEquals(1, executions.size());
+    assertEquals(MEMO_VALUE, executions.get(0).getMemo(MEMO_KEY, String.class));
+  }
+
+  @Test
+  public void testSimpleCronWorkflow() {
+    assumeFalse("skipping as test will timeout", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue());
+    options =
+        WorkflowOptions.newBuilder(options)
+            .setWorkflowRunTimeout(Duration.ofHours(1))
+            .setCronSchedule("0 */6 * * *")
+            .build();
+    TestWorkflows.TestWorkflowWithCronSchedule workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflowWithCronSchedule.class, options);
+
+    testWorkflowRule.registerDelayedCallback(
+        Duration.ofDays(1), WorkflowStub.fromTyped(workflow)::cancel);
+    WorkflowClient.start(workflow::execute, testName.getMethodName());
+
+    try {
+      workflow.execute(testName.getMethodName());
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+
+    Map<Integer, String> lastCompletionResults =
+        TestWorkflowWithCronScheduleImpl.lastCompletionResults.get(testName.getMethodName());
+    assertEquals(4, lastCompletionResults.size());
+    // Run 3 failed. So on run 4 we get the last completion result from run 2.
+    assertEquals("run 2", lastCompletionResults.get(4));
+    // The last failure ought to be the one from run 3
+    assertTrue(TestWorkflowWithCronScheduleImpl.lastFail.isPresent());
+    assertTrue(
+        TestWorkflowWithCronScheduleImpl.lastFail.get().getMessage().contains("simulated error"));
   }
 
   @ActivityInterface
@@ -123,6 +202,14 @@ public class WorkflowIdSignedPayloadsTest {
     }
   }
 
+  public static class SimpleCronWorkflow implements TestWorkflows.TestWorkflowReturnString {
+
+    @Override
+    public String execute() {
+      return null;
+    }
+  }
+
   public static class SimpleWorkflowWithAnActivity implements TestWorkflows.TestWorkflow1 {
 
     private final SimpleActivity activity =
@@ -159,14 +246,21 @@ public class WorkflowIdSignedPayloadsTest {
       assertEquals("result", result);
       // Child Workflow
       if (!Workflow.getInfo().getParentWorkflowId().isPresent()) {
+        ChildWorkflowOptions childOptions = ChildWorkflowOptions.newBuilder().setMemo(MEMO).build();
         TestWorkflows.TestWorkflow1 child =
-            Workflow.newChildWorkflowStub(TestWorkflows.TestWorkflow1.class);
+            Workflow.newChildWorkflowStub(TestWorkflows.TestWorkflow1.class, childOptions);
         result = child.execute(input);
         assertEquals("result", result);
       }
+      // Memo
+      String memoValue = (String) Workflow.getMemo(MEMO_KEY, String.class);
+      if (memoValue != null) {
+        assertEquals(MEMO_VALUE, memoValue);
+      }
       // continueAsNew
       if (!Workflow.getInfo().getContinuedExecutionRunId().isPresent()) {
-        Workflow.continueAsNew(input);
+        ContinueAsNewOptions casOptions = ContinueAsNewOptions.newBuilder().setMemo(MEMO).build();
+        Workflow.continueAsNew(casOptions, input);
       }
       return result;
     }

--- a/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
@@ -202,14 +202,6 @@ public class WorkflowIdSignedPayloadsTest {
     }
   }
 
-  public static class SimpleCronWorkflow implements TestWorkflows.TestWorkflowReturnString {
-
-    @Override
-    public String execute() {
-      return null;
-    }
-  }
-
   public static class SimpleWorkflowWithAnActivity implements TestWorkflows.TestWorkflow1 {
 
     private final SimpleActivity activity =


### PR DESCRIPTION
Add data converter context to memo, lastFailure and schedules.

# Note about schedules and data converter context: 

Schedules don't interact well with `WorkflowContext` because the full workflow ID (only a prefix) is not available when serializing the input. The workflow ID may also be changes after the input is serialized. The workflow ID will also be wrong on APIs like getting the previous result or failure.

closes https://github.com/temporalio/sdk-java/issues/1895
