### PR TITLE
Don't return update handles until desired stage reached

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -3,8 +3,9 @@ on: [push, pull_request]
 
 jobs:
   features-test:
-    uses: temporalio/features/.github/workflows/java.yaml@main
+    uses: temporalio/features/.github/workflows/java.yaml@java-breaking-update
     with:
       java-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+      features-repo-ref: java-breaking-update

--- a/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
@@ -72,7 +72,7 @@ final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
 
   @Override
   public CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit) {
-    WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput output =
+    WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput<T> output =
         workflowClientInvoker.pollWorkflowUpdate(
             new WorkflowClientCallsInterceptor.PollWorkflowUpdateInput<>(
                 execution, updateName, id, resultClass, resultType, timeout, unit));

--- a/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
@@ -27,7 +27,6 @@ import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
 import java.lang.reflect.Type;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;

--- a/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
@@ -73,11 +73,15 @@ final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
 
   @Override
   public CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit) {
+    WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput<T> pollCall;
     if (previousPollCall == null) {
       pollUntilComplete(timeout, unit);
     }
+    pollCall = previousPollCall;
+    // Get result may be called more than once for non-complete wait policies, so reset it here.
+    previousPollCall = null;
 
-    return previousPollCall
+    return pollCall
         .getResult()
         .exceptionally(
             failure -> {

--- a/temporal-sdk/src/main/java/io/temporal/client/UpdateOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/UpdateOptions.java
@@ -50,7 +50,7 @@ public final class UpdateOptions<T> {
   private final String updateName;
   private final String updateId;
   private final String firstExecutionRunId;
-  private final UpdateWaitPolicy waitPolicy;
+  private final WorkflowUpdateStage waitPolicy;
   private final Class<T> resultClass;
   private final Type resultType;
 
@@ -58,7 +58,7 @@ public final class UpdateOptions<T> {
       String updateName,
       String updateId,
       String firstExecutionRunId,
-      UpdateWaitPolicy waitPolicy,
+      WorkflowUpdateStage waitPolicy,
       Class<T> resultClass,
       Type resultType) {
     this.updateName = updateName;
@@ -81,7 +81,7 @@ public final class UpdateOptions<T> {
     return firstExecutionRunId;
   }
 
-  public UpdateWaitPolicy getWaitPolicy() {
+  public WorkflowUpdateStage getWaitPolicy() {
     return waitPolicy;
   }
 
@@ -152,7 +152,7 @@ public final class UpdateOptions<T> {
     private String updateName;
     private String updateId;
     private String firstExecutionRunId;
-    private UpdateWaitPolicy waitPolicy;
+    private WorkflowUpdateStage waitPolicy;
     private Class<T> resultClass;
     private Type resultType;
 
@@ -208,7 +208,7 @@ public final class UpdateOptions<T> {
      *   <li><b>Completed</b> Wait for the update to be completed by the workflow.
      * </ul>
      */
-    public Builder<T> setWaitPolicy(UpdateWaitPolicy waitPolicy) {
+    public Builder<T> setWaitPolicy(WorkflowUpdateStage waitPolicy) {
       this.waitPolicy = waitPolicy;
       return this;
     }
@@ -239,7 +239,7 @@ public final class UpdateOptions<T> {
           updateName,
           updateId,
           firstExecutionRunId == null ? "" : firstExecutionRunId,
-          waitPolicy == null ? UpdateWaitPolicy.ACCEPTED : waitPolicy,
+          waitPolicy == null ? WorkflowUpdateStage.ACCEPTED : waitPolicy,
           resultClass,
           resultType == null ? resultClass : resultType);
     }

--- a/temporal-sdk/src/main/java/io/temporal/client/UpdateWaitPolicy.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/UpdateWaitPolicy.java
@@ -23,7 +23,19 @@ package io.temporal.client;
 import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 
 public enum UpdateWaitPolicy {
-  /** Update request waits for the update to be accepted by the workflow */
+  /**
+   * Update request waits for the update to be until the update request has been admitted by the
+   * server - it may be the case that due to a considerations like load or resource limits that an
+   * update is made to wait before the server will indicate that it has been received and will be
+   * processed. This value does not wait for any sort of acknowledgement from a worker.
+   */
+  ADMITTED(
+      UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED),
+
+  /**
+   * Update request waits for the update to be accepted (and validated, if there is a validator) by
+   * the workflow
+   */
   ACCEPTED(
       UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED),
 

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -107,7 +107,8 @@ public interface WorkflowStub {
 
   /**
    * Asynchronously update a workflow execution by invoking its update handler and returning a
-   * handle to the update request.
+   * handle to the update request. If {@link UpdateWaitPolicy#COMPLETED} is specified, in the
+   * options, the handle will not be returned until the update is completed.
    *
    * @param options options that will be used to configure and start a new update request.
    * @param args update method arguments

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -107,7 +107,7 @@ public interface WorkflowStub {
 
   /**
    * Asynchronously update a workflow execution by invoking its update handler and returning a
-   * handle to the update request. If {@link UpdateWaitPolicy#COMPLETED} is specified, in the
+   * handle to the update request. If {@link WorkflowUpdateStage#COMPLETED} is specified, in the
    * options, the handle will not be returned until the update is completed.
    *
    * @param options options that will be used to configure and start a new update request.

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -362,7 +362,7 @@ class WorkflowStubImpl implements WorkflowStub {
                 options.getResultType());
         if (options.getWaitPolicy() == WorkflowUpdateStage.COMPLETED) {
           // Don't return the handle until completed, since that's what's been asked for
-          handle.pollUntilComplete(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+          handle.waitCompleted();
         }
         return handle;
       }

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -297,7 +297,7 @@ class WorkflowStubImpl implements WorkflowStub {
       UpdateOptions<R> options =
           UpdateOptions.<R>newBuilder()
               .setUpdateName(updateName)
-              .setWaitPolicy(UpdateWaitPolicy.COMPLETED)
+              .setWaitPolicy(WorkflowUpdateStage.COMPLETED)
               .setResultClass(resultClass)
               .build();
       return startUpdate(options, args).getResultAsync().get();
@@ -316,7 +316,7 @@ class WorkflowStubImpl implements WorkflowStub {
     UpdateOptions<R> options =
         UpdateOptions.<R>newBuilder()
             .setUpdateName(updateName)
-            .setWaitPolicy(UpdateWaitPolicy.ACCEPTED)
+            .setWaitPolicy(WorkflowUpdateStage.ACCEPTED)
             .setResultClass(resultClass)
             .setResultType(resultClass)
             .build();
@@ -360,7 +360,7 @@ class WorkflowStubImpl implements WorkflowStub {
                 result.getReference().getWorkflowExecution(),
                 options.getResultClass(),
                 options.getResultType());
-        if (options.getWaitPolicy() == UpdateWaitPolicy.COMPLETED) {
+        if (options.getWaitPolicy() == WorkflowUpdateStage.COMPLETED) {
           // Don't return the handle until completed, since that's what's been asked for
           handle.pollUntilComplete(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
         }

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateStage.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateStage.java
@@ -22,7 +22,7 @@ package io.temporal.client;
 
 import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 
-public enum UpdateWaitPolicy {
+public enum WorkflowUpdateStage {
   /**
    * Update request waits for the update to be until the update request has been admitted by the
    * server - it may be the case that due to a considerations like load or resource limits that an
@@ -45,7 +45,7 @@ public enum UpdateWaitPolicy {
 
   private final UpdateWorkflowExecutionLifecycleStage policy;
 
-  UpdateWaitPolicy(UpdateWorkflowExecutionLifecycleStage policy) {
+  WorkflowUpdateStage(UpdateWorkflowExecutionLifecycleStage policy) {
     this.policy = policy;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -333,12 +333,12 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
             .setFirstExecutionRunId(input.getFirstExecutionRunId())
             .setRequest(request)
             .build();
-    Deadline pollTimeoutDeadline = Deadline.after(POLL_UPDATE_TIMEOUT_S, TimeUnit.SECONDS);
 
     // Re-attempt the update until it is at least accepted, or passes the lifecycle stage specified
     // by the user.
     UpdateWorkflowExecutionResponse result;
     do {
+      Deadline pollTimeoutDeadline = Deadline.after(POLL_UPDATE_TIMEOUT_S, TimeUnit.SECONDS);
       result = genericClient.update(updateRequest, pollTimeoutDeadline);
     } while (result.getStage().getNumber() < input.getWaitPolicy().getLifecycleStage().getNumber()
         && result.getStage().getNumber()

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -408,20 +408,18 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
 
     Deadline pollTimeoutDeadline = Deadline.after(input.getTimeout(), input.getTimeoutUnit());
     pollWorkflowUpdateHelper(future, pollUpdateRequest, pollTimeoutDeadline);
-    return new PollWorkflowUpdateOutput(
+    return new PollWorkflowUpdateOutput<>(
         future.thenApply(
             (result) -> {
               if (result.hasOutcome()) {
                 switch (result.getOutcome().getValueCase()) {
                   case SUCCESS:
                     Optional<Payloads> updateResult = Optional.of(result.getOutcome().getSuccess());
-                    R resultValue =
-                        convertResultPayloads(
-                            updateResult,
-                            input.getResultClass(),
-                            input.getResultType(),
-                            dataConverterWithWorkflowContext);
-                    return resultValue;
+                    return convertResultPayloads(
+                        updateResult,
+                        input.getResultClass(),
+                        input.getResultType(),
+                        dataConverterWithWorkflowContext);
                   case FAILURE:
                     throw new WorkflowUpdateException(
                         input.getWorkflowExecution(),
@@ -443,31 +441,23 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
       CompletableFuture<PollWorkflowExecutionUpdateResponse> resultCF,
       PollWorkflowExecutionUpdateRequest request,
       Deadline deadline) {
-
-    Deadline pollTimeoutDeadline =
-        Deadline.after(POLL_UPDATE_TIMEOUT_S, TimeUnit.SECONDS).minimum(deadline);
     genericClient
-        .pollUpdateAsync(request, pollTimeoutDeadline)
+        .pollUpdateAsync(request, deadline)
         .whenComplete(
             (r, e) -> {
               if ((e instanceof StatusRuntimeException
                       && ((StatusRuntimeException) e).getStatus().getCode()
                           == Status.Code.DEADLINE_EXCEEDED)
-                  || pollTimeoutDeadline.isExpired()
+                  || deadline.isExpired()
                   || (e == null && !r.hasOutcome())) {
-                // if the request has timed out, stop retrying
-                if (!deadline.isExpired()) {
-                  pollWorkflowUpdateHelper(resultCF, request, deadline);
-                } else {
-                  resultCF.completeExceptionally(
-                      new TimeoutException(
-                          "WorkflowId="
-                              + request.getUpdateRef().getWorkflowExecution().getWorkflowId()
-                              + ", runId="
-                              + request.getUpdateRef().getWorkflowExecution().getRunId()
-                              + ", updateId="
-                              + request.getUpdateRef().getUpdateId()));
-                }
+                resultCF.completeExceptionally(
+                    new TimeoutException(
+                        "WorkflowId="
+                            + request.getUpdateRef().getWorkflowExecution().getWorkflowId()
+                            + ", runId="
+                            + request.getUpdateRef().getWorkflowExecution().getRunId()
+                            + ", updateId="
+                            + request.getUpdateRef().getUpdateId()));
               } else if (e != null) {
                 resultCF.completeExceptionally(e);
               } else {

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -445,11 +445,14 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
         .pollUpdateAsync(request, deadline)
         .whenComplete(
             (r, e) -> {
+              if (e == null && !r.hasOutcome()) {
+                pollWorkflowUpdateHelper(resultCF, request, deadline);
+                return;
+              }
               if ((e instanceof StatusRuntimeException
                       && ((StatusRuntimeException) e).getStatus().getCode()
                           == Status.Code.DEADLINE_EXCEEDED)
-                  || deadline.isExpired()
-                  || (e == null && !r.hasOutcome())) {
+                  || deadline.isExpired()) {
                 resultCF.completeExceptionally(
                     new TimeoutException(
                         "WorkflowId="

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestWorkflows.java
@@ -178,16 +178,6 @@ public class TestWorkflows {
   }
 
   @WorkflowInterface
-  public interface SimpleWorkflowWithUpdate {
-
-    @WorkflowMethod
-    String execute();
-
-    @UpdateMethod
-    String update(String value);
-  }
-
-  @WorkflowInterface
   public interface WorkflowWithUpdate {
 
     @WorkflowMethod

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -66,12 +66,7 @@ import io.temporal.api.command.v1.StartTimerCommandAttributes;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.RetryPolicy;
 import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.api.enums.v1.CancelExternalWorkflowExecutionFailedCause;
-import io.temporal.api.enums.v1.EventType;
-import io.temporal.api.enums.v1.RetryState;
-import io.temporal.api.enums.v1.SignalExternalWorkflowExecutionFailedCause;
-import io.temporal.api.enums.v1.StartChildWorkflowExecutionFailedCause;
-import io.temporal.api.enums.v1.TimeoutType;
+import io.temporal.api.enums.v1.*;
 import io.temporal.api.errordetails.v1.QueryFailedFailure;
 import io.temporal.api.failure.v1.ApplicationFailureInfo;
 import io.temporal.api.failure.v1.Failure;
@@ -1810,6 +1805,9 @@ class StateMachines {
                   UpdateRef.newBuilder()
                       .setWorkflowExecution(ctx.getExecution())
                       .setUpdateId(data.id))
+              .setStage(
+                  UpdateWorkflowExecutionLifecycleStage
+                      .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED)
               .build();
 
       data.acceptance.complete(response);
@@ -1852,6 +1850,9 @@ class StateMachines {
                       .setWorkflowExecution(ctx.getExecution())
                       .setUpdateId(data.id))
               .setOutcome(response.getOutcome())
+              .setStage(
+                  UpdateWorkflowExecutionLifecycleStage
+                      .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED)
               .build();
 
       data.complete.complete(updateResponse);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1625,6 +1625,9 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
                     .setUpdateId(rejection.getRejectedRequest().getMeta().getUpdateId())
                     .setWorkflowExecution(ctx.getExecution()))
             .setOutcome(Outcome.newBuilder().setFailure(rejection.getFailure()).build())
+            .setStage(
+                UpdateWorkflowExecutionLifecycleStage
+                    .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED)
             .build();
     u.getAcceptance().complete(response);
   }
@@ -2159,7 +2162,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     } catch (TimeoutException e) {
       PollWorkflowExecutionUpdateResponse resp =
           PollWorkflowExecutionUpdateResponse.getDefaultInstance();
-      // Set stage to admitted
       return resp.toBuilder()
           .setStage(
               UpdateWorkflowExecutionLifecycleStage

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -2157,7 +2157,14 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           .setOutcome(completionResponse.getOutcome())
           .build();
     } catch (TimeoutException e) {
-      return PollWorkflowExecutionUpdateResponse.getDefaultInstance();
+      PollWorkflowExecutionUpdateResponse resp =
+          PollWorkflowExecutionUpdateResponse.getDefaultInstance();
+      // Set stage to admitted
+      return resp.toBuilder()
+          .setStage(
+              UpdateWorkflowExecutionLifecycleStage
+                  .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)
+          .build();
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof StatusRuntimeException) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Add admitted stage to wait policy
* Don't return update handle from startUpdate until the update is complete if the user specified that stage (not sure why they would, though, when using start)
* Retry submitting update to server until seen accepted

## Why?
See https://github.com/temporalio/features/issues/432

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/2002

2. How was this tested:
Existing / new tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
