### PR TITLE
Allow WorkflowImplementationOptions to be passed in TestWorkflowExtension (#1626)

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -31,13 +31,16 @@ import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerOptions;
+import io.temporal.worker.WorkflowImplementationOptions;
 import io.temporal.workflow.DynamicWorkflow;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Parameter;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -91,7 +94,7 @@ public class TestWorkflowExtension
   private final WorkerOptions workerOptions;
   private final WorkflowClientOptions workflowClientOptions;
   private final WorkerFactoryOptions workerFactoryOptions;
-  private final Class<?>[] workflowTypes;
+  private final Map<Class<?>, WorkflowImplementationOptions> workflowTypes;
   private final Object[] activityImplementations;
   private final boolean useExternalService;
   private final String target;
@@ -128,7 +131,8 @@ public class TestWorkflowExtension
     supportedParameterTypes.add(WorkflowOptions.class);
     supportedParameterTypes.add(Worker.class);
 
-    for (Class<?> workflowType : workflowTypes) {
+    for (Entry<Class<?>, WorkflowImplementationOptions> entry : workflowTypes.entrySet()) {
+      Class<?> workflowType = entry.getKey();
       if (DynamicWorkflow.class.isAssignableFrom(workflowType)) {
         includesDynamicWorkflow = true;
         continue;
@@ -211,7 +215,7 @@ public class TestWorkflowExtension
     String taskQueue =
         String.format("WorkflowTest-%s-%s", context.getDisplayName(), context.getUniqueId());
     Worker worker = testEnvironment.newWorker(taskQueue, workerOptions);
-    worker.registerWorkflowImplementationTypes(workflowTypes);
+    workflowTypes.forEach((wft, o) -> worker.registerWorkflowImplementationTypes(o, wft));
     worker.registerActivitiesImplementations(activityImplementations);
 
     if (!doNotStart) {
@@ -281,14 +285,13 @@ public class TestWorkflowExtension
 
   public static class Builder {
 
-    private static final Class<?>[] NO_WORKFLOWS = new Class<?>[0];
     private static final Object[] NO_ACTIVITIES = new Object[0];
 
     private WorkerOptions workerOptions = WorkerOptions.getDefaultInstance();
     private WorkflowClientOptions workflowClientOptions;
     private WorkerFactoryOptions workerFactoryOptions;
     private String namespace = "UnitTest";
-    private Class<?>[] workflowTypes = NO_WORKFLOWS;
+    private Map<Class<?>, WorkflowImplementationOptions> workflowTypes = new HashMap<>();
     private Object[] activityImplementations = NO_ACTIVITIES;
     private boolean useExternalService = false;
     private String target = null;
@@ -345,9 +348,33 @@ public class TestWorkflowExtension
      *
      * @see Worker#registerWorkflowImplementationTypes(Class[])
      */
-    public Builder setWorkflowTypes(Class<?>... workflowTypes) {
-      this.workflowTypes = workflowTypes;
+    public Builder registerWorkflowImplementationTypes(Class<?>... workflowTypes) {
+      WorkflowImplementationOptions defaultOptions =
+          WorkflowImplementationOptions.newBuilder().build();
+      Arrays.stream(workflowTypes).forEach(wf -> this.workflowTypes.put(wf, defaultOptions));
       return this;
+    }
+
+    /**
+     * Specify workflow implementation types to register with the Temporal worker.
+     *
+     * @see Worker#registerWorkflowImplementationTypes(Class[])
+     */
+    public Builder registerWorkflowImplementationTypes(
+        WorkflowImplementationOptions options, Class<?>... workflowTypes) {
+      Arrays.stream(workflowTypes).forEach(wf -> this.workflowTypes.put(wf, options));
+      return this;
+    }
+
+    /**
+     * Specify workflow implementation types to register with the Temporal worker.
+     *
+     * @see Worker#registerWorkflowImplementationTypes(Class[])
+     * @deprecated use registerWorkflowImplementationTypes instead
+     */
+    @Deprecated
+    public Builder setWorkflowTypes(Class<?>... workflowTypes) {
+      return this.registerWorkflowImplementationTypes(workflowTypes);
     }
 
     /**

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
@@ -23,12 +23,21 @@ package io.temporal.testing.internal;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.worker.WorkflowImplementationOptions;
 import java.time.Duration;
 
 public class SDKTestOptions {
   // When set to true increases test, activity and workflow timeouts to large values to support
   // stepping through code in a debugger without timing out.
   private static final boolean DEBUGGER_TIMEOUTS = false;
+
+  public static WorkflowImplementationOptions
+      newWorkflowImplementationOptionsWithDefaultStartToCloseTimeout() {
+    return WorkflowImplementationOptions.newBuilder()
+        .setDefaultActivityOptions(
+            ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofMinutes(1)).build())
+        .build();
+  }
 
   public static WorkflowOptions newWorkflowOptionsForTaskQueue200sTimeout(String taskQueue) {
     return WorkflowOptions.newBuilder()

--- a/temporal-testing/src/test/java/io/temporal/testing/junit5/TestWorkflowExtensionDynamicTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/junit5/TestWorkflowExtensionDynamicTest.java
@@ -49,7 +49,7 @@ public class TestWorkflowExtensionDynamicTest {
   @RegisterExtension
   public static final TestWorkflowExtension testWorkflow =
       TestWorkflowExtension.newBuilder()
-          .setWorkflowTypes(HelloDynamicWorkflowImpl.class)
+          .registerWorkflowImplementationTypes(HelloDynamicWorkflowImpl.class)
           .setActivityImplementations(new HelloDynamicActivityImpl())
           .build();
 

--- a/temporal-testing/src/test/java/io/temporal/testing/junit5/TestWorkflowExtensionTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/junit5/TestWorkflowExtensionTest.java
@@ -53,7 +53,7 @@ public class TestWorkflowExtensionTest {
   @RegisterExtension
   public static final TestWorkflowExtension testWorkflow =
       TestWorkflowExtension.newBuilder()
-          .setWorkflowTypes(HelloWorkflowImpl.class)
+          .registerWorkflowImplementationTypes(HelloWorkflowImpl.class)
           .setActivityImplementations(new HelloActivityImpl())
           .setInitialTime(Instant.parse("2021-10-10T10:01:00Z"))
           .build();

--- a/temporal-testing/src/test/java/io/temporal/testing/junit5/workflowImplementationOptions/TestWorkflowImplementationOptions.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/junit5/workflowImplementationOptions/TestWorkflowImplementationOptions.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.testing.junit5.workflowImplementationOptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.temporal.testing.TestWorkflowExtension;
+import io.temporal.testing.WorkflowInitialTime;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.junit5.workflowImplementationOptions.TestWorkflowImplementationOptionsCommon.HelloActivityImpl;
+import io.temporal.testing.junit5.workflowImplementationOptions.TestWorkflowImplementationOptionsCommon.HelloWorkflow;
+import io.temporal.testing.junit5.workflowImplementationOptions.TestWorkflowImplementationOptionsCommon.HelloWorkflowImpl;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+public class TestWorkflowImplementationOptions {
+
+  @RegisterExtension
+  public static final TestWorkflowExtension testWorkflow =
+      TestWorkflowExtension.newBuilder()
+          .registerWorkflowImplementationTypes(
+              SDKTestOptions.newWorkflowImplementationOptionsWithDefaultStartToCloseTimeout(),
+              HelloWorkflowImpl.class)
+          .setActivityImplementations(new HelloActivityImpl())
+          .setInitialTime(Instant.parse("2021-10-10T10:01:00Z"))
+          .build();
+
+  @Test
+  @WorkflowInitialTime("2020-01-01T01:00:00Z")
+  public void extensionShouldLaunchTestEnvironmentWithWorkflowImplementationOptions(
+      HelloWorkflow workflow) {
+
+    assertEquals(
+        String.format(
+            "Hello World from activity BuildGreeting and workflow HelloWorkflow with %s startToCloseTimeout",
+            SDKTestOptions.newWorkflowImplementationOptionsWithDefaultStartToCloseTimeout()
+                .getDefaultActivityOptions()
+                .getStartToCloseTimeout()),
+        workflow.sayHello("World"));
+  }
+}

--- a/temporal-testing/src/test/java/io/temporal/testing/junit5/workflowImplementationOptions/TestWorkflowImplementationOptionsCommon.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/junit5/workflowImplementationOptions/TestWorkflowImplementationOptionsCommon.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.testing.junit5.workflowImplementationOptions;
+
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityInfo;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import org.slf4j.Logger;
+
+public class TestWorkflowImplementationOptionsCommon {
+
+  @WorkflowInterface
+  public interface HelloWorkflow {
+
+    @WorkflowMethod
+    String sayHello(String name);
+  }
+
+  @ActivityInterface
+  public interface HelloActivity {
+    String buildGreeting(String name);
+  }
+
+  public static class HelloActivityImpl implements HelloActivity {
+    @Override
+    public String buildGreeting(String name) {
+      ActivityInfo activityInfo = Activity.getExecutionContext().getInfo();
+      return String.format(
+          "Hello %s from activity %s and workflow %s with %s startToCloseTimeout",
+          name,
+          activityInfo.getActivityType(),
+          activityInfo.getWorkflowType(),
+          activityInfo.getStartToCloseTimeout());
+    }
+  }
+
+  public static class HelloWorkflowImpl implements HelloWorkflow {
+
+    private static final Logger logger = Workflow.getLogger(HelloWorkflowImpl.class);
+
+    // There is no startToCloseTimeout set and no WorkflowImplementationOptions
+    private final HelloActivity helloActivity = Workflow.newActivityStub(HelloActivity.class);
+
+    @Override
+    public String sayHello(String name) {
+      logger.info("Hello, {}", name);
+      Workflow.sleep(Duration.ofHours(1));
+      return helloActivity.buildGreeting(name);
+    }
+  }
+}

--- a/temporal-testing/src/test/java/io/temporal/testing/junit5/workflowImplementationOptions/TestWorkflowImplementationOptionsViceVersa.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/junit5/workflowImplementationOptions/TestWorkflowImplementationOptionsViceVersa.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.testing.junit5.workflowImplementationOptions;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.testing.TestWorkflowExtension;
+import io.temporal.testing.WorkflowInitialTime;
+import io.temporal.testing.junit5.workflowImplementationOptions.TestWorkflowImplementationOptionsCommon.HelloActivityImpl;
+import io.temporal.testing.junit5.workflowImplementationOptions.TestWorkflowImplementationOptionsCommon.HelloWorkflowImpl;
+import io.temporal.worker.Worker;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+public class TestWorkflowImplementationOptionsViceVersa {
+
+  @RegisterExtension
+  public static final TestWorkflowExtension testWorkflow =
+      TestWorkflowExtension.newBuilder()
+          .registerWorkflowImplementationTypes(HelloWorkflowImpl.class)
+          .setActivityImplementations(new HelloActivityImpl())
+          .setInitialTime(Instant.parse("2021-10-10T10:01:00Z"))
+          .build();
+
+  @Test
+  @WorkflowInitialTime("2020-01-01T01:00:00Z")
+  public void extensionShouldNotBeAbleToCallActivityBasedOnMissingTimeouts(
+      TestWorkflowEnvironment testEnv, WorkflowOptions workflowOptions, Worker worker)
+      throws InterruptedException, ExecutionException, TimeoutException {
+
+    WorkflowStub cut =
+        testEnv.getWorkflowClient().newUntypedWorkflowStub("HelloWorkflow", workflowOptions);
+    cut.start("World");
+
+    CompletableFuture<String> resultAsync = cut.getResultAsync(String.class);
+    assertThrows(TimeoutException.class, () -> resultAsync.get(5, TimeUnit.SECONDS));
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->
(/)
<!--- For ALL Contributors 👇 -->

## What was changed
It is possible to configure WorkflowImplementationsOptions using TestWorkflowExtension.
https://github.com/temporalio/sdk-java/issues/1626

## Why?
In order to configure WorkflowImplementationOptions  (like default ActivityOptions) using TestWorkflowExtension two new Methods registerWorkflowImplementationTypes are implemented. I choosed registerWorkflowImplementationTypes and not setWorkflowTypes because I found the registerWorkflowImplementationTypes like the one needed to configure WorkflowImplementationOptions to a worker in "non-test" Code. 

## Checklist
1. Closes [1626](https://github.com/temporalio/sdk-java/issues/1626)

2. How was this tested:
With my tests in a different project and through 2 Unit-Tests. One (TestWorkflowImplementationOptions.java) providing WorkflowImplementationOptions and one not providing the options (which would run into end endless loop). I did not find a more direct-way to tests this. So just testing side-effects of the implementation. An because side-effects might change in future TestWorkflowImplementationOptionsViceVersa.java for testing that TestWorkflowImplementationOptions.java would brake if the side-effect changes. 

3. Any docs updates needed?
I did not find a documentation that needs to be adapted. But https://github.com/temporalio/documentation/blob/main/docs-src/java/testing-frameworks.md should be fixed, It contains a broken link to https://github.com/temporalio/samples-java/tree/main/src/test/java/io/temporal/samples which should be https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples. As it is a different repository. I will open up another pull-request for it.