### PR TITLE
Update Java SDK retry options for poll operations to match Core SDK.

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -385,7 +385,7 @@ public final class RpcRetryOptions {
 
     private static boolean isInvalidDuration(Duration d) {
       if (d == null) {
-        return true;
+        return false;
       }
       return d.isNegative() || d.isZero();
     }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -20,11 +20,7 @@
 
 package io.temporal.serviceclient;
 
-import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.BACKOFF;
-import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.CONGESTION_INITIAL_INTERVAL;
-import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.EXPIRATION_INTERVAL;
-import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.INITIAL_INTERVAL;
-import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.MAXIMUM_JITTER_COEFFICIENT;
+import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.*;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -362,7 +358,7 @@ public final class RpcRetryOptions {
       }
       Duration maximumInterval = this.maximumInterval;
       if (maximumInterval == null && maximumAttempts == 0) {
-        maximumInterval = initialInterval.multipliedBy(50);
+        maximumInterval = initialInterval.multipliedBy(MAXIMUM_INTERVAL_MULTIPLIER);
       }
       double maximumJitterCoefficient = this.maximumJitterCoefficient;
       if (maximumJitterCoefficient < 0) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -208,8 +208,8 @@ public final class RpcRetryOptions {
      * is the cap of the increase. <br>
      * Default is 50x of initial interval. Can't be less than {@link #setInitialInterval(Duration)}
      *
-     * @param maximumInterval the maximum interval value. Defaults to 50x initial interval, which
-     *     is used if set to {@code null}.
+     * @param maximumInterval the maximum interval value. Defaults to 50x initial interval, which is
+     *     used if set to {@code null}.
      */
     public Builder setMaximumInterval(Duration maximumInterval) {
       if (isInvalidDuration(maximumInterval)) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -25,11 +25,12 @@ import java.time.Duration;
 
 /** Default rpc retry options for long polls like waiting for the workflow finishing and result. */
 public class DefaultStubLongPollRpcRetryOptions {
-  public static final Duration INITIAL_INTERVAL = Duration.ofMillis(50);
+
+  public static final Duration INITIAL_INTERVAL = Duration.ofMillis(200);
   public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
-  public static final Duration MAXIMUM_INTERVAL = Duration.ofMinutes(1);
-  public static final double BACKOFF = 1.2;
-  public static final double MAXIMUM_JITTER_COEFFICIENT = 0.1;
+  public static final Duration MAXIMUM_INTERVAL = Duration.ofSeconds(10);
+  public static final double BACKOFF = 2.0;
+  public static final double MAXIMUM_JITTER_COEFFICIENT = 0.2;
 
   // partial build because expiration is not set, long polls work with absolute deadlines instead
   public static final RpcRetryOptions INSTANCE = getBuilder().build();

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubLongPollRpcRetryOptions.java
@@ -42,14 +42,11 @@ public class DefaultStubLongPollRpcRetryOptions {
   }
 
   private static RpcRetryOptions.Builder getBuilder() {
-    RpcRetryOptions.Builder roBuilder =
-        RpcRetryOptions.newBuilder()
-            .setInitialInterval(INITIAL_INTERVAL)
-            .setCongestionInitialInterval(CONGESTION_INITIAL_INTERVAL)
-            .setBackoffCoefficient(BACKOFF)
-            .setMaximumInterval(MAXIMUM_INTERVAL)
-            .setMaximumJitterCoefficient(MAXIMUM_JITTER_COEFFICIENT);
-
-    return roBuilder;
+    return RpcRetryOptions.newBuilder()
+        .setInitialInterval(INITIAL_INTERVAL)
+        .setCongestionInitialInterval(CONGESTION_INITIAL_INTERVAL)
+        .setBackoffCoefficient(BACKOFF)
+        .setMaximumInterval(MAXIMUM_INTERVAL)
+        .setMaximumJitterCoefficient(MAXIMUM_JITTER_COEFFICIENT);
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -34,8 +34,8 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
   public static final Duration EXPIRATION_INTERVAL = Duration.ofMinutes(1);
   public static final int MAXIMUM_INTERVAL_MULTIPLIER = 50;
-  public static final Duration MAXIMUM_INTERVAL = INITIAL_INTERVAL.multipliedBy(
-      MAXIMUM_INTERVAL_MULTIPLIER);
+  public static final Duration MAXIMUM_INTERVAL =
+      INITIAL_INTERVAL.multipliedBy(MAXIMUM_INTERVAL_MULTIPLIER);
   public static final double BACKOFF = 1.7;
   public static final double MAXIMUM_JITTER_COEFFICIENT = 0.2;
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -36,7 +36,7 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   public static final int MAXIMUM_INTERVAL_MULTIPLIER = 50;
   public static final Duration MAXIMUM_INTERVAL = INITIAL_INTERVAL.multipliedBy(
       MAXIMUM_INTERVAL_MULTIPLIER);
-  public static final double BACKOFF = 1.5;
+  public static final double BACKOFF = 1.7;
   public static final double MAXIMUM_JITTER_COEFFICIENT = 0.2;
 
   public static final RpcRetryOptions INSTANCE;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -29,22 +29,17 @@ import java.time.Duration;
  * finishing).
  */
 public class DefaultStubServiceOperationRpcRetryOptions {
-  public static final Duration INITIAL_INTERVAL = Duration.ofMillis(50);
+
+  public static final Duration INITIAL_INTERVAL = Duration.ofMillis(100);
   public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
   public static final Duration EXPIRATION_INTERVAL = Duration.ofMinutes(1);
-  public static final Duration MAXIMUM_INTERVAL;
-  public static final double BACKOFF = 2;
-  public static final double MAXIMUM_JITTER_COEFFICIENT = 0.1;
+  public static final Duration MAXIMUM_INTERVAL = Duration.ofMillis(5000);
+  public static final double BACKOFF = 1.5;
+  public static final double MAXIMUM_JITTER_COEFFICIENT = 0.2;
 
   public static final RpcRetryOptions INSTANCE;
 
   static {
-    Duration maxInterval = EXPIRATION_INTERVAL.dividedBy(10);
-    if (maxInterval.compareTo(INITIAL_INTERVAL) < 0) {
-      maxInterval = INITIAL_INTERVAL;
-    }
-    MAXIMUM_INTERVAL = maxInterval;
-
     INSTANCE = getBuilder().validateBuildWithDefaults();
   }
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/rpcretry/DefaultStubServiceOperationRpcRetryOptions.java
@@ -33,7 +33,9 @@ public class DefaultStubServiceOperationRpcRetryOptions {
   public static final Duration INITIAL_INTERVAL = Duration.ofMillis(100);
   public static final Duration CONGESTION_INITIAL_INTERVAL = Duration.ofMillis(1000);
   public static final Duration EXPIRATION_INTERVAL = Duration.ofMinutes(1);
-  public static final Duration MAXIMUM_INTERVAL = Duration.ofMillis(5000);
+  public static final int MAXIMUM_INTERVAL_MULTIPLIER = 50;
+  public static final Duration MAXIMUM_INTERVAL = INITIAL_INTERVAL.multipliedBy(
+      MAXIMUM_INTERVAL_MULTIPLIER);
   public static final double BACKOFF = 1.5;
   public static final double MAXIMUM_JITTER_COEFFICIENT = 0.2;
 

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -20,6 +20,8 @@
 
 package io.temporal.internal.retryer;
 
+import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.CONGESTION_INITIAL_INTERVAL;
+import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcRetryOptions.MAXIMUM_JITTER_COEFFICIENT;
 import static org.junit.Assert.*;
 
 import io.grpc.Context;
@@ -101,8 +103,9 @@ public class GrpcSyncRetryerTest {
     try {
       DEFAULT_SYNC_RETRYER.retry(
           () -> {
-            if (attempts.incrementAndGet() > 1)
+            if (attempts.incrementAndGet() > 1) {
               fail("We should not retry on exception that we specified to don't retry");
+            }
             throw new StatusRuntimeException(Status.fromCode(STATUS_CODE));
           },
           new GrpcRetryer.GrpcRetryerOptions(options, null),
@@ -130,7 +133,9 @@ public class GrpcSyncRetryerTest {
     try {
       DEFAULT_SYNC_RETRYER.retry(
           () -> {
-            if (attempts.incrementAndGet() > 1) fail("We should not retry on InterruptedException");
+            if (attempts.incrementAndGet() > 1) {
+              fail("We should not retry on InterruptedException");
+            }
             throw new InterruptedException();
           },
           new GrpcRetryer.GrpcRetryerOptions(options, null),
@@ -156,8 +161,9 @@ public class GrpcSyncRetryerTest {
     try {
       DEFAULT_SYNC_RETRYER.retry(
           () -> {
-            if (attempts.incrementAndGet() > 1)
+            if (attempts.incrementAndGet() > 1) {
               fail("We should not retry if the exception is not StatusRuntimeException");
+            }
             throw new IllegalArgumentException("simulated");
           },
           new GrpcRetryer.GrpcRetryerOptions(options, null),
@@ -335,7 +341,7 @@ public class GrpcSyncRetryerTest {
     assertEquals(3, options.getMaximumAttempts());
 
     // The following were added latter; they must silently use default values if unspecified
-    assertEquals(Duration.ofMillis(1000), options.getCongestionInitialInterval());
-    assertEquals(0.1, options.getMaximumJitterCoefficient(), 0.01);
+    assertEquals(CONGESTION_INITIAL_INTERVAL, options.getCongestionInitialInterval());
+    assertEquals(MAXIMUM_JITTER_COEFFICIENT, options.getMaximumJitterCoefficient(), 0.01);
   }
 }


### PR DESCRIPTION
## What was changed
* Update default initial interval for non-poll retries to 100ms (from 50ms)
* Update default maximum interval for non-poll retries to 5s (was 6s)
* Update default backoff factor for non-poll retries to 1.7 (was 2.0)
* Update default jitter factor for non-poll retries to 20% (was 10%)
* Update default initial interval for poll retries to 200ms (was 50ms)
* Update default maximum interval for poll retries to 10s (was 60s)
* Update default backoff factor for poll retries to 2.0 (was 1.2)
* Update default jitter factor for poll retries to 20% (was 10%)
* Code cleanups in argument validation code
* Default maximum interval is now computed from initial interval as documented (was hardcoded at 6s)

## Why?
These changes bring the Java SDK's RPC retry options in line with those of the Core SDK, as the latter have been more carefully reasoned through... with one exception.

The Java poller's existing backoff factor of 1.2 was wildly inappropriate, causing the first 10 retries to hammer the server within less than 1.5 seconds.  Even more confusingly, Java's maximum interval was far, far too long, as a 60s delay between the server becoming available and the worker noticing that fact is unreasonable and unnecessary.  The poller now uses a 2.0 backoff and 10s cap, exactly in line with Core SDK.

Regarding Java's non-poll RPCs, OTOH, 2.0 is not as aggressive as Core SDK's choice of 1.5, and yet Core is actually in the wrong here: all 10 permitted retries can complete within the 10-second window expected for namespace migrations in Temporal Cloud.  1.7 seems to be the ideal number here, as it leads to a cumulative delay window of 11.8 to 17.8 seconds.  I've used 1.7 here, and Core SDK should be updated to use it as well.