### PR TITLE
Bump some GHA actions back due to glibc compatibility

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -139,8 +139,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     env:
       # This is required to allow continuing usage of Node 16 for actions,
-      # as Node 20 won't run on the docker image we use for linux builds
-      # (Node 20 require glibc 2.28+, but container image has glibc 2.27).
+      # as Node 20 won't run on the builder we use for linux builds
+      # (Node 20 require glibc 2.28+, but ubuntu-1804 has glibc 2.27).
       # https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -137,6 +137,12 @@ jobs:
             os_family: windows
             arch: amd64
     runs-on: ${{ matrix.runner }}
+    env:
+      # This is required to allow continuing usage of Node 16 for actions,
+      # as Node 20 won't run on the docker image we use for linux builds
+      # (Node 20 require glibc 2.28+, but container image has glibc 2.27).
+      # https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -149,21 +155,24 @@ jobs:
         run: git tag "$INPUT_TAG"
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        # FIXME: v4+ requires Node 20
+        uses: actions/setup-java@v3
         with:
           java-version: "11"
           distribution: "temurin"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
-
+        # FIXME: v3+ requires Node 20
+        uses: gradle/gradle-build-action@v2
+      
       - name: Build native test server
         run: ./gradlew :temporal-test-server:build
 
       # path ends in a wildcard because on windows the file ends in '.exe'
       # path excludes *.txt because native-image also writes a build manifest txt file
       - name: Upload executable to workflow
-        uses: actions/upload-artifact@v4
+        # FIXME: v4+ requires Node 20
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os_family }}_${{ matrix.arch }}
           path: |
@@ -182,7 +191,8 @@ jobs:
 
       # when no artifact is specified, all artifacts are downloaded and expanded into CWD
       - name: Fetch executables
-        uses: actions/download-artifact@v4
+        # Need v3 here to stay compatible with the build_native_images job.
+        uses: actions/download-artifact@v3-node20
 
       # example: linux_amd64/ -> temporal-test-server_1.2.3_linux_amd64
       # the name of the directory created becomes the basename of the archive (*.tar.gz or *.zip) and


### PR DESCRIPTION
## What was changed

- Reverted some GHA actions back to their Node 16 based equivalent.

## Why?

- The `build_native_images` job, part of the production release workflow, executes on a ubuntu-1804 runner to provide compatibility with older glibc systems (ubuntu-1804 uses glibc 2.27). However, Node 20, which is used by most recent GHA actions, require at least glibc 2.28, and therefore, can't run on Ubuntu 18.04 runners.