### PR TITLE
Change build_native_images mac runner to macos-13

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -125,12 +125,13 @@ jobs:
     needs: create_draft_release
     if: github.event.inputs.do_build_native_images == 'true'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runner: buildjet-2vcpu-ubuntu-1804
             os_family: linux
             arch: amd64
-          - runner: macos-latest
+          - runner: macos-13
             os_family: macOS
             arch: amd64
           - runner: windows-2019


### PR DESCRIPTION
Change build_native_images mac runner to macos-13. `macos-latest` now points to `aarch64`. Funny enough this doesn't cause an error since out `graal` plugin we use only checks for `64` so still downloads the `x86_64` toolchain.
