### PR TITLE
Fix flake in resetWorkflowIdFromWorkflowTaskTest

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -403,7 +403,7 @@ public class WorkflowWorkerTest {
     // Assert that the reset event id is received by WorkflowTaskHandler
     assertEquals(Long.valueOf(1), resetEventIdQueue.take());
     // Cleanup
-    worker.shutdown(new ShutdownManager(), false).get();
+    worker.shutdown(new ShutdownManager(), true).get();
   }
 
   private ReplayWorkflowFactory setUpMockWorkflowFactory() throws Throwable {


### PR DESCRIPTION
Didn't see any flakyness during the PR or when locally testing but this test started immediately failing in CI after being merged https://github.com/temporalio/sdk-java/actions/runs/9452261550/job/26035046059. I suspect the graceful worker shutdown is interacting weirdly with the mocks.