### PR TITLE
Add test verifying no-tq CaN command works

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -936,12 +936,12 @@ class StateMachines {
     } else {
       a.setWorkflowRunTimeout(sr.getWorkflowRunTimeout());
     }
-    if (d.hasTaskQueue()) {
+    if (d.hasTaskQueue() && !d.getTaskQueue().getName().isEmpty()) {
       a.setTaskQueue(d.getTaskQueue());
     } else {
       a.setTaskQueue(sr.getTaskQueue());
     }
-    if (d.hasWorkflowType()) {
+    if (d.hasWorkflowType() && !d.getWorkflowType().getName().isEmpty()) {
       a.setWorkflowType(d.getWorkflowType());
     } else {
       a.setWorkflowType(sr.getWorkflowType());

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1527,7 +1527,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       ContinueAsNewWorkflowExecutionCommandAttributes d,
       long workflowTaskCompletedId,
       String identity) {
-    System.out.println("Attribute: " + d);
     workflow.action(Action.CONTINUE_AS_NEW, ctx, d, workflowTaskCompletedId);
     workflowTaskStateMachine.getData().workflowCompleted = true;
     HistoryEvent event = ctx.getEvents().get(ctx.getEvents().size() - 1);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1527,6 +1527,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       ContinueAsNewWorkflowExecutionCommandAttributes d,
       long workflowTaskCompletedId,
       String identity) {
+    System.out.println("Attribute: " + d);
     workflow.action(Action.CONTINUE_AS_NEW, ctx, d, workflowTaskCompletedId);
     workflowTaskStateMachine.getData().workflowCompleted = true;
     HistoryEvent event = ctx.getEvents().get(ctx.getEvents().size() - 1);

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/ContinueAsNewTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/ContinueAsNewTest.java
@@ -1,0 +1,98 @@
+package io.temporal.testserver.functional;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.common.interceptors.*;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.testserver.functional.common.TestWorkflows;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.ContinueAsNewOptions;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ContinueAsNewTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new StripsTqFromCanInterceptor())
+                  .build())
+          .setWorkflowTypes(TestWorkflow.class)
+          .build();
+
+  @Test
+  public void repeatedFailure() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowTaskTimeout(Duration.ofSeconds(1))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+
+    TestWorkflows.WorkflowTakesBool workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowTakesBool.class, options);
+    workflowStub.execute(true);
+
+    WorkflowExecution execution = WorkflowStub.fromTyped(workflowStub).getExecution();
+    // Verify the latest history is from being CaN'd
+    WorkflowExecutionHistory lastHist =
+        testWorkflowRule.getExecutionHistory(execution.getWorkflowId());
+    Assert.assertFalse(
+        lastHist
+            .getEvents()
+            .get(0)
+            .getWorkflowExecutionStartedEventAttributes()
+            .getFirstExecutionRunId()
+            .isEmpty());
+  }
+
+  public static class TestWorkflow implements TestWorkflows.WorkflowTakesBool {
+    @Override
+    public void execute(boolean doContinue) {
+      if (doContinue) {
+        Workflow.continueAsNew(false);
+      }
+    }
+  }
+
+  // Verify that we can strip the TQ name and test server continues onto same TQ
+  private static class StripsTqFromCanInterceptor extends WorkerInterceptorBase {
+    @Override
+    public WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next) {
+      return new WorkflowInboundCallsInterceptorBase(next) {
+        @Override
+        public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
+          next.init(new StripsTqFromCanCmd(outboundCalls));
+        }
+      };
+    }
+  }
+
+  private static class StripsTqFromCanCmd extends WorkflowOutboundCallsInterceptorBase {
+
+    private final WorkflowOutboundCallsInterceptor next;
+
+    public StripsTqFromCanCmd(WorkflowOutboundCallsInterceptor next) {
+      super(next);
+      this.next = next;
+    }
+
+    @Override
+    public void continueAsNew(ContinueAsNewInput input) {
+      next.continueAsNew(
+          new ContinueAsNewInput(
+              input.getWorkflowType(),
+              ContinueAsNewOptions.newBuilder(input.getOptions()).setTaskQueue(null).build(),
+              input.getArgs(),
+              input.getHeader()));
+    }
+  }
+}

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/ContinueAsNewTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/ContinueAsNewTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.testserver.functional;
 
 import io.temporal.api.common.v1.WorkflowExecution;

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/ContinueAsNewTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/ContinueAsNewTest.java
@@ -110,7 +110,7 @@ public class ContinueAsNewTest {
       next.continueAsNew(
           new ContinueAsNewInput(
               input.getWorkflowType(),
-              ContinueAsNewOptions.newBuilder(input.getOptions()).setTaskQueue(null).build(),
+              ContinueAsNewOptions.newBuilder(input.getOptions()).setTaskQueue("").build(),
               input.getArgs(),
               input.getHeader()));
     }

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
@@ -31,6 +31,12 @@ public class TestWorkflows {
   }
 
   @WorkflowInterface
+  public interface WorkflowTakesBool {
+    @WorkflowMethod
+    void execute(boolean arg);
+  }
+
+  @WorkflowInterface
   public interface WorkflowReturnsString {
     @WorkflowMethod
     String execute();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Nothing, just added a test. Test can't repro the real problem, which is that only over real gRPC transport does this problem show up when the messages are set but contain empty strings. That is manually confirmed fixed.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/1424

2. How was this tested:
It is a test bruh

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
