### PR TITLE
Wrap GRPC::CANCELED and DEADLINE_EXCEEDED in new exception type

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
@@ -22,6 +22,12 @@ package io.temporal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 
+/**
+ *  Error that occurs when an update call times out or is cancelled.
+ *  
+ *  <p>Note, this is not related to any general concept of timing out or cancelling
+ *  a running update, this is only related to the client call itself.
+ */
 public class WorkflowUpdateTimeoutOrCancelledException extends WorkflowServiceException {
   public WorkflowUpdateTimeoutOrCancelledException(
       WorkflowExecution execution, String updateId, String updateName, Throwable cause) {

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
@@ -23,10 +23,10 @@ package io.temporal.client;
 import io.temporal.api.common.v1.WorkflowExecution;
 
 /**
- *  Error that occurs when an update call times out or is cancelled.
- *  
- *  <p>Note, this is not related to any general concept of timing out or cancelling
- *  a running update, this is only related to the client call itself.
+ * Error that occurs when an update call times out or is cancelled.
+ *
+ * <p>Note, this is not related to any general concept of timing out or cancelling a running update,
+ * this is only related to the client call itself.
  */
 public class WorkflowUpdateTimeoutOrCancelledException extends WorkflowServiceException {
   public WorkflowUpdateTimeoutOrCancelledException(

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateTimeoutOrCancelledException.java
@@ -1,0 +1,10 @@
+package io.temporal.client;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+
+public class WorkflowUpdateTimeoutOrCancelledException extends WorkflowServiceException {
+  public WorkflowUpdateTimeoutOrCancelledException(
+      WorkflowExecution execution, String updateId, String updateName, Throwable cause) {
+    super(execution, "", cause);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/LazyUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/LazyUpdateHandleImpl.java
@@ -110,12 +110,13 @@ public final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
                   // does not exist or because the update ID does not exist.
                   throw sre;
                 }
+                throw sre;
               } else if (failure instanceof WorkflowException) {
                 throw (WorkflowException) failure;
               } else if (failure instanceof TimeoutException) {
-                throw new CompletionException((TimeoutException) failure);
+                throw new CompletionException(failure);
               }
-              throw new WorkflowServiceException(execution, workflowType, (Throwable) failure);
+              throw new WorkflowServiceException(execution, workflowType, failure);
             });
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTestTimeout.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTestTimeout.java
@@ -27,17 +27,13 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.base.Stopwatch;
-import io.temporal.client.UpdateHandle;
-import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowStub;
-import io.temporal.client.WorkflowUpdateStage;
+import io.temporal.client.*;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -111,7 +107,9 @@ public class UpdateTestTimeout {
     // Verify get throws the correct exception in around the right amount of time
     Stopwatch stopWatch = Stopwatch.createStarted();
     ExecutionException executionException = assertThrows(ExecutionException.class, result::get);
-    assertThat(executionException.getCause(), is(instanceOf(TimeoutException.class)));
+    assertThat(
+        executionException.getCause(),
+        is(instanceOf(WorkflowUpdateTimeoutOrCancelledException.class)));
     stopWatch.stop();
     long elapsedSeconds = stopWatch.elapsed(TimeUnit.SECONDS);
     assertTrue(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateExceptionWrapped.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateExceptionWrapped.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.updateTest;
+
+import static org.junit.Assert.assertThrows;
+
+import io.grpc.Context;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.*;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.workflow.CompletablePromise;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows.WorkflowWithUpdate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpdateExceptionWrapped {
+
+  private static ScheduledExecutorService scheduledExecutor;
+
+  @BeforeClass
+  public static void beforeClass() {
+    scheduledExecutor = Executors.newScheduledThreadPool(1);
+  }
+
+  private static final Logger log = LoggerFactory.getLogger(UpdateTest.class);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkerOptions(WorkerOptions.newBuilder().build())
+          .setWorkflowTypes(TestUpdateWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testUpdateStart() {
+    String workflowId = UUID.randomUUID().toString();
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .setWorkflowId(workflowId)
+            .build();
+    WorkflowWithUpdate workflow = workflowClient.newWorkflowStub(WorkflowWithUpdate.class, options);
+    // To execute workflow client.execute() would do. But we want to start workflow and immediately
+    // return.
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+    testWorkflowRule.getTestEnvironment().shutdownNow();
+    testWorkflowRule.getTestEnvironment().awaitTermination(1000, TimeUnit.MILLISECONDS);
+
+    final AtomicReference<WorkflowUpdateTimeoutOrCancelledException> exception =
+        new AtomicReference<>();
+
+    Context.current()
+        .withDeadlineAfter(500, TimeUnit.MILLISECONDS, scheduledExecutor)
+        .run(
+            () ->
+                exception.set(
+                    assertThrows(
+                        WorkflowUpdateTimeoutOrCancelledException.class,
+                        () -> workflow.update(0, ""))));
+  }
+
+  @Test
+  public void testUpdatePoll() {
+    String workflowId = UUID.randomUUID().toString();
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .setWorkflowId(workflowId)
+            .build();
+    WorkflowWithUpdate workflow = workflowClient.newWorkflowStub(WorkflowWithUpdate.class, options);
+    // To execute workflow client.execute() would do. But we want to start workflow and immediately
+    // return.
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+    UpdateHandle handle =
+        WorkflowStub.fromTyped(workflow)
+            .startUpdate("update", WorkflowUpdateStage.ACCEPTED, String.class, 0, " ");
+
+    testWorkflowRule.getTestEnvironment().shutdownNow();
+    testWorkflowRule.getTestEnvironment().awaitTermination(1000, TimeUnit.MILLISECONDS);
+
+    final AtomicReference<WorkflowUpdateTimeoutOrCancelledException> exception =
+        new AtomicReference<>();
+
+    Context.current()
+        .withDeadlineAfter(500, TimeUnit.MILLISECONDS, scheduledExecutor)
+        .run(
+            () ->
+                exception.set(
+                    assertThrows(
+                        WorkflowUpdateTimeoutOrCancelledException.class,
+                        () -> handle.getResultAsync().get())));
+  }
+
+  public static class TestUpdateWorkflowImpl implements WorkflowWithUpdate {
+    String state = "initial";
+    List<String> updates = new ArrayList<>();
+    CompletablePromise<Void> promise = Workflow.newPromise();
+
+    @Override
+    public String execute() {
+      promise.get();
+      return "";
+    }
+
+    @Override
+    public String getState() {
+      return state;
+    }
+
+    @Override
+    public String update(Integer index, String value) {
+      return "";
+    }
+
+    @Override
+    public void updateValidator(Integer index, String value) {}
+
+    @Override
+    public void complete() {
+      promise.complete(null);
+    }
+
+    @Override
+    public void completeValidator() {}
+  }
+}


### PR DESCRIPTION
Wrap GRPC::CANCELED and DEADLINE_EXCEEDED in new exception type `WorkflowUpdateTimeoutOrCancelledException`

closes https://github.com/temporalio/sdk-java/issues/2069