### PR TITLE
Bump jsonpath to 2.9.0 to fix the vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
 
     gsonVersion = '2.10.1' // [2.0,)
 
-    jsonPathVersion = '2.8.0' // compileOnly
+    jsonPathVersion = '2.9.0' // compileOnly
 
     cronUtilsVersion = '9.2.1' // for test server only
 


### PR DESCRIPTION
## Describe what has changed in this PR

Currently temporal-testing is using json path 2.8.0 which is causing the temporal-testing to have a CVE detected in maven.

Temporal-testing mvn:  https://mvnrepository.com/artifact/io.temporal/temporal-testing/1.23.2

jsonpath mvn: https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path

To fix this, I am bumping the jsonpath version to 2.9.0 which seems to be free from the cve. 

## Why I made this change ? 

I want to use temporal for my projects and snyk is detecting a vulnerability for temporal-testing jar(3p vulnerability). Hence fixing this.

