### PR TITLE
Support newer JSON history format

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/WorkflowExecutionHistory.java
@@ -83,7 +83,8 @@ public final class WorkflowExecutionHistory
   }
 
   /**
-   * @return full json that can be used for replay and which is compatible with tctl
+   * @param prettyPrint Whether to pretty print the JSON.
+   * @return Full json that can be used for replay.
    */
   public String toJson(boolean prettyPrint) {
     return super.toJson(prettyPrint);

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryJsonUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/HistoryJsonUtils.java
@@ -65,7 +65,15 @@ public final class HistoryJsonUtils {
   }
 
   public static String historyFormatJsonToProtoJson(String historyFormatJson) {
-    return convertEnumValues(historyFormatJson, ProtoEnumNameUtils::simplifiedToUniqueName);
+    return convertEnumValues(
+        historyFormatJson,
+        (enumName, prefix) -> {
+          // Only convert if the enum name isn't already converted
+          if (enumName.indexOf('_') >= 0) {
+            return enumName;
+          }
+          return ProtoEnumNameUtils.simplifiedToUniqueName(enumName, prefix);
+        });
   }
 
   private static String convertEnumValues(

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -84,20 +84,33 @@ public class WorkflowExecutionHistory {
   }
 
   /**
-   * @return full json that can be used for replay and which is compatible with tctl
+   * @param prettyPrint Whether to pretty print the JSON.
+   * @return Full json that can be used for replay.
    */
   public String toJson(boolean prettyPrint) {
+    return toJson(prettyPrint, false);
+  }
+
+  /**
+   * @param prettyPrint Whether to pretty print the JSON.
+   * @param legacyFormat If true, will use the older-style protobuf enum formatting as done by
+   *     Temporal tooling in the past. This is not recommended.
+   * @return Full JSON that can be used for replay.
+   */
+  public String toJson(boolean prettyPrint, boolean legacyFormat) {
     JsonFormat.Printer printer = JsonFormat.printer();
     try {
       String protoJson = printer.print(history);
-      String historyFormatJson = HistoryJsonUtils.protoJsonToHistoryFormatJson(protoJson);
+      if (legacyFormat) {
+        protoJson = HistoryJsonUtils.protoJsonToHistoryFormatJson(protoJson);
+      }
 
       if (prettyPrint) {
         @SuppressWarnings("deprecation")
-        JsonElement je = GSON_PARSER.parse(historyFormatJson);
+        JsonElement je = GSON_PARSER.parse(protoJson);
         return GSON_PRETTY_PRINTER.toJson(je);
       } else {
-        return historyFormatJson;
+        return protoJson;
       }
     } catch (InvalidProtocolBufferException e) {
       throw new DataConverterException(e);


### PR DESCRIPTION
## What was changed

* Changed `WorkflowExecutionHistory.fromJson` to support proper protobuf JSON fields
* Changed existing `WorkflowExecutionHistory.toJson` method to emit proper protobuf JSON fields
  * 💥 Please make a note in release notes that this default behavior changed
* Added `WorkflowExecutionHistory.toJson` overload that lets you specify legacy format boolean to emit it the way it used to
