### PR TITLE
Send unset catchupWindow in schedules if not specified

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
@@ -161,11 +161,13 @@ public class ScheduleProtoUtil {
   }
 
   public SchedulePolicies policyToProto(SchedulePolicy policy) {
-    return SchedulePolicies.newBuilder()
-        .setCatchupWindow(ProtobufTimeUtils.toProtoDuration(policy.getCatchupWindow()))
-        .setPauseOnFailure(policy.isPauseOnFailure())
-        .setOverlapPolicy(policy.getOverlap())
-        .build();
+    SchedulePolicies.Builder builder = SchedulePolicies.newBuilder();
+    if (policy.getCatchupWindow() != null) {
+      builder.setCatchupWindow(ProtobufTimeUtils.toProtoDuration(policy.getCatchupWindow()));
+    }
+    builder.setPauseOnFailure(policy.isPauseOnFailure());
+    builder.setOverlapPolicy(policy.getOverlap());
+    return builder.build();
   }
 
   public List<Range> scheduleRangeToProto(List<ScheduleRange> scheduleRanges) {


### PR DESCRIPTION
## What was changed

If the catchupWindow property is not set in SchedulePolicy, it is sent as a zero duration in the appropriate protobuf message. However, the server expects an unset value here. The previous behavior led to setting the actual catchupWindow on the server to the minimal value (10 seconds) instead of the default (1 year).

## Why?
Schedules are created with wrong `catchupWindow`. That leads to missed runs

## Checklist

1. Closes  #2065

2. How was this tested:
Tested in existing `ScheduleTest`

3. Any docs updates needed?
Nope
