### PR TITLE
Fix caching in LazyUpdateHandleImpl

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
@@ -84,7 +84,7 @@ final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
       }
     }
 
-    if (pollCall != null) {
+    if (pollCall == null) {
       pollCall = pollUntilComplete(timeout, unit);
     }
 

--- a/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/LazyUpdateHandleImpl.java
@@ -75,7 +75,6 @@ final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
   public CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit) {
 
     WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput<T> pollCall = null;
-    boolean setFromWaitCompleted = false;
 
     // If waitCompleted was called, use the result from that call.
     synchronized (this) {
@@ -85,7 +84,7 @@ final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
       }
     }
 
-    if (!setFromWaitCompleted) {
+    if (pollCall != null) {
       pollCall = pollUntilComplete(timeout, unit);
     }
 


### PR DESCRIPTION
Fix caching in `LazyUpdateHandleImpl`. `setFromWaitCompleted` was not being used.

Note: Very likely I will refactor all these handlers as part of https://github.com/temporalio/sdk-java/issues/2094
