### PR TITLE
Fix signal CAN non determinism test

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalContinueAsNewNonDeterminism.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalContinueAsNewNonDeterminism.java
@@ -114,7 +114,6 @@ public class SignalContinueAsNewNonDeterminism {
     @Override
     public void signal() throws ExecutionException, InterruptedException {
       // Intentionally introduce non determinism
-      Thread.sleep(500);
       if (continueAsNew.getNow(false)) {
         Workflow.continueAsNew(true);
       }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalContinueAsNewNonDeterminism.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalContinueAsNewNonDeterminism.java
@@ -47,7 +47,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class SignalContinueAsNewNonDeterminism {
-  private static final Semaphore workflowTaskProcessed = new Semaphore(1);
+  private static final Semaphore workflowTaskProcessed = new Semaphore(0);
 
   private static final CompletableFuture<Boolean> continueAsNew = new CompletableFuture<>();
 
@@ -78,10 +78,11 @@ public class SignalContinueAsNewNonDeterminism {
 
     WorkflowClient.start(client::execute, false);
     for (int i = 0; i < 5; i++) {
-      workflowTaskProcessed.acquire();
       client.signal();
+      workflowTaskProcessed.acquire();
     }
     continueAsNew.complete(true);
+
     // Force replay, expected to fail with NonDeterministicException
     testWorkflowRule.invalidateWorkflowCache();
     client.signal();
@@ -113,6 +114,7 @@ public class SignalContinueAsNewNonDeterminism {
     @Override
     public void signal() throws ExecutionException, InterruptedException {
       // Intentionally introduce non determinism
+      Thread.sleep(500);
       if (continueAsNew.getNow(false)) {
         Workflow.continueAsNew(true);
       }


### PR DESCRIPTION
Fix race in `testSignalContinueAsNewNonDeterminism` where the workflow may have not processed a signal before we started attempting to introduce non determinism.
