### PR TITLE
Workflow-friendly concurrency primitives

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -109,6 +109,14 @@ public final class WorkflowInternal {
     return new WorkflowQueueImpl<>(capacity);
   }
 
+  public static WorkflowLock newWorkflowLock() {
+    return new WorkflowLockImpl();
+  }
+
+  public static WorkflowSemaphore newWorkflowSemaphore(int permits) {
+    return new WorkflowSemaphoreImpl(permits);
+  }
+
   public static <E> CompletablePromise<E> newCompletablePromise() {
     return new CompletablePromiseImpl<>();
   }
@@ -479,13 +487,13 @@ public final class WorkflowInternal {
 
   public static void await(String reason, Supplier<Boolean> unblockCondition)
       throws DestroyWorkflowThreadError {
-    assertNotReadOnly("await");
+    assertNotReadOnly(reason);
     getWorkflowOutboundInterceptor().await(reason, unblockCondition);
   }
 
   public static boolean await(Duration timeout, String reason, Supplier<Boolean> unblockCondition)
       throws DestroyWorkflowThreadError {
-    assertNotReadOnly("await with timeout");
+    assertNotReadOnly(reason);
     return getWorkflowOutboundInterceptor().await(timeout, reason, unblockCondition);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowLockImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowLockImpl.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.internal.sync;
 
 import static io.temporal.internal.sync.WorkflowInternal.assertNotReadOnly;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowLockImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowLockImpl.java
@@ -1,0 +1,57 @@
+package io.temporal.internal.sync;
+
+import static io.temporal.internal.sync.WorkflowInternal.assertNotReadOnly;
+
+import com.google.common.base.Preconditions;
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.WorkflowLock;
+import java.time.Duration;
+
+class WorkflowLockImpl implements WorkflowLock {
+  private boolean locked = false;
+
+  @Override
+  public void lock() {
+    WorkflowInternal.await(
+        "WorkflowLock.lock",
+        () -> {
+          CancellationScope.throwCanceled();
+          return !locked;
+        });
+    locked = true;
+  }
+
+  @Override
+  public boolean tryLock() {
+    assertNotReadOnly("WorkflowLock.tryLock");
+    if (!locked) {
+      locked = true;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean tryLock(Duration timeout) {
+    boolean unlocked =
+        WorkflowInternal.await(
+            timeout,
+            "WorkflowLock.tryLock",
+            () -> {
+              CancellationScope.throwCanceled();
+              return !locked;
+            });
+    if (unlocked) {
+      locked = true;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public void unlock() {
+    assertNotReadOnly("WorkflowLock.unlock");
+    Preconditions.checkState(locked, "WorkflowLock.unlock called when not locked");
+    locked = false;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowLockImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowLockImpl.java
@@ -74,4 +74,9 @@ class WorkflowLockImpl implements WorkflowLock {
     Preconditions.checkState(locked, "WorkflowLock.unlock called when not locked");
     locked = false;
   }
+
+  @Override
+  public boolean isHeld() {
+    return locked;
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowSemaphoreImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowSemaphoreImpl.java
@@ -42,7 +42,7 @@ class WorkflowSemaphoreImpl implements WorkflowSemaphore {
   @Override
   public void acquire(int permits) {
     Preconditions.checkArgument(
-        permits > 0, "WorkflowSemaphore.acquire called with negative permits");
+        permits >= 0, "WorkflowSemaphore.acquire called with negative permits");
     WorkflowInternal.await(
         "WorkflowSemaphore.acquire",
         () -> {
@@ -66,7 +66,7 @@ class WorkflowSemaphoreImpl implements WorkflowSemaphore {
   public boolean tryAcquire(int permits) {
     assertNotReadOnly("WorkflowSemaphore.tryAcquire");
     Preconditions.checkArgument(
-        permits > 0, "WorkflowSemaphore.tryAcquire called with negative permits");
+        permits >= 0, "WorkflowSemaphore.tryAcquire called with negative permits");
     if (currentPermits >= permits) {
       currentPermits -= permits;
       return true;
@@ -77,7 +77,7 @@ class WorkflowSemaphoreImpl implements WorkflowSemaphore {
   @Override
   public boolean tryAcquire(int permits, Duration timeout) {
     Preconditions.checkArgument(
-        permits > 0, "WorkflowSemaphore.tryAcquire called with negative permits");
+        permits >= 0, "WorkflowSemaphore.tryAcquire called with negative permits");
     boolean acquired =
         WorkflowInternal.await(
             timeout,
@@ -101,7 +101,7 @@ class WorkflowSemaphoreImpl implements WorkflowSemaphore {
   public void release(int permits) {
     assertNotReadOnly("WorkflowSemaphore.release");
     Preconditions.checkArgument(
-        permits > 0, "WorkflowSemaphore.release called with negative permits");
+        permits >= 0, "WorkflowSemaphore.release called with negative permits");
     currentPermits += permits;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowSemaphoreImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowSemaphoreImpl.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.internal.sync;
 
 import static io.temporal.internal.sync.WorkflowInternal.assertNotReadOnly;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowSemaphoreImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowSemaphoreImpl.java
@@ -1,0 +1,87 @@
+package io.temporal.internal.sync;
+
+import static io.temporal.internal.sync.WorkflowInternal.assertNotReadOnly;
+
+import com.google.common.base.Preconditions;
+import io.temporal.workflow.CancellationScope;
+import io.temporal.workflow.WorkflowSemaphore;
+import java.time.Duration;
+
+class WorkflowSemaphoreImpl implements WorkflowSemaphore {
+  private int currentPermits;
+
+  public WorkflowSemaphoreImpl(int permits) {
+    this.currentPermits = permits;
+  }
+
+  @Override
+  public void acquire() {
+    acquire(1);
+  }
+
+  @Override
+  public void acquire(int permits) {
+    Preconditions.checkArgument(
+        permits > 0, "WorkflowSemaphore.acquire called with negative permits");
+    WorkflowInternal.await(
+        "WorkflowSemaphore.acquire",
+        () -> {
+          CancellationScope.throwCanceled();
+          return currentPermits >= permits;
+        });
+    currentPermits -= permits;
+  }
+
+  @Override
+  public boolean tryAcquire() {
+    return tryAcquire(1);
+  }
+
+  @Override
+  public boolean tryAcquire(Duration timeout) {
+    return tryAcquire(1, timeout);
+  }
+
+  @Override
+  public boolean tryAcquire(int permits) {
+    assertNotReadOnly("WorkflowSemaphore.tryAcquire");
+    Preconditions.checkArgument(
+        permits > 0, "WorkflowSemaphore.tryAcquire called with negative permits");
+    if (currentPermits >= permits) {
+      currentPermits -= permits;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean tryAcquire(int permits, Duration timeout) {
+    Preconditions.checkArgument(
+        permits > 0, "WorkflowSemaphore.tryAcquire called with negative permits");
+    boolean acquired =
+        WorkflowInternal.await(
+            timeout,
+            "WorkflowSemaphore.tryAcquire",
+            () -> {
+              CancellationScope.throwCanceled();
+              return currentPermits >= permits;
+            });
+    if (acquired) {
+      currentPermits -= permits;
+    }
+    return acquired;
+  }
+
+  @Override
+  public void release() {
+    release(1);
+  }
+
+  @Override
+  public void release(int permits) {
+    assertNotReadOnly("WorkflowSemaphore.release");
+    Preconditions.checkArgument(
+        permits > 0, "WorkflowSemaphore.release called with negative permits");
+    currentPermits += permits;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -508,6 +508,27 @@ public final class Workflow {
   }
 
   /**
+   * Creates a {@link WorkflowLock} implementation that can be used from workflow code.
+   *
+   * @apiNote The lock returned is not reentrant. If a workflow thread tries to acquire a lock that
+   *     it already holds, the call will block indefinitely.
+   * @return new instance of {@link WorkflowLock}
+   */
+  public static WorkflowLock newWorkflowLock() {
+    return WorkflowInternal.newWorkflowLock();
+  }
+
+  /**
+   * Creates a {@link WorkflowSemaphore} implementation that can be used from workflow code.
+   *
+   * @param permits the given number of permits for the semaphore.
+   * @return new instance of {@link WorkflowSemaphore}
+   */
+  public static WorkflowSemaphore newWorkflowSemaphore(int permits) {
+    return WorkflowInternal.newWorkflowSemaphore(permits);
+  }
+
+  /**
    * Registers an implementation object. The object must implement at least one interface annotated
    * with {@link WorkflowInterface}. All its methods annotated with @{@link SignalMethod}
    * and @{@link QueryMethod} are registered.

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowLock.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowLock.java
@@ -1,0 +1,40 @@
+package io.temporal.workflow;
+
+import java.time.Duration;
+
+/**
+ * Workflow lock is an alternative to {@link java.util.concurrent.locks.Lock} that is deterministic
+ * and compatible with Temporal's concurrency model. API is designed to be used in a workflow code
+ * only. It is not allowed to be used in an activity code.
+ *
+ * <p>In Temporal concurrency model, only one thread in a workflow code can execute at a time.
+ */
+public interface WorkflowLock {
+  /**
+   * Acquires the lock.
+   *
+   * @throws io.temporal.failure.CanceledFailure if thread (or current {@link CancellationScope} was
+   *     canceled).
+   */
+  void lock();
+
+  /**
+   * Acquires the lock only if it is free at the time of invocation.
+   *
+   * @return true if the lock was acquired and false otherwise
+   */
+  boolean tryLock();
+
+  /**
+   * Acquires the lock if it is free within the given waiting time.
+   *
+   * @throws io.temporal.failure.CanceledFailure if thread (or current {@link CancellationScope} was
+   *     canceled).
+   * @return true if the lock was acquired and false if the waiting time elapsed before the lock was
+   *     acquired.
+   */
+  boolean tryLock(Duration timeout);
+
+  /** Releases the lock. */
+  void unlock();
+}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowLock.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowLock.java
@@ -57,4 +57,11 @@ public interface WorkflowLock {
 
   /** Releases the lock. */
   void unlock();
+
+  /**
+   * Checks if a lock is held.
+   *
+   * @return true if the lock is held and false otherwise.
+   */
+  boolean isHeld();
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowLock.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowLock.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow;
 
 import java.time.Duration;

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowSemaphore.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowSemaphore.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow;
 
 import java.time.Duration;

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowSemaphore.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowSemaphore.java
@@ -1,0 +1,115 @@
+package io.temporal.workflow;
+
+import java.time.Duration;
+
+/**
+ * Workflow semaphore is an alternative to {@link java.util.concurrent.Semaphore} that is
+ * deterministic and compatible with Temporal's concurrency model. API is designed to be used in a
+ * workflow code only. It is not allowed to be used in an activity code.
+ *
+ * <p>In Temporal concurrency model, only one thread in a workflow code can execute at a time.
+ */
+public interface WorkflowSemaphore {
+  /**
+   * Acquires a permit from this semaphore, blocking until one is available.
+   *
+   * <p>Acquires a permit, if one is available and returns immediately, reducing the number of
+   * available permits by one.
+   *
+   * @throws io.temporal.failure.CanceledFailure if thread (or current {@link CancellationScope} was
+   *     canceled).
+   */
+  void acquire();
+
+  /**
+   * Acquires the given number of permits from this semaphore, blocking until all are available.
+   *
+   * <p>Acquires the given number of permits, if they are available, and returns immediately,
+   * reducing the number of available permits by the given amount.
+   *
+   * @param permits the number of permits to acquire
+   * @throws io.temporal.failure.CanceledFailure if thread (or current {@link CancellationScope} was
+   *     canceled).
+   * @throws IllegalArgumentException if permits is negative
+   */
+  void acquire(int permits);
+
+  /**
+   * Acquires the given number of permits from this semaphore, only if all are available at the time
+   * of invocation.
+   *
+   * <p>Acquires a permit, if one is available and returns immediately, with the value true,
+   * reducing the number of available permits by one.
+   *
+   * @return true if the permit was acquired and false otherwise
+   */
+  boolean tryAcquire();
+
+  /**
+   * Acquires a permit from this semaphore, if one becomes available within the given waiting time.
+   *
+   * <p>Acquires a permit, if one is available and returns immediately, with the value true,
+   * reducing the number of available permits by one.
+   *
+   * @param timeout the maximum time to wait for a permit
+   * @return true if a permit was acquired and false if the waiting time elapsed before a permit was
+   *     acquired
+   * @throws io.temporal.failure.CanceledFailure if thread (or current {@link CancellationScope} was
+   *     canceled).
+   */
+  boolean tryAcquire(Duration timeout);
+
+  /**
+   * Acquires the given number of permits from this semaphore, only if all are available at the time
+   * of invocation.
+   *
+   * <p>Acquires the given number of permits, if they are available, and returns immediately, with
+   * the value true, reducing the number of available permits by the given amount.
+   *
+   * <p>If insufficient permits are available then this method will return immediately with the
+   * value false and the number of available permits is unchanged.
+   *
+   * @param permits the number of permits to acquire
+   * @return true if the permits were acquired and false otherwise
+   * @throws IllegalArgumentException if permits is negative
+   */
+  boolean tryAcquire(int permits);
+
+  /**
+   * Acquires the given number of permits from this semaphore, if all become available within the
+   * given waiting time.
+   *
+   * <p>Acquires the given number of permits, if they are available and returns immediately, with
+   * the value true, reducing the number of available permits by the given amount.
+   *
+   * @param permits the number of permits to acquire
+   * @param timeout the maximum duration to wait for a permit
+   * @return true if the permits was acquired and false if the waiting time elapsed before a permit
+   *     was acquired
+   * @throws io.temporal.failure.CanceledFailure if thread (or current {@link CancellationScope} was
+   *     canceled).
+   * @throws IllegalArgumentException if permits is negative
+   */
+  boolean tryAcquire(int permits, Duration timeout);
+
+  /**
+   * Releases a permit, returning it to the semaphore.
+   *
+   * <p>There is no requirement that a coroutine that releases a permit must have acquired that
+   * permit by calling {@link #acquire()}. Correct usage of a semaphore is established by
+   * programming convention in the application.
+   */
+  void release();
+
+  /**
+   * Releases the given number of permits, returning them to the semaphore.
+   *
+   * <p>There is no requirement that a coroutine that releases a permit must have acquired that
+   * permit by calling {@link #acquire()}. Correct usage of a semaphore is established by
+   * programming convention in the application.
+   *
+   * @param permits the number of permits to release
+   * @throws IllegalArgumentException if permits is negative
+   */
+  void release(int permits);
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
@@ -66,6 +66,8 @@ public class WorkflowInternalLockTest {
               WorkflowLock l2 = WorkflowInternal.newWorkflowLock();
               trace.add("root begin");
               l2.lock();
+              trace.add("l1.isHeld " + l1.isHeld());
+              trace.add("l2.isHeld " + l2.isHeld());
               WorkflowThread.newThread(
                       () -> {
                         trace.add("thread1 begin");
@@ -96,6 +98,8 @@ public class WorkflowInternalLockTest {
     String[] expected =
         new String[] {
           "root begin",
+          "l1.isHeld false",
+          "l2.isHeld true",
           "root done",
           "thread1 begin",
           "thread1 lock 1 success",

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.internal.sync;
 
 import static org.junit.Assert.*;

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
@@ -1,0 +1,302 @@
+package io.temporal.internal.sync;
+
+import static org.junit.Assert.*;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import io.temporal.workflow.*;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowInternalLockTest {
+  @Rule public final Tracer trace = new Tracer();
+
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = new ThreadPoolExecutor(1, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    threadPool.shutdown();
+  }
+
+  @Test
+  public void testThreadInterleaving() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowLock l1 = WorkflowInternal.newWorkflowLock();
+              WorkflowLock l2 = WorkflowInternal.newWorkflowLock();
+              trace.add("root begin");
+              l2.lock();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        l1.lock();
+                        trace.add("thread1 lock 1 success");
+                        l2.lock();
+                        trace.add("thread1 lock 2 success");
+                        l1.unlock();
+                        trace.add("thread1 unlock 1 success");
+                      },
+                      false)
+                  .start();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread2 begin");
+                        l2.unlock();
+                        trace.add("thread2 unlock 2 success");
+                        l1.lock();
+                        trace.add("thread2 lock 1 success");
+                        l1.unlock();
+                        trace.add("thread2 unlock 1 success");
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+    String[] expected =
+        new String[] {
+          "root begin",
+          "root done",
+          "thread1 begin",
+          "thread1 lock 1 success",
+          "thread2 begin",
+          "thread2 unlock 2 success",
+          "thread1 lock 2 success",
+          "thread1 unlock 1 success",
+          "thread2 lock 1 success",
+          "thread2 unlock 1 success",
+        };
+    trace.setExpected(expected);
+    r.close();
+  }
+
+  @Test
+  public void testLockCanceled() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowLock l = WorkflowInternal.newWorkflowLock();
+              trace.add("root begin");
+              l.lock();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        try {
+                          l.lock();
+                        } catch (CanceledFailure e) {
+                          trace.add("thread1 CanceledFailure");
+                        }
+                        trace.add("thread1 done");
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+    r.cancel("test");
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+
+    String[] expected =
+        new String[] {
+          "root begin", "root done", "thread1 begin", "thread1 CanceledFailure", "thread1 done",
+        };
+    trace.setExpected(expected);
+  }
+
+  @Test
+  public void testTryLock() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowLock l = WorkflowInternal.newWorkflowLock();
+              trace.add("root begin");
+              l.lock();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        if (l.tryLock()) {
+                          trace.add("thread1 tryLock success");
+                        } else {
+                          trace.add("thread1 tryLock failure");
+                        }
+                        trace.add("thread1 done");
+                        l.unlock();
+                      },
+                      false)
+                  .start();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread2 begin");
+                        if (l.tryLock()) {
+                          trace.add("thread2 tryLock success");
+                        } else {
+                          trace.add("thread2 tryLock failure");
+                        }
+                        trace.add("thread2 done");
+                        l.unlock();
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+
+    String[] expected =
+        new String[] {
+          "root begin",
+          "root done",
+          "thread1 begin",
+          "thread1 tryLock failure",
+          "thread1 done",
+          "thread2 begin",
+          "thread2 tryLock success",
+          "thread2 done",
+        };
+    trace.setExpected(expected);
+  }
+
+  @WorkflowInterface
+  public interface WorkflowLockTestWorkflow {
+    @WorkflowMethod
+    List<String> test();
+  }
+
+  public static class TestLockTimeout implements WorkflowLockTestWorkflow {
+    @Override
+    public List<String> test() {
+      List<String> trace = new ArrayList<>();
+      WorkflowLock l = WorkflowInternal.newWorkflowLock();
+      trace.add("root begin");
+      trace.add("tryLock " + l.tryLock());
+      trace.add("tryLock " + l.tryLock());
+      WorkflowThread.newThread(
+              () -> {
+                trace.add("thread1 begin");
+                Workflow.sleep(2000);
+                l.unlock();
+                trace.add("thread1 unlock");
+              },
+              false)
+          .start();
+      // Try to lock again before the above thread unlocks
+      trace.add("tryLock with timeout " + l.tryLock(Duration.ofMillis(1000)));
+      // Try to lock again after the above thread unlocks
+      trace.add("tryLock with timeout " + l.tryLock(Duration.ofMillis(2000)));
+      trace.add("root done");
+      return trace;
+    }
+  }
+
+  @Test
+  public void testLockTimeout() {
+    TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
+    try {
+      String testTaskQueue = "testTaskQueue";
+      Worker worker = testEnv.newWorker(testTaskQueue);
+      worker.registerWorkflowImplementationTypes(TestLockTimeout.class);
+      testEnv.start();
+      WorkflowLockTestWorkflow workflow =
+          testEnv
+              .getWorkflowClient()
+              .newWorkflowStub(
+                  WorkflowLockTestWorkflow.class,
+                  WorkflowOptions.newBuilder().setTaskQueue(testTaskQueue).build());
+      List<String> trace = workflow.test();
+      List<String> expected =
+          Arrays.asList(
+              "root begin",
+              "tryLock true",
+              "tryLock false",
+              "thread1 begin",
+              "tryLock with timeout false",
+              "thread1 unlock",
+              "tryLock with timeout true",
+              "root done");
+      assertEquals(expected, trace);
+    } finally {
+      testEnv.close();
+    }
+  }
+
+  public static class TestTryLockCancelled implements WorkflowLockTestWorkflow {
+    @Override
+    public List<String> test() {
+      List<String> trace = new ArrayList<>();
+      WorkflowLock l = WorkflowInternal.newWorkflowLock();
+      trace.add("root begin");
+      trace.add("tryLock " + l.tryLock());
+      WorkflowThread t1 =
+          WorkflowThread.newThread(
+              () -> {
+                trace.add("thread1 begin");
+                try {
+                  trace.add("tryLock with timeout " + l.tryLock(Duration.ofMillis(2000)));
+                } catch (CanceledFailure e) {
+                  trace.add("thread1 CanceledFailure");
+                }
+                trace.add("thread1 done");
+              },
+              false);
+      t1.start();
+      Workflow.sleep(1000);
+      t1.cancel();
+      trace.add("tryLock with timeout " + l.tryLock(Duration.ofMillis(2000)));
+      trace.add("root done");
+      return trace;
+    }
+  }
+
+  @Test
+  public void tesTryLockCancelled() {
+    TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
+    try {
+      String testTaskQueue = "testTaskQueue";
+      Worker worker = testEnv.newWorker(testTaskQueue);
+      worker.registerWorkflowImplementationTypes(TestTryLockCancelled.class);
+      testEnv.start();
+      WorkflowLockTestWorkflow workflow =
+          testEnv
+              .getWorkflowClient()
+              .newWorkflowStub(
+                  WorkflowLockTestWorkflow.class,
+                  WorkflowOptions.newBuilder().setTaskQueue(testTaskQueue).build());
+      List<String> trace = workflow.test();
+      List<String> expected =
+          Arrays.asList(
+              "root begin",
+              "tryLock true",
+              "thread1 begin",
+              "thread1 CanceledFailure",
+              "thread1 done",
+              "tryLock with timeout false",
+              "root done");
+      assertEquals(expected, trace);
+    } finally {
+      testEnv.close();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalSemaphoreTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalSemaphoreTest.java
@@ -1,0 +1,340 @@
+package io.temporal.internal.sync;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import io.temporal.workflow.*;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowInternalSemaphoreTest {
+  @Rule public final Tracer trace = new Tracer();
+
+  private static ExecutorService threadPool;
+
+  @BeforeClass
+  public static void beforeClass() {
+    threadPool = new ThreadPoolExecutor(1, 1000, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    threadPool.shutdown();
+  }
+
+  @Test
+  public void testThreadInterleaving() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowSemaphore s1 = WorkflowInternal.newWorkflowSemaphore(100);
+              trace.add("root begin");
+              s1.acquire(10);
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        s1.acquire(50);
+                        trace.add("thread1 acquire 50 success");
+                        s1.acquire(50);
+                        trace.add("thread1 acquire 50 success");
+                        s1.release(100);
+                        trace.add("thread1 release 100 success");
+                      },
+                      false)
+                  .start();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread2 begin");
+                        s1.release(10);
+                        trace.add("thread2 release 10 success");
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+    String[] expected =
+        new String[] {
+          "root begin",
+          "root done",
+          "thread1 begin",
+          "thread1 acquire 50 success",
+          "thread2 begin",
+          "thread2 release 10 success",
+          "thread1 acquire 50 success",
+          "thread1 release 100 success",
+        };
+    trace.setExpected(expected);
+    r.close();
+  }
+
+  @Test
+  public void testSemaphoreReleaseWithoutAcquire() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowSemaphore s1 = WorkflowInternal.newWorkflowSemaphore(0);
+              trace.add("root begin");
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        s1.acquire(50);
+                        trace.add("thread1 acquire 50 success");
+                        s1.acquire(50);
+                        trace.add("thread1 acquire 50 success");
+                        s1.release(100);
+                        trace.add("thread1 release 100 success");
+                      },
+                      false)
+                  .start();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread2 begin");
+                        // There is no requirement to acquire before release
+                        s1.release(100);
+                        trace.add("thread2 release 100 success");
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+    String[] expected =
+        new String[] {
+          "root begin",
+          "root done",
+          "thread1 begin",
+          "thread2 begin",
+          "thread2 release 100 success",
+          "thread1 acquire 50 success",
+          "thread1 acquire 50 success",
+          "thread1 release 100 success",
+        };
+    trace.setExpected(expected);
+    r.close();
+  }
+
+  @Test
+  public void testSemaphoreAcquireCanceled() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowSemaphore s = WorkflowInternal.newWorkflowSemaphore(100);
+              trace.add("root begin");
+              s.acquire(100);
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        try {
+                          s.acquire();
+                        } catch (CanceledFailure e) {
+                          trace.add("thread1 CanceledFailure");
+                        }
+                        trace.add("thread1 done");
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+    r.cancel("test");
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+
+    String[] expected =
+        new String[] {
+          "root begin", "root done", "thread1 begin", "thread1 CanceledFailure", "thread1 done",
+        };
+    trace.setExpected(expected);
+  }
+
+  @Test
+  public void testTryAcquire() {
+    DeterministicRunner r =
+        DeterministicRunner.newRunner(
+            threadPool::submit,
+            DummySyncWorkflowContext.newDummySyncWorkflowContext(),
+            () -> {
+              WorkflowSemaphore s = WorkflowInternal.newWorkflowSemaphore(100);
+              trace.add("root begin");
+              s.acquire(100);
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread1 begin");
+                        if (s.tryAcquire()) {
+                          trace.add("thread1 tryAcquire success");
+                        } else {
+                          trace.add("thread1 tryAcquire failure");
+                        }
+                        trace.add("thread1 done");
+                        s.release(100);
+                      },
+                      false)
+                  .start();
+              WorkflowThread.newThread(
+                      () -> {
+                        trace.add("thread2 begin");
+                        if (s.tryAcquire()) {
+                          trace.add("thread2 tryAcquire success");
+                        } else {
+                          trace.add("thread2 tryAcquire failure");
+                        }
+                        trace.add("thread2 done");
+                        s.release();
+                      },
+                      false)
+                  .start();
+              trace.add("root done");
+            });
+    r.runUntilAllBlocked(DeterministicRunner.DEFAULT_DEADLOCK_DETECTION_TIMEOUT_MS);
+
+    String[] expected =
+        new String[] {
+          "root begin",
+          "root done",
+          "thread1 begin",
+          "thread1 tryAcquire failure",
+          "thread1 done",
+          "thread2 begin",
+          "thread2 tryAcquire success",
+          "thread2 done",
+        };
+    trace.setExpected(expected);
+  }
+
+  @WorkflowInterface
+  public interface WorkflowSemaphoreTestWorkflow {
+    @WorkflowMethod
+    List<String> test();
+  }
+
+  public static class TestAcquireTimeout implements WorkflowSemaphoreTestWorkflow {
+    @Override
+    public List<String> test() {
+      List<String> trace = new ArrayList<>();
+      WorkflowSemaphore s = WorkflowInternal.newWorkflowSemaphore(100);
+      trace.add("root begin");
+      trace.add("tryAcquire " + s.tryAcquire(100));
+      trace.add("tryAcquire " + s.tryAcquire(100));
+      WorkflowThread.newThread(
+              () -> {
+                trace.add("thread1 begin");
+                Workflow.sleep(2000);
+                s.release(100);
+                trace.add("thread1 release");
+              },
+              false)
+          .start();
+      // Try to lock again before the above thread unlocks
+      trace.add("tryAcquire with timeout " + s.tryAcquire(100, Duration.ofMillis(1000)));
+      // Try to lock again after the above thread unlocks
+      trace.add("tryAcquire with timeout " + s.tryAcquire(100, Duration.ofMillis(2000)));
+      trace.add("root done");
+      return trace;
+    }
+  }
+
+  @Test
+  public void testAcquireTimeout() {
+    TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
+    try {
+      String testTaskQueue = "testTaskQueue";
+      Worker worker = testEnv.newWorker(testTaskQueue);
+      worker.registerWorkflowImplementationTypes(TestAcquireTimeout.class);
+      testEnv.start();
+      WorkflowSemaphoreTestWorkflow workflow =
+          testEnv
+              .getWorkflowClient()
+              .newWorkflowStub(
+                  WorkflowSemaphoreTestWorkflow.class,
+                  WorkflowOptions.newBuilder().setTaskQueue(testTaskQueue).build());
+      List<String> trace = workflow.test();
+      List<String> expected =
+          Arrays.asList(
+              "root begin",
+              "tryAcquire true",
+              "tryAcquire false",
+              "thread1 begin",
+              "tryAcquire with timeout false",
+              "thread1 release",
+              "tryAcquire with timeout true",
+              "root done");
+      assertEquals(expected, trace);
+    } finally {
+      testEnv.close();
+    }
+  }
+
+  public static class TestTryAcquireCancelled implements WorkflowSemaphoreTestWorkflow {
+    @Override
+    public List<String> test() {
+      List<String> trace = new ArrayList<>();
+      WorkflowSemaphore s = WorkflowInternal.newWorkflowSemaphore(100);
+      trace.add("root begin");
+      trace.add("tryAcquire " + s.tryAcquire(100));
+      WorkflowThread t1 =
+          WorkflowThread.newThread(
+              () -> {
+                trace.add("thread1 begin");
+                try {
+                  trace.add("tryAcquire with timeout " + s.tryAcquire(Duration.ofMillis(2000)));
+                } catch (CanceledFailure e) {
+                  trace.add("thread1 CanceledFailure");
+                }
+                trace.add("thread1 done");
+              },
+              false);
+      t1.start();
+      Workflow.sleep(1000);
+      t1.cancel();
+      trace.add("tryAcquire with timeout " + s.tryAcquire(Duration.ofMillis(2000)));
+      trace.add("root done");
+      return trace;
+    }
+  }
+
+  @Test
+  public void tesTryLockCancelled() {
+    TestWorkflowEnvironment testEnv = TestWorkflowEnvironment.newInstance();
+    try {
+      String testTaskQueue = "testTaskQueue";
+      Worker worker = testEnv.newWorker(testTaskQueue);
+      worker.registerWorkflowImplementationTypes(TestTryAcquireCancelled.class);
+      testEnv.start();
+      WorkflowSemaphoreTestWorkflow workflow =
+          testEnv
+              .getWorkflowClient()
+              .newWorkflowStub(
+                  WorkflowSemaphoreTestWorkflow.class,
+                  WorkflowOptions.newBuilder().setTaskQueue(testTaskQueue).build());
+      List<String> trace = workflow.test();
+      List<String> expected =
+          Arrays.asList(
+              "root begin",
+              "tryAcquire true",
+              "thread1 begin",
+              "thread1 CanceledFailure",
+              "thread1 done",
+              "tryAcquire with timeout false",
+              "root done");
+      assertEquals(expected, trace);
+    } finally {
+      testEnv.close();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalSemaphoreTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalSemaphoreTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.internal.sync;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Add Workflow-friendly concurrency primitives. This PR adds a workflow safe `Mutex` and `Semaphore` based on the Java interfaces

* https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/Lock.html
* https://docs.oracle.com/javase%2F8%2Fdocs%2Fapi%2F%2F/java/util/concurrent/Semaphore.html
