### PR TITLE
Update README.md for temporal-spring-boot-starter-alpha

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/README.md
+++ b/temporal-spring-boot-autoconfigure-alpha/README.md
@@ -119,7 +119,7 @@ spring.temporal:
     # workflow-cache:
       # max-instances: 600
       # max-threads: 600
-    # start-workers: false # disable auto-start of WorkersFactory and Workers if you want to make any custom changes before the start
+    # startWorkers: false # disable auto-start of WorkersFactory and Workers if you want to make any custom changes before the start
 ```
 </details>
 
@@ -235,4 +235,8 @@ public class Test {
 }
 ```
 
-
+If you wish to mock a child workflow you may need to:
+- exclude its package from the auto discovery configuration
+- disallow the workers from automatically starting on the test startup by setting `spring.temporal.startWorkers` to `false`.
+- in your test, you can register the mock instance to the worker the same as you would do it regularly: `worker.registerWorkflowImplementationFactory(IChildWorkflow.class, () -> mockChildWorkflowInstance);`
+- then start the workers


### PR DESCRIPTION
## What was changed
Changes done to the README.md file in the temporal-spring-boot-starter-alpha module:
- Fix a configuration typo (`spring.temporal.start-workers` -> `spring.temporal.startWorkers` as the first option does not work)
- Add description for how to test a child workflow while using the library

## Why?
- The configuration of how to disable the automatic startup of workers was wrong
- To help the library users easily write child workflow tests 

3. Any docs updates needed?
Updated README.md under temporal-spring-boot-starter-alpha
