### PR TITLE
Allow creating a stub of an update only interface

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
@@ -47,10 +47,7 @@ import io.temporal.internal.sync.StubMarker;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.WorkerFactory;
-import io.temporal.workflow.Functions;
-import io.temporal.workflow.QueryMethod;
-import io.temporal.workflow.SignalMethod;
-import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -175,7 +172,12 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
   @Override
   public <T> T newWorkflowStub(
       Class<T> workflowInterface, String workflowId, Optional<String> runId) {
-    checkAnnotation(workflowInterface, WorkflowMethod.class, QueryMethod.class, SignalMethod.class);
+    checkAnnotation(
+        workflowInterface,
+        WorkflowMethod.class,
+        QueryMethod.class,
+        SignalMethod.class,
+        UpdateMethod.class);
     if (Strings.isNullOrEmpty(workflowId)) {
       throw new IllegalArgumentException("workflowId is null or empty");
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateAnnotationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateAnnotationTest.java
@@ -1,0 +1,72 @@
+package io.temporal.workflow.updateTest;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.UpdateMethod;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UpdateAnnotationTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(WorkflowImpl.class).build();
+
+  @Test
+  public void testUpdateOnlyInterface() {
+    // Verify a stub to an interface with only @UpdateMethod can be created.
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .build();
+    WorkflowTestInterface workflow =
+        workflowClient.newWorkflowStub(WorkflowTestInterface.class, options);
+
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+
+    UpdateWorkflowInterface updateOnlyWorkflow =
+        workflowClient.newWorkflowStub(UpdateWorkflowInterface.class, execution.getWorkflowId());
+    updateOnlyWorkflow.update();
+
+    String result =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(execution, Optional.empty())
+            .getResult(String.class);
+    assertEquals("success", result);
+  }
+
+  public interface UpdateWorkflowInterface {
+    @UpdateMethod
+    void update();
+  }
+
+  @WorkflowInterface
+  public interface WorkflowTestInterface extends UpdateWorkflowInterface {
+    @WorkflowMethod
+    String execute();
+  }
+
+  public static class WorkflowImpl implements WorkflowTestInterface {
+    boolean complete = false;
+
+    @Override
+    public String execute() {
+      Workflow.await(() -> complete);
+      return "success";
+    }
+
+    @Override
+    public void update() {
+      complete = true;
+    }
+  }
+}


### PR DESCRIPTION
Allow creating a stub of an update only interface.

closes https://github.com/temporalio/sdk-java/issues/1966