### PR TITLE
Removed heardcoded 10 second timeout for an activity under test

### DIFF
--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -363,16 +363,12 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
                       localActivity));
 
       try {
-        // 10 seconds is just a "reasonable" wait to not make an infinite waiting
-        return activityFuture.get(10, TimeUnit.SECONDS);
+        return activityFuture.get();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       } catch (ExecutionException e) {
         log.error("Exception during processing of activity task");
-        throw new RuntimeException(e);
-      } catch (TimeoutException e) {
-        log.error("Timeout trying execute activity task {}", activityTask);
         throw new RuntimeException(e);
       }
     }


### PR DESCRIPTION
## What was changed
Removed hardcoded 10-second timeout for TestActivityEnvironment.

## Why?
We want to support unit testing activities that take longer than 10 seconds.

Reported at https://community.temporal.io/t/activities-run-in-tests-using-testactivityenvironment-intermittently-fails-with-java-util-concurrent-timeoutexception/10397/3