### PR TITLE
Clarify local connection option

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/README.md
+++ b/temporal-spring-boot-autoconfigure-alpha/README.md
@@ -18,6 +18,7 @@ The following configuration connects to a locally started Temporal Server
 spring.temporal:
   connection:
     target: local # you can specify a host:port here for a remote connection
+    # specifying local is equivalent to WorkflowServiceStubs.newLocalServiceStubs() so all other connection options are ignored. 
     # enable-https: true
   # namespace: default # you can specify a custom namespace that you are using
 ```


### PR DESCRIPTION
Clarify local connection option behaviour. If users want to specify connection options and not use the local service stubs default they can always specify target as "localhost:7233" and set all the options they want themselves


closes https://github.com/temporalio/sdk-java/issues/1815