### PR TITLE
SpringBoot - add server-name to mtls config options

### DIFF
--- a/temporal-spring-boot-autoconfigure-alpha/README.md
+++ b/temporal-spring-boot-autoconfigure-alpha/README.md
@@ -56,6 +56,7 @@ spring.temporal:
       cert-chain-file: /path/to/cert.pem # If you use PKCS12 (.pkcs12, .pfx or .p12), you don't need to set it because certificates chain is bundled into the key file
       # key-password: <password_for_the_key>
       # insecure-trust-manager: true # or add ca.pem to java default truststore
+      # server-name: <server_name_override> # optional server name overrider, used as authority of ManagedChannelBuilder
 ```
 
 Alternatively with PKCS8 you can pass the content of the key and certificates chain as strings, which allows to pass them from the environment variable for example:

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/ConnectionProperties.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/properties/ConnectionProperties.java
@@ -74,6 +74,7 @@ public class ConnectionProperties {
     private final @Nullable String certChainFile;
     private final @Nullable String keyPassword;
     private final @Nullable Boolean insecureTrustManager;
+    private final @Nullable String serverName;
 
     /**
      * @param pkcs number of PKCS standard to use (8 and 12 are supported). Selects if {@link
@@ -96,7 +97,8 @@ public class ConnectionProperties {
         @Nullable String keyFile,
         @Nullable String certChainFile,
         @Nullable String keyPassword,
-        @Nullable Boolean insecureTrustManager) {
+        @Nullable Boolean insecureTrustManager,
+        @Nullable String serverName) {
       this.pkcs = pkcs;
       this.key = key;
       this.certChain = certChain;
@@ -104,6 +106,7 @@ public class ConnectionProperties {
       this.certChainFile = certChainFile;
       this.keyPassword = keyPassword;
       this.insecureTrustManager = insecureTrustManager;
+      this.serverName = serverName;
     }
 
     @Nullable
@@ -139,6 +142,11 @@ public class ConnectionProperties {
     @Nullable
     public Boolean getInsecureTrustManager() {
       return insecureTrustManager;
+    }
+
+    @Nullable
+    public String getServerName() {
+      return serverName;
     }
   }
 }

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
@@ -151,6 +151,12 @@ public class ServiceStubOptionsTemplate {
         throw new BeanCreationException("Failure reading PKCS12 mTLS cert key file", e);
       }
     }
+
+    String serverName = mtlsProperties.getServerName();
+    if (serverName != null) {
+      stubsOptionsBuilder.setChannelInitializer(
+          channelBuilder -> channelBuilder.overrideAuthority(serverName));
+    }
   }
 
   private void applyMTLSProperties(

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/MTLSWithServerNameOverrideTest.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/java/io/temporal/spring/boot/autoconfigure/MTLSWithServerNameOverrideTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = MTLSWithServerNameOverrideTest.Configuration.class)
+@ActiveProfiles(profiles = "mtls-with-server-name-override")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MTLSWithServerNameOverrideTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+  @Autowired TemporalProperties temporalProperties;
+  @Autowired WorkflowClient workflowClient;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  public void testProperties() {
+    assertEquals("myservername", temporalProperties.getConnection().getMTLS().getServerName());
+  }
+
+  @Test
+  public void testClient() {
+    assertEquals(
+        "myservername", workflowClient.getWorkflowServiceStubs().getRawChannel().authority());
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure-alpha/src/test/resources/application.yml
@@ -110,3 +110,17 @@ spring:
         - io.temporal.spring.boot.autoconfigure.bytaskqueue
     start-workers: false
 
+---
+spring:
+  config:
+    activate:
+      on-profile: mtls-with-server-name-override
+  temporal:
+    connection:
+      mtls:
+        key-file: classpath:pkcs8-pk.pem
+        cert-chain-file: classpath:pkcs8-crt-chain.pem
+        server-name: myservername
+      target: 127.0.0.1:7233
+    test-server:
+      enabled: false


### PR DESCRIPTION
adds server-name to mtls config. allows to override authority on ChannelInitializer when using mtls

closes https://github.com/temporalio/sdk-java/issues/1996