### PR TITLE
Prefix some errors with rule identifiers

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
@@ -50,7 +50,7 @@ public class PotentialDeadlockException extends RuntimeException {
   PotentialDeadlockException(
       String threadName, WorkflowThreadContext workflowThreadContext, long detectionTimestamp) {
     super(
-        "Potential deadlock detected. Workflow thread \""
+        "[TMPRL1101] Potential deadlock detected. Workflow thread \""
             + threadName
             + "\" didn't yield control for over a second.");
     this.workflowThreadContext = workflowThreadContext;

--- a/temporal-sdk/src/main/java/io/temporal/worker/NonDeterministicException.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/NonDeterministicException.java
@@ -32,10 +32,10 @@ package io.temporal.worker;
  */
 public class NonDeterministicException extends IllegalStateException {
   public NonDeterministicException(String message, Throwable cause) {
-    super(message, cause);
+    super("[TMPRL1100] " + message, cause);
   }
 
   public NonDeterministicException(String message) {
-    super(message);
+    super("[TMPRL1100] " + message);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
@@ -1315,7 +1315,8 @@ public class VersionStateMachineTest {
             e.getCause()
                 .getCause()
                 .getMessage()
-                .startsWith("getVersion call before the existing version marker event."));
+                .startsWith(
+                    "[TMPRL1100] getVersion call before the existing version marker event."));
       }
     }
   }


### PR DESCRIPTION
## What was changed

Add a couple of https://github.com/temporalio/rules references as error prefixes