### PR TITLE
Fix shutdown behavior of unstarted LA slot queue

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -689,6 +689,7 @@ final class LocalActivityWorker implements Startable, Shutdownable {
               false);
 
       this.workerMetricsScope.counter(MetricsType.WORKER_START_COUNTER).inc(1);
+      this.slotQueue.start();
       return true;
     } else {
       return false;
@@ -698,9 +699,9 @@ final class LocalActivityWorker implements Startable, Shutdownable {
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
     if (activityAttemptTaskExecutor != null && !activityAttemptTaskExecutor.isShutdown()) {
-      slotQueue.shutdown();
-      return activityAttemptTaskExecutor
+      return slotQueue
           .shutdown(shutdownManager, interruptTasks)
+          .thenCompose(r -> activityAttemptTaskExecutor.shutdown(shutdownManager, interruptTasks))
           .thenCompose(
               r ->
                   shutdownManager.shutdownExecutor(
@@ -717,21 +718,24 @@ final class LocalActivityWorker implements Startable, Shutdownable {
 
   @Override
   public void awaitTermination(long timeout, TimeUnit unit) {
-    slotQueue.shutdown();
     long timeoutMillis = unit.toMillis(timeout);
-    ShutdownManager.awaitTermination(scheduledExecutor, timeoutMillis);
+    long remainingTimeout = ShutdownManager.awaitTermination(scheduledExecutor, timeoutMillis);
+    ShutdownManager.awaitTermination(slotQueue, remainingTimeout);
   }
 
   @Override
   public boolean isShutdown() {
-    return activityAttemptTaskExecutor != null && activityAttemptTaskExecutor.isShutdown();
+    return activityAttemptTaskExecutor != null
+        && activityAttemptTaskExecutor.isShutdown()
+        && slotQueue.isShutdown();
   }
 
   @Override
   public boolean isTerminated() {
     return activityAttemptTaskExecutor != null
         && activityAttemptTaskExecutor.isTerminated()
-        && scheduledExecutor.isTerminated();
+        && scheduledExecutor.isTerminated()
+        && slotQueue.isTerminated();
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/worker/LocalActivityWorkerNoneRegisteredNotStartedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/LocalActivityWorkerNoneRegisteredNotStartedTest.java
@@ -26,20 +26,18 @@ import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
-import io.temporal.workflow.shared.TestActivities;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class LocalActivityWorkerNotStartedTest {
+public class LocalActivityWorkerNoneRegisteredNotStartedTest {
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(NothingWorkflowImpl.class)
-          .setActivityImplementations(new NothingActivityImpl())
           .setWorkerOptions(WorkerOptions.newBuilder().setLocalActivityWorkerOnly(true).build())
           // Don't start the worker
           .setDoNotStart(true)
@@ -73,10 +71,5 @@ public class LocalActivityWorkerNotStartedTest {
     public void execute() {
       Workflow.sleep(500);
     }
-  }
-
-  public static class NothingActivityImpl implements TestActivities.NoArgsActivity {
-    @Override
-    public void execute() {}
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/worker/LocalActivityWorkerNotStartedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/LocalActivityWorkerNotStartedTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LocalActivityWorkerNotStartedTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(NothingWorkflowImpl.class)
+          .setWorkerOptions(WorkerOptions.newBuilder().setLocalActivityWorkerOnly(true).build())
+          // Don't start the worker
+          .setDoNotStart(true)
+          .build();
+
+  @Test
+  public void canShutDownProperlyWhenNotStarted() {
+    // Shut down the (never started) worker
+    testWorkflowRule.getTestEnvironment().getWorkerFactory().shutdown();
+    testWorkflowRule.getWorker().awaitTermination(1, java.util.concurrent.TimeUnit.SECONDS);
+    Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+    for (Thread thread : threadSet) {
+      if (thread.getName().contains("LocalActivitySlotSupplierQueue")) {
+        throw new RuntimeException("Thread should be terminated");
+      }
+    }
+  }
+
+  @WorkflowInterface
+  public interface NothingWorkflow {
+    @WorkflowMethod
+    void execute();
+  }
+
+  public static class NothingWorkflowImpl implements NothingWorkflow {
+    @Override
+    public void execute() {
+      Workflow.sleep(500);
+    }
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed a possible hang when shutting down a never-started worker, as well as normalized the shutdown of this slot queue to look more like other things.

## Why?
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/2194

2. How was this tested:
Added tests, and there are a number of existing tests covering shutdown with running LAs

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
