### PR TITLE
Add support for update admitted event

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
@@ -537,6 +537,10 @@ class TestHistoryBuilder {
           result.setChildWorkflowExecutionTerminatedEventAttributes(
               (ChildWorkflowExecutionTerminatedEventAttributes) attributes);
           break;
+        case EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
+          result.setWorkflowExecutionUpdateAdmittedEventAttributes(
+              (WorkflowExecutionUpdateAdmittedEventAttributes) attributes);
+          break;
         case EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
           result.setWorkflowExecutionUpdateAcceptedEventAttributes(
               (WorkflowExecutionUpdateAcceptedEventAttributes) attributes);

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/UpdateProtocolStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/UpdateProtocolStateMachineTest.java
@@ -706,7 +706,7 @@ public class UpdateProtocolStateMachineTest {
           WorkflowExecutionUpdateAcceptedEventAttributes.newBuilder()
               .setProtocolInstanceId("protocol_id")
               .setAcceptedRequestMessageId("id")
-              .setAcceptedRequestSequencingEventId(2));
+              .setAcceptedRequestSequencingEventId(5));
       h.add(
           EventType.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED,
           WorkflowExecutionUpdateCompletedEventAttributes.newBuilder()

--- a/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure-alpha/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -337,7 +337,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
       addRegisteredActivityImpl(worker, beanName, bean.getClass().getName(), activityImplMetadata);
       if (log.isInfoEnabled()) {
         log.info(
-            "Registering auto-discovered activity bean '{}' of class {} on a worker {}with a task queue '{}'",
+            "Registering auto-discovered activity bean '{}' of class {} on a worker {} with a task queue '{}'",
             beanName,
             targetClass,
             byWorkerName != null ? "'" + byWorkerName + "' " : "",
@@ -346,7 +346,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
     } catch (TypeAlreadyRegisteredException registeredEx) {
       if (log.isInfoEnabled()) {
         log.info(
-            "Skipping auto-discovered activity bean '{}' of class {} on a worker {}with a task queue '{}'"
+            "Skipping auto-discovered activity bean '{}' of class {} on a worker {} with a task queue '{}'"
                 + " as activity type '{}' is already registered on the worker",
             beanName,
             targetClass,


### PR DESCRIPTION
Add support for update admitted event. Required some modification to how the Java SDK batches event during replay because when the SDK processed an update admitted event while replaying it needs to know if it was accepted or not. Preciously the SDK batches events like [WFT started, WFT completed, Command events] and now it batches events like [Non command events, WFT scheduled, WFT started, WFT completed, Command events]
.