### PR TITLE
Ignore history events with worker_may_ignore: true.

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -58,7 +58,8 @@ public final class WorkflowStateMachines {
 
   /** Initial set of SDK flags that will be set on all new workflow executions. */
   private static final List<SdkFlag> initialFlags =
-      Collections.unmodifiableList(Arrays.asList(SdkFlag.SKIP_YIELD_ON_DEFAULT_VERSION));
+      Collections.unmodifiableList(
+          Collections.singletonList(SdkFlag.SKIP_YIELD_ON_DEFAULT_VERSION));
 
   /**
    * EventId of the WorkflowTaskStarted event of the Workflow Task that was picked up by a worker
@@ -157,7 +158,7 @@ public final class WorkflowStateMachines {
 
   private final WFTBuffer wftBuffer = new WFTBuffer();
 
-  private List<Message> messages = new ArrayList<Message>();
+  private List<Message> messages = new ArrayList<>();
 
   private final SdkFlags flags;
 
@@ -356,8 +357,8 @@ public final class WorkflowStateMachines {
   }
 
   private List<Message> takeLTE(long eventId) {
-    List<Message> m = new ArrayList<Message>();
-    List<Message> remainingMessages = new ArrayList<Message>();
+    List<Message> m = new ArrayList<>();
+    List<Message> remainingMessages = new ArrayList<>();
     for (Message msg : this.messages) {
       if (msg.getEventId() > eventId) {
         remainingMessages.add(msg);
@@ -428,16 +429,16 @@ public final class WorkflowStateMachines {
       replaying = false;
     }
 
-    final long initialCommandEventId = getInitialCommandEventId(event);
-    if (initialCommandEventId < 0L) {
+    final OptionalLong initialCommandEventId = getInitialCommandEventId(event);
+    if (!initialCommandEventId.isPresent()) {
       return;
     }
 
-    EntityStateMachine c = stateMachines.get(initialCommandEventId);
+    EntityStateMachine c = stateMachines.get(initialCommandEventId.getAsLong());
     if (c != null) {
       c.handleEvent(event, hasNextEvent);
       if (c.isFinalState()) {
-        stateMachines.remove(initialCommandEventId);
+        stateMachines.remove(initialCommandEventId.getAsLong());
       }
     } else {
       handleNonStatefulEvent(event, hasNextEvent);
@@ -587,9 +588,7 @@ public final class WorkflowStateMachines {
 
   public List<Message> takeMessages() {
     List<Message> result = new ArrayList<>(messageOutbox.size());
-    for (Message message : messageOutbox) {
-      result.add(message);
-    }
+    result.addAll(messageOutbox);
     messageOutbox.clear();
     return result;
   }
@@ -962,10 +961,9 @@ public final class WorkflowStateMachines {
     VersionStateMachine stateMachine =
         versions.computeIfAbsent(
             changeId,
-            (idKey) -> {
-              return VersionStateMachine.newInstance(
-                  changeId, this::isReplaying, commandSink, stateMachineSink);
-            });
+            (idKey) ->
+                VersionStateMachine.newInstance(
+                    changeId, this::isReplaying, commandSink, stateMachineSink));
     return stateMachine.getVersion(
         minSupported,
         maxSupported,
@@ -1196,60 +1194,85 @@ public final class WorkflowStateMachines {
     }
   }
 
-  private long getInitialCommandEventId(HistoryEvent event) {
+  /**
+   * Extracts the eventId of the "initial command" for the given event.
+   *
+   * <p>The "initial command" is the event which started a group of related events:
+   * ActivityTaskScheduled, TimerStarted, and so on; for events which are not part of a group, the
+   * event's own eventId is returned. If the event has an unknown type but is marked as ignorable,
+   * then {@link OptionalLong#empty()} is returned instead.
+   *
+   * @return the eventId of the initial command, or {@link OptionalLong#empty()}
+   */
+  private OptionalLong getInitialCommandEventId(HistoryEvent event) {
     switch (event.getEventType()) {
       case EVENT_TYPE_ACTIVITY_TASK_STARTED:
-        return event.getActivityTaskStartedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(event.getActivityTaskStartedEventAttributes().getScheduledEventId());
       case EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
-        return event.getActivityTaskCompletedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(
+            event.getActivityTaskCompletedEventAttributes().getScheduledEventId());
       case EVENT_TYPE_ACTIVITY_TASK_FAILED:
-        return event.getActivityTaskFailedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(event.getActivityTaskFailedEventAttributes().getScheduledEventId());
       case EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
-        return event.getActivityTaskTimedOutEventAttributes().getScheduledEventId();
+        return OptionalLong.of(
+            event.getActivityTaskTimedOutEventAttributes().getScheduledEventId());
       case EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:
-        return event.getActivityTaskCancelRequestedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(
+            event.getActivityTaskCancelRequestedEventAttributes().getScheduledEventId());
       case EVENT_TYPE_ACTIVITY_TASK_CANCELED:
-        return event.getActivityTaskCanceledEventAttributes().getScheduledEventId();
+        return OptionalLong.of(
+            event.getActivityTaskCanceledEventAttributes().getScheduledEventId());
       case EVENT_TYPE_TIMER_FIRED:
-        return event.getTimerFiredEventAttributes().getStartedEventId();
+        return OptionalLong.of(event.getTimerFiredEventAttributes().getStartedEventId());
       case EVENT_TYPE_TIMER_CANCELED:
-        return event.getTimerCanceledEventAttributes().getStartedEventId();
+        return OptionalLong.of(event.getTimerCanceledEventAttributes().getStartedEventId());
       case EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
-        return event
-            .getRequestCancelExternalWorkflowExecutionFailedEventAttributes()
-            .getInitiatedEventId();
+        return OptionalLong.of(
+            event
+                .getRequestCancelExternalWorkflowExecutionFailedEventAttributes()
+                .getInitiatedEventId());
       case EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
-        return event
-            .getExternalWorkflowExecutionCancelRequestedEventAttributes()
-            .getInitiatedEventId();
+        return OptionalLong.of(
+            event
+                .getExternalWorkflowExecutionCancelRequestedEventAttributes()
+                .getInitiatedEventId());
       case EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED:
-        return event.getStartChildWorkflowExecutionFailedEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getStartChildWorkflowExecutionFailedEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
-        return event.getChildWorkflowExecutionStartedEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getChildWorkflowExecutionStartedEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
-        return event.getChildWorkflowExecutionCompletedEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getChildWorkflowExecutionCompletedEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED:
-        return event.getChildWorkflowExecutionFailedEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getChildWorkflowExecutionFailedEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED:
-        return event.getChildWorkflowExecutionCanceledEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getChildWorkflowExecutionCanceledEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT:
-        return event.getChildWorkflowExecutionTimedOutEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getChildWorkflowExecutionTimedOutEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED:
-        return event.getChildWorkflowExecutionTerminatedEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getChildWorkflowExecutionTerminatedEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
-        return event
-            .getSignalExternalWorkflowExecutionFailedEventAttributes()
-            .getInitiatedEventId();
+        return OptionalLong.of(
+            event.getSignalExternalWorkflowExecutionFailedEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED:
-        return event.getExternalWorkflowExecutionSignaledEventAttributes().getInitiatedEventId();
+        return OptionalLong.of(
+            event.getExternalWorkflowExecutionSignaledEventAttributes().getInitiatedEventId());
       case EVENT_TYPE_WORKFLOW_TASK_STARTED:
-        return event.getWorkflowTaskStartedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(event.getWorkflowTaskStartedEventAttributes().getScheduledEventId());
       case EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
-        return event.getWorkflowTaskCompletedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(
+            event.getWorkflowTaskCompletedEventAttributes().getScheduledEventId());
       case EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT:
-        return event.getWorkflowTaskTimedOutEventAttributes().getScheduledEventId();
+        return OptionalLong.of(
+            event.getWorkflowTaskTimedOutEventAttributes().getScheduledEventId());
       case EVENT_TYPE_WORKFLOW_TASK_FAILED:
-        return event.getWorkflowTaskFailedEventAttributes().getScheduledEventId();
+        return OptionalLong.of(event.getWorkflowTaskFailedEventAttributes().getScheduledEventId());
 
       case EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
       case EVENT_TYPE_TIMER_STARTED:
@@ -1268,11 +1291,11 @@ public final class WorkflowStateMachines {
       case EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
       case EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
       case EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
-        return event.getEventId();
+        return OptionalLong.of(event.getEventId());
 
       default:
         if (event.getWorkerMayIgnore()) {
-          return -1L;
+          return OptionalLong.empty();
         }
         throw new IllegalArgumentException("Unexpected event type: " + event.getEventType());
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (C) 2024 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.temporal.internal.replay;
+
+import static io.temporal.testing.WorkflowHistoryLoader.readHistoryFromResource;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.LocalActivityOptions;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class UnknownHistoryEventReplayerTest {
+
+  public static final String TASK_QUEUE = "unknown-history-event";
+  public static final String RES_CLEAN = "testUnknownHistoryEventClean.json";
+  public static final String RES_MAY_IGNORE = "testUnknownHistoryEventMayIgnore.json";
+  public static final String RES_MAY_NOT_IGNORE = "testUnknownHistoryEventMayNotIgnore.json";
+
+  @Rule
+  public Timeout testTimeout = Timeout.seconds(10);
+
+  private TestWorkflowEnvironment testEnvironment;
+  private Worker worker;
+
+  @Before
+  public void setUp() {
+    testEnvironment = TestWorkflowEnvironment.newInstance();
+    worker = testEnvironment.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(MyWorkflowImpl.class);
+    worker.registerActivitiesImplementations(new MyActivityImpl());
+    testEnvironment.start();
+  }
+
+  @After
+  public void tearDown() {
+    testEnvironment.close();
+  }
+
+  @Test
+  public void testRun() {
+    WorkflowClient client = testEnvironment.getWorkflowClient();
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).setWorkflowId("plain-run").build();
+    MyWorkflow stub = client.newWorkflowStub(MyWorkflow.class, options);
+    stub.execute();
+    WorkflowExecutionHistory history = client.fetchHistory("plain-run");
+    System.out.println(history.toJson(true));
+  }
+
+  @Test
+  public void testClean() throws Exception {
+    WorkflowExecutionHistory history = readHistoryFromResource(RES_CLEAN);
+    worker.replayWorkflowExecution(history);
+  }
+
+  @Test
+  public void testMayIgnore() throws Exception {
+    WorkflowExecutionHistory history = readHistoryFromResource(RES_MAY_IGNORE);
+    worker.replayWorkflowExecution(history);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testMayNotIgnore() throws Exception {
+    WorkflowExecutionHistory history = readHistoryFromResource(RES_MAY_NOT_IGNORE);
+    worker.replayWorkflowExecution(history);
+  }
+
+  @WorkflowInterface
+  public interface MyWorkflow {
+
+    @WorkflowMethod
+    void execute();
+  }
+
+  @ActivityInterface
+  public interface MyActivity {
+
+    @ActivityMethod
+    void execute();
+  }
+
+  public static class MyWorkflowImpl implements MyWorkflow {
+
+    @Override
+    public void execute() {
+      MyActivity activity =
+          Workflow.newLocalActivityStub(
+              MyActivity.class,
+              LocalActivityOptions.newBuilder()
+                  .setScheduleToCloseTimeout(Duration.ofSeconds(1))
+                  .build());
+      activity.execute();
+    }
+  }
+
+  public static class MyActivityImpl implements MyActivity {
+
+    @Override
+    public void execute() {
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 Temporal Technologies, Inc. All Rights Reserved.
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
  *
  * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -9,36 +9,28 @@
  * you may not use this material except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.temporal.internal.replay;
 
 import static io.temporal.testing.WorkflowHistoryLoader.readHistoryFromResource;
 
-import io.temporal.activity.ActivityInterface;
-import io.temporal.activity.ActivityMethod;
-import io.temporal.activity.LocalActivityOptions;
+import io.temporal.activity.*;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
-import io.temporal.workflow.Workflow;
-import io.temporal.workflow.WorkflowInterface;
-import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.*;
 import java.time.Duration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.Timeout;
 
 public class UnknownHistoryEventReplayerTest {

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
@@ -48,8 +48,7 @@ public class UnknownHistoryEventReplayerTest {
   public static final String RES_MAY_IGNORE = "testUnknownHistoryEventMayIgnore.json";
   public static final String RES_MAY_NOT_IGNORE = "testUnknownHistoryEventMayNotIgnore.json";
 
-  @Rule
-  public Timeout testTimeout = Timeout.seconds(10);
+  @Rule public Timeout testTimeout = Timeout.seconds(10);
 
   private TestWorkflowEnvironment testEnvironment;
   private Worker worker;
@@ -128,7 +127,6 @@ public class UnknownHistoryEventReplayerTest {
   public static class MyActivityImpl implements MyActivity {
 
     @Override
-    public void execute() {
-    }
+    public void execute() {}
   }
 }

--- a/temporal-sdk/src/test/resources/testUnknownHistoryEventClean.json
+++ b/temporal-sdk/src/test/resources/testUnknownHistoryEventClean.json
@@ -1,0 +1,123 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2024-02-29T20:38:37.858Z",
+      "eventType": "WorkflowExecutionStarted",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "MyWorkflow"
+        },
+        "taskQueue": {
+          "name": "unknown-history-event"
+        },
+        "input": {},
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "447c6032-30a1-4dd7-8f7b-f965ba68715c",
+        "identity": "2732293@aten",
+        "firstExecutionRunId": "447c6032-30a1-4dd7-8f7b-f965ba68715c",
+        "attempt": 1,
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2024-02-29T20:38:37.858Z",
+      "eventType": "WorkflowTaskScheduled",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "unknown-history-event"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2024-02-29T20:38:37.867Z",
+      "eventType": "WorkflowTaskStarted",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "2732293@aten"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "WorkflowTaskCompleted",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "2732293@aten",
+        "sdkMetadata": {
+          "langUsedFlags": [
+            1
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "MarkerRecorded",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "activityId": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IjdjMzMxNzJkLTFhMGUtM2UxMS1iYTM4LTliNjY4ZTFkNzg5NyI\u003d"
+              }
+            ]
+          },
+          "input": {},
+          "meta": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "eyJmaXJzdFNrZCI6MTcwOTIzOTExNzkzMywiYXRwdCI6MSwiYmFja29mZiI6bnVsbH0\u003d"
+              }
+            ]
+          },
+          "time": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "MTcwOTIzOTExNzg4NQ\u003d\u003d"
+              }
+            ]
+          },
+          "type": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IkV4ZWN1dGUi"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "WorkflowExecutionCompleted",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {},
+        "workflowTaskCompletedEventId": "3"
+      }
+    }
+  ]
+}

