### PR TITLE
Make sure task failures use a serialization context

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -167,7 +167,10 @@ class SyncWorkflow implements ReplayWorkflow {
               // Rethrow instead on rejecting the update to fail the WFT
               throw r;
             } catch (Exception e) {
-              callbacks.reject(this.dataConverter.exceptionToFailure(e));
+              callbacks.reject(
+                  workflowContext
+                      .getDataConverterWithCurrentWorkflowContext()
+                      .exceptionToFailure(e));
               return;
             } finally {
               workflowContext.setReadOnly(false);


### PR DESCRIPTION
Make sure task failures use a serialization context. User reported some places we serialized exceptions did not have a workflow context associated with them. This PR should hopefully address all these places.