### PR TITLE
Add Mend reachability analysis

### DIFF
--- a/whitesource.config
+++ b/whitesource.config
@@ -1,1 +1,13 @@
-gradle.ignoredConfigurations=.*test.*
+
+{
+  "settingsInheritedFrom": "temporalio/whitesource-config@main",
+  "scanSettings": {
+    "configMode": "EXTERNAL",
+    "configExternalURL": "https://raw.githubusercontent.com/temporalio/sdk-java/master/whitesource.config",
+    "enableReachability": true
+  },
+  "checkRunSettings": {
+    "strictMode": "warning"
+  },
+  "gradle.ignoredConfigurations": ".*test.*"
+}


### PR DESCRIPTION
## What was changed
This is the json snippet support gave me, but I added the gradle ignore we had before.

## Why?
"Reachability analysis" should make the Mend dependency alerts less noisy by seeing when we aren't using the vulnerable component of the problematic library.

## Checklist

### How was this tested:
I'm hoping I can test this scanning change while this is a PR. I'll update this later with whatever I figure out.