### PR TITLE
Enable next retry delay test for server

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityNextRetryDelayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityNextRetryDelayTest.java
@@ -46,8 +46,6 @@ public class ActivityNextRetryDelayTest {
 
   @Test
   public void activityNextRetryDelay() {
-    assumeFalse(
-        "Real Server doesn't support next retry delay yet", SDKTestWorkflowRule.useExternalService);
     TestWorkflowReturnDuration workflow =
         testWorkflowRule.newWorkflowStub(TestWorkflowReturnDuration.class);
     Duration result = workflow.execute(false);

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityNextRetryDelayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityNextRetryDelayTest.java
@@ -21,7 +21,6 @@
 package io.temporal.activity;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
 
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.testing.internal.SDKTestOptions;


### PR DESCRIPTION
Enable next retry delay test for Server since the Server now supports next retry delay.