### PR TITLE
Add identity to WorkerOptions

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -594,9 +594,15 @@ public final class Worker {
     } else if (clientOptions.getBinaryChecksum() != null) {
       buildId = clientOptions.getBinaryChecksum();
     }
+
+    String identity = clientOptions.getIdentity();
+    if (options.getIdentity() != null) {
+      identity = options.getIdentity();
+    }
+
     return SingleWorkerOptions.newBuilder()
         .setDataConverter(clientOptions.getDataConverter())
-        .setIdentity(clientOptions.getIdentity())
+        .setIdentity(identity)
         .setBuildId(buildId)
         .setUseBuildIdForVersioning(options.isUsingBuildIdForVersioning())
         .setEnableLoggingInReplay(factoryOptions.isEnableLoggingInReplay())

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -86,6 +86,7 @@ public final class WorkerOptions {
     private SlotSupplier<WorkflowSlotInfo> workflowSlotSupplier;
     private SlotSupplier<ActivitySlotInfo> activitySlotSupplier;
     private SlotSupplier<LocalActivitySlotInfo> localActivitySlotSupplier;
+    private String identity;
 
     private Builder() {}
 
@@ -416,6 +417,12 @@ public final class WorkerOptions {
       this.localActivitySlotSupplier = localActivitySlotSupplier;
     }
 
+    /** Override identity of the worker primary specified in a WorkflowClient options. */
+    public Builder setIdentity(String identity) {
+      this.identity = identity;
+      return this;
+    }
+
     public WorkerOptions build() {
       return new WorkerOptions(
           maxWorkerActivitiesPerSecond,
@@ -436,7 +443,8 @@ public final class WorkerOptions {
           disableEagerExecution,
           useBuildIdForVersioning,
           buildId,
-          stickyTaskQueueDrainTimeout);
+          stickyTaskQueueDrainTimeout,
+          identity);
     }
 
     public WorkerOptions validateAndBuildWithDefaults() {
@@ -525,7 +533,8 @@ public final class WorkerOptions {
           buildId,
           stickyTaskQueueDrainTimeout == null
               ? DEFAULT_STICKY_TASK_QUEUE_DRAIN_TIMEOUT
-              : stickyTaskQueueDrainTimeout);
+              : stickyTaskQueueDrainTimeout,
+          identity);
     }
   }
 
@@ -548,6 +557,7 @@ public final class WorkerOptions {
   private final boolean useBuildIdForVersioning;
   private final String buildId;
   private final Duration stickyTaskQueueDrainTimeout;
+  private final String identity;
 
   private WorkerOptions(
       double maxWorkerActivitiesPerSecond,
@@ -568,7 +578,8 @@ public final class WorkerOptions {
       boolean disableEagerExecution,
       boolean useBuildIdForVersioning,
       String buildId,
-      Duration stickyTaskQueueDrainTimeout) {
+      Duration stickyTaskQueueDrainTimeout,
+      String identity) {
     this.maxWorkerActivitiesPerSecond = maxWorkerActivitiesPerSecond;
     this.maxConcurrentActivityExecutionSize = maxConcurrentActivityExecutionSize;
     this.maxConcurrentWorkflowTaskExecutionSize = maxConcurrentWorkflowTaskExecutionSize;
@@ -588,6 +599,7 @@ public final class WorkerOptions {
     this.useBuildIdForVersioning = useBuildIdForVersioning;
     this.buildId = buildId;
     this.stickyTaskQueueDrainTimeout = stickyTaskQueueDrainTimeout;
+    this.identity = identity;
   }
 
   public double getMaxWorkerActivitiesPerSecond() {
@@ -683,6 +695,11 @@ public final class WorkerOptions {
     return localActivitySlotSupplier;
   }
 
+  @Nullable
+  public String getIdentity() {
+    return identity;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -706,7 +723,8 @@ public final class WorkerOptions {
         && Objects.equals(defaultHeartbeatThrottleInterval, that.defaultHeartbeatThrottleInterval)
         && Objects.equals(stickyQueueScheduleToStartTimeout, that.stickyQueueScheduleToStartTimeout)
         && Objects.equals(buildId, that.buildId)
-        && Objects.equals(stickyTaskQueueDrainTimeout, that.stickyTaskQueueDrainTimeout);
+        && Objects.equals(stickyTaskQueueDrainTimeout, that.stickyTaskQueueDrainTimeout)
+        && Objects.equals(identity, that.identity);
   }
 
   @Override
@@ -730,7 +748,8 @@ public final class WorkerOptions {
         disableEagerExecution,
         useBuildIdForVersioning,
         buildId,
-        stickyTaskQueueDrainTimeout);
+        stickyTaskQueueDrainTimeout,
+        identity);
   }
 
   @Override
@@ -775,6 +794,8 @@ public final class WorkerOptions {
         + '\''
         + ", stickyTaskQueueDrainTimeout="
         + stickyTaskQueueDrainTimeout
+        + ", identity="
+        + identity
         + '}';
   }
 }


### PR DESCRIPTION
Provides the ability to override worker identity specified in a WorkflowClient

## Checklist

1. Closes #2078 

2. How was this tested: manual tests

3. Any docs updates needed? 
It would be great to have a docs section about identities in the sdk docs, but there is no such yet 
