### PR TITLE
Expose the workflow execution retry policy from the client (#1866)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
@@ -87,6 +87,12 @@ final class WorkflowInfoImpl implements WorkflowInfo {
     return context.getRetryOptions();
   }
 
+  @Nullable
+  @Override
+  public RetryOptions getRetryOptions() {
+    return context.getRetryOptions();
+  }
+
   @Override
   public Duration getWorkflowRunTimeout() {
     return context.getWorkflowRunTimeout();

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -90,6 +90,12 @@ public interface WorkflowInfo {
    */
   String getTaskQueue();
 
+  /*
+  * @return Workflow Retry Options
+  * */
+  @Nullable
+  RetryOptions getRetryOptions();
+
   @Nullable
   RetryOptions getRetryOptions();
 


### PR DESCRIPTION
## What was changed
Added a getter to the WorkflowInfo interface to return the retry policy of a workflow execution

## Why?
Addressing requirement

1. Closes Issue 1866

2. How was this tested:
Manually, since there was no pre-existing testing class for WorkflowInfoImpl

3. Any docs updates needed?
No
