### PR TITLE
Move workflow update polling inside of interceptor

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -8,3 +8,4 @@ jobs:
       java-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+      features-repo-ref: java-update-iceptor-change

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
@@ -23,6 +23,7 @@ package io.temporal.opentracing.internal;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.temporal.client.UpdateHandle;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptorBase;
 import io.temporal.opentracing.OpenTracingOptions;
@@ -119,7 +120,7 @@ public class OpenTracingWorkflowClientCallsInterceptor extends WorkflowClientCal
   }
 
   @Override
-  public <R> StartUpdateOutput<R> startUpdate(StartUpdateInput<R> input) {
+  public <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
     Span workflowStartUpdateSpan =
         contextAccessor.writeSpanContextToHeader(
             () ->

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptor.java
@@ -22,8 +22,8 @@ package io.temporal.common.interceptors;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
-import io.temporal.api.update.v1.UpdateRef;
 import io.temporal.api.update.v1.WaitPolicy;
+import io.temporal.client.UpdateHandle;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.Experimental;
 import java.lang.reflect.Type;
@@ -78,7 +78,7 @@ public interface WorkflowClientCallsInterceptor {
   <R> QueryOutput<R> query(QueryInput<R> input);
 
   @Experimental
-  <R> StartUpdateOutput<R> startUpdate(StartUpdateInput<R> input);
+  <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input);
 
   @Experimental
   <R> PollWorkflowUpdateOutput<R> pollWorkflowUpdate(PollWorkflowUpdateInput<R> input);
@@ -383,6 +383,7 @@ public interface WorkflowClientCallsInterceptor {
   @Experimental
   final class StartUpdateInput<R> {
     private final WorkflowExecution workflowExecution;
+    private final Optional<String> workflowType;
     private final String updateName;
     private final Header header;
     private final Object[] arguments;
@@ -394,6 +395,7 @@ public interface WorkflowClientCallsInterceptor {
 
     public StartUpdateInput(
         WorkflowExecution workflowExecution,
+        Optional<String> workflowType,
         String updateName,
         Header header,
         String updateId,
@@ -403,6 +405,7 @@ public interface WorkflowClientCallsInterceptor {
         String firstExecutionRunId,
         WaitPolicy waitPolicy) {
       this.workflowExecution = workflowExecution;
+      this.workflowType = workflowType;
       this.header = header;
       this.updateId = updateId;
       this.updateName = updateName;
@@ -415,6 +418,10 @@ public interface WorkflowClientCallsInterceptor {
 
     public WorkflowExecution getWorkflowExecution() {
       return workflowExecution;
+    }
+
+    public Optional<String> getWorkflowType() {
+      return workflowType;
     }
 
     public String getUpdateName() {
@@ -447,44 +454,6 @@ public interface WorkflowClientCallsInterceptor {
 
     public WaitPolicy getWaitPolicy() {
       return waitPolicy;
-    }
-  }
-
-  @Experimental
-  final class UpdateOutput<R> {
-    private final R result;
-
-    public UpdateOutput(R result) {
-      this.result = result;
-    }
-
-    public R getResult() {
-      return result;
-    }
-  }
-
-  @Experimental
-  final class StartUpdateOutput<R> {
-    private final UpdateRef reference;
-    private final R result;
-    private final boolean hasResult;
-
-    public StartUpdateOutput(UpdateRef reference, boolean hasResult, R result) {
-      this.reference = reference;
-      this.result = result;
-      this.hasResult = hasResult;
-    }
-
-    public UpdateRef getReference() {
-      return reference;
-    }
-
-    public boolean hasResult() {
-      return hasResult;
-    }
-
-    public R getResult() {
-      return result;
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptorBase.java
@@ -20,6 +20,7 @@
 
 package io.temporal.common.interceptors;
 
+import io.temporal.client.UpdateHandle;
 import java.util.concurrent.TimeoutException;
 
 /** Convenience base class for {@link WorkflowClientCallsInterceptor} implementations. */
@@ -62,7 +63,7 @@ public class WorkflowClientCallsInterceptorBase implements WorkflowClientCallsIn
   }
 
   @Override
-  public <R> StartUpdateOutput<R> startUpdate(StartUpdateInput<R> input) {
+  public <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
     return next.startUpdate(input);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedUpdateHandleImpl.java
@@ -18,9 +18,10 @@
  * limitations under the License.
  */
 
-package io.temporal.client;
+package io.temporal.internal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.UpdateHandle;
 import io.temporal.common.Experimental;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedUpdateHandleImpl.java
@@ -27,13 +27,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @Experimental
-final class CompletedUpdateHandleImpl<T> implements UpdateHandle<T> {
+public final class CompletedUpdateHandleImpl<T> implements UpdateHandle<T> {
 
   private final String id;
   private final WorkflowExecution execution;
   private final T result;
 
-  CompletedUpdateHandleImpl(String id, WorkflowExecution execution, T result) {
+  public CompletedUpdateHandleImpl(String id, WorkflowExecution execution, T result) {
     this.id = id;
     this.execution = execution;
     this.result = result;

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/LazyUpdateHandleImpl.java
@@ -18,11 +18,14 @@
  * limitations under the License.
  */
 
-package io.temporal.client;
+package io.temporal.internal.client;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.UpdateHandle;
+import io.temporal.client.WorkflowException;
+import io.temporal.client.WorkflowServiceException;
 import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
@@ -33,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 @Experimental
-final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
+public final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
 
   private final WorkflowClientCallsInterceptor workflowClientInvoker;
   private final String workflowType;
@@ -44,7 +47,7 @@ final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
   private final Type resultType;
   private WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput<T> waitCompletedPollCall;
 
-  LazyUpdateHandleImpl(
+  public LazyUpdateHandleImpl(
       WorkflowClientCallsInterceptor workflowClientInvoker,
       String workflowType,
       String updateName,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moved update polling to be inside of the interceptor a-la other SDKs

## Why?
Consistent, allows interceptor to change things post-polling

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/2094

2. How was this tested:
Added an integ test using the interceptor

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
