### PR TITLE
Align Update API across test server and real server

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -387,6 +387,8 @@ public final class WorkflowStateMachines {
         // other state machines because a rejected update produces no event in history.
         protocolStateMachines.entrySet().removeIf(entry -> entry.getValue().isFinalState());
         break;
+      default:
+        break;
     }
   }
 
@@ -625,6 +627,9 @@ public final class WorkflowStateMachines {
     List<Message> result = new ArrayList<>(messageOutbox.size());
     result.addAll(messageOutbox);
     messageOutbox.clear();
+    // Remove any finished update protocol state machines. We can't remove them on an event like
+    // other state machines because a rejected update produces no event in history.
+    protocolStateMachines.entrySet().removeIf(entry -> entry.getValue().isFinalState());
     return result;
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -62,7 +62,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -368,8 +367,6 @@ public class WorkflowTestingTest {
   }
 
   @Test
-  @Ignore // TODO: Find a way to mock workflows as reflection doesn't work cglib generated proxies
-  // mockito employs.
   public void testMockedChildSimulatedTimeout() {
     String details = "timeout Details";
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -60,7 +60,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
 import org.junit.*;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -60,10 +60,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.*;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
 import org.junit.runner.Description;
@@ -367,6 +365,8 @@ public class WorkflowTestingTest {
   }
 
   @Test
+  @Ignore // TODO: Find a way to mock workflows as reflection doesn't work cglib generated proxies
+  // mockito employs.
   public void testMockedChildSimulatedTimeout() {
     String details = "timeout Details";
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -423,19 +423,19 @@ class StateMachines {
   /** Represents an accepted update workflow execution request */
   static final class UpdateWorkflowExecutionData {
     final String id;
-    final CompletableFuture<UpdateWorkflowExecutionResponse> acceptance;
-    final CompletableFuture<UpdateWorkflowExecutionResponse> complete;
+    final CompletableFuture<Boolean> accepted;
+    final CompletableFuture<Outcome> outcome;
     final Request initialRequest;
 
     public UpdateWorkflowExecutionData(
         String id,
         Request initialRequest,
-        CompletableFuture<UpdateWorkflowExecutionResponse> acceptance,
-        CompletableFuture<UpdateWorkflowExecutionResponse> complete) {
+        CompletableFuture<Boolean> accepted,
+        CompletableFuture<Outcome> outcome) {
       this.id = id;
       this.initialRequest = initialRequest;
-      this.acceptance = acceptance;
-      this.complete = complete;
+      this.accepted = accepted;
+      this.outcome = outcome;
     }
 
     @Override
@@ -560,10 +560,10 @@ class StateMachines {
   public static StateMachine<UpdateWorkflowExecutionData> newUpdateWorkflowExecution(
       String updateId,
       Request initialRequest,
-      CompletableFuture<UpdateWorkflowExecutionResponse> acceptance,
-      CompletableFuture<UpdateWorkflowExecutionResponse> complete) {
+      CompletableFuture<Boolean> accepted,
+      CompletableFuture<Outcome> outcome) {
     return new StateMachine<>(
-            new UpdateWorkflowExecutionData(updateId, initialRequest, acceptance, complete))
+            new UpdateWorkflowExecutionData(updateId, initialRequest, accepted, outcome))
         .add(NONE, START, STARTED, StateMachines::acceptUpdate)
         .add(STARTED, COMPLETE, COMPLETED, StateMachines::completeUpdate);
   }
@@ -1805,19 +1805,6 @@ class StateMachines {
       if (!ctx.getWorkflowMutableState().isTerminalState()) {
         ctx.addEvent(event);
       }
-
-      UpdateWorkflowExecutionResponse response =
-          UpdateWorkflowExecutionResponse.newBuilder()
-              .setUpdateRef(
-                  UpdateRef.newBuilder()
-                      .setWorkflowExecution(ctx.getExecution())
-                      .setUpdateId(data.id))
-              .setStage(
-                  UpdateWorkflowExecutionLifecycleStage
-                      .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED)
-              .build();
-
-      data.acceptance.complete(response);
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
     }
@@ -1850,19 +1837,6 @@ class StateMachines {
         ctx.addEvent(event);
       }
 
-      UpdateWorkflowExecutionResponse updateResponse =
-          UpdateWorkflowExecutionResponse.newBuilder()
-              .setUpdateRef(
-                  UpdateRef.newBuilder()
-                      .setWorkflowExecution(ctx.getExecution())
-                      .setUpdateId(data.id))
-              .setOutcome(response.getOutcome())
-              .setStage(
-                  UpdateWorkflowExecutionLifecycleStage
-                      .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED)
-              .build();
-
-      data.complete.complete(updateResponse);
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1805,6 +1805,10 @@ class StateMachines {
       if (!ctx.getWorkflowMutableState().isTerminalState()) {
         ctx.addEvent(event);
       }
+      ctx.onCommit(
+          (int historySize) -> {
+            data.accepted.complete(true);
+          });
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
     }
@@ -1836,7 +1840,10 @@ class StateMachines {
       if (!ctx.getWorkflowMutableState().isTerminalState()) {
         ctx.addEvent(event);
       }
-
+      ctx.onCommit(
+          (int historySize) -> {
+            data.outcome.complete(response.getOutcome());
+          });
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -20,6 +20,7 @@
 
 package io.temporal.internal.testservice;
 
+import static io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.*;
 import static io.temporal.internal.testservice.CronUtils.getBackoffInterval;
 import static io.temporal.internal.testservice.StateMachines.DEFAULT_WORKFLOW_EXECUTION_TIMEOUT_MILLISECONDS;
 import static io.temporal.internal.testservice.StateMachines.DEFAULT_WORKFLOW_TASK_TIMEOUT_MILLISECONDS;
@@ -101,12 +102,7 @@ import io.temporal.internal.testservice.StateMachines.WorkflowTaskData;
 import io.temporal.serviceclient.StatusUtils;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -1602,9 +1598,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
 
     update =
         StateMachines.newUpdateWorkflowExecution(
-            protocolInstanceId, u.getRequest().getRequest(), u.getAcceptance(), u.getCompletion());
+            protocolInstanceId, u.getRequest().getRequest(), u.getAccepted(), u.getOutcome());
     updates.put(protocolInstanceId, update);
     update.action(StateMachines.Action.START, ctx, msg, workflowTaskCompletedId);
+    ctx.onCommit(
+        (int historySize) -> {
+          u.getAccepted().complete(true);
+        });
   }
 
   private void processRejectionMessage(
@@ -1620,18 +1620,11 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     UpdateWorkflowExecution u =
         workflowTaskStateMachine.getData().updateRequest.get(msg.getProtocolInstanceId());
     // If an update validation fail, do not write to history and do not store the update.
-    UpdateWorkflowExecutionResponse response =
-        UpdateWorkflowExecutionResponse.newBuilder()
-            .setUpdateRef(
-                UpdateRef.newBuilder()
-                    .setUpdateId(rejection.getRejectedRequest().getMeta().getUpdateId())
-                    .setWorkflowExecution(ctx.getExecution()))
-            .setOutcome(Outcome.newBuilder().setFailure(rejection.getFailure()).build())
-            .setStage(
-                UpdateWorkflowExecutionLifecycleStage
-                    .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED)
-            .build();
-    u.getAcceptance().complete(response);
+    ctx.onCommit(
+        (int historySize) -> {
+          u.getOutcome().complete(Outcome.newBuilder().setFailure(rejection.getFailure()).build());
+          u.getAccepted().complete(false);
+        });
   }
 
   private void processOutcomeMessage(
@@ -1645,6 +1638,12 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           .asRuntimeException();
     }
     update.action(Action.COMPLETE, ctx, msg, workflowTaskCompletedId);
+    UpdateWorkflowExecution u =
+        workflowTaskStateMachine.getData().updateRequest.get(msg.getProtocolInstanceId());
+    ctx.onCommit(
+        (int historySize) -> {
+          u.getOutcome().complete(response.getOutcome());
+        });
   }
 
   @Override
@@ -2094,39 +2093,68 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   @Override
   public UpdateWorkflowExecutionResponse updateWorkflowExecution(
       UpdateWorkflowExecutionRequest request, Deadline deadline) {
-    try {
-      UpdateHandle updateHandle = getOrCreateUpdate(request);
-      switch (request.getWaitPolicy().getLifecycleStage()) {
-        case UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED:
-          UpdateWorkflowExecutionResponse acceptResponse =
-              updateHandle
-                  .getAcceptance()
-                  .get(
-                      deadline != null
-                          ? deadline.timeRemaining(TimeUnit.MILLISECONDS)
-                          : Long.MAX_VALUE,
-                      TimeUnit.MILLISECONDS);
-          if (acceptResponse.getOutcome().hasFailure()) {
-            return acceptResponse;
-          }
-          return updateHandle
-              .getCompletion()
-              .get(
-                  deadline != null ? deadline.timeRemaining(TimeUnit.MILLISECONDS) : Long.MAX_VALUE,
-                  TimeUnit.MILLISECONDS);
-        case UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED:
-          return updateHandle
-              .getAcceptance()
-              .get(
-                  deadline != null ? deadline.timeRemaining(TimeUnit.MILLISECONDS) : Long.MAX_VALUE,
-                  TimeUnit.MILLISECONDS);
-        default:
-          throw Status.INTERNAL
-              .withDescription(
-                  "TestServer does not support this wait policy: "
-                      + request.getWaitPolicy().getLifecycleStage())
-              .asRuntimeException();
+    if (request
+            .getWaitPolicy()
+            .getLifecycleStage()
+            .equals(UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED)
+        || !request.hasWaitPolicy()) {
+      throw Status.INVALID_ARGUMENT
+          .withDescription("LifeCycle stage is required")
+          .asRuntimeException();
+    }
+    if (request
+        .getWaitPolicy()
+        .getLifecycleStage()
+        .equals(UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)) {
+      throw Status.PERMISSION_DENIED
+          .withDescription("Admitted stage is not supported")
+          .asRuntimeException();
+    }
+    // If the workflow is in a terminal state, return the current state of the update if it
+    // completed
+    if (isTerminalState()) {
+      UpdateHandle updateHandle = getUpdate(request.getRequest().getMeta().getUpdateId());
+      if (updateHandle.getOutcome().isDone()) {
+        return UpdateWorkflowExecutionResponse.newBuilder()
+            .setUpdateRef(updateHandle.getRef())
+            .setStage(updateHandle.getStage())
+            .setOutcome(updateHandle.getOutcomeNow())
+            .build();
+      } else {
+        throw Status.NOT_FOUND
+            .withDescription("workflow execution already completed")
+            .asRuntimeException();
       }
+    }
+    // Now that we have validated the request we can create the update handle and wait for it to
+    // reach the desired stage.
+    UpdateHandle updateHandle = getOrCreateUpdate(request);
+    try {
+      UpdateWorkflowExecutionLifecycleStage reachedStage =
+          updateHandle.waitForStage(
+              request.getWaitPolicy().getLifecycleStage(),
+              deadline.timeRemaining(TimeUnit.MILLISECONDS),
+              TimeUnit.MILLISECONDS);
+      UpdateWorkflowExecutionResponse.Builder response =
+          UpdateWorkflowExecutionResponse.newBuilder()
+              .setUpdateRef(updateHandle.getRef())
+              .setStage(reachedStage);
+      if (reachedStage == UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED) {
+        response.setOutcome(updateHandle.getOutcomeNow());
+      }
+      return response.build();
+    } catch (TimeoutException e) {
+      UpdateWorkflowExecutionLifecycleStage stage = updateHandle.getStage();
+      UpdateWorkflowExecutionResponse.Builder response =
+          UpdateWorkflowExecutionResponse.newBuilder()
+              .setUpdateRef(updateHandle.getRef())
+              .setStage(stage);
+      if (stage
+          == UpdateWorkflowExecutionLifecycleStage
+              .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED) {
+        response.setOutcome(updateHandle.getOutcomeNow());
+      }
+      return response.build();
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     } catch (ExecutionException e) {
@@ -2138,37 +2166,78 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           .withCause(cause)
           .withDescription(cause.getMessage())
           .asRuntimeException();
-    } catch (TimeoutException e) {
-      throw Status.DEADLINE_EXCEEDED
-          .withCause(e)
-          .withDescription("update deadline exceeded")
-          .asRuntimeException();
     }
   }
 
   @Override
   public PollWorkflowExecutionUpdateResponse pollUpdateWorkflowExecution(
       PollWorkflowExecutionUpdateRequest request, Deadline deadline) {
+    UpdateHandle updateHandle = getUpdate(request.getUpdateRef().getUpdateId());
     try {
-      UpdateHandle updateHandle = getUpdate(request.getUpdateRef().getUpdateId());
-      UpdateWorkflowExecutionResponse completionResponse =
-          updateHandle
-              .getCompletion()
-              .get(
-                  deadline != null ? deadline.timeRemaining(TimeUnit.MILLISECONDS) : Long.MAX_VALUE,
-                  TimeUnit.MILLISECONDS);
+      // If the workflow is in a terminal state, return the current state of the update if it
+      // completed
+      if (isTerminalState()) {
+        if (updateHandle.getOutcome().isDone()) {
+          return PollWorkflowExecutionUpdateResponse.newBuilder()
+              .setUpdateRef(updateHandle.getRef())
+              .setStage(updateHandle.getStage())
+              .setOutcome(updateHandle.getOutcomeNow())
+              .build();
+        } else {
+          throw Status.NOT_FOUND
+              .withDescription("workflow execution already completed")
+              .asRuntimeException();
+        }
+      }
 
-      return PollWorkflowExecutionUpdateResponse.newBuilder()
-          .setOutcome(completionResponse.getOutcome())
-          .build();
+      // If no wait policy is specified or is ADMITTED, return the current state of the update
+      if (!request.hasWaitPolicy()
+          || request
+              .getWaitPolicy()
+              .getLifecycleStage()
+              .equals(UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED)
+          || request
+              .getWaitPolicy()
+              .getLifecycleStage()
+              .equals(UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)) {
+        UpdateWorkflowExecutionLifecycleStage stage = updateHandle.getStage();
+        PollWorkflowExecutionUpdateResponse.Builder response =
+            PollWorkflowExecutionUpdateResponse.newBuilder()
+                .setUpdateRef(updateHandle.getRef())
+                .setStage(stage);
+        if (stage
+            == UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED) {
+          response.setOutcome(updateHandle.getOutcomeNow());
+        }
+        return response.build();
+      }
+
+      // Wait for the update to reach the specified stage
+      UpdateWorkflowExecutionLifecycleStage reachedStage =
+          updateHandle.waitForStage(
+              request.getWaitPolicy().getLifecycleStage(),
+              deadline.timeRemaining(TimeUnit.MILLISECONDS),
+              TimeUnit.MILLISECONDS);
+      PollWorkflowExecutionUpdateResponse.Builder response =
+          PollWorkflowExecutionUpdateResponse.newBuilder()
+              .setUpdateRef(updateHandle.getRef())
+              .setStage(reachedStage);
+      if (reachedStage == UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED) {
+        response.setOutcome(updateHandle.getOutcomeNow());
+      }
+      return response.build();
     } catch (TimeoutException e) {
-      PollWorkflowExecutionUpdateResponse resp =
-          PollWorkflowExecutionUpdateResponse.getDefaultInstance();
-      return resp.toBuilder()
-          .setStage(
-              UpdateWorkflowExecutionLifecycleStage
-                  .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)
-          .build();
+      PollWorkflowExecutionUpdateResponse.Builder response =
+          PollWorkflowExecutionUpdateResponse.newBuilder()
+              .setUpdateRef(request.getUpdateRef())
+              .setStage(updateHandle.getStage());
+      if (updateHandle.getStage()
+          == UpdateWorkflowExecutionLifecycleStage
+              .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED) {
+        response.setOutcome(updateHandle.getOutcomeNow());
+      }
+      return response.build();
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof StatusRuntimeException) {
@@ -2194,15 +2263,17 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       if (inflightUpdate.isPresent()) {
         return new UpdateHandle(
             inflightUpdate.get().getId(),
-            inflightUpdate.get().getAcceptance(),
-            inflightUpdate.get().getCompletion());
+            getExecutionId().getExecution(),
+            inflightUpdate.get().getAccepted(),
+            inflightUpdate.get().getOutcome());
       }
       StateMachine<UpdateWorkflowExecutionData> acceptedUpdate = updates.get(updateId);
       if (acceptedUpdate != null) {
         return new UpdateHandle(
             acceptedUpdate.getData().id,
-            acceptedUpdate.getData().acceptance,
-            acceptedUpdate.getData().complete);
+            getExecutionId().getExecution(),
+            acceptedUpdate.getData().accepted,
+            acceptedUpdate.getData().outcome);
       }
 
       UpdateWorkflowExecution update = new UpdateWorkflowExecution(updateRequest);
@@ -2213,7 +2284,11 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             }
             workflowTaskStateMachine.action(Action.UPDATE_WORKFLOW_EXECUTION, ctx, update, 0);
           });
-      return new UpdateHandle(update.getId(), update.getAcceptance(), update.getCompletion());
+      return new UpdateHandle(
+          update.getId(),
+          getExecutionId().getExecution(),
+          update.getAccepted(),
+          update.getOutcome());
     } finally {
       lock.unlock();
     }
@@ -2229,15 +2304,17 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       if (inflightUpdate.isPresent()) {
         return new UpdateHandle(
             inflightUpdate.get().getId(),
-            inflightUpdate.get().getAcceptance(),
-            inflightUpdate.get().getCompletion());
+            getExecutionId().getExecution(),
+            inflightUpdate.get().getAccepted(),
+            inflightUpdate.get().getOutcome());
       }
       StateMachine<UpdateWorkflowExecutionData> acceptedUpdate = updates.get(updateId);
       if (acceptedUpdate != null) {
         return new UpdateHandle(
             acceptedUpdate.getData().id,
-            acceptedUpdate.getData().acceptance,
-            acceptedUpdate.getData().complete);
+            getExecutionId().getExecution(),
+            acceptedUpdate.getData().accepted,
+            acceptedUpdate.getData().outcome);
       }
       throw Status.NOT_FOUND
           .withDescription("update " + updateId + " not found")
@@ -2436,10 +2513,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   static class UpdateWorkflowExecution {
     private final String id;
     private final UpdateWorkflowExecutionRequest request;
-    private final CompletableFuture<UpdateWorkflowExecutionResponse> acceptance =
-        new CompletableFuture<>();
-    private final CompletableFuture<UpdateWorkflowExecutionResponse> completion =
-        new CompletableFuture<>();
+    private final CompletableFuture<Boolean> accepted = new CompletableFuture<>();
+    private final CompletableFuture<Outcome> outcome = new CompletableFuture<>();
 
     private UpdateWorkflowExecution(UpdateWorkflowExecutionRequest request) {
       this.request = request;
@@ -2451,12 +2526,12 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       return request;
     }
 
-    public CompletableFuture<UpdateWorkflowExecutionResponse> getAcceptance() {
-      return acceptance;
+    public CompletableFuture<Boolean> getAccepted() {
+      return accepted;
     }
 
-    public CompletableFuture<UpdateWorkflowExecutionResponse> getCompletion() {
-      return completion;
+    public CompletableFuture<Outcome> getOutcome() {
+      return outcome;
     }
 
     public String getId() {
@@ -2471,38 +2546,81 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           + '\''
           + ", request="
           + request
-          + ", acceptance="
-          + acceptance
-          + ", completion="
-          + completion
+          + ", accepted="
+          + accepted
+          + ", outcome="
+          + outcome
           + '}';
     }
   }
 
   static class UpdateHandle {
     private final String id;
-    private final CompletableFuture<UpdateWorkflowExecutionResponse> acceptance;
-    private final CompletableFuture<UpdateWorkflowExecutionResponse> completion;
+    private final WorkflowExecution execution;
+    private final CompletableFuture<Boolean> accepted;
+    private final CompletableFuture<Outcome> outcome;
 
     private UpdateHandle(
         String id,
-        CompletableFuture<UpdateWorkflowExecutionResponse> acceptance,
-        CompletableFuture<UpdateWorkflowExecutionResponse> completion) {
+        WorkflowExecution execution,
+        CompletableFuture<Boolean> accepted,
+        CompletableFuture<Outcome> outcome) {
       this.id = id;
-      this.acceptance = acceptance;
-      this.completion = completion;
+      this.execution = execution;
+      this.accepted = accepted;
+      this.outcome = outcome;
     }
 
-    public CompletableFuture<UpdateWorkflowExecutionResponse> getAcceptance() {
-      return acceptance;
+    public Future<Boolean> getAccepted() {
+      return accepted;
     }
 
-    public CompletableFuture<UpdateWorkflowExecutionResponse> getCompletion() {
-      return completion;
+    public Future<Outcome> getOutcome() {
+      return outcome;
+    }
+
+    public Outcome getOutcomeNow() {
+      try {
+        return outcome.get();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public UpdateWorkflowExecutionLifecycleStage waitForStage(
+        UpdateWorkflowExecutionLifecycleStage stage, long timeout, TimeUnit unit)
+        throws ExecutionException, InterruptedException, TimeoutException {
+      switch (stage) {
+        case UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED:
+          break;
+        case UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED:
+          accepted.get(timeout, unit);
+          break;
+        case UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED:
+          outcome.get(timeout, unit);
+          break;
+      }
+      return getStage();
+    }
+
+    public UpdateWorkflowExecutionLifecycleStage getStage() {
+      if (!accepted.isDone()) {
+        return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED;
+      } else if (!outcome.isDone()) {
+        return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED;
+      }
+      return UpdateWorkflowExecutionLifecycleStage
+          .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED;
     }
 
     public String getId() {
       return id;
+    }
+
+    public UpdateRef getRef() {
+      return UpdateRef.newBuilder().setUpdateId(id).setWorkflowExecution(execution).build();
     }
   }
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1634,8 +1634,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           .asRuntimeException();
     }
     update.action(Action.COMPLETE, ctx, msg, workflowTaskCompletedId);
-    UpdateWorkflowExecution u =
-        workflowTaskStateMachine.getData().updateRequest.get(protocolInstanceId);
   }
 
   @Override

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -1601,10 +1601,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             protocolInstanceId, u.getRequest().getRequest(), u.getAccepted(), u.getOutcome());
     updates.put(protocolInstanceId, update);
     update.action(StateMachines.Action.START, ctx, msg, workflowTaskCompletedId);
-    ctx.onCommit(
-        (int historySize) -> {
-          u.getAccepted().complete(true);
-        });
   }
 
   private void processRejectionMessage(
@@ -1639,11 +1635,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     }
     update.action(Action.COMPLETE, ctx, msg, workflowTaskCompletedId);
     UpdateWorkflowExecution u =
-        workflowTaskStateMachine.getData().updateRequest.get(msg.getProtocolInstanceId());
-    ctx.onCommit(
-        (int historySize) -> {
-          u.getOutcome().complete(response.getOutcome());
-        });
+        workflowTaskStateMachine.getData().updateRequest.get(protocolInstanceId);
   }
 
   @Override

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -811,7 +811,6 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         @Nullable Deadline deadline = Context.current().getDeadline();
         UpdateWorkflowExecutionResponse response =
             mutableState.updateWorkflowExecution(request, deadline);
-        System.out.println("updateWorkflowExecution: " + response);
         responseObserver.onNext(response);
         responseObserver.onCompleted();
       } catch (StatusRuntimeException e) {

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowUpdateTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowUpdateTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assume.assumeFalse;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 import io.temporal.api.update.v1.*;
@@ -148,7 +149,7 @@ public class WorkflowUpdateTest {
 
   @Test
   public void update() {
-    // Assert that we can update a workflow and poll the update.å
+    // Assert that we can update a workflow and poll the update.
     WorkflowOptions options =
         WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
 
@@ -211,7 +212,7 @@ public class WorkflowUpdateTest {
 
   @Test
   public void updateAdmittedNotSupported() {
-    // Assert that we can't update an update with wait stage ADMITTED. Expect a
+    // Assert that we can't send an update with wait stage ADMITTED. Expect a
     // PERMISSION_DENIED error.
     WorkflowOptions options =
         WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
@@ -241,6 +242,17 @@ public class WorkflowUpdateTest {
             UpdateWorkflowExecutionLifecycleStage
                 .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
             TestWorkflows.UpdateType.COMPLETE);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+        updateResponse.getStage());
+    Assert.assertEquals(
+        Outcome.newBuilder()
+            .setSuccess(
+                Payloads.newBuilder()
+                    .addPayloads(DefaultDataConverter.newDefaultInstance().toPayload(null).get())
+                    .build())
+            .build(),
+        updateResponse.getOutcome());
 
     PollWorkflowExecutionUpdateResponse response =
         pollWorkflowUpdate(
@@ -285,7 +297,7 @@ public class WorkflowUpdateTest {
 
   @Test
   public void duplicateRejectedUpdate() {
-    // Assert that a rejected updates are not stored and a new request can use the same update id.
+    // Assert that rejected updates are not stored and a new request can use the same update id.
     WorkflowOptions options =
         WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
 

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowUpdateTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowUpdateTest.java
@@ -1,0 +1,718 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.testserver.functional;
+
+import static org.junit.Assume.assumeFalse;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
+import io.temporal.api.update.v1.*;
+import io.temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateRequest;
+import io.temporal.api.workflowservice.v1.PollWorkflowExecutionUpdateResponse;
+import io.temporal.api.workflowservice.v1.UpdateWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse;
+import io.temporal.client.*;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.testserver.functional.common.TestWorkflows;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowUpdateTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(UpdateWorkflowImpl.class).build();
+
+  @Test
+  public void updateBadWorkflow() {
+    // Assert that we can't update a non-existent workflow. Expect a NOT_FOUND error.
+    WorkflowExecution badExec = WorkflowExecution.newBuilder().setWorkflowId("workflowId").build();
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                updateWorkflow(
+                    badExec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+                    TestWorkflows.UpdateType.BLOCK));
+    // Server does not return a consistent error message here, so we can't assert on the message
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+  }
+
+  @Test
+  public void pollUpdateBadWorkflow() {
+    // Assert that we can't poll an update for a non-existent workflow. Expect a NOT_FOUND error.
+    WorkflowExecution badExec = WorkflowExecution.newBuilder().setWorkflowId("workflowId").build();
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                pollWorkflowUpdate(
+                    badExec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+  }
+
+  @Test
+  public void pollUpdateBadUpdate() {
+    // Assert that we can't poll an update for a non-existent update ID. Expect a NOT_FOUND error.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                pollWorkflowUpdate(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+  }
+
+  @Test
+  public void updateAndPollCompletedWorkflow() {
+    // Assert that we can't update or poll a new update request for a completed workflow. Expect a
+    // NOT_FOUND
+    // error.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+    workflowStub.signal();
+    workflowStub.execute();
+
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                updateWorkflow(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+                    TestWorkflows.UpdateType.BLOCK));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+
+    exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                pollWorkflowUpdate(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+  }
+
+  @Test
+  public void update() {
+    // Assert that we can update a workflow and poll the update.å
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            TestWorkflows.UpdateType.BLOCK);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+        updateResponse.getStage());
+
+    PollWorkflowExecutionUpdateResponse pollUpdateResponse =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+        pollUpdateResponse.getStage());
+  }
+
+  @Test
+  public void updateAdmittedNotSupported() {
+    // Assert that we can't update an update with wait stage ADMITTED. Expect a
+    // PERMISSION_DENIED error.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                updateWorkflow(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+                    TestWorkflows.UpdateType.BLOCK));
+    Assert.assertEquals(Status.PERMISSION_DENIED.getCode(), exception.getStatus().getCode());
+
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.COMPLETE);
+
+    PollWorkflowExecutionUpdateResponse response =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED);
+    Assert.assertEquals(updateResponse.getOutcome(), response.getOutcome());
+    Assert.assertEquals(updateResponse.getUpdateRef(), response.getUpdateRef());
+    Assert.assertEquals(updateResponse.getStage(), response.getStage());
+  }
+
+  @Test
+  public void duplicateUpdate() {
+    // Assert that sending a duplicate update request returns the same response as the original
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse1 =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.COMPLETE);
+
+    UpdateWorkflowExecutionResponse updateResponse2 =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.BLOCK);
+    Assert.assertEquals(updateResponse1, updateResponse2);
+  }
+
+  @Test
+  public void duplicateRejectedUpdate() {
+    // Assert that a rejected updates are not stored and a new request can use the same update id.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse1 =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.REJECT);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+        updateResponse1.getStage());
+
+    UpdateWorkflowExecutionResponse updateResponse2 =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.COMPLETE);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+        updateResponse2.getStage());
+
+    workflowStub.signal();
+    workflowStub.execute();
+    Assert.assertEquals(updateResponse1.getUpdateRef(), updateResponse2.getUpdateRef());
+    Assert.assertNotEquals(updateResponse1.getOutcome(), updateResponse2.getOutcome());
+  }
+
+  @Test
+  public void updateRejected() {
+    // Assert that we can't poll for a rejected update. Expect a NOT_FOUND error.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            TestWorkflows.UpdateType.REJECT);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+        updateResponse.getStage());
+
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                pollWorkflowUpdate(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+  }
+
+  @Test
+  public void updateWaitStage() {
+    // Assert that wait for stage returns when the update has reached at least the specified stage.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            TestWorkflows.UpdateType.COMPLETE);
+    // Current behaviour is not defined, server may return ACCEPTED or COMPLETED
+    Assert.assertTrue(
+        updateResponse
+                .getStage()
+                .equals(
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED)
+            || updateResponse
+                .getStage()
+                .equals(
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED));
+
+    PollWorkflowExecutionUpdateResponse pollUpdateResponse =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+        pollUpdateResponse.getStage());
+  }
+
+  @Test(timeout = 120000)
+  public void updateNotAcceptedTimeout() {
+    // Assert that if an update cannot be accepted it will be considered admitted.
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+    testWorkflowRule.getTestEnvironment().shutdownNow();
+    testWorkflowRule.getTestEnvironment().awaitTermination(5, TimeUnit.SECONDS);
+
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            TestWorkflows.UpdateType.COMPLETE);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+        updateResponse.getStage());
+
+    updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.COMPLETE);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+        updateResponse.getStage());
+
+    PollWorkflowExecutionUpdateResponse pollUpdateResponse =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+        pollUpdateResponse.getStage());
+
+    pollUpdateResponse =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+        pollUpdateResponse.getStage());
+
+    pollUpdateResponse = pollWorkflowUpdate(exec, "updateId", null);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+        pollUpdateResponse.getStage());
+  }
+
+  @Test(timeout = 60000)
+  public void updateWaitCompletedTimeout() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.BLOCK);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+        updateResponse.getStage());
+
+    PollWorkflowExecutionUpdateResponse pollUpdateResponse =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+        pollUpdateResponse.getStage());
+
+    pollUpdateResponse = pollWorkflowUpdate(exec, "updateId", null);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+        pollUpdateResponse.getStage());
+  }
+
+  @Test
+  public void updateAndPollByWorkflowId() {
+    // Assert that we can update and poll a workflow by its workflowId without specifying the runId
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    WorkflowExecution workflowExecution =
+        WorkflowExecution.newBuilder().setWorkflowId(exec.getWorkflowId()).build();
+    UpdateWorkflowExecutionResponse updateResponse =
+        updateWorkflow(
+            workflowExecution,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.COMPLETE);
+    Assert.assertEquals(updateResponse.getUpdateRef().getWorkflowExecution(), exec);
+
+    PollWorkflowExecutionUpdateResponse pollUpdateResponse =
+        pollWorkflowUpdate(
+            workflowExecution,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED);
+    assertPollResponseEqualsUpdateResponse(pollUpdateResponse, updateResponse);
+  }
+
+  @Test
+  public void getCompletedUpdateOfCompletedWorkflow() {
+    // Assert that we can get and poll a completed update from a completed workflow.
+    assumeFalse("Skipping as real server has a bug", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse updateResponse1 =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.COMPLETE);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+        updateResponse1.getStage());
+
+    workflowStub.signal();
+    workflowStub.execute();
+
+    UpdateWorkflowExecutionResponse updateResponse2 =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+            TestWorkflows.UpdateType.BLOCK);
+    Assert.assertEquals(updateResponse1, updateResponse2);
+
+    PollWorkflowExecutionUpdateResponse pollUpdateResponse =
+        pollWorkflowUpdate(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED);
+    assertPollResponseEqualsUpdateResponse(pollUpdateResponse, updateResponse1);
+  }
+
+  @Test
+  public void getIncompleteUpdateOfCompletedWorkflow() {
+    // Assert that we can't get an incomplete update of a completed workflow. Expect a NOT_FOUND
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+
+    TestWorkflows.WorkflowWithUpdate workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.WorkflowWithUpdate.class, options);
+    WorkflowExecution exec = WorkflowClient.start(workflowStub::execute);
+
+    UpdateWorkflowExecutionResponse response =
+        updateWorkflow(
+            exec,
+            "updateId",
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+            TestWorkflows.UpdateType.BLOCK);
+    Assert.assertEquals(
+        UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+        response.getStage());
+
+    workflowStub.signal();
+    workflowStub.execute();
+
+    StatusRuntimeException exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                updateWorkflow(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+                    TestWorkflows.UpdateType.BLOCK));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+    exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                updateWorkflow(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+                    TestWorkflows.UpdateType.BLOCK));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+    exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                pollWorkflowUpdate(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+    exception =
+        Assert.assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                pollWorkflowUpdate(
+                    exec,
+                    "updateId",
+                    UpdateWorkflowExecutionLifecycleStage
+                        .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED));
+    Assert.assertEquals(Status.NOT_FOUND.getCode(), exception.getStatus().getCode());
+  }
+
+  private UpdateWorkflowExecutionResponse updateWorkflow(
+      WorkflowExecution execution,
+      String updateId,
+      UpdateWorkflowExecutionLifecycleStage stage,
+      TestWorkflows.UpdateType type) {
+    UpdateWorkflowExecutionResponse response =
+        testWorkflowRule
+            .getWorkflowClient()
+            .getWorkflowServiceStubs()
+            .blockingStub()
+            .updateWorkflowExecution(
+                UpdateWorkflowExecutionRequest.newBuilder()
+                    .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                    .setWorkflowExecution(execution)
+                    .setRequest(
+                        Request.newBuilder()
+                            .setInput(
+                                Input.newBuilder()
+                                    .setName("update")
+                                    .setArgs(
+                                        DefaultDataConverter.newDefaultInstance()
+                                            .toPayloads(type)
+                                            .get())
+                                    .build())
+                            .setMeta(Meta.newBuilder().setUpdateId(updateId).build()))
+                    .setWaitPolicy(WaitPolicy.newBuilder().setLifecycleStage(stage).build())
+                    .build());
+
+    // There are some assertions that we can always make...
+    Assert.assertEquals(updateId, response.getUpdateRef().getUpdateId());
+    Assert.assertEquals(
+        execution.getWorkflowId(), response.getUpdateRef().getWorkflowExecution().getWorkflowId());
+    return response;
+  }
+
+  private PollWorkflowExecutionUpdateResponse pollWorkflowUpdate(
+      WorkflowExecution execution, String updateId, UpdateWorkflowExecutionLifecycleStage stage) {
+    WaitPolicy.Builder waitPolicy = WaitPolicy.newBuilder();
+    if (stage != null) {
+      waitPolicy.setLifecycleStage(stage);
+    }
+    return testWorkflowRule
+        .getWorkflowClient()
+        .getWorkflowServiceStubs()
+        .blockingStub()
+        .pollWorkflowExecutionUpdate(
+            PollWorkflowExecutionUpdateRequest.newBuilder()
+                .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                .setWaitPolicy(waitPolicy.build())
+                .setUpdateRef(
+                    UpdateRef.newBuilder()
+                        .setUpdateId(updateId)
+                        .setWorkflowExecution(execution)
+                        .build())
+                .build());
+  }
+
+  private void assertPollResponseEqualsUpdateResponse(
+      PollWorkflowExecutionUpdateResponse pollResponse,
+      UpdateWorkflowExecutionResponse updateResponse) {
+    Assert.assertEquals(pollResponse.getStage(), updateResponse.getStage());
+    Assert.assertEquals(pollResponse.getOutcome(), updateResponse.getOutcome());
+    Assert.assertEquals(pollResponse.getUpdateRef(), updateResponse.getUpdateRef());
+  }
+
+  public static class UpdateWorkflowImpl implements TestWorkflows.WorkflowWithUpdate {
+    boolean unblock = false;
+
+    @Override
+    public void execute() {
+      // wait forever to keep it in running state
+      Workflow.await(() -> unblock);
+    }
+
+    @Override
+    public void update(TestWorkflows.UpdateType type) {
+      if (type == TestWorkflows.UpdateType.DELAYED_COMPLETE) {
+        Workflow.sleep(Duration.ofSeconds(1));
+      } else if (type == TestWorkflows.UpdateType.BLOCK) {
+        Workflow.await(() -> false);
+      }
+    }
+
+    @Override
+    public void updateValidator(TestWorkflows.UpdateType type) {
+      if (type == TestWorkflows.UpdateType.REJECT) {
+        throw new IllegalArgumentException("REJECT");
+      }
+    }
+
+    @Override
+    public void signal() {
+      unblock = true;
+    }
+  }
+}

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
@@ -66,6 +66,7 @@ public class TestWorkflows {
     REJECT,
     COMPLETE,
     DELAYED_COMPLETE,
-    BLOCK
+    BLOCK,
+    FINISH_WORKFLOW,
   }
 }

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
@@ -20,8 +20,7 @@
 
 package io.temporal.testserver.functional.common;
 
-import io.temporal.workflow.WorkflowInterface;
-import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.*;
 
 public class TestWorkflows {
   @WorkflowInterface
@@ -46,5 +45,27 @@ public class TestWorkflows {
   public interface PrimitiveChildWorkflow {
     @WorkflowMethod
     void execute();
+  }
+
+  @WorkflowInterface
+  public interface WorkflowWithUpdate {
+    @WorkflowMethod
+    void execute();
+
+    @UpdateMethod
+    void update(UpdateType type);
+
+    @UpdateValidatorMethod(updateName = "update")
+    void updateValidator(UpdateType type);
+
+    @SignalMethod
+    void signal();
+  }
+
+  public enum UpdateType {
+    REJECT,
+    COMPLETE,
+    DELAYED_COMPLETE,
+    BLOCK
   }
 }


### PR DESCRIPTION
Align test server update APIs with real server update APIs. Key part is all the tests in temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowUpdateTest.java to ensure the test server and real server behave the same. Some tests may be disabled as I found bugs in the real server while writing these tests.
