### PR TITLE
Improve test time and flaky schedule test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
   unit_test_jdk8:
     name: Unit test with docker service [JDK8]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
     steps:
     - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   unit_test_edge:
     name: Unit test with in-memory test service [Edge]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
     steps:
     - name: Checkout repo

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   code-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -58,7 +58,7 @@ subprojects {
         }
         forkEvery = 1
 
-        var coresDivider = project.hasProperty("jacoco") ? 4 : 2 // penalize jacoco build to reduce load and random timeouts
+        var coresDivider = 4
         maxParallelForks = Math.max(Runtime.runtime.availableProcessors().intdiv(coresDivider), 1) ?: 1
 
         // Captures the list of failed tests to log after build is done.

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -58,7 +58,7 @@ subprojects {
         }
         forkEvery = 1
 
-        var coresDivider = 4
+        var coresDivider = project.hasProperty("jacoco") ? 4 : 2 // penalize jacoco build to reduce load and random timeouts
         maxParallelForks = Math.max(Runtime.runtime.availableProcessors().intdiv(coresDivider), 1) ?: 1
 
         // Captures the list of failed tests to log after build is done.

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -260,8 +260,7 @@ public class ScheduleTest {
 
   @Test(timeout = 30000)
   public void backfillSchedules() {
-    // assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
-    Instant now = Instant.now();
+    Instant now = Instant.ofEpochSecond(100000);
     ScheduleClient client = createScheduleClient();
     // Create schedule
     ScheduleOptions options =

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -260,13 +260,13 @@ public class ScheduleTest {
 
   @Test(timeout = 30000)
   public void backfillSchedules() {
-    Instant now = Instant.ofEpochSecond(100000);
+    Instant backfillTime = Instant.ofEpochSecond(100000);
     ScheduleClient client = createScheduleClient();
     // Create schedule
     ScheduleOptions options =
         ScheduleOptions.newBuilder()
             .setBackfills(
-                Arrays.asList(new ScheduleBackfill(now.minusMillis(20500), now.minusMillis(10000))))
+                Arrays.asList(new ScheduleBackfill(backfillTime.minusMillis(20500), backfillTime.minusMillis(10000))))
             .build();
     String scheduleId = UUID.randomUUID().toString();
     Schedule schedule =
@@ -282,8 +282,8 @@ public class ScheduleTest {
 
     handle.backfill(
         Arrays.asList(
-            new ScheduleBackfill(now.minusMillis(5500), now.minusMillis(2500)),
-            new ScheduleBackfill(now.minusMillis(2500), now)));
+            new ScheduleBackfill(backfillTime.minusMillis(5500), backfillTime.minusMillis(2500)),
+            new ScheduleBackfill(backfillTime.minusMillis(2500), backfillTime)));
     waitForActions(handle, 15);
     // Cleanup schedule
     handle.delete();
@@ -291,8 +291,8 @@ public class ScheduleTest {
     try {
       handle.backfill(
           Arrays.asList(
-              new ScheduleBackfill(now.minusMillis(5500), now.minusMillis(2500)),
-              new ScheduleBackfill(now.minusMillis(2500), now)));
+              new ScheduleBackfill(backfillTime.minusMillis(5500), backfillTime.minusMillis(2500)),
+              new ScheduleBackfill(backfillTime.minusMillis(2500), backfillTime)));
       Assert.fail();
     } catch (ScheduleException e) {
     }

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -266,7 +266,9 @@ public class ScheduleTest {
     ScheduleOptions options =
         ScheduleOptions.newBuilder()
             .setBackfills(
-                Arrays.asList(new ScheduleBackfill(backfillTime.minusMillis(20500), backfillTime.minusMillis(10000))))
+                Arrays.asList(
+                    new ScheduleBackfill(
+                        backfillTime.minusMillis(20500), backfillTime.minusMillis(10000))))
             .build();
     String scheduleId = UUID.randomUUID().toString();
     Schedule schedule =


### PR DESCRIPTION
Java SDK test time was approaching 25 min, talked with Josh and we decided to try using larger runners to cut down on the test time for now.