--- a/temporal-sdk/src/test/resources/testUnknownHistoryEventMayIgnore.json
+++ b/temporal-sdk/src/test/resources/testUnknownHistoryEventMayIgnore.json
@@ -1,0 +1,120 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2024-02-29T20:38:37.858Z",
+      "eventType": "WorkflowExecutionStarted",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "MyWorkflow"
+        },
+        "taskQueue": {
+          "name": "unknown-history-event"
+        },
+        "input": {},
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "447c6032-30a1-4dd7-8f7b-f965ba68715c",
+        "identity": "2732293@aten",
+        "firstExecutionRunId": "447c6032-30a1-4dd7-8f7b-f965ba68715c",
+        "attempt": 1,
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2024-02-29T20:38:37.858Z",
+      "eventType": "WorkflowTaskScheduled",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "unknown-history-event"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2024-02-29T20:38:37.867Z",
+      "eventType": "WorkflowTaskStarted",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "2732293@aten"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "WorkflowTaskCompleted",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "2732293@aten",
+        "sdkMetadata": {
+          "langUsedFlags": [
+            1
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "MarkerRecorded",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "activityId": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IjdjMzMxNzJkLTFhMGUtM2UxMS1iYTM4LTliNjY4ZTFkNzg5NyI\u003d"
+              }
+            ]
+          },
+          "input": {},
+          "meta": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "eyJmaXJzdFNrZCI6MTcwOTIzOTExNzkzMywiYXRwdCI6MSwiYmFja29mZiI6bnVsbH0\u003d"
+              }
+            ]
+          },
+          "time": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "MTcwOTIzOTExNzg4NQ\u003d\u003d"
+              }
+            ]
+          },
+          "type": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IkV4ZWN1dGUi"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "Unknown",
+      "workerMayIgnore": true
+    }
+  ]
+}

--- a/temporal-sdk/src/test/resources/testUnknownHistoryEventMayNotIgnore.json
+++ b/temporal-sdk/src/test/resources/testUnknownHistoryEventMayNotIgnore.json
@@ -1,0 +1,119 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2024-02-29T20:38:37.858Z",
+      "eventType": "WorkflowExecutionStarted",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "MyWorkflow"
+        },
+        "taskQueue": {
+          "name": "unknown-history-event"
+        },
+        "input": {},
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "447c6032-30a1-4dd7-8f7b-f965ba68715c",
+        "identity": "2732293@aten",
+        "firstExecutionRunId": "447c6032-30a1-4dd7-8f7b-f965ba68715c",
+        "attempt": 1,
+        "header": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2024-02-29T20:38:37.858Z",
+      "eventType": "WorkflowTaskScheduled",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "unknown-history-event"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2024-02-29T20:38:37.867Z",
+      "eventType": "WorkflowTaskStarted",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "2732293@aten"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "WorkflowTaskCompleted",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "2732293@aten",
+        "sdkMetadata": {
+          "langUsedFlags": [
+            1
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "MarkerRecorded",
+      "markerRecordedEventAttributes": {
+        "markerName": "LocalActivity",
+        "details": {
+          "activityId": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IjdjMzMxNzJkLTFhMGUtM2UxMS1iYTM4LTliNjY4ZTFkNzg5NyI\u003d"
+              }
+            ]
+          },
+          "input": {},
+          "meta": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "eyJmaXJzdFNrZCI6MTcwOTIzOTExNzkzMywiYXRwdCI6MSwiYmFja29mZiI6bnVsbH0\u003d"
+              }
+            ]
+          },
+          "time": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "MTcwOTIzOTExNzg4NQ\u003d\u003d"
+              }
+            ]
+          },
+          "type": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg\u003d\u003d"
+                },
+                "data": "IkV4ZWN1dGUi"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2024-02-29T20:38:38.001Z",
+      "eventType": "Unknown"
+    }
+  ]
+}


### PR DESCRIPTION
## What was changed
* Unknown event types with `worker_may_ignore: true` are skipped
* All other unknown event types continue to throw
* Added new replay tests verifying that `worker_may_ignore` is handled correctly

## Why?
The new `worker_may_ignore` flag is intended to mark events that can be handled as no-ops if the SDK doesn't know the event type.

## Checklist

1. Closes https://github.com/temporalio/sdk-java/issues/1945

2. How was this tested: added new unit tests to verify the new behavior before implementing it.