### PR TITLE
Apply serialization context to Dynamic Workflows

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DynamicSyncWorkflowDefinition.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DynamicSyncWorkflowDefinition.java
@@ -36,16 +36,17 @@ final class DynamicSyncWorkflowDefinition implements SyncWorkflowDefinition {
 
   private final Functions.Func<? extends DynamicWorkflow> factory;
   private final WorkerInterceptor[] workerInterceptors;
-  private final DataConverter dataConverter;
+  // don't pass it down to other classes, it's a "cached" instance for internal usage only
+  private final DataConverter dataConverterWithWorkflowContext;
   private WorkflowInboundCallsInterceptor workflowInvoker;
 
   public DynamicSyncWorkflowDefinition(
       Functions.Func<? extends DynamicWorkflow> factory,
       WorkerInterceptor[] workerInterceptors,
-      DataConverter dataConverter) {
+      DataConverter dataConverterWithWorkflowContext) {
     this.factory = factory;
     this.workerInterceptors = workerInterceptors;
-    this.dataConverter = dataConverter;
+    this.dataConverterWithWorkflowContext = dataConverterWithWorkflowContext;
   }
 
   @Override
@@ -61,11 +62,11 @@ final class DynamicSyncWorkflowDefinition implements SyncWorkflowDefinition {
 
   @Override
   public Optional<Payloads> execute(Header header, Optional<Payloads> input) {
-    Values args = new EncodedValues(input, dataConverter);
+    Values args = new EncodedValues(input, dataConverterWithWorkflowContext);
     WorkflowInboundCallsInterceptor.WorkflowOutput result =
         workflowInvoker.execute(
             new WorkflowInboundCallsInterceptor.WorkflowInput(header, new Object[] {args}));
-    return dataConverter.toPayloads(result.getResult());
+    return dataConverterWithWorkflowContext.toPayloads(result.getResult());
   }
 
   class RootWorkflowInboundCallsInterceptor extends BaseRootWorkflowInboundCallsInterceptor {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -230,7 +230,10 @@ public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFa
     if (factory == null) {
       if (dynamicWorkflowImplementationFactory != null) {
         return new DynamicSyncWorkflowDefinition(
-            dynamicWorkflowImplementationFactory, workerInterceptors, dataConverter);
+            dynamicWorkflowImplementationFactory,
+            workerInterceptors,
+            dataConverter.withContext(
+                new WorkflowSerializationContext(namespace, workflowExecution.getWorkflowId())));
       }
       // throw Error to abort the workflow task, not fail the workflow
       throw new Error(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Apply serialization context to Dynamic Workflows

## Why? 
Serialization context should be applied inside a workflow even if it is dynamic 

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/1982

2. How was this tested:
Added new integration test to cover dynamic workflow and activity

3. Any docs updates needed?
No
