### PR TITLE
Fix UnsupportedOperationException in handleSingleEventLookahead

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -260,7 +260,7 @@ public final class WorkflowStateMachines {
   }
 
   public void setMessages(List<Message> messages) {
-    this.messages = messages;
+    this.messages = new ArrayList<>(messages);
   }
 
   /**


### PR DESCRIPTION
Saw a feature test failure 

https://github.com/temporalio/sdk-java/actions/runs/9004033452/job/24736072159

```
15:03:44.177 [Workflow Executor taskQueue="features-update/worker_restart-53dad4af-01db-498a-85ac-53a6c668cb0e", namespace="features-ns-c0890b76-c01f-43dd-8085-0d5e86de9891": 1] WARN  i.t.i.r.ReplayWorkflowTaskHandler - Workflow task processing failure. startedEventId=12, WorkflowId=5a643741-9333-44cf-abd5-62703fc9ed51, RunId=12fc431a-f015-47f1-8cbe-525fa758ace1. If seen continuously the workflow might be stuck.
java.lang.UnsupportedOperationException: null
	at java.base/java.util.Collections$UnmodifiableCollection.add(Collections.java:1060)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleSingleEventLookahead(WorkflowStateMachines.java:360)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleEventsBatch(WorkflowStateMachines.java:311)
	at io.temporal.internal.statemachines.WorkflowStateMachines.handleEvent(WorkflowStateMachines.java:289)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.applyServerHistory(ReplayWorkflowRunTaskHandler.java:249)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleWorkflowTaskImpl(ReplayWorkflowRunTaskHandler.java:231)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleWorkflowTask(ReplayWorkflowRunTaskHandler.java:165)
	at io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTaskWithQuery(ReplayWorkflowTaskHandler.java:135)
	at io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTask(ReplayWorkflowTaskHandler.java:100)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handleTask(WorkflowWorker.java:453)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:344)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:285)
	at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

The root cause is we were not copying the list of protocol messages from the workflow task just the reference to it which can't be modified 