### PR TITLE
Update dependencies to address some CVE scans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.54.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.57.2' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.5' : '1.9.9' // [1.0.0,)
@@ -50,13 +50,13 @@ ext {
 
     gsonVersion = '2.10.1' // [2.0,)
 
-    jsonPathVersion = '2.8.0' // compileOnly
+    jsonPathVersion = '2.9.0' // compileOnly
 
     cronUtilsVersion = '9.2.1' // for test server only
 
     // Spring Boot 3 requires Java 17, java-sdk builds against 2.x version because we support Java 8.
     // We do test compatibility with Spring Boot 3 in integration tests.
-    springBootVersion = project.hasProperty("edgeDepsTest") ? '3.0.4' : '2.7.12'// [2.4.0,)
+    springBootVersion = project.hasProperty("edgeDepsTest") ? '3.0.4' : '2.7.18'// [2.4.0,)
 
     // test scoped
     // we don't upgrade to 1.3 and 1.4 because they require slf4j 2.x

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.57.2' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.56.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.5' : '1.9.9' // [1.0.0,)

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.56.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.54.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.10.5' : '1.9.9' // [1.0.0,)

--- a/temporal-remote-data-encoder/build.gradle
+++ b/temporal-remote-data-encoder/build.gradle
@@ -1,7 +1,7 @@
 description = '''Temporal Workflow Java SDK'''
 
 ext {
-    okhttpVersion = '4.10.0'
+    okhttpVersion = '4.11.0'
     servletVersion = '4.0.1'
 }
 

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -19,7 +19,9 @@ dependencies {
     // It's useful only for unit tests and debugging.
     // For these use-cases Temporal users can add this dep in the classpath temporary or permanently themselves.
     compileOnly "com.jayway.jsonpath:json-path:$jsonPathVersion"
-    testImplementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
+    testImplementation("com.jayway.jsonpath:json-path:$jsonPathVersion"){
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 
     testImplementation project(':temporal-testing')
     testImplementation "junit:junit:${junitVersion}"

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -20,7 +20,9 @@ dependencies {
     // This dependency is included in temporal-sdk module as optional with compileOnly scope.
     // To make things easier for users, it's helpful for the testing module to bring this dependency
     // transitively as most users work with history jsons in tests.
-    implementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
+    implementation("com.jayway.jsonpath:json-path:$jsonPathVersion"){
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
 
     junit4Api 'junit:junit:4.13.2'
 


### PR DESCRIPTION
Update dependencies to address some CVE scans. Just upgrading dependencies with CVE issues, none directly effecting the Java SDK, but some tools will still warn just for having it as a dependency in some way. I plan to do a more through sweep of all dependencies when I add virtual thread support to the Java SDK. 