### PR TITLE
Add shortcut to set API key

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -27,14 +27,12 @@ import io.grpc.*;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.temporal.authorization.AuthorizationGrpcMetadataProvider;
 import io.temporal.authorization.AuthorizationTokenSupplier;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -513,21 +511,22 @@ public class ServiceStubsOptions {
     }
 
     /**
-     * @param apiKey authentication token supplier to be called on each gRPC
-     * request. Will append "Bearer " to the token if it's not already present.
+     * Add a {@link AuthorizationGrpcMetadataProvider} to the gRPC metadata providers that supplies
+     * an authentication token on each gRPC request.
+     *
+     * @param apiKey authentication token supplier to be called on each gRPC request. SDK will
+     *     automatically add the "Bearer " prefix.
      * @return {@code this}
      */
     public T addApiKey(AuthorizationTokenSupplier apiKey) {
-      addGrpcMetadataProvider(new AuthorizationGrpcMetadataProvider(() -> {
-        String token = apiKey.supply();
-        if (token.startsWith("Bearer ") || token.startsWith("bearer ")) {
-          return token;
-        }
-        return "Bearer " + apiKey.supply();
-      }));
+      addGrpcMetadataProvider(
+          new AuthorizationGrpcMetadataProvider(
+              () -> {
+                return "Bearer " + apiKey.supply();
+              }));
       return self();
     }
-    
+
     /**
      * @param grpcMetadataProviders gRPC metadata/headers providers to be called on each gRPC
      *     request to supply additional headers


### PR DESCRIPTION
closes https://github.com/temporalio/sdk-java/issues/1997

Add shortcut to add an api key to a connection. Instead of 

```
    WorkflowServiceStubsOptions.Builder stubOptions =
        WorkflowServiceStubsOptions.newBuilder()
             ...
            .addGrpcMetadataProvider(
                new AuthorizationGrpcMetadataProvider(() -> "Bearer " + API_KEY))
```

Users can now set

```
    WorkflowServiceStubsOptions.Builder stubOptions =
        WorkflowServiceStubsOptions.newBuilder()
             ...
            .addApiKey(
                () -> API_KEY)
```