### PR TITLE
Allow specifying workflow id when starting the workflow

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -144,6 +144,8 @@ public interface WorkflowStub {
 
   WorkflowExecution start(Object... args);
 
+  WorkflowExecution startWithId(String workflowId, Object... args);
+
   WorkflowExecution signalWithStart(String signalName, Object[] signalArgs, Object[] startArgs);
 
   Optional<String> getWorkflowType();

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -129,6 +129,16 @@ class WorkflowStubImpl implements WorkflowStub {
     return startWithOptions(WorkflowOptions.merge(null, null, options), args);
   }
 
+  @Override
+  public WorkflowExecution startWithId(String workflowId, Object... args) {
+    if (options == null) {
+      throw new IllegalStateException("Required parameter WorkflowOptions is missing");
+    }
+    WorkflowOptions workflowOptions =
+        WorkflowOptions.newBuilder(options).setWorkflowId(workflowId).build();
+    return startWithOptions(WorkflowOptions.merge(null, null, workflowOptions), args);
+  }
+
   private WorkflowExecution signalWithStartWithOptions(
       WorkflowOptions options, String signalName, Object[] signalArgs, Object[] startArgs) {
     checkExecutionIsNotStarted();

--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowMethodMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowMethodMetadata.java
@@ -70,6 +70,10 @@ public final class POJOWorkflowMethodMetadata {
     return workflowInterface;
   }
 
+  public Optional<Integer> getWorkflowIdParameterIndex() {
+    return workflowMethod.getWorkflowIdParameterIndex();
+  }
+
   /** Compare and hash based on method and the interface type only. */
   @Override
   public boolean equals(Object o) {

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowId.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowId.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the method parameter is the workflow id. If such parameter is present in
+ * a @WorkflowMethod then it will override the value in WorkflowOptions.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface WorkflowId {}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
@@ -95,6 +95,12 @@ public class TestWorkflows {
   }
 
   @WorkflowInterface
+  public interface TestWorkflowIdArg {
+    @WorkflowMethod
+    String execute(@WorkflowId String arg1, String arg2);
+  }
+
+  @WorkflowInterface
   public interface TestWorkflowWithCronSchedule {
     @WorkflowMethod
     @CronSchedule("0 * * * *")

--- a/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
@@ -78,6 +78,11 @@ class TimeLockingInterceptor extends WorkflowClientInterceptorBase {
     }
 
     @Override
+    public WorkflowExecution startWithId(String workflowId, Object... args) {
+      return next.startWithId(workflowId, args);
+    }
+
+    @Override
     public WorkflowExecution signalWithStart(
         String signalName, Object[] signalArgs, Object[] startArgs) {
       return next.signalWithStart(signalName, signalArgs, startArgs);


### PR DESCRIPTION
## What was changed

For now this is an experiment to gather feedback.

- Add a new method to `WorkflowStub`:  `WorkflowExecution startWithId(String workflowId, Object... args);`
- Add a new annotation `@WorkflowId` for a paramater on a `@WorkflowMethod`
- Extend `WorkflowInvocationHandler`: if a `@WorkflowId` is specified, start workflow with `startWithId()`
- Added tests

## Why?

Currently the `workflowId` can only be set in `WorkflowOptions`, along with other options that are basically static config for a workflow instance, whereas`workflowId` differs typically between workflow executions.

This makes injecting pre-configured workflow instances where they are to be started virtually impossible, which adds noise to the call site. With this new API, such code becomes possible (spring-like pseudo-code). The idea is that ExampleWorkflowImpl could be created by an IOC container for each request (e.g. in spring Request scope).

```
@Controller
class WorkflowController {

  @Autowired private ExampleWorkflow workflow;

  @PostMapping
  public void start(UUID idempotencyKey, Data data) {
    workflow.execute(idempotencyKey, data)
  }
}


@WorkflowInterface
public interface ExampleWorkflow {
  @WorkflowMethod
  String execute(@WorkflowId UUID idempotencyKey, Data data);
}
```

## Checklist

1. Closes: N/A

2. How was this tested: With the added junit tests

3. Any docs updates needed? Probably, as this is a public API addition.