### PR TITLE
Adding attempt number into MDC context for better diagnosing

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/logging/LoggerTag.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/logging/LoggerTag.java
@@ -37,4 +37,5 @@ public final class LoggerTag {
   public static final String WORKER_TYPE = "WorkerType";
   public static final String SIDE_EFFECT_ID = "SideEffectId";
   public static final String CHILD_WORKFLOW_ID = "ChildWorkflowId";
+  public static final String ATTEMPT = "Attempt";
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -247,6 +247,7 @@ final class ActivityWorker implements SuspendableWorker {
       MDC.put(LoggerTag.WORKFLOW_ID, pollResponse.getWorkflowExecution().getWorkflowId());
       MDC.put(LoggerTag.WORKFLOW_TYPE, pollResponse.getWorkflowType().getName());
       MDC.put(LoggerTag.RUN_ID, pollResponse.getWorkflowExecution().getRunId());
+      MDC.put(LoggerTag.ATTEMPT, Integer.toString(pollResponse.getAttempt()));
 
       ActivityTaskHandler.Result result = null;
       try {
@@ -257,6 +258,7 @@ final class ActivityWorker implements SuspendableWorker {
         MDC.remove(LoggerTag.WORKFLOW_ID);
         MDC.remove(LoggerTag.WORKFLOW_TYPE);
         MDC.remove(LoggerTag.RUN_ID);
+        MDC.remove(LoggerTag.ATTEMPT);
         if (
         // handleActivity throw an exception (not a normal scenario)
         result == null

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -441,6 +441,7 @@ final class LocalActivityWorker implements Startable, Shutdownable {
         MDC.put(LoggerTag.WORKFLOW_ID, activityTask.getWorkflowExecution().getWorkflowId());
         MDC.put(LoggerTag.WORKFLOW_TYPE, activityTask.getWorkflowType().getName());
         MDC.put(LoggerTag.RUN_ID, activityTask.getWorkflowExecution().getRunId());
+        MDC.put(LoggerTag.ATTEMPT, Integer.toString(activityTask.getAttempt()));
 
         slotSupplier.markSlotUsed(
             new LocalActivitySlotInfo(
@@ -506,6 +507,7 @@ final class LocalActivityWorker implements Startable, Shutdownable {
         MDC.remove(LoggerTag.WORKFLOW_ID);
         MDC.remove(LoggerTag.WORKFLOW_TYPE);
         MDC.remove(LoggerTag.RUN_ID);
+        MDC.remove(LoggerTag.ATTEMPT);
       }
     }
 


### PR DESCRIPTION
## What was changed
Added a new LoggerTag for the Attempt number for LocalActivityWorker, ActivityWorker and WorkflowWorker.

## Why?
When diagnosing logs it's quite useful to have this value, specially when executions may overlap each other.

## Checklist

1. Closes https://github.com/temporalio/sdk-java/issues/2192

2. How was this tested:
Run tests locally, change is quite simple, I didn't do further testing.

3. Any docs updates needed?
I didn't find it required. Am I missing something?
