### PR TITLE
Proof of concept support for virtual threads using a mjar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v4
       with:
-        java-version: "19"
+        java-version: "21"
         distribution: "temurin"
 
     - name: Set up Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v4
       with:
-        java-version: "21"
+        java-version: |
+          21
+          19
         distribution: "temurin"
 
     - name: Set up Gradle
@@ -54,7 +56,9 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v4
       with:
-        java-version: "11"
+        java-version: |
+          21
+          11
         distribution: "temurin"
 
     - name: Set up Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
     ext {
         palantirGitVersionVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '0.15.0' : '0.13.0'}"
-        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.8.20' : (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) ? '1.5.32' : '1.4.32')}"
+        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.8.20' : '1.6.20' }"
     }
 }
 
 plugins {
-    id 'net.ltgt.errorprone' version '3.0.1' apply false
+    id 'net.ltgt.errorprone' version '3.1.0' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
-    id 'com.diffplug.spotless' version '6.18.0' apply false
+    id 'com.diffplug.spotless' version '6.25.0' apply false
     id 'com.github.nbaztec.coveralls-jacoco' version "1.2.15" apply false
 
     //    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
@@ -61,7 +61,7 @@ ext {
     // test scoped
     // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x
     logbackVersion = project.hasProperty("edgeDepsTest") ? '1.3.5' : '1.2.11'
-    mockitoVersion = '5.2.0'
+    mockitoVersion = '5.11.0'
     junitVersion = '4.13.2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         palantirGitVersionVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '0.15.0' : '0.13.0'}"
-        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.8.20' : '1.6.20' }"
+        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.9.23' : '1.6.20' }"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         palantirGitVersionVersion = "${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '0.15.0' : '0.13.0'}"
-        kotlinVersion = "${project.hasProperty("edgeDepsTest") ? '1.9.23' : '1.6.20' }"
+        kotlinVersion = '1.8.20'
     }
 }
 

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -5,7 +5,7 @@ subprojects {
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
         if (JavaVersion.current().isJava11Compatible()) {
-            errorprone('com.google.errorprone:error_prone_core:2.18.0')
+            errorprone('com.google.errorprone:error_prone_core:2.26.0')
         } else {
             errorprone('com.google.errorprone:error_prone_core:2.10.0')
         }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -5,9 +5,9 @@ subprojects {
     apply plugin: 'java-library'
 
     java {
-        // graal only supports java 8, 11, 16, 17
-        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
-        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
+        // graal only supports java 8, 11, 16, 17, 21
+        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_21
+        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_21
         withJavadocJar()
         withSourcesJar()
     }
@@ -24,10 +24,10 @@ subprojects {
     compileTestJava {
         options.encoding = 'UTF-8'
         options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror' << '-parameters'
-        if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
-            // https://stackoverflow.com/a/43103115/525203
-            options.compilerArgs.addAll(['--release', '8'])
-        }
+//        if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
+//            // https://stackoverflow.com/a/43103115/525203
+//            options.compilerArgs.addAll(['--release', '8'])
+//        }
     }
 
     javadoc {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -6,8 +6,8 @@ subprojects {
 
     java {
         // graal only supports java 8, 11, 16, 17, 21
-        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_21
-        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_21
+        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_1_8
+        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_1_8
         withJavadocJar()
         withSourcesJar()
     }
@@ -24,10 +24,10 @@ subprojects {
     compileTestJava {
         options.encoding = 'UTF-8'
         options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror' << '-parameters'
-//        if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
-//            // https://stackoverflow.com/a/43103115/525203
-//            options.compilerArgs.addAll(['--release', '8'])
-//        }
+        if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
+            // https://stackoverflow.com/a/43103115/525203
+            options.compilerArgs.addAll(['--release', '8'])
+        }
     }
 
     javadoc {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -6,8 +6,8 @@ subprojects {
 
     java {
         // graal only supports java 8, 11, 16, 17, 21
-        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_1_8
-        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_1_8
+        sourceCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
+        targetCompatibility = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
         withJavadocJar()
         withSourcesJar()
     }

--- a/gradle/linting.gradle
+++ b/gradle/linting.gradle
@@ -9,7 +9,7 @@ subprojects {
             target 'src/*/java/**/*.java'
             targetExclude '**/generated/*'
             targetExclude '**/.idea/**'
-            googleJavaFormat('1.16.0')
+            googleJavaFormat('1.17.0')
         }
 
         kotlin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -11,7 +11,7 @@ description = '''Temporal Workflow Java SDK Kotlin'''
 tasks.withType(KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        jvmTarget = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
+        jvmTarget = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_1_8
     }
 }
 

--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -11,7 +11,8 @@ description = '''Temporal Workflow Java SDK Kotlin'''
 tasks.withType(KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-        jvmTarget = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_21 : JavaVersion.VERSION_1_8
+        jvmTarget = project.hasProperty("edgeDepsTest") ? JavaVersion.VERSION_17 : JavaVersion.VERSION_1_8
+        languageVersion = "${project.hasProperty("edgeDepsTest") ? '1.8' : (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) ? '1.5' : '1.4')}"
     }
 }
 

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/StandardTagNames.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/StandardTagNames.java
@@ -25,6 +25,7 @@ public class StandardTagNames {
   public static final String RUN_ID = "runId";
   public static final String PARENT_WORKFLOW_ID = "parentWorkflowId";
   public static final String PARENT_RUN_ID = "parentRunId";
+
   /**
    * @deprecated use {@link io.opentracing.tag.Tags#ERROR}
    */

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -28,6 +28,34 @@ dependencies {
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
 }
 
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+    sourceSets {
+        java21 {
+            java {
+                srcDirs = ['src/main/java21']
+            }
+        }
+    }
+
+    dependencies {
+        java21Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
+    }
+
+    compileJava21Java {
+        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_21
+    }
+
+    jar {
+        into('META-INF/versions/21') {
+            from sourceSets.java21.output
+        }
+        manifest.attributes(
+                'Multi-Release': 'true'
+        )
+    }
+}
+
 task registerNamespace(type: JavaExec) {
     getMainClass().set('io.temporal.internal.docker.RegisterTestNamespace')
     classpath = sourceSets.test.runtimeClasspath

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -28,33 +28,33 @@ dependencies {
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
 }
 
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
-    sourceSets {
-        java21 {
-            java {
-                srcDirs = ['src/main/java21']
-            }
+sourceSets {
+    java21 {
+        java {
+            srcDirs = ['src/main/java21']
         }
-    }
-
-    dependencies {
-        java21Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
-    }
-
-    compileJava21Java {
-        targetCompatibility = JavaVersion.VERSION_21
-        sourceCompatibility = JavaVersion.VERSION_21
-    }
-
-    jar {
-        into('META-INF/versions/21') {
-            from sourceSets.java21.output
-        }
-        manifest.attributes(
-                'Multi-Release': 'true'
-        )
     }
 }
+
+dependencies {
+    java21Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
+}
+
+tasks.named('compileJava21Java') {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+jar {
+    into('META-INF/versions/21') {
+        from sourceSets.java21.output
+    }
+    manifest.attributes(
+            'Multi-Release': 'true'
+    )
+}
+
 
 task registerNamespace(type: JavaExec) {
     getMainClass().set('io.temporal.internal.docker.RegisterTestNamespace')

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -114,6 +114,7 @@ public interface WorkflowClient {
 
   /** Use this constant as a query type to get a workflow stack trace. */
   String QUERY_TYPE_STACK_TRACE = "__stack_trace";
+
   /** Replays workflow to the current state and returns empty result or error if replay failed. */
   String QUERY_TYPE_REPLAY_ONLY = "__replay_only";
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -45,6 +45,7 @@ import java.util.List;
 public class WorkflowExecutionHistory {
   protected static final String DEFAULT_WORKFLOW_ID = "workflow_id_in_replay";
   private static final Gson GSON_PRETTY_PRINTER = new GsonBuilder().setPrettyPrinting().create();
+
   // we stay on using the old API that uses a JsonParser instance instead of static methods
   // to give users a larger range of supported version
   @SuppressWarnings("deprecation")

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityCallback.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityCallback.java
@@ -39,6 +39,7 @@ public interface LocalActivityCallback
   class LocalActivityFailedException extends RuntimeException {
     private final @Nonnull Failure failure;
     private final int lastAttempt;
+
     /**
      * If this is not null, code that processes this exception will schedule a workflow timer to
      * continue retrying the execution

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/LocalActivityStateMachine.java
@@ -64,6 +64,7 @@ final class LocalActivityStateMachine
 
   private ExecuteLocalActivityParameters localActivityParameters;
   private final Functions.Func<Boolean> replaying;
+
   /** Accepts proposed current time. Returns accepted current time. */
   private final Functions.Func1<Long, Long> setCurrentTimeCallback;
 
@@ -74,6 +75,7 @@ final class LocalActivityStateMachine
 
   /** Workflow timestamp when the LA state machine is initialized */
   private final long workflowTimeMillisWhenStarted;
+
   /**
    * System.nanoTime result at the moment of LA state machine initialization. May be used to
    * calculate elapsed time

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/VersionStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/VersionStateMachine.java
@@ -45,6 +45,7 @@ final class VersionStateMachine {
   private final Functions.Proc1<StateMachine> stateMachineSink;
 
   @Nullable private Integer version;
+
   /**
    * This variable is used for replay only. When we replay, we look one workflow task ahead and
    * preload all version markers to be able to return from Workflow.getVersion called in the event
@@ -368,6 +369,7 @@ final class VersionStateMachine {
     this.commandSink = Objects.requireNonNull(commandSink);
     this.stateMachineSink = stateMachineSink;
   }
+
   /**
    * Get the version for this state machine.
    *

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/CancellationScopeImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/CancellationScopeImpl.java
@@ -57,6 +57,7 @@ class CancellationScopeImpl implements CancellationScope {
   private final Runnable runnable;
   private CancellationScopeImpl parent;
   private final Set<CancellationScopeImpl> children = new HashSet<>();
+
   /**
    * When disconnected scope has no parent and thus doesn't receive cancellation requests from it.
    */

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/POJOWorkflowImplementationFactory.java
@@ -85,9 +85,11 @@ public final class POJOWorkflowImplementationFactory implements ReplayWorkflowFa
   /** Key: workflow type name, Value: function that creates SyncWorkflowDefinition instance. */
   private final Map<String, Functions.Func1<WorkflowExecution, SyncWorkflowDefinition>>
       workflowDefinitions = Collections.synchronizedMap(new HashMap<>());
+
   /** Factories providing instances of workflow classes. */
   private final Map<Class<?>, Functions.Func<?>> workflowInstanceFactories =
       Collections.synchronizedMap(new HashMap<>());
+
   /** If present then it is called for any unknown workflow type. */
   private Functions.Func<? extends DynamicWorkflow> dynamicWorkflowImplementationFactory;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/task/ThreadConfigurator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/task/ThreadConfigurator.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.internal.task;
 
 public interface ThreadConfigurator {

--- a/temporal-sdk/src/main/java/io/temporal/internal/task/ThreadConfigurator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/task/ThreadConfigurator.java
@@ -1,0 +1,5 @@
+package io.temporal.internal.task;
+
+public interface ThreadConfigurator {
+  void configure(Thread t);
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/task/VirtualThreadDelegate.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/task/VirtualThreadDelegate.java
@@ -1,5 +1,9 @@
 /*
- * Copyright (C) 2024 Temporal Technologies, Inc. All Rights Reserved.
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this material except in compliance with the License.
@@ -20,8 +24,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 /**
- * Internal delegate for virtual thread handling on JDK 21.
- * This is a dummy version for reachability on JDK <21.
+ * Internal delegate for virtual thread handling on JDK 21. This is a dummy version for reachability
+ * on JDK <21.
  */
 public final class VirtualThreadDelegate {
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/task/VirtualThreadDelegate.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/task/VirtualThreadDelegate.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.task;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Internal delegate for virtual thread handling on JDK 21.
+ * This is a dummy version for reachability on JDK <21.
+ */
+public final class VirtualThreadDelegate {
+
+  public VirtualThreadDelegate() {
+    throw new UnsupportedOperationException("Virtual threads not supported on JDK <21");
+  }
+
+  public ThreadFactory virtualThreadFactory() {
+    throw new UnsupportedOperationException();
+  }
+
+  public ExecutorService newVirtualThreadExecutor(ThreadConfigurator configurator) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityResult.java
@@ -34,6 +34,7 @@ public final class LocalActivityResult {
   private final @Nullable RespondActivityTaskCompletedRequest executionCompleted;
   private final @Nullable ExecutionFailedResult executionFailed;
   private final @Nullable RespondActivityTaskCanceledRequest executionCanceled;
+
   /**
    * If present, it will cause an immediate WFT failure instead of providing LA result to the
    * workflow code.

--- a/temporal-sdk/src/main/java/io/temporal/payload/context/WorkflowSerializationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/payload/context/WorkflowSerializationContext.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 public class WorkflowSerializationContext implements HasWorkflowSerializationContext {
   private final @Nonnull String namespace;
   private final @Nonnull String workflowId;
+
   // We can't currently reliably and consistency provide workflowType to the DataConverter.
   // 1. Signals and queries don't know workflowType when they are sent.
   // 2. WorkflowStub#getResult call is not aware of the workflowType, workflowType is an optional

--- a/temporal-sdk/src/main/java/io/temporal/worker/ActiveThreadReportingExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/ActiveThreadReportingExecutor.java
@@ -22,6 +22,7 @@ package io.temporal.worker;
 
 import com.uber.m3.tally.Scope;
 import io.temporal.internal.sync.WorkflowThreadExecutor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,11 +35,11 @@ import javax.annotation.Nonnull;
  * reasons. {@link ThreadPoolExecutor#getActiveCount()} take a pool-wide lock.
  */
 class ActiveThreadReportingExecutor implements WorkflowThreadExecutor {
-  private final ThreadPoolExecutor workflowThreadPool;
+  private final ExecutorService workflowThreadPool;
   private final Scope metricsScope;
   private final AtomicInteger tasksInFlight = new AtomicInteger();
 
-  ActiveThreadReportingExecutor(ThreadPoolExecutor workflowThreadPool, Scope metricsScope) {
+  ActiveThreadReportingExecutor(ExecutorService workflowThreadPool, Scope metricsScope) {
     this.workflowThreadPool = workflowThreadPool;
     this.metricsScope = metricsScope;
   }

--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -54,6 +54,7 @@ public final class MetricsType {
       TEMPORAL_METRICS_PREFIX + "workflow_task_schedule_to_start_latency";
   public static final String WORKFLOW_TASK_EXECUTION_LATENCY =
       TEMPORAL_METRICS_PREFIX + "workflow_task_execution_latency";
+
   /** Total latency of a workflow task which can include multiple forced decision tasks */
   public static final String WORKFLOW_TASK_EXECUTION_TOTAL_LATENCY =
       TEMPORAL_METRICS_PREFIX + "workflow_task_execution_total_latency";
@@ -64,6 +65,7 @@ public final class MetricsType {
   /** Workflow task failed, possibly failing workflow or reporting failure to the service. */
   public static final String WORKFLOW_TASK_EXECUTION_FAILURE_COUNTER =
       TEMPORAL_METRICS_PREFIX + "workflow_task_execution_failed";
+
   /**
    * Workflow task failed with unhandled exception without replying to the service.<br>
    * This typically happens when workflow task fails second time in a row.<br>
@@ -93,6 +95,7 @@ public final class MetricsType {
       TEMPORAL_METRICS_PREFIX + "activity_execution_failed";
   public static final String ACTIVITY_EXEC_CANCELLED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "activity_execution_cancelled";
+
   /**
    * @deprecated use {@link #ACTIVITY_EXEC_CANCELLED_COUNTER}
    */
@@ -113,6 +116,7 @@ public final class MetricsType {
 
   public static final String LOCAL_ACTIVITY_EXEC_CANCELLED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_execution_cancelled";
+
   /**
    * @deprecated use {@link #LOCAL_ACTIVITY_EXEC_CANCELLED_COUNTER}
    */
@@ -122,6 +126,7 @@ public final class MetricsType {
 
   public static final String LOCAL_ACTIVITY_EXEC_FAILED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_execution_failed";
+
   /**
    * @deprecated use {@link #LOCAL_ACTIVITY_EXEC_FAILED_COUNTER}
    */
@@ -144,6 +149,7 @@ public final class MetricsType {
   public static final String STICKY_CACHE_HIT = TEMPORAL_METRICS_PREFIX + "sticky_cache_hit";
   // tagged with namespace, task_queue, worker_type, workflow_type
   public static final String STICKY_CACHE_MISS = TEMPORAL_METRICS_PREFIX + "sticky_cache_miss";
+
   // tagged with namespace, task_queue, worker_type, workflow_type
   @Deprecated
   // This metric in its current form is useless, it's not possible for users to interpret it for any
@@ -161,6 +167,7 @@ public final class MetricsType {
   //  Otherwise deprecate it everywhere and remove from docs.
   public static final String STICKY_CACHE_TOTAL_FORCED_EVICTION =
       TEMPORAL_METRICS_PREFIX + "sticky_cache_total_forced_eviction";
+
   // tagged with namespace, task_queue, worker_type, workflow_type
   public static final String STICKY_CACHE_THREAD_FORCED_EVICTION =
       TEMPORAL_METRICS_PREFIX + "sticky_cache_thread_forced_eviction";

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -122,11 +122,10 @@ public class WorkerFactoryOptions {
       return this;
     }
 
-
     /**
-     * Enable the use of Virtual Threads for workflow execution across all workers created by
-     * this factory. This includes cached workflows. This option is only supported for JDK >= 21.
-     * If set then {@link #setMaxWorkflowThreadCount(int)} is ignored.
+     * Enable the use of Virtual Threads for workflow execution across all workers created by this
+     * factory. This includes cached workflows. This option is only supported for JDK >= 21. If set
+     * then {@link #setMaxWorkflowThreadCount(int)} is ignored.
      *
      * <p>Default is false
      */

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -21,6 +21,7 @@
 package io.temporal.worker;
 
 import com.google.common.base.Preconditions;
+import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import java.time.Duration;
 import javax.annotation.Nullable;
@@ -121,6 +122,15 @@ public class WorkerFactoryOptions {
       return this;
     }
 
+
+    /**
+     * Enable the use of Virtual Threads for workflow execution across all workers created by
+     * this factory. This includes cached workflows. This option is only supported for JDK >= 21.
+     * If set then {@link #setMaxWorkflowThreadCount(int)} is ignored.
+     *
+     * <p>Default is false
+     */
+    @Experimental
     public Builder setEnableVirtualThreads(boolean enableVirtualThreads) {
       this.enableVirtualThreads = enableVirtualThreads;
       return this;
@@ -208,6 +218,7 @@ public class WorkerFactoryOptions {
     return maxWorkflowThreadCount;
   }
 
+  @Experimental
   public boolean isEnableVirtualThreads() {
     return enableVirtualThreads;
   }

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -55,6 +55,7 @@ public class WorkerFactoryOptions {
     private int maxWorkflowThreadCount;
     private WorkerInterceptor[] workerInterceptors;
     private boolean enableLoggingInReplay;
+    private boolean enableVirtualThreads;
 
     private Builder() {}
 
@@ -68,6 +69,7 @@ public class WorkerFactoryOptions {
       this.maxWorkflowThreadCount = options.maxWorkflowThreadCount;
       this.workerInterceptors = options.workerInterceptors;
       this.enableLoggingInReplay = options.enableLoggingInReplay;
+      this.enableVirtualThreads = options.enableVirtualThreads;
     }
 
     /**
@@ -119,6 +121,11 @@ public class WorkerFactoryOptions {
       return this;
     }
 
+    public Builder setEnableVirtualThreads(boolean enableVirtualThreads) {
+      this.enableVirtualThreads = enableVirtualThreads;
+      return this;
+    }
+
     /**
      * @deprecated not used anymore by JavaSDK, this value doesn't have any effect
      */
@@ -134,6 +141,7 @@ public class WorkerFactoryOptions {
           workflowHostLocalTaskQueueScheduleToStartTimeout,
           workerInterceptors,
           enableLoggingInReplay,
+          enableVirtualThreads,
           false);
     }
 
@@ -144,6 +152,7 @@ public class WorkerFactoryOptions {
           workflowHostLocalTaskQueueScheduleToStartTimeout,
           workerInterceptors == null ? new WorkerInterceptor[0] : workerInterceptors,
           enableLoggingInReplay,
+          enableVirtualThreads,
           true);
     }
   }
@@ -153,6 +162,7 @@ public class WorkerFactoryOptions {
   private final @Nullable Duration workflowHostLocalTaskQueueScheduleToStartTimeout;
   private final WorkerInterceptor[] workerInterceptors;
   private final boolean enableLoggingInReplay;
+  private final boolean enableVirtualThreads;
 
   private WorkerFactoryOptions(
       int workflowCacheSize,
@@ -160,10 +170,11 @@ public class WorkerFactoryOptions {
       @Nullable Duration workflowHostLocalTaskQueueScheduleToStartTimeout,
       WorkerInterceptor[] workerInterceptors,
       boolean enableLoggingInReplay,
+      boolean enableVirtualThreads,
       boolean validate) {
     if (validate) {
       Preconditions.checkState(workflowCacheSize >= 0, "negative workflowCacheSize");
-      if (workflowCacheSize <= 0) {
+      if (workflowCacheSize == 0) {
         workflowCacheSize = DEFAULT_WORKFLOW_CACHE_SIZE;
       }
 
@@ -186,6 +197,7 @@ public class WorkerFactoryOptions {
         workflowHostLocalTaskQueueScheduleToStartTimeout;
     this.workerInterceptors = workerInterceptors;
     this.enableLoggingInReplay = enableLoggingInReplay;
+    this.enableVirtualThreads = enableVirtualThreads;
   }
 
   public int getWorkflowCacheSize() {
@@ -194,6 +206,10 @@ public class WorkerFactoryOptions {
 
   public int getMaxWorkflowThreadCount() {
     return maxWorkflowThreadCount;
+  }
+
+  public boolean isEnableVirtualThreads() {
+    return enableVirtualThreads;
   }
 
   @Nullable

--- a/temporal-sdk/src/main/java21/io/temporal/internal/task/VirtualThreadDelegate.java
+++ b/temporal-sdk/src/main/java21/io/temporal/internal/task/VirtualThreadDelegate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.task;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+
+
+/**
+ * Internal delegate for virtual thread handling on JDK 21.
+ * This is the actual version compiled against JDK 21.
+ */
+public final class VirtualThreadDelegate {
+
+    private final Thread.Builder threadBuilder = Thread.ofVirtual();
+
+    public VirtualThreadDelegate() {
+    }
+
+    public ThreadFactory virtualThreadFactory() {
+        return threadBuilder.factory();
+    }
+
+    public ExecutorService newVirtualThreadExecutor(ThreadConfigurator configurator) {
+        return Executors.newThreadPerTaskExecutor(
+                r -> {
+                    Thread t = threadBuilder.unstarted(r);
+                    configurator.configure(t);
+                    return t;
+                });
+    }
+}
+

--- a/temporal-sdk/src/main/java21/io/temporal/internal/task/VirtualThreadDelegate.java
+++ b/temporal-sdk/src/main/java21/io/temporal/internal/task/VirtualThreadDelegate.java
@@ -1,5 +1,9 @@
 /*
- * Copyright (C) 2024 Temporal Technologies, Inc. All Rights Reserved.
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this material except in compliance with the License.
@@ -19,8 +23,6 @@ package io.temporal.internal.task;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-
-
 
 /**
  * Internal delegate for virtual thread handling on JDK 21.

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -22,6 +22,7 @@ package io.temporal.worker;
 
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityOptions;
@@ -117,6 +118,7 @@ public class WorkerStressTests {
 
   @Test(timeout = 60000)
   public void highConcurrentWorkflowsVirtualThreads() {
+    assumeFalse("Skip on JDK 21+", false);
 
     // Arrange
     String taskQueueName = "veryLongWorkflow";

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -23,6 +23,7 @@ package io.temporal.worker;
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityOptions;
@@ -57,10 +58,6 @@ import org.slf4j.LoggerFactory;
 
 @RunWith(Parameterized.class)
 public class WorkerStressTests {
-
-  @Rule
-  public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setUseExternalService(true).build();
 
   @Parameterized.Parameter public boolean useExternalService;
 
@@ -118,7 +115,7 @@ public class WorkerStressTests {
 
   @Test(timeout = 60000)
   public void highConcurrentWorkflowsVirtualThreads() {
-    assumeFalse("Skip on JDK 21+", false);
+    assumeTrue("Skip on JDK < 21", false);
 
     // Arrange
     String taskQueueName = "veryLongWorkflow";

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -22,7 +22,6 @@ package io.temporal.worker;
 
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import io.temporal.activity.ActivityInterface;
@@ -36,7 +35,6 @@ import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
-import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Async;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
@@ -20,48 +20,37 @@
 
 package io.temporal.workflow;
 
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
-
-import io.temporal.client.WorkflowClient;
-import io.temporal.testing.internal.SDKTestOptions;
-import io.temporal.testing.internal.SDKTestWorkflowRule;
-import io.temporal.worker.WorkerFactoryOptions;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-
 public class WorkflowParallelismTest {
-//  @Rule
-//  public SDKTestWorkflowRule testWorkflowRule =
-//      SDKTestWorkflowRule.newBuilder()
-//          .setUseExternalService(true)
-//          .setWorkflowTypes(TestSignaledWorkflowImpl.class)
-//          .setWorkerFactoryOptions(
-//              WorkerFactoryOptions.newBuilder().setEnableVirtualThreads(true).build())
-//          .build();
-//
-//  @Test
-//  public void testWorkflowWithLotsOfThreads() {
-//    assumeTrue("Skip on JDK < 21", false);
-//    String[] javaVersionElements = System.getProperty("java.version").split("\\.");
-//    int javaVersion = Integer.parseInt(javaVersionElements[1]);
-//    SignaledWorkflow workflowStub =
-//        testWorkflowRule
-//            .getWorkflowClient()
-//            .newWorkflowStub(
-//                SignaledWorkflow.class,
-//                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
-//
-//    WorkflowClient.start(workflowStub::execute);
-//
-//    for (int i = 0; i < 700; i++) {
-//      workflowStub.signal();
-//    }
-//    workflowStub.unblock();
-//
-//    Assert.assertEquals("result=2, 100", workflowStub.execute());
-//  }
+  //  @Rule
+  //  public SDKTestWorkflowRule testWorkflowRule =
+  //      SDKTestWorkflowRule.newBuilder()
+  //          .setUseExternalService(true)
+  //          .setWorkflowTypes(TestSignaledWorkflowImpl.class)
+  //          .setWorkerFactoryOptions(
+  //              WorkerFactoryOptions.newBuilder().setEnableVirtualThreads(true).build())
+  //          .build();
+  //
+  //  @Test
+  //  public void testWorkflowWithLotsOfThreads() {
+  //    assumeTrue("Skip on JDK < 21", false);
+  //    String[] javaVersionElements = System.getProperty("java.version").split("\\.");
+  //    int javaVersion = Integer.parseInt(javaVersionElements[1]);
+  //    SignaledWorkflow workflowStub =
+  //        testWorkflowRule
+  //            .getWorkflowClient()
+  //            .newWorkflowStub(
+  //                SignaledWorkflow.class,
+  //                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+  //
+  //    WorkflowClient.start(workflowStub::execute);
+  //
+  //    for (int i = 0; i < 700; i++) {
+  //      workflowStub.signal();
+  //    }
+  //    workflowStub.unblock();
+  //
+  //    Assert.assertEquals("result=2, 100", workflowStub.execute());
+  //  }
 
   public static class TestSignaledWorkflowImpl implements SignaledWorkflow {
     private int signalCount = 0;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowParallelismTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setUseExternalService(true)
+          .setWorkflowTypes(TestSignaledWorkflowImpl.class)
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder().setEnableVirtualThreads(true).build())
+          .build();
+
+  @Test
+  public void testWorkflowRetry() {
+    String[] javaVersionElements = System.getProperty("java.version").split("\\.");
+    int javaVersion = Integer.parseInt(javaVersionElements[1]);
+    SignaledWorkflow workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                SignaledWorkflow.class,
+                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+
+    WorkflowClient.start(workflowStub::execute);
+
+    for (int i = 0; i < 700; i++) {
+      workflowStub.signal();
+    }
+    workflowStub.unblock();
+
+    Assert.assertEquals("result=2, 100", workflowStub.execute());
+  }
+
+  public static class TestSignaledWorkflowImpl implements SignaledWorkflow {
+    private int signalCount = 0;
+    private boolean unblocked = false;
+
+    @Override
+    public String execute() {
+      Workflow.await(() -> unblocked);
+      return String.valueOf(signalCount);
+    }
+
+    @Override
+    public void signal() {
+      signalCount++;
+      Workflow.await(() -> unblocked);
+    }
+
+    @Override
+    public void unblock() {
+      unblocked = true;
+    }
+  }
+
+  @WorkflowInterface
+  public interface SignaledWorkflow {
+
+    @WorkflowMethod
+    String execute();
+
+    @SignalMethod
+    void signal();
+
+    @SignalMethod
+    void unblock();
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
@@ -21,6 +21,7 @@
 package io.temporal.workflow;
 
 import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.testing.internal.SDKTestOptions;
@@ -31,36 +32,36 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class WorkflowParallelismTest {
-  @Rule
-  public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder()
-          .setUseExternalService(true)
-          .setWorkflowTypes(TestSignaledWorkflowImpl.class)
-          .setWorkerFactoryOptions(
-              WorkerFactoryOptions.newBuilder().setEnableVirtualThreads(true).build())
-          .build();
-
-  @Test
-  public void testWorkflowRetry() {
-    assumeFalse("Skip on JDK 21+", false);
-    String[] javaVersionElements = System.getProperty("java.version").split("\\.");
-    int javaVersion = Integer.parseInt(javaVersionElements[1]);
-    SignaledWorkflow workflowStub =
-        testWorkflowRule
-            .getWorkflowClient()
-            .newWorkflowStub(
-                SignaledWorkflow.class,
-                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
-
-    WorkflowClient.start(workflowStub::execute);
-
-    for (int i = 0; i < 700; i++) {
-      workflowStub.signal();
-    }
-    workflowStub.unblock();
-
-    Assert.assertEquals("result=2, 100", workflowStub.execute());
-  }
+//  @Rule
+//  public SDKTestWorkflowRule testWorkflowRule =
+//      SDKTestWorkflowRule.newBuilder()
+//          .setUseExternalService(true)
+//          .setWorkflowTypes(TestSignaledWorkflowImpl.class)
+//          .setWorkerFactoryOptions(
+//              WorkerFactoryOptions.newBuilder().setEnableVirtualThreads(true).build())
+//          .build();
+//
+//  @Test
+//  public void testWorkflowWithLotsOfThreads() {
+//    assumeTrue("Skip on JDK < 21", false);
+//    String[] javaVersionElements = System.getProperty("java.version").split("\\.");
+//    int javaVersion = Integer.parseInt(javaVersionElements[1]);
+//    SignaledWorkflow workflowStub =
+//        testWorkflowRule
+//            .getWorkflowClient()
+//            .newWorkflowStub(
+//                SignaledWorkflow.class,
+//                SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()));
+//
+//    WorkflowClient.start(workflowStub::execute);
+//
+//    for (int i = 0; i < 700; i++) {
+//      workflowStub.signal();
+//    }
+//    workflowStub.unblock();
+//
+//    Assert.assertEquals("result=2, 100", workflowStub.execute());
+//  }
 
   public static class TestSignaledWorkflowImpl implements SignaledWorkflow {
     private int signalCount = 0;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowParallelismTest.java
@@ -20,6 +20,8 @@
 
 package io.temporal.workflow;
 
+import static org.junit.Assume.assumeFalse;
+
 import io.temporal.client.WorkflowClient;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
@@ -40,6 +42,7 @@ public class WorkflowParallelismTest {
 
   @Test
   public void testWorkflowRetry() {
+    assumeFalse("Skip on JDK 21+", false);
     String[] javaVersionElements = System.getProperty("java.version").split("\\.");
     int javaVersion = Integer.parseInt(javaVersionElements[1]);
     SignaledWorkflow workflowStub =

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -85,6 +85,7 @@ public class ServiceStubsOptions {
    * Interval at which server will be pinged in order to determine if connections are still alive.
    */
   protected final Duration keepAliveTime;
+
   /**
    * Amount of time that client would wait for the keep alive ping response from the server before
    * closing the connection.

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -31,9 +31,11 @@ public final class WorkflowServiceStubsOptions extends ServiceStubsOptions {
    * empty result after this server timeout.
    */
   public static final Duration DEFAULT_SERVER_LONG_POLL_RPC_TIMEOUT = Duration.ofSeconds(60);
+
   /** Default RPC timeout used for all long poll calls. */
   public static final Duration DEFAULT_POLL_RPC_TIMEOUT =
       DEFAULT_SERVER_LONG_POLL_RPC_TIMEOUT.plus(Duration.ofSeconds(10));
+
   /** Default RPC timeout for workflow queries */
   public static final Duration DEFAULT_QUERY_RPC_TIMEOUT = Duration.ofSeconds(10);
 

--- a/temporal-shaded/build.gradle
+++ b/temporal-shaded/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'io.github.goooler.shadow' version '8.1.7'
 }
 
 description = '''Temporal Java SDK and Testing Framework with gRPC, Protobuf 3 and Guava shaded'''

--- a/temporal-shaded/build.gradle
+++ b/temporal-shaded/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.github.goooler.shadow' version '8.1.7'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 description = '''Temporal Java SDK and Testing Framework with gRPC, Protobuf 3 and Guava shaded'''

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/RequestContext.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/RequestContext.java
@@ -89,6 +89,7 @@ final class RequestContext {
 
   static final class TimerLockChange {
     private final String caller;
+
     /** +1 or -1 */
     private final int change;
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -145,10 +145,12 @@ class StateMachines {
     String cronSchedule;
     Payloads lastCompletionResult;
     Optional<Failure> lastFailure;
+
     /**
      * @see WorkflowExecutionStartedEventAttributes#getFirstExecutionRunId()
      */
     final @Nonnull String firstExecutionRunId;
+
     /**
      * @see WorkflowExecutionStartedEventAttributes#getOriginalExecutionRunId()
      */

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -135,6 +135,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   private final SelfAdvancingTimer timerService;
   private final LongSupplier clock;
   private final ExecutionId executionId;
+
   /** Parent workflow if this workflow was started as a child workflow. */
   private final Optional<TestWorkflowMutableState> parent;
 
@@ -155,6 +156,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       new HashMap<>();
   private final Map<String, StateMachine<UpdateWorkflowExecutionData>> updates = new HashMap<>();
   private final StateMachine<WorkflowData> workflow;
+
   /** A single workflow task state machine is used for the whole workflow lifecycle. */
   private final StateMachine<WorkflowTaskData> workflowTaskStateMachine;
 


### PR DESCRIPTION
Proof of concept support for virtual threads inside workflows using a multi release jar. A multi release jar is how most other large java projects chose to add support for virtual threads.

TODO:
* Decided if we should support virtual threads for the polling and executor threads as well
* Finalize and document `VirtualThreadDelegate`
* Update any internal SDK documentation around assuming executors are always backed by a fixed size thread pool
* Get the unit tests to work, they don't seem to respect the multi-jar at the moment
* Decided on if to use the gradle approach or incorporate gradle toolchains
