### PR TITLE
Implement test server support for sync Nexus operation commands

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/CommandVerifier.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/CommandVerifier.java
@@ -55,6 +55,7 @@ class CommandVerifier {
               eventAttributesFailure,
               e);
         }
+        break;
       case COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION:
         try {
           nexusEndpointStore.getEndpointByName(
@@ -74,6 +75,7 @@ class CommandVerifier {
               eventAttributesFailure,
               e);
         }
+        break;
     }
     return null;
   }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
@@ -90,10 +90,7 @@ class NexusTaskToken {
       out.writeInt(attempt);
       return ByteString.copyFrom(bout.toByteArray());
     } catch (IOException e) {
-      throw Status.INVALID_ARGUMENT
-          .withCause(e)
-          .withDescription(e.getMessage())
-          .asRuntimeException();
+      throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
     }
   }
 
@@ -108,7 +105,10 @@ class NexusTaskToken {
       int attempt = in.readInt();
       return new NexusTaskToken(namespace, workflowId, runId, scheduledEventId, attempt);
     } catch (IOException e) {
-      throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
+      throw Status.INVALID_ARGUMENT
+          .withCause(e)
+          .withDescription(e.getMessage())
+          .asRuntimeException();
     }
   }
 }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
@@ -90,7 +90,10 @@ class NexusTaskToken {
       out.writeInt(attempt);
       return ByteString.copyFrom(bout.toByteArray());
     } catch (IOException e) {
-      throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
+      throw Status.INVALID_ARGUMENT
+          .withCause(e)
+          .withDescription(e.getMessage())
+          .asRuntimeException();
     }
   }
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.testservice;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.temporal.api.common.v1.WorkflowExecution;
+import java.io.*;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+class NexusTaskToken {
+
+  @Nonnull private final ExecutionId executionId;
+  private final long scheduledEventId;
+  private final int attempt;
+
+  NexusTaskToken(
+      @Nonnull String namespace,
+      @Nonnull WorkflowExecution execution,
+      long scheduledEventId,
+      int attempt) {
+    this(
+        new ExecutionId(Objects.requireNonNull(namespace), Objects.requireNonNull(execution)),
+        scheduledEventId,
+        attempt);
+  }
+
+  NexusTaskToken(
+      @Nonnull String namespace,
+      @Nonnull String workflowId,
+      @Nonnull String runId,
+      long scheduledEventId,
+      int attempt) {
+    this(
+        namespace,
+        WorkflowExecution.newBuilder()
+            .setWorkflowId(Objects.requireNonNull(workflowId))
+            .setRunId(Objects.requireNonNull(runId))
+            .build(),
+        scheduledEventId,
+        attempt);
+  }
+
+  NexusTaskToken(@Nonnull ExecutionId executionId, long scheduledEventId, int attempt) {
+    this.executionId = Objects.requireNonNull(executionId);
+    this.scheduledEventId = scheduledEventId;
+    this.attempt = attempt;
+  }
+
+  public ExecutionId getExecutionId() {
+    return executionId;
+  }
+
+  public long getScheduledEventId() {
+    return scheduledEventId;
+  }
+
+  public long getAttempt() {
+    return attempt;
+  }
+
+  /** Used for task tokens. */
+  public ByteString toBytes() {
+    try (ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bout)) {
+      out.writeUTF(executionId.getNamespace());
+      WorkflowExecution execution = executionId.getExecution();
+      out.writeUTF(execution.getWorkflowId());
+      out.writeUTF(execution.getRunId());
+      out.writeLong(scheduledEventId);
+      out.writeInt(attempt);
+      return ByteString.copyFrom(bout.toByteArray());
+    } catch (IOException e) {
+      throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
+    }
+  }
+
+  static NexusTaskToken fromBytes(ByteString serialized) {
+    ByteArrayInputStream bin = new ByteArrayInputStream(serialized.toByteArray());
+    DataInputStream in = new DataInputStream(bin);
+    try {
+      String namespace = in.readUTF();
+      String workflowId = in.readUTF();
+      String runId = in.readUTF();
+      long scheduledEventId = in.readLong();
+      int attempt = in.readInt();
+      return new NexusTaskToken(namespace, workflowId, runId, scheduledEventId, attempt);
+    } catch (IOException e) {
+      throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
+    }
+  }
+}

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/RequestContext.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/RequestContext.java
@@ -124,6 +124,7 @@ final class RequestContext {
   // If an eager dispatch was performed, it should be reset to null
   private WorkflowTask workflowTaskForMatching;
   private final List<ActivityTask> activityTasks = new ArrayList<>();
+  private final List<TestWorkflowStore.NexusTask> nexusTasks = new ArrayList<>();
   private final List<Timer> timers = new ArrayList<>();
   private long workflowCompletedAtEventId = -1;
   private boolean needWorkflowTask;
@@ -157,6 +158,7 @@ final class RequestContext {
 
   void add(RequestContext ctx) {
     this.activityTasks.addAll(ctx.getActivityTasks());
+    this.nexusTasks.addAll(ctx.getNexusTasks());
     this.timers.addAll(ctx.getTimers());
     this.events.addAll(ctx.getEvents());
   }
@@ -252,6 +254,10 @@ final class RequestContext {
     this.activityTasks.add(activityTask);
   }
 
+  void addNexusTask(TestWorkflowStore.NexusTask nexusTask) {
+    this.nexusTasks.add(nexusTask);
+  }
+
   /**
    * @return cancellation handle
    */
@@ -267,6 +273,10 @@ final class RequestContext {
 
   List<ActivityTask> getActivityTasks() {
     return activityTasks;
+  }
+
+  List<TestWorkflowStore.NexusTask> getNexusTasks() {
+    return nexusTasks;
   }
 
   List<HistoryEvent> getEvents() {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -2444,11 +2444,13 @@ class StateMachines {
 
   static RetryPolicy getDefaultNexusOperationRetryPolicy() {
     return RetryPolicy.newBuilder()
-        .addNonRetryableErrorTypes("BAD_REQUEST")
-        .setInitialInterval(Durations.fromMillis(100))
-        .setMaximumInterval(Durations.fromSeconds(5))
+        .addAllNonRetryableErrorTypes(
+            Arrays.asList(
+                "BAD_REQUEST", "INVALID_ARGUMENT", "NOT_FOUND", "DEADLINE_EXCEEDED", "CANCELLED"))
+        .setInitialInterval(Durations.fromSeconds(1))
+        .setMaximumInterval(Durations.fromSeconds(10))
         .setBackoffCoefficient(2.0)
-        .setMaximumAttempts(5)
+        .setMaximumAttempts(10)
         .build();
   }
 }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestNexusEndpointStore.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestNexusEndpointStore.java
@@ -35,6 +35,8 @@ public interface TestNexusEndpointStore extends Closeable {
 
   Endpoint getEndpoint(String id);
 
+  Endpoint getEndpointByName(String name);
+
   List<Endpoint> listEndpoints(long pageSize, byte[] nextPageToken, String name);
 
   void validateEndpointSpec(EndpointSpec spec);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServicesStarter.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServicesStarter.java
@@ -51,7 +51,11 @@ public class TestServicesStarter implements Closeable {
     this.testService =
         new TestService(this.workflowStore, this.selfAdvancingTimer, lockTimeSkipping);
     this.workflowService =
-        new TestWorkflowService(this.workflowStore, this.visibilityStore, this.selfAdvancingTimer);
+        new TestWorkflowService(
+            this.workflowStore,
+            this.visibilityStore,
+            this.nexusEndpointStore,
+            this.selfAdvancingTimer);
     this.services = Arrays.asList(this.operatorService, this.testService, this.workflowService);
   }
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
@@ -111,6 +111,12 @@ interface TestWorkflowMutableState {
 
   void cancelActivityTaskById(String id, RespondActivityTaskCanceledByIdRequest canceledRequest);
 
+  void startNexusTask(long scheduledEventId, RespondNexusTaskCompletedRequest request);
+
+  void completeNexusTask(long scheduledEventId, RespondNexusTaskCompletedRequest request);
+
+  void failNexusTask(long scheduledEventId, RespondNexusTaskFailedRequest request);
+
   QueryWorkflowResponse query(QueryWorkflowRequest queryRequest, long deadline);
 
   UpdateWorkflowExecutionResponse updateWorkflowExecution(

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -22,11 +22,7 @@ package io.temporal.internal.testservice;
 
 import static io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.*;
 import static io.temporal.internal.testservice.CronUtils.getBackoffInterval;
-import static io.temporal.internal.testservice.StateMachines.DEFAULT_WORKFLOW_EXECUTION_TIMEOUT_MILLISECONDS;
-import static io.temporal.internal.testservice.StateMachines.DEFAULT_WORKFLOW_TASK_TIMEOUT_MILLISECONDS;
-import static io.temporal.internal.testservice.StateMachines.MAX_WORKFLOW_TASK_TIMEOUT_MILLISECONDS;
-import static io.temporal.internal.testservice.StateMachines.NO_EVENT_ID;
-import static io.temporal.internal.testservice.StateMachines.newActivityStateMachine;
+import static io.temporal.internal.testservice.StateMachines.*;
 import static io.temporal.internal.testservice.TestServiceRetryState.validateAndOverrideRetryPolicy;
 
 import com.google.common.base.Preconditions;
@@ -39,21 +35,7 @@ import com.google.protobuf.util.Timestamps;
 import io.grpc.Deadline;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.temporal.api.command.v1.CancelTimerCommandAttributes;
-import io.temporal.api.command.v1.CancelWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.Command;
-import io.temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.FailWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.ProtocolMessageCommandAttributes;
-import io.temporal.api.command.v1.RecordMarkerCommandAttributes;
-import io.temporal.api.command.v1.RequestCancelActivityTaskCommandAttributes;
-import io.temporal.api.command.v1.RequestCancelExternalWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributes;
-import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.StartTimerCommandAttributes;
-import io.temporal.api.command.v1.UpsertWorkflowSearchAttributesCommandAttributes;
+import io.temporal.api.command.v1.*;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.RetryPolicy;
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -61,28 +43,14 @@ import io.temporal.api.enums.v1.*;
 import io.temporal.api.errordetails.v1.QueryFailedFailure;
 import io.temporal.api.failure.v1.ApplicationFailureInfo;
 import io.temporal.api.failure.v1.Failure;
-import io.temporal.api.history.v1.ActivityTaskScheduledEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionCanceledEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionCompletedEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionFailedEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionStartedEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionTimedOutEventAttributes;
-import io.temporal.api.history.v1.ExternalWorkflowExecutionCancelRequestedEventAttributes;
-import io.temporal.api.history.v1.HistoryEvent;
-import io.temporal.api.history.v1.MarkerRecordedEventAttributes;
-import io.temporal.api.history.v1.StartChildWorkflowExecutionFailedEventAttributes;
-import io.temporal.api.history.v1.UpsertWorkflowSearchAttributesEventAttributes;
-import io.temporal.api.history.v1.WorkflowExecutionContinuedAsNewEventAttributes;
-import io.temporal.api.history.v1.WorkflowExecutionSignaledEventAttributes;
+import io.temporal.api.history.v1.*;
+import io.temporal.api.nexus.v1.Endpoint;
 import io.temporal.api.protocol.v1.Message;
 import io.temporal.api.query.v1.QueryRejected;
 import io.temporal.api.query.v1.WorkflowQueryResult;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.update.v1.*;
-import io.temporal.api.workflow.v1.PendingActivityInfo;
-import io.temporal.api.workflow.v1.PendingChildExecutionInfo;
-import io.temporal.api.workflow.v1.WorkflowExecutionConfig;
-import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
+import io.temporal.api.workflow.v1.*;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.ServerFailure;
@@ -137,6 +105,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   private final OptionalLong parentChildInitiatedEventId;
   private final TestWorkflowStore store;
   private final TestVisibilityStore visibilityStore;
+  private final TestNexusEndpointStore nexusEndpointStore;
   private final TestWorkflowService service;
   private final CommandVerifier commandVerifier;
 
@@ -145,6 +114,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   private final Map<Long, StateMachine<ActivityTaskData>> activities = new HashMap<>();
   private final Map<String, Long> activityById = new HashMap<>();
   private final Map<Long, StateMachine<ChildWorkflowData>> childWorkflows = new HashMap<>();
+  private final Map<Long, StateMachine<NexusOperationData>> nexusOperations = new HashMap<>();
   private final Map<String, StateMachine<TimerData>> timers = new HashMap<>();
   private final Map<String, StateMachine<SignalExternalData>> externalSignals = new HashMap<>();
   private final Map<String, StateMachine<CancelExternalData>> externalCancellations =
@@ -176,11 +146,13 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       TestWorkflowService service,
       TestWorkflowStore store,
       TestVisibilityStore visibilityStore,
+      TestNexusEndpointStore nexusEndpointStore,
       SelfAdvancingTimer selfAdvancingTimer) {
     this.store = store;
     this.visibilityStore = visibilityStore;
+    this.nexusEndpointStore = nexusEndpointStore;
     this.service = service;
-    this.commandVerifier = new CommandVerifier(visibilityStore);
+    this.commandVerifier = new CommandVerifier(visibilityStore, nexusEndpointStore);
     startRequest = overrideStartWorkflowExecutionRequest(startRequest);
     this.startRequest = startRequest;
     this.executionId =
@@ -690,6 +662,14 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             identity,
             workflowTaskCompletedId);
         break;
+      case COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION:
+        processScheduleNexusOperation(
+            ctx, d.getScheduleNexusOperationCommandAttributes(), workflowTaskCompletedId);
+        break;
+      case COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION:
+        processRequestCancelNexusOperation(
+            ctx, d.getRequestCancelNexusOperationCommandAttributes(), workflowTaskCompletedId);
+        break;
       default:
         throw Status.INVALID_ARGUMENT
             .withDescription("Unknown command type: " + d.getCommandType() + " for " + d)
@@ -723,6 +703,61 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       }
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  private void processScheduleNexusOperation(
+      RequestContext ctx,
+      ScheduleNexusOperationCommandAttributes attr,
+      long workflowTaskCompletedId) {
+    attr = validateScheduleNexusOperation(attr);
+    Endpoint endpoint = nexusEndpointStore.getEndpointByName(attr.getEndpoint());
+    StateMachine<StateMachines.NexusOperationData> operationStateMachine =
+        newNexusOperation(endpoint);
+    long scheduleEventId = ctx.getNextEventId();
+    nexusOperations.put(scheduleEventId, operationStateMachine);
+
+    operationStateMachine.action(Action.INITIATE, ctx, attr, workflowTaskCompletedId);
+    ctx.addTimer(
+        ProtobufTimeUtils.toJavaDuration(
+            operationStateMachine.getData().scheduledEvent.getScheduleToCloseTimeout()),
+        () ->
+            timeoutNexusOperation(
+                scheduleEventId,
+                TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+                operationStateMachine.getData().getAttempt()),
+        "NexusOperation ScheduleToCloseTimeout");
+    ctx.lockTimer("processScheduleNexusOperation");
+  }
+
+  private ScheduleNexusOperationCommandAttributes validateScheduleNexusOperation(
+      ScheduleNexusOperationCommandAttributes attr) {
+    // TODO(pj): implement me
+    return attr;
+  }
+
+  // TODO(pj): refactor cancellation to be a separate state machine as implemented in OSS
+  private void processRequestCancelNexusOperation(
+      RequestContext ctx,
+      RequestCancelNexusOperationCommandAttributes attr,
+      long workflowTaskCompletedId) {
+    long scheduleEventId = attr.getScheduledEventId();
+    StateMachine<?> operation = nexusOperations.get(scheduleEventId);
+    if (operation == null) {
+      throw Status.INVALID_ARGUMENT
+          .withDescription("Nexus operation not found for scheduleEventId=" + scheduleEventId)
+          .asRuntimeException();
+    }
+
+    State before = operation.getState();
+    operation.action(Action.REQUEST_CANCELLATION, ctx, attr, workflowTaskCompletedId);
+    if (before == State.INITIATED) {
+      // request is null here, because it's caused not by a separate cancel request, but by a
+      // command
+      operation.action(Action.CANCEL, ctx, null, 0);
+      //      nexusOperations.remove(scheduleEventId); // TODO: server doesn't currently remove
+      // operations on terminal state
+      ctx.setNeedWorkflowTask(true);
     }
   }
 
@@ -2006,6 +2041,132 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     }
   }
 
+  @Override
+  public void startNexusTask(long scheduledEventId, RespondNexusTaskCompletedRequest request) {
+    update(
+        ctx -> {
+          StateMachine<NexusOperationData> operation = getPendingNexusOperation(scheduledEventId);
+          operation.action(StateMachines.Action.START, ctx, request, 0);
+          operation.getData().identity = request.getIdentity();
+        });
+  }
+
+  @Override
+  public void completeNexusTask(long scheduledEventId, RespondNexusTaskCompletedRequest request) {
+    update(
+        ctx -> {
+          StateMachine<NexusOperationData> operation = getPendingNexusOperation(scheduledEventId);
+          throwIfOperationTokenDoesntMatch(request.getTaskToken(), operation.getData());
+          if (request.getResponse().hasCancelOperation()) {
+            operation.action(Action.REQUEST_CANCELLATION, ctx, request, 0);
+          } else {
+            operation.action(StateMachines.Action.COMPLETE, ctx, request, 0);
+          }
+          // nexusOperations.remove(scheduledEventId); // TODO: server currently does not delete on
+          // completion
+          scheduleWorkflowTask(ctx);
+          ctx.unlockTimer("completeNexusTask");
+        });
+  }
+
+  @Override
+  public void failNexusTask(long scheduledEventId, RespondNexusTaskFailedRequest request) {
+    update(
+        ctx -> {
+          StateMachine<NexusOperationData> operation = getPendingNexusOperation(scheduledEventId);
+          throwIfOperationTokenDoesntMatch(request.getTaskToken(), operation.getData());
+          operation.action(StateMachines.Action.FAIL, ctx, request, 0);
+          if (isTerminalState(operation.getState())) {
+            // nexusOperations.remove(scheduledEventId); // TODO: server currently does not delete
+            // on completion
+            scheduleWorkflowTask(ctx);
+          } else {
+            addNexusOperationRetryTimer(ctx, operation);
+          }
+          // Allow time skipping when waiting for retry
+          ctx.unlockTimer("failNexusTask");
+        });
+  }
+
+  private void timeoutNexusOperation(
+      long scheduledEventId, TimeoutType timeoutType, int timeoutAttempt) {
+    boolean unlockTimer = true;
+    try {
+      update(
+          ctx -> {
+            StateMachine<NexusOperationData> operation = getPendingNexusOperation(scheduledEventId);
+            int attempt = operation.getData().getAttempt();
+            if (timeoutAttempt != attempt
+                || (operation.getState() != State.INITIATED
+                    && operation.getState() != State.STARTED)) {
+              throw Status.NOT_FOUND.withDescription("Timer fired earlier").asRuntimeException();
+            }
+            operation.action(StateMachines.Action.TIME_OUT, ctx, timeoutType, 0);
+            if (isTerminalState(operation.getState())) {
+              nexusOperations.remove(scheduledEventId);
+              scheduleWorkflowTask(ctx);
+            } else {
+              addNexusOperationRetryTimer(ctx, operation);
+            }
+          });
+    } catch (StatusRuntimeException e) {
+      // NOT_FOUND is expected as timers are not removed
+      if (e.getStatus().getCode() != Status.Code.NOT_FOUND) {
+        log.error("Failure trying to add task for a Nexus operation retry", e);
+      }
+      unlockTimer = false;
+    } catch (Exception e) {
+      // Cannot fail to timer threads
+      log.error("Failure trying to timeout a Nexus operation", e);
+    } finally {
+      if (unlockTimer) {
+        timerService.unlockTimeSkipping("timeoutNexusOperation: " + scheduledEventId);
+      }
+    }
+  }
+
+  private void addNexusOperationRetryTimer(
+      RequestContext ctx, StateMachine<NexusOperationData> operation) {
+    NexusOperationData data = operation.getData();
+    int attempt = data.getAttempt();
+    Duration nextDelay = ProtobufTimeUtils.toJavaDuration(data.nextBackoffInterval);
+    data.nextAttemptScheduleTime = clock.getAsLong() + nextDelay.toMillis();
+    ctx.addTimer(
+        nextDelay,
+        () -> {
+          // Timers are not removed, so skip if it is not for this attempt.
+          if (operation.getState() != State.INITIATED && data.getAttempt() != attempt) {
+            return;
+          }
+
+          LockHandle lockHandle =
+              timerService.lockTimeSkipping(
+                  "nexusOperationRetryTimer " + operation.getData().operationId);
+          boolean unlockTimer = false;
+
+          try {
+            // TODO this lock is getting released somewhere on the operation completion.
+            //  We should rework it to pass the lockHandle downstream and use it for the release.
+            update(ctx1 -> ctx1.addNexusTask(data.nexusTask));
+          } catch (StatusRuntimeException e) {
+            // NOT_FOUND is expected as timers are not removed
+            if (e.getStatus().getCode() != Status.Code.NOT_FOUND) {
+              log.error("Failure trying to add task for a Nexus operation retry", e);
+            }
+            unlockTimer = true;
+          } catch (Exception e) {
+            log.error("Failure trying to add task for a Nexus operation retry", e);
+            unlockTimer = true;
+          } finally {
+            if (unlockTimer) {
+              // Allow time skipping when waiting for an operation retry
+              lockHandle.unlock("nexusOperationRetryTimer " + operation.getData().operationId);
+            }
+          }
+        },
+        "Nexus Operation Retry");
+  }
+
   // TODO(maxim): Add workflow retry on run timeout
   private void timeoutWorkflow() {
     lock.lock();
@@ -2738,6 +2899,12 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             .map(TestWorkflowMutableStateImpl::constructPendingActivityInfo)
             .collect(Collectors.toList());
 
+    List<PendingNexusOperationInfo> pendingNexusOperations =
+        this.nexusOperations.values().stream()
+            .filter(sm -> !isTerminalState(sm.getState()))
+            .map(TestWorkflowMutableStateImpl::constructPendingNexusOperationInfo)
+            .collect(Collectors.toList());
+
     List<PendingChildExecutionInfo> pendingChildren =
         this.childWorkflows.values().stream()
             .filter(sm -> !isTerminalState(sm.getState()))
@@ -2748,6 +2915,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         .setExecutionConfig(executionConfig)
         .setWorkflowExecutionInfo(executionInfo)
         .addAllPendingActivities(pendingActivities)
+        .addAllPendingNexusOperations(pendingNexusOperations)
         .addAllPendingChildren(pendingChildren)
         .build();
   }
@@ -2853,6 +3021,45 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         Preconditions.checkNotNull(
             retryState.getRetryPolicy(), "retryPolicy should always be present");
     builder.setMaximumAttempts(retryPolicy.getMaximumAttempts());
+  }
+
+  private static PendingNexusOperationInfo constructPendingNexusOperationInfo(
+      StateMachine<NexusOperationData> sm) {
+    NexusOperationData data = sm.getData();
+    PendingNexusOperationInfo.Builder builder =
+        PendingNexusOperationInfo.newBuilder()
+            .setEndpoint(data.scheduledEvent.getEndpoint())
+            .setService(data.scheduledEvent.getService())
+            .setOperation(data.scheduledEvent.getOperation())
+            .setOperationId(data.operationId)
+            .setScheduledEventId(data.scheduledEventId)
+            .setScheduleToCloseTimeout(data.scheduledEvent.getScheduleToCloseTimeout())
+            .setState(convertNexusOperationState(sm.getState(), data))
+            .setAttempt(data.getAttempt())
+            .setLastAttemptCompleteTime(Timestamps.fromMillis(data.lastAttemptCompleteTime))
+            .setNextAttemptScheduleTime(Timestamps.fromMillis(data.nextAttemptScheduleTime));
+
+    data.retryState.getPreviousRunFailure().ifPresent(builder::setLastAttemptFailure);
+
+    // TODO(pj): support cancellation info
+
+    return builder.build();
+  }
+
+  private static PendingNexusOperationState convertNexusOperationState(
+      State state, NexusOperationData data) {
+    // Terminal states have already been filtered out, so only handle pending states.
+    if (data.getAttempt() > 1) {
+      return PendingNexusOperationState.PENDING_NEXUS_OPERATION_STATE_BACKING_OFF;
+    }
+    switch (state) {
+      case INITIATED:
+        return PendingNexusOperationState.PENDING_NEXUS_OPERATION_STATE_SCHEDULED;
+      case STARTED:
+        return PendingNexusOperationState.PENDING_NEXUS_OPERATION_STATE_STARTED;
+      default:
+        return PendingNexusOperationState.PENDING_NEXUS_OPERATION_STATE_UNSPECIFIED;
+    }
   }
 
   private static void populateWorkflowExecutionInfoFromHistory(
@@ -2980,6 +3187,16 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     return activity;
   }
 
+  private StateMachine<NexusOperationData> getPendingNexusOperation(long scheduledEventId) {
+    StateMachine<NexusOperationData> operation = nexusOperations.get(scheduledEventId);
+    if (operation == null) {
+      throw Status.NOT_FOUND
+          .withDescription("unknown Nexus operation with scheduledEventId: " + scheduledEventId)
+          .asRuntimeException();
+    }
+    return operation;
+  }
+
   private StateMachine<ChildWorkflowData> getChildWorkflow(long initiatedEventId) {
     StateMachine<ChildWorkflowData> child = childWorkflows.get(initiatedEventId);
     if (child == null) {
@@ -3014,6 +3231,19 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
         throw Status.NOT_FOUND
             .withDescription(
                 "invalid activityID or activity already timed out or invoking workflow is completed")
+            .asRuntimeException();
+      }
+    }
+  }
+
+  private void throwIfOperationTokenDoesntMatch(ByteString taskToken, NexusOperationData data) {
+    if (!taskToken.isEmpty()) {
+      NexusTaskToken deserialized = NexusTaskToken.fromBytes(taskToken);
+      if (deserialized.getAttempt() != data.getAttempt()
+          || deserialized.getScheduledEventId() != data.scheduledEventId) {
+        throw Status.NOT_FOUND
+            .withDescription(
+                "invalid Nexus operationId or operation already timed out or workflow is completed")
             .asRuntimeException();
       }
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
@@ -23,12 +23,7 @@ package io.temporal.internal.testservice;
 import com.google.protobuf.Timestamp;
 import io.grpc.Deadline;
 import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
-import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
-import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueRequest;
-import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
-import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueRequest;
-import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.*;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -136,6 +131,24 @@ interface TestWorkflowStore {
     }
   }
 
+  class NexusTask {
+    private final TaskQueueId taskQueueId;
+    private final PollNexusTaskQueueResponse.Builder task;
+
+    public NexusTask(TaskQueueId taskQueueId, PollNexusTaskQueueResponse.Builder task) {
+      this.taskQueueId = taskQueueId;
+      this.task = task;
+    }
+
+    public TaskQueueId getTaskQueueId() {
+      return taskQueueId;
+    }
+
+    public PollNexusTaskQueueResponse.Builder getTask() {
+      return task;
+    }
+  }
+
   Timestamp currentTime();
 
   long save(RequestContext requestContext);
@@ -155,6 +168,9 @@ interface TestWorkflowStore {
    */
   Future<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
       PollActivityTaskQueueRequest pollRequest);
+
+  Future<PollNexusTaskQueueResponse.Builder> pollNexusTaskQueue(
+      PollNexusTaskQueueRequest pollRequest);
 
   void sendQueryTask(
       ExecutionId executionId, TaskQueueId taskQueue, PollWorkflowTaskQueueResponse.Builder task);

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusEndpointTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusEndpointTest.java
@@ -56,7 +56,7 @@ public class NexusEndpointTest {
   @Test
   public void testValidateEndpointSpec() {
     // Create and Update use same validation logic, so just test once
-    EndpointSpec.Builder specBuilder = getTestEndpointSpecBuilder("valid_name_01");
+    EndpointSpec.Builder specBuilder = getTestEndpointSpecBuilder("valid-name-01");
 
     // Valid
     Endpoint testEndpoint = createTestEndpoint(specBuilder);
@@ -77,11 +77,11 @@ public class NexusEndpointTest {
     assertEquals(
         "Nexus endpoint name ("
             + specBuilder.getName()
-            + ") does not match expected pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$",
+            + ") does not match expected pattern: ^[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9]$",
         ex.getStatus().getDescription());
 
     // Missing target
-    specBuilder.setName("valid_name_02");
+    specBuilder.setName("valid-name-02");
     specBuilder.clearTarget();
     ex = assertThrows(StatusRuntimeException.class, () -> createTestEndpoint(specBuilder));
     assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
@@ -100,7 +100,7 @@ public class NexusEndpointTest {
 
   @Test
   public void testCreate() {
-    EndpointSpec.Builder specBuilder = getTestEndpointSpecBuilder("valid_create_test_endpoint");
+    EndpointSpec.Builder specBuilder = getTestEndpointSpecBuilder("valid-create-test-endpoint");
 
     // Valid create
     Endpoint testEndpoint = createTestEndpoint(specBuilder);
@@ -119,7 +119,7 @@ public class NexusEndpointTest {
   @Test
   public void testUpdate() {
     // Setup
-    Endpoint testEndpoint = createTestEndpoint(getTestEndpointSpecBuilder("update_test_endpoint"));
+    Endpoint testEndpoint = createTestEndpoint(getTestEndpointSpecBuilder("update-test-endpoint"));
     assertEquals(1, testEndpoint.getVersion());
     EndpointSpec updatedSpec =
         EndpointSpec.newBuilder(testEndpoint.getSpec())
@@ -172,7 +172,7 @@ public class NexusEndpointTest {
         ex.getStatus().getDescription());
 
     // Updated name already registered
-    EndpointSpec.Builder otherSpec = getTestEndpointSpecBuilder("other_test_endpoint");
+    EndpointSpec.Builder otherSpec = getTestEndpointSpecBuilder("other-test-endpoint");
     createTestEndpoint(otherSpec);
     ex =
         assertThrows(
@@ -214,7 +214,7 @@ public class NexusEndpointTest {
   @Test
   public void testDelete() {
     // Setup
-    Endpoint testEndpoint = createTestEndpoint(getTestEndpointSpecBuilder("delete_test_endpoint"));
+    Endpoint testEndpoint = createTestEndpoint(getTestEndpointSpecBuilder("delete-test-endpoint"));
     assertEquals(1, testEndpoint.getVersion());
 
     // Not found
@@ -276,7 +276,7 @@ public class NexusEndpointTest {
   @Test
   public void testGet() {
     // Setup
-    Endpoint testEndpoint = createTestEndpoint(getTestEndpointSpecBuilder("get_test_endpoint"));
+    Endpoint testEndpoint = createTestEndpoint(getTestEndpointSpecBuilder("get-test-endpoint"));
     assertEquals(1, testEndpoint.getVersion());
 
     // Not found
@@ -311,7 +311,7 @@ public class NexusEndpointTest {
     // Setup
     List<Endpoint> testEndpoints = new ArrayList<>(3);
     for (int i = 0; i < 3; i++) {
-      testEndpoints.add(createTestEndpoint(getTestEndpointSpecBuilder("list_test_endpoint_" + i)));
+      testEndpoints.add(createTestEndpoint(getTestEndpointSpecBuilder("list-test-endpoint-" + i)));
     }
     testEndpoints.sort(Comparator.comparing(Endpoint::getId));
 
@@ -322,7 +322,7 @@ public class NexusEndpointTest {
             .getOperatorServiceStubs()
             .blockingStub()
             .listNexusEndpoints(
-                ListNexusEndpointsRequest.newBuilder().setName("some_missing_name").build());
+                ListNexusEndpointsRequest.newBuilder().setName("some-missing-name").build());
     assertEquals(0, resp.getEndpointsCount());
 
     // List with filter for existing name

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -20,6 +20,8 @@
 
 package io.temporal.testserver.functional;
 
+import static org.junit.Assume.assumeFalse;
+
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
 import io.temporal.api.command.v1.Command;
@@ -45,13 +47,23 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class NexusWorkflowTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setDoNotStart(true).setTestTimeoutSeconds(1000).build();
+      SDKTestWorkflowRule.newBuilder().setDoNotStart(true).build();
+
+  @Before
+  public void checkExternal() {
+    // TODO: remove this skip once 1.25.0 is officially released and
+    // https://github.com/temporalio/sdk-java/issues/2165 is resolved
+    assumeFalse(
+        "Nexus APIs are not supported for server versions < 1.25.0",
+        testWorkflowRule.isUseExternalService());
+  }
 
   @Test
   public void testNexusOperationSyncCompletion() {

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.testserver.functional;
+
+import com.google.protobuf.ByteString;
+import io.temporal.api.command.v1.Command;
+import io.temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes;
+import io.temporal.api.command.v1.ScheduleNexusOperationCommandAttributes;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.CommandType;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.enums.v1.TaskQueueKind;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.nexus.v1.*;
+import io.temporal.api.operatorservice.v1.CreateNexusEndpointRequest;
+import io.temporal.api.taskqueue.v1.TaskQueue;
+import io.temporal.api.workflowservice.v1.*;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NexusWorkflowTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setDoNotStart(true).build();
+
+  @Test
+  public void testNexusOperationSyncCompletion() {
+    Endpoint testEndpoint = createEndpoint("test-sync-completion-endpoint");
+    CompletableFuture<Void> nexusPoller = CompletableFuture.runAsync(pollAndCompleteNexusTask());
+
+    try {
+      WorkflowOptions options =
+          WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build();
+      WorkflowStub stub =
+          testWorkflowRule
+              .getWorkflowClient()
+              .newUntypedWorkflowStub("TestNexusOperationSyncCompletionWorkflow", options);
+      WorkflowExecution execution = stub.start();
+
+      // Get first WFT and respond with ScheduleNexusOperation command
+      PollWorkflowTaskQueueResponse pollResp =
+          testWorkflowRule
+              .getWorkflowClient()
+              .getWorkflowServiceStubs()
+              .blockingStub()
+              .pollWorkflowTaskQueue(
+                  PollWorkflowTaskQueueRequest.newBuilder()
+                      .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+                      .setTaskQueue(
+                          TaskQueue.newBuilder()
+                              .setName(testWorkflowRule.getTaskQueue())
+                              .setKind(TaskQueueKind.TASK_QUEUE_KIND_NORMAL))
+                      .setIdentity("test")
+                      .build());
+      testWorkflowRule
+          .getWorkflowClient()
+          .getWorkflowServiceStubs()
+          .blockingStub()
+          .respondWorkflowTaskCompleted(
+              RespondWorkflowTaskCompletedRequest.newBuilder()
+                  .setIdentity("test")
+                  .setTaskToken(pollResp.getTaskToken())
+                  .addCommands(
+                      Command.newBuilder()
+                          .setCommandType(CommandType.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION)
+                          .setScheduleNexusOperationCommandAttributes(
+                              ScheduleNexusOperationCommandAttributes.newBuilder()
+                                  .setEndpoint(testEndpoint.getSpec().getName())
+                                  .setService("service")
+                                  .setOperation("operation")
+                                  .setInput(
+                                      Payload.newBuilder()
+                                          .setData(ByteString.copyFromUtf8("input"))))
+                          .build())
+                  .build());
+
+      // Wait for Nexus operation result to be recorded
+      nexusPoller.get(2, TimeUnit.SECONDS);
+
+      pollResp =
+          testWorkflowRule
+              .getWorkflowClient()
+              .getWorkflowServiceStubs()
+              .blockingStub()
+              .pollWorkflowTaskQueue(
+                  PollWorkflowTaskQueueRequest.newBuilder()
+                      .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+                      .setTaskQueue(
+                          TaskQueue.newBuilder()
+                              .setName(testWorkflowRule.getTaskQueue())
+                              .setKind(TaskQueueKind.TASK_QUEUE_KIND_NORMAL))
+                      .setIdentity("test")
+                      .build());
+      Assert.assertTrue(
+          pollResp.getHistory().getEventsList().stream()
+              .anyMatch(
+                  event -> event.getEventType() == EventType.EVENT_TYPE_NEXUS_OPERATION_COMPLETED));
+      List<HistoryEvent> events =
+          testWorkflowRule.getHistoryEvents(
+              execution.getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_COMPLETED);
+      Assert.assertEquals(1, events.size());
+      HistoryEvent completedEvent = events.get(0);
+
+      testWorkflowRule
+          .getWorkflowClient()
+          .getWorkflowServiceStubs()
+          .blockingStub()
+          .respondWorkflowTaskCompleted(
+              RespondWorkflowTaskCompletedRequest.newBuilder()
+                  .setIdentity("test")
+                  .setTaskToken(pollResp.getTaskToken())
+                  .addCommands(
+                      Command.newBuilder()
+                          .setCommandType(CommandType.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION)
+                          .setCompleteWorkflowExecutionCommandAttributes(
+                              CompleteWorkflowExecutionCommandAttributes.newBuilder()
+                                  .setResult(
+                                      Payloads.newBuilder()
+                                          .addPayloads(
+                                              completedEvent
+                                                  .getNexusOperationCompletedEventAttributes()
+                                                  .getResult()))))
+                  .build());
+
+      String result = stub.getResult(String.class);
+      Assert.assertEquals(result, "input");
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+    } finally {
+      nexusPoller.cancel(true);
+    }
+  }
+
+  private Runnable pollAndCompleteNexusTask() {
+    return () -> {
+      PollNexusTaskQueueResponse pollResp =
+          testWorkflowRule
+              .getWorkflowClient()
+              .getWorkflowServiceStubs()
+              .blockingStub()
+              .pollNexusTaskQueue(
+                  PollNexusTaskQueueRequest.newBuilder()
+                      .setIdentity(UUID.randomUUID().toString())
+                      .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+                      .setTaskQueue(
+                          TaskQueue.newBuilder()
+                              .setName(testWorkflowRule.getTaskQueue())
+                              .setKind(TaskQueueKind.TASK_QUEUE_KIND_NORMAL))
+                      .build());
+
+      testWorkflowRule
+          .getWorkflowClient()
+          .getWorkflowServiceStubs()
+          .blockingStub()
+          .respondNexusTaskCompleted(
+              RespondNexusTaskCompletedRequest.newBuilder()
+                  .setIdentity(UUID.randomUUID().toString())
+                  .setNamespace(testWorkflowRule.getTestEnvironment().getNamespace())
+                  .setTaskToken(pollResp.getTaskToken())
+                  .setResponse(
+                      Response.newBuilder()
+                          .setStartOperation(
+                              StartOperationResponse.newBuilder()
+                                  .setSyncSuccess(
+                                      StartOperationResponse.Sync.newBuilder()
+                                          .setPayload(
+                                              pollResp
+                                                  .getRequest()
+                                                  .getStartOperation()
+                                                  .getPayload()))))
+                  .build());
+    };
+  }
+
+  private Endpoint createEndpoint(String name) {
+    return testWorkflowRule
+        .getTestEnvironment()
+        .getOperatorServiceStubs()
+        .blockingStub()
+        .createNexusEndpoint(
+            CreateNexusEndpointRequest.newBuilder()
+                .setSpec(
+                    EndpointSpec.newBuilder()
+                        .setName(name)
+                        .setDescription(
+                            Payload.newBuilder().setData(ByteString.copyFromUtf8("test endpoint")))
+                        .setTarget(
+                            EndpointTarget.newBuilder()
+                                .setWorker(
+                                    EndpointTarget.Worker.newBuilder()
+                                        .setNamespace(
+                                            testWorkflowRule.getTestEnvironment().getNamespace())
+                                        .setTaskQueue(testWorkflowRule.getTaskQueue()))))
+                .build())
+        .getEndpoint();
+  }
+}


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added test server support for Nexus operation commands, including sync completion, timeouts, failures, and retries. Added most of the stubs for implementing asynchronous operations in followup PRs.

The test server will only support worker targets, not external, so there is no added logic for making HTTP requests.
The implementation largely follows the same design as ActivityTasks.
