### PR TITLE
Tag workflow_task_execution_failed with error type

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -41,6 +41,7 @@ public class MetricsTag {
   public static final String STATUS_CODE = "status_code";
   public static final String EXCEPTION = "exception";
   public static final String OPERATION_NAME = "operation";
+  public static final String TASK_FAILURE_TYPE = "failure_reason";
 
   /** Used to pass metrics scope to the interceptor */
   public static final CallOptions.Key<Scope> METRICS_TAGS_CALL_OPTIONS_KEY =


### PR DESCRIPTION
This PR adds a tag to `workflow_task_execution_failed` called `failure_reason` that can be equal to `WorkflowError| NonDetermismError` depending on why the workflow task failed.

closes https://github.com/temporalio/sdk-java/issues/1929