### PR TITLE
Add ScheduleClientInterceptor APIs (fixes #2048)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleClientOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleClientOptions.java
@@ -23,6 +23,7 @@ package io.temporal.client.schedules;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.GlobalDataConverter;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.List;
@@ -56,11 +57,14 @@ public final class ScheduleClientOptions {
     private static final String DEFAULT_NAMESPACE = "default";
     private static final List<ContextPropagator> EMPTY_CONTEXT_PROPAGATORS =
         Collections.emptyList();
+    private static final List<ScheduleClientInterceptor> EMPTY_INTERCEPTORS =
+        Collections.emptyList();
 
     private String namespace;
     private DataConverter dataConverter;
     private String identity;
     private List<ContextPropagator> contextPropagators;
+    private List<ScheduleClientInterceptor> interceptors;
 
     private Builder() {}
 
@@ -72,6 +76,7 @@ public final class ScheduleClientOptions {
       dataConverter = options.dataConverter;
       identity = options.identity;
       contextPropagators = options.contextPropagators;
+      interceptors = options.interceptors;
     }
 
     /** Set the namespace this client will operate on. */
@@ -106,13 +111,24 @@ public final class ScheduleClientOptions {
       return this;
     }
 
+    /**
+     * Set the interceptors for this client.
+     *
+     * @param interceptors specifies the list of interceptors to use with the client.
+     */
+    public Builder setInterceptors(List<ScheduleClientInterceptor> interceptors) {
+      this.interceptors = interceptors;
+      return this;
+    }
+
     public ScheduleClientOptions build() {
       String name = identity == null ? ManagementFactory.getRuntimeMXBean().getName() : identity;
       return new ScheduleClientOptions(
           namespace == null ? DEFAULT_NAMESPACE : namespace,
           dataConverter == null ? GlobalDataConverter.get() : dataConverter,
           name,
-          contextPropagators == null ? EMPTY_CONTEXT_PROPAGATORS : contextPropagators);
+          contextPropagators == null ? EMPTY_CONTEXT_PROPAGATORS : contextPropagators,
+          interceptors == null ? EMPTY_INTERCEPTORS : interceptors);
     }
   }
 
@@ -120,16 +136,19 @@ public final class ScheduleClientOptions {
   private final DataConverter dataConverter;
   private final String identity;
   private final List<ContextPropagator> contextPropagators;
+  private final List<ScheduleClientInterceptor> interceptors;
 
   private ScheduleClientOptions(
       String namespace,
       DataConverter dataConverter,
       String identity,
-      List<ContextPropagator> contextPropagators) {
+      List<ContextPropagator> contextPropagators,
+      List<ScheduleClientInterceptor> interceptors) {
     this.namespace = namespace;
     this.dataConverter = dataConverter;
     this.identity = identity;
     this.contextPropagators = contextPropagators;
+    this.interceptors = interceptors;
   }
 
   /**
@@ -166,5 +185,14 @@ public final class ScheduleClientOptions {
    */
   public List<ContextPropagator> getContextPropagators() {
     return contextPropagators;
+  }
+
+  /**
+   * Get the interceptors of this client
+   *
+   * @return The list of interceptors to use with the client.
+   */
+  public List<ScheduleClientInterceptor> getInterceptors() {
+    return interceptors;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/ScheduleClientInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/ScheduleClientInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.common.interceptors;
+
+import io.temporal.client.schedules.ScheduleClient;
+import io.temporal.client.schedules.ScheduleHandle;
+import io.temporal.common.Experimental;
+
+/**
+ * Intercepts calls to the {@link ScheduleClient} and {@link ScheduleHandle} related to the
+ * lifecycle of a Schedule.
+ */
+@Experimental
+public interface ScheduleClientInterceptor {
+
+  /**
+   * Called once during creation of ScheduleClient to create a chain of ScheduleClient Interceptors
+   *
+   * @param next next schedule client interceptor in the chain of interceptors
+   * @return new interceptor that should decorate calls to {@code next}
+   */
+  ScheduleClientCallsInterceptor scheduleClientCallsInterceptor(
+      ScheduleClientCallsInterceptor next);
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/ScheduleClientInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/ScheduleClientInterceptorBase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.common.interceptors;
+
+import io.temporal.common.Experimental;
+
+/** Convenience base class for ScheduleClientInterceptor implementations. */
+@Experimental
+public class ScheduleClientInterceptorBase implements ScheduleClientInterceptor {
+
+  @Override
+  public ScheduleClientCallsInterceptor scheduleClientCallsInterceptor(
+      ScheduleClientCallsInterceptor next) {
+    return next;
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/TracingScheduleInterceptor.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/TracingScheduleInterceptor.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.client.schedules;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.temporal.common.interceptors.ScheduleClientCallsInterceptor;
+import io.temporal.common.interceptors.ScheduleClientCallsInterceptorBase;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
+import io.temporal.testing.internal.TracingWorkerInterceptor;
+import io.temporal.workflow.unsafe.WorkflowUnsafe;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A ScheduleClientInterceptor that just logs the calls it intercepts. The implementation is taken
+ * from TracingWorkerInterceptor, with very minor tweaks.
+ */
+public class TracingScheduleInterceptor implements ScheduleClientInterceptor {
+  private static final Logger log = LoggerFactory.getLogger(TracingWorkerInterceptor.class);
+
+  private final FilteredTrace trace;
+  private List<String> expected;
+
+  public TracingScheduleInterceptor(FilteredTrace trace) {
+    this.trace = trace;
+  }
+
+  public String getTrace() {
+    return String.join("\n", trace.getImpl());
+  }
+
+  public void setExpected(String... expected) {
+    this.expected = Arrays.asList(expected);
+  }
+
+  public void assertExpected() {
+    if (expected != null) {
+      List<String> traceElements = trace.getImpl();
+      if (traceElements.isEmpty()) {
+        fail("Expected to find traces, but found none");
+      }
+
+      for (int i = 0; i < traceElements.size(); i++) {
+        String t = traceElements.get(i);
+        String expectedRegExp;
+        if (expected.size() <= i) {
+          expectedRegExp = "";
+        } else {
+          expectedRegExp = expected.get(i);
+        }
+        assertTrue(
+            t
+                + " doesn't match "
+                + expectedRegExp
+                + ": \n expected=\n"
+                + String.join("\n", expected)
+                + "\n actual=\n"
+                + String.join("\n", traceElements)
+                + "\n",
+            t.matches(expectedRegExp));
+      }
+    }
+  }
+
+  @Override
+  public ScheduleClientCallsInterceptor scheduleClientCallsInterceptor(
+      ScheduleClientCallsInterceptor next) {
+    return new TracingScheduleCallsInterceptor(trace, next);
+  }
+
+  public static class TracingScheduleCallsInterceptor extends ScheduleClientCallsInterceptorBase {
+    private final FilteredTrace trace;
+    private final ScheduleClientCallsInterceptor next;
+
+    public TracingScheduleCallsInterceptor(
+        FilteredTrace trace, ScheduleClientCallsInterceptor next) {
+      super(next);
+      this.trace = trace;
+      this.next = next;
+    }
+
+    @Override
+    public void createSchedule(CreateScheduleInput input) {
+      trace.add("createSchedule: " + input.getId());
+      next.createSchedule(input);
+    }
+
+    @Override
+    public ListScheduleOutput listSchedules(ListSchedulesInput input) {
+      trace.add("listSchedules");
+      return next.listSchedules(input);
+    }
+
+    @Override
+    public void backfillSchedule(BackfillScheduleInput input) {
+      trace.add("backfillSchedule: " + input.getScheduleId());
+      next.backfillSchedule(input);
+    }
+
+    @Override
+    public void deleteSchedule(DeleteScheduleInput input) {
+      trace.add("deleteSchedule: " + input.getScheduleId());
+      next.deleteSchedule(input);
+    }
+
+    @Override
+    public DescribeScheduleOutput describeSchedule(DescribeScheduleInput input) {
+      trace.add("describeSchedule: " + input.getScheduleId());
+      return next.describeSchedule(input);
+    }
+
+    @Override
+    public void pauseSchedule(PauseScheduleInput input) {
+      trace.add("pauseSchedule: " + input.getScheduleId());
+      next.pauseSchedule(input);
+    }
+
+    @Override
+    public void triggerSchedule(TriggerScheduleInput input) {
+      trace.add("triggerSchedule: " + input.getScheduleId());
+      next.triggerSchedule(input);
+    }
+
+    @Override
+    public void unpauseSchedule(UnpauseScheduleInput input) {
+      trace.add("unpauseSchedule: " + input.getScheduleId());
+      next.unpauseSchedule(input);
+    }
+
+    @Override
+    public void updateSchedule(UpdateScheduleInput input) {
+      trace.add("updateSchedule: " + input.getDescription().getId());
+      next.updateSchedule(input);
+    }
+  }
+
+  public static class FilteredTrace {
+
+    private final List<String> impl = Collections.synchronizedList(new ArrayList<>());
+
+    public boolean add(String s) {
+      log.trace("FilteredTrace isReplaying=" + WorkflowUnsafe.isReplaying());
+      if (!WorkflowUnsafe.isReplaying()) {
+        return impl.add(s);
+      }
+      return true;
+    }
+
+    List<String> getImpl() {
+      return impl;
+    }
+  }
+}


### PR DESCRIPTION
## What was changed
This adds APIs for users to specify interceptors when creating a `ScheduleClient`. Previously there was interceptor infrastructure built into the internals of the client, but no public API to allow users to actually add them.

## Why?
So that users can add interceptors as needed.

## Checklist

1. Closes #2048 

2. How was this tested:
Unit tests

3. Any docs updates needed?
Not sure. The current docs don't talk about how `ScheduleClient` is created right now, so probably not?
