### PR TITLE
Test server support for async Nexus operations

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
@@ -27,7 +27,7 @@ import java.io.*;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-class NexusOperationRef {
+public class NexusOperationRef {
 
   @Nonnull private final ExecutionId executionId;
   private final long scheduledEventId;
@@ -94,7 +94,7 @@ class NexusOperationRef {
     }
   }
 
-  static NexusOperationRef fromBytes(ByteString serialized) {
+  public static NexusOperationRef fromBytes(ByteString serialized) {
     ByteArrayInputStream bin = new ByteArrayInputStream(serialized.toByteArray());
     DataInputStream in = new DataInputStream(bin);
     try {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
@@ -1,23 +1,3 @@
-/*
- * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
- *
- * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Modifications copyright (C) 2017 Uber Technologies, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this material except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.temporal.internal.testservice;
 
 import com.google.protobuf.ByteString;
@@ -31,46 +11,31 @@ public class NexusOperationRef {
 
   @Nonnull private final ExecutionId executionId;
   private final long scheduledEventId;
-  private final int attempt;
-  private final boolean isCancel;
 
   NexusOperationRef(
-      @Nonnull String namespace,
-      @Nonnull WorkflowExecution execution,
-      long scheduledEventId,
-      int attempt,
-      boolean isCancel) {
+      @Nonnull String namespace, @Nonnull WorkflowExecution execution, long scheduledEventId) {
     this(
         new ExecutionId(Objects.requireNonNull(namespace), Objects.requireNonNull(execution)),
-        scheduledEventId,
-        attempt,
-        isCancel);
+        scheduledEventId);
   }
 
   NexusOperationRef(
       @Nonnull String namespace,
       @Nonnull String workflowId,
       @Nonnull String runId,
-      long scheduledEventId,
-      int attempt,
-      boolean isCancel) {
+      long scheduledEventId) {
     this(
         namespace,
         WorkflowExecution.newBuilder()
             .setWorkflowId(Objects.requireNonNull(workflowId))
             .setRunId(Objects.requireNonNull(runId))
             .build(),
-        scheduledEventId,
-        attempt,
-        isCancel);
+        scheduledEventId);
   }
 
-  public NexusOperationRef(
-      @Nonnull ExecutionId executionId, long scheduledEventId, int attempt, boolean isCancel) {
+  public NexusOperationRef(@Nonnull ExecutionId executionId, long scheduledEventId) {
     this.executionId = Objects.requireNonNull(executionId);
     this.scheduledEventId = scheduledEventId;
-    this.attempt = attempt;
-    this.isCancel = isCancel;
   }
 
   public ExecutionId getExecutionId() {
@@ -81,15 +46,6 @@ public class NexusOperationRef {
     return scheduledEventId;
   }
 
-  public long getAttempt() {
-    return attempt;
-  }
-
-  public boolean isCancel() {
-    return isCancel;
-  }
-
-  /** Used for task tokens. */
   public ByteString toBytes() {
     try (ByteArrayOutputStream bout = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bout)) {
@@ -98,8 +54,6 @@ public class NexusOperationRef {
       out.writeUTF(execution.getWorkflowId());
       out.writeUTF(execution.getRunId());
       out.writeLong(scheduledEventId);
-      out.writeInt(attempt);
-      out.writeBoolean(isCancel);
       return ByteString.copyFrom(bout.toByteArray());
     } catch (IOException e) {
       throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
@@ -107,17 +61,18 @@ public class NexusOperationRef {
   }
 
   public static NexusOperationRef fromBytes(ByteString serialized) {
-    ByteArrayInputStream bin = new ByteArrayInputStream(serialized.toByteArray());
+    return fromBytes(serialized.toByteArray());
+  }
+
+  public static NexusOperationRef fromBytes(byte[] serialized) {
+    ByteArrayInputStream bin = new ByteArrayInputStream(serialized);
     DataInputStream in = new DataInputStream(bin);
     try {
       String namespace = in.readUTF();
       String workflowId = in.readUTF();
       String runId = in.readUTF();
       long scheduledEventId = in.readLong();
-      int attempt = in.readInt();
-      boolean isCancel = in.readBoolean();
-      return new NexusOperationRef(
-          namespace, workflowId, runId, scheduledEventId, attempt, isCancel);
+      return new NexusOperationRef(namespace, workflowId, runId, scheduledEventId);
     } catch (IOException e) {
       throw Status.INVALID_ARGUMENT
           .withCause(e)

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
@@ -27,13 +27,13 @@ import java.io.*;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-class NexusTaskToken {
+class NexusOperationRef {
 
   @Nonnull private final ExecutionId executionId;
   private final long scheduledEventId;
   private final int attempt;
 
-  NexusTaskToken(
+  NexusOperationRef(
       @Nonnull String namespace,
       @Nonnull WorkflowExecution execution,
       long scheduledEventId,
@@ -44,7 +44,7 @@ class NexusTaskToken {
         attempt);
   }
 
-  NexusTaskToken(
+  NexusOperationRef(
       @Nonnull String namespace,
       @Nonnull String workflowId,
       @Nonnull String runId,
@@ -60,7 +60,7 @@ class NexusTaskToken {
         attempt);
   }
 
-  NexusTaskToken(@Nonnull ExecutionId executionId, long scheduledEventId, int attempt) {
+  NexusOperationRef(@Nonnull ExecutionId executionId, long scheduledEventId, int attempt) {
     this.executionId = Objects.requireNonNull(executionId);
     this.scheduledEventId = scheduledEventId;
     this.attempt = attempt;
@@ -94,7 +94,7 @@ class NexusTaskToken {
     }
   }
 
-  static NexusTaskToken fromBytes(ByteString serialized) {
+  static NexusOperationRef fromBytes(ByteString serialized) {
     ByteArrayInputStream bin = new ByteArrayInputStream(serialized.toByteArray());
     DataInputStream in = new DataInputStream(bin);
     try {
@@ -103,7 +103,7 @@ class NexusTaskToken {
       String runId = in.readUTF();
       long scheduledEventId = in.readLong();
       int attempt = in.readInt();
-      return new NexusTaskToken(namespace, workflowId, runId, scheduledEventId, attempt);
+      return new NexusOperationRef(namespace, workflowId, runId, scheduledEventId, attempt);
     } catch (IOException e) {
       throw Status.INVALID_ARGUMENT
           .withCause(e)

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusOperationRef.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.internal.testservice;
 
 import com.google.protobuf.ByteString;

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/NexusTaskToken.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.testservice;
+
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.temporal.api.common.v1.WorkflowExecution;
+import java.io.*;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+public class NexusTaskToken {
+
+  @Nonnull private final NexusOperationRef ref;
+  private final int attempt;
+  private final boolean isCancel;
+
+  NexusTaskToken(
+      @Nonnull String namespace,
+      @Nonnull WorkflowExecution execution,
+      long scheduledEventId,
+      int attempt,
+      boolean isCancel) {
+    this(
+        new ExecutionId(Objects.requireNonNull(namespace), Objects.requireNonNull(execution)),
+        scheduledEventId,
+        attempt,
+        isCancel);
+  }
+
+  NexusTaskToken(
+      @Nonnull String namespace,
+      @Nonnull String workflowId,
+      @Nonnull String runId,
+      long scheduledEventId,
+      int attempt,
+      boolean isCancel) {
+    this(
+        namespace,
+        WorkflowExecution.newBuilder()
+            .setWorkflowId(Objects.requireNonNull(workflowId))
+            .setRunId(Objects.requireNonNull(runId))
+            .build(),
+        scheduledEventId,
+        attempt,
+        isCancel);
+  }
+
+  NexusTaskToken(
+      @Nonnull ExecutionId executionId, long scheduledEventId, int attempt, boolean isCancel) {
+    this(
+        new NexusOperationRef(Objects.requireNonNull(executionId), scheduledEventId),
+        attempt,
+        isCancel);
+  }
+
+  public NexusTaskToken(@Nonnull NexusOperationRef ref, int attempt, boolean isCancel) {
+    this.ref = Objects.requireNonNull(ref);
+    this.attempt = attempt;
+    this.isCancel = isCancel;
+  }
+
+  public NexusOperationRef getOperationRef() {
+    return ref;
+  }
+
+  public long getAttempt() {
+    return attempt;
+  }
+
+  public boolean isCancel() {
+    return isCancel;
+  }
+
+  /** Used for task tokens. */
+  public ByteString toBytes() {
+    try (ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bout)) {
+      ExecutionId executionId = ref.getExecutionId();
+      out.writeUTF(executionId.getNamespace());
+      WorkflowExecution execution = executionId.getExecution();
+      out.writeUTF(execution.getWorkflowId());
+      out.writeUTF(execution.getRunId());
+      out.writeLong(ref.getScheduledEventId());
+      out.writeInt(attempt);
+      out.writeBoolean(isCancel);
+      return ByteString.copyFrom(bout.toByteArray());
+    } catch (IOException e) {
+      throw Status.INTERNAL.withCause(e).withDescription(e.getMessage()).asRuntimeException();
+    }
+  }
+
+  public static NexusTaskToken fromBytes(ByteString serialized) {
+    ByteArrayInputStream bin = new ByteArrayInputStream(serialized.toByteArray());
+    DataInputStream in = new DataInputStream(bin);
+    try {
+      String namespace = in.readUTF();
+      String workflowId = in.readUTF();
+      String runId = in.readUTF();
+      long scheduledEventId = in.readLong();
+      int attempt = in.readInt();
+      boolean isCancel = in.readBoolean();
+      return new NexusTaskToken(namespace, workflowId, runId, scheduledEventId, attempt, isCancel);
+    } catch (IOException e) {
+      throw Status.INVALID_ARGUMENT
+          .withCause(e)
+          .withDescription(e.getMessage())
+          .asRuntimeException();
+    }
+  }
+}

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -871,12 +871,12 @@ class StateMachines {
                     .setWorkflowTaskCompletedEventId(workflowTaskCompletedId))
             .build());
 
-    NexusTaskToken ref =
+    NexusTaskToken taskToken =
         new NexusTaskToken(ctx.getExecutionId(), data.scheduledEventId, data.getAttempt(), true);
 
     PollNexusTaskQueueResponse.Builder pollResponse =
         PollNexusTaskQueueResponse.newBuilder()
-            .setTaskToken(ref.toBytes())
+            .setTaskToken(taskToken.toBytes())
             .setRequest(
                 io.temporal.api.nexus.v1.Request.newBuilder()
                     .setCancelOperation(

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -341,7 +341,7 @@ class StateMachines {
 
   static final class NexusOperationData {
     // Timeout for an individual Start or Cancel Operation request.
-    final java.time.Duration requestTimeout = java.time.Duration.ofSeconds(5);
+    final java.time.Duration requestTimeout = java.time.Duration.ofSeconds(10);
 
     String operationId;
     Endpoint endpoint;
@@ -614,6 +614,7 @@ class StateMachines {
         .add(INITIATED, START, STARTED, StateMachines::startNexusOperation)
         .add(INITIATED, TIME_OUT, TIMED_OUT, StateMachines::timeoutNexusOperation)
         // Transitions directly to CANCELED if operation has not been started
+        // TODO: properly support cancel before start
         .add(
             INITIATED,
             REQUEST_CANCELLATION,

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
@@ -22,16 +22,13 @@ package io.temporal.internal.testservice;
 
 import io.grpc.Deadline;
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
+import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.enums.v1.SignalExternalWorkflowExecutionFailedCause;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
-import io.temporal.api.history.v1.ChildWorkflowExecutionCanceledEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionCompletedEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionFailedEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionStartedEventAttributes;
-import io.temporal.api.history.v1.ChildWorkflowExecutionTimedOutEventAttributes;
-import io.temporal.api.history.v1.ExternalWorkflowExecutionCancelRequestedEventAttributes;
-import io.temporal.api.history.v1.StartChildWorkflowExecutionFailedEventAttributes;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.history.v1.*;
+import io.temporal.api.nexus.v1.StartOperationResponse;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.workflowservice.v1.*;
 import java.util.Optional;
@@ -111,11 +108,14 @@ interface TestWorkflowMutableState {
 
   void cancelActivityTaskById(String id, RespondActivityTaskCanceledByIdRequest canceledRequest);
 
-  void startNexusTask(long scheduledEventId, RespondNexusTaskCompletedRequest request);
+  void startNexusOperation(
+      long scheduledEventId, String clientIdentity, StartOperationResponse.Async resp);
 
-  void completeNexusTask(long scheduledEventId, RespondNexusTaskCompletedRequest request);
+  void cancelNexusOperation(NexusOperationRef ref);
 
-  void failNexusTask(long scheduledEventId, RespondNexusTaskFailedRequest request);
+  void completeNexusOperation(NexusOperationRef ref, Payload result);
+
+  void failNexusOperation(NexusOperationRef ref, Failure failure);
 
   QueryWorkflowResponse query(QueryWorkflowRequest queryRequest, long deadline);
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
@@ -111,11 +111,13 @@ interface TestWorkflowMutableState {
   void startNexusOperation(
       long scheduledEventId, String clientIdentity, StartOperationResponse.Async resp);
 
-  void cancelNexusOperation(NexusOperationRef ref);
+  void cancelNexusOperation(NexusOperationRef ref, Failure failure);
 
   void completeNexusOperation(NexusOperationRef ref, Payload result);
 
   void failNexusOperation(NexusOperationRef ref, Failure failure);
+
+  boolean validateOperationTaskToken(NexusTaskToken tt);
 
   QueryWorkflowResponse query(QueryWorkflowRequest queryRequest, long deadline);
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -759,9 +759,9 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     State before = operation.getState();
     operation.action(Action.REQUEST_CANCELLATION, ctx, attr, workflowTaskCompletedId);
     if (before == State.INITIATED) {
-      // request is null here, because it's caused not by a separate cancel request, but by a
-      // command
-      operation.action(Action.CANCEL, ctx, null, 0);
+      // Operation canceled before started, so immediately remove operation since no new
+      // cancellation task
+      // will be generated.
       nexusOperations.remove(scheduleEventId);
       ctx.setNeedWorkflowTask(true);
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -709,7 +709,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       RequestContext ctx,
       ScheduleNexusOperationCommandAttributes attr,
       long workflowTaskCompletedId) {
-    attr = validateScheduleNexusOperation(attr);
     Endpoint endpoint = nexusEndpointStore.getEndpointByName(attr.getEndpoint());
     StateMachine<StateMachines.NexusOperationData> operation = newNexusOperation(endpoint);
     long scheduleEventId = ctx.getNextEventId();
@@ -733,16 +732,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           "NexusOperation ScheduleToCloseTimeout");
     }
     ctx.lockTimer("processScheduleNexusOperation");
-  }
-
-  private ScheduleNexusOperationCommandAttributes validateScheduleNexusOperation(
-      ScheduleNexusOperationCommandAttributes attr) {
-    ScheduleNexusOperationCommandAttributes.Builder result =
-        ScheduleNexusOperationCommandAttributes.newBuilder(attr);
-
-    // TODO: extra validation
-
-    return result.build();
   }
 
   private void processRequestCancelNexusOperation(

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -38,9 +38,12 @@ import io.temporal.api.common.v1.RetryPolicy;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.*;
 import io.temporal.api.errordetails.v1.WorkflowExecutionAlreadyStartedFailure;
+import io.temporal.api.failure.v1.ApplicationFailureInfo;
 import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.WorkflowExecutionContinuedAsNewEventAttributes;
 import io.temporal.api.namespace.v1.NamespaceInfo;
+import io.temporal.api.nexus.v1.StartOperationResponse;
 import io.temporal.api.testservice.v1.LockTimeSkippingRequest;
 import io.temporal.api.testservice.v1.SleepRequest;
 import io.temporal.api.testservice.v1.UnlockTimeSkippingRequest;
@@ -59,6 +62,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -749,7 +753,6 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       PollNexusTaskQueueRequest request,
       StreamObserver<PollNexusTaskQueueResponse> responseObserver) {
     try (Context.CancellableContext ctx = deadlineCtx(getLongPollDeadline())) {
-
       PollNexusTaskQueueResponse.Builder task;
       try {
         task = pollTaskQueue(ctx, store.pollNexusTaskQueue(request));
@@ -766,7 +769,6 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         responseObserver.onCompleted();
         return;
       }
-
       responseObserver.onNext(task.build());
       responseObserver.onCompleted();
     }
@@ -777,14 +779,31 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       RespondNexusTaskCompletedRequest request,
       StreamObserver<RespondNexusTaskCompletedResponse> responseObserver) {
     try {
-      NexusTaskToken taskToken = NexusTaskToken.fromBytes(request.getTaskToken());
-      TestWorkflowMutableState mutableState = getMutableState(taskToken.getExecutionId());
-      if (request.getResponse().hasStartOperation()
-          && request.getResponse().getStartOperation().hasAsyncSuccess()) {
-        // Start event is only recorded for async success
-        mutableState.startNexusTask(taskToken.getScheduledEventId(), request);
+      NexusOperationRef ref = NexusOperationRef.fromBytes(request.getTaskToken());
+      TestWorkflowMutableState mutableState = getMutableState(ref.getExecutionId());
+      if (request.getResponse().hasCancelOperation()) {
+        mutableState.cancelNexusOperation(ref);
+      } else if (request.getResponse().hasStartOperation()) {
+        StartOperationResponse startResp = request.getResponse().getStartOperation();
+        if (startResp.hasOperationError()) {
+          Failure failure =
+              nexusFailureToApplicationFailure(startResp.getOperationError().getFailure());
+          mutableState.failNexusOperation(ref, failure);
+        } else if (startResp.hasAsyncSuccess()) {
+          // Start event is only recorded for async success
+          mutableState.startNexusOperation(
+              ref.getScheduledEventId(), request.getIdentity(), startResp.getAsyncSuccess());
+        } else if (startResp.hasSyncSuccess()) {
+          mutableState.completeNexusOperation(ref, startResp.getSyncSuccess().getPayload());
+        } else {
+          throw Status.INVALID_ARGUMENT
+              .withDescription("Expected success or OperationError to be set on request.")
+              .asRuntimeException();
+        }
       } else {
-        mutableState.completeNexusTask(taskToken.getScheduledEventId(), request);
+        throw Status.INVALID_ARGUMENT
+            .withDescription("Expected StartOperation or CancelOperation to be set on request.")
+            .asRuntimeException();
       }
       responseObserver.onNext(RespondNexusTaskCompletedResponse.getDefaultInstance());
       responseObserver.onCompleted();
@@ -798,14 +817,95 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       RespondNexusTaskFailedRequest request,
       StreamObserver<RespondNexusTaskFailedResponse> responseObserver) {
     try {
-      NexusTaskToken taskToken = NexusTaskToken.fromBytes(request.getTaskToken());
-      TestWorkflowMutableState mutableState = getMutableState(taskToken.getExecutionId());
-      mutableState.failNexusTask(taskToken.getScheduledEventId(), request);
+      if (!request.hasError()) {
+        throw Status.INVALID_ARGUMENT
+            .withDescription("Nexus handler error not set on RespondNexusTaskFailedRequest")
+            .asRuntimeException();
+      }
+      NexusOperationRef ref = NexusOperationRef.fromBytes(request.getTaskToken());
+      TestWorkflowMutableState mutableState = getMutableState(ref.getExecutionId());
+      Failure failure = nexusFailureToApplicationFailure(request.getError().getFailure());
+      mutableState.failNexusOperation(ref, failure);
       responseObserver.onNext(RespondNexusTaskFailedResponse.getDefaultInstance());
       responseObserver.onCompleted();
     } catch (StatusRuntimeException e) {
       handleStatusRuntimeException(e, responseObserver);
     }
+  }
+
+  public void completeNexusOperation(
+      ByteString token,
+      String namespace,
+      WorkflowExecution execution,
+      HistoryEvent completionEvent) {
+    ExecutionId executionId = new ExecutionId(namespace, execution);
+    TestWorkflowMutableState target = getMutableState(executionId);
+    NexusOperationRef ref = NexusOperationRef.fromBytes(token);
+
+    switch (completionEvent.getEventType()) {
+      case EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+        Payloads result =
+            completionEvent.getWorkflowExecutionCompletedEventAttributes().getResult();
+        // All of our SDKs support returning a single value from workflows, we can safely ignore the
+        // rest of the payloads. Additionally, even if a workflow could return more than a single
+        // value,
+        // Nexus does not support it.
+        Payload p =
+            (result.getPayloadsCount() > 0) ? result.getPayloads(0) : Payload.getDefaultInstance();
+        target.completeNexusOperation(ref, p);
+        break;
+      case EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
+        target.failNexusOperation(
+            ref, completionEvent.getWorkflowExecutionFailedEventAttributes().getFailure());
+        break;
+      case EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
+        target.cancelNexusOperation(ref);
+        break;
+      case EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+        Failure terminated =
+            Failure.newBuilder()
+                .setMessage("operation terminated")
+                .setApplicationFailureInfo(
+                    ApplicationFailureInfo.newBuilder().setNonRetryable(true))
+                .build();
+        target.failNexusOperation(ref, terminated);
+        break;
+      case EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
+        Failure timedOut =
+            Failure.newBuilder()
+                .setMessage("operation exceeded internal timeout")
+                .setApplicationFailureInfo(
+                    ApplicationFailureInfo.newBuilder().setNonRetryable(true))
+                .build();
+        target.failNexusOperation(ref, timedOut);
+        break;
+      default:
+        throw Status.INTERNAL
+            .withDescription("invalid workflow execution status: " + completionEvent.getEventType())
+            .asRuntimeException();
+    }
+  }
+
+  private static Failure nexusFailureToApplicationFailure(
+      io.temporal.api.nexus.v1.Failure failure) {
+    return Failure.newBuilder()
+        .setMessage(failure.getMessage())
+        .setApplicationFailureInfo(
+            ApplicationFailureInfo.newBuilder()
+                .setType("NexusOperationFailure")
+                .setNonRetryable(true)
+                .setDetails(
+                    Payloads.newBuilder()
+                        .addPayloads(
+                            Payload.newBuilder()
+                                .putAllMetadata(
+                                    failure.getMetadataMap().entrySet().stream()
+                                        .collect(
+                                            Collectors.toMap(
+                                                Map.Entry::getKey,
+                                                e -> ByteString.copyFromUtf8(e.getValue()))))
+                                .setData(failure.getDetails()))))
+        .build();
   }
 
   @Override

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -833,14 +833,9 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     }
   }
 
-  public void completeNexusOperation(
-      ByteString token,
-      String namespace,
-      WorkflowExecution execution,
-      HistoryEvent completionEvent) {
-    ExecutionId executionId = new ExecutionId(namespace, execution);
-    TestWorkflowMutableState target = getMutableState(executionId);
+  public void completeNexusOperation(ByteString token, HistoryEvent completionEvent) {
     NexusOperationRef ref = NexusOperationRef.fromBytes(token);
+    TestWorkflowMutableState target = getMutableState(ref.getExecutionId());
 
     switch (completionEvent.getEventType()) {
       case EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1152,6 +1152,10 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     //    if (previousRunStartRequest.hasRetryPolicy()) {
     //      startRequestBuilder.setRetryPolicy(previousRunStartRequest.getRetryPolicy());
     //    }
+    if (previousRunStartRequest.getCompletionCallbacksCount() > 0) {
+      startRequestBuilder.addAllCompletionCallbacks(
+          previousRunStartRequest.getCompletionCallbacksList());
+    }
     if (ca.hasRetryPolicy()) {
       startRequestBuilder.setRetryPolicy(ca.getRetryPolicy());
     }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStore.java
@@ -134,10 +134,13 @@ interface TestWorkflowStore {
   class NexusTask {
     private final TaskQueueId taskQueueId;
     private final PollNexusTaskQueueResponse.Builder task;
+    private Timestamp deadline;
 
-    public NexusTask(TaskQueueId taskQueueId, PollNexusTaskQueueResponse.Builder task) {
+    public NexusTask(
+        TaskQueueId taskQueueId, PollNexusTaskQueueResponse.Builder task, Timestamp deadline) {
       this.taskQueueId = taskQueueId;
       this.task = task;
+      this.deadline = deadline;
     }
 
     public TaskQueueId getTaskQueueId() {
@@ -146,6 +149,14 @@ interface TestWorkflowStore {
 
     public PollNexusTaskQueueResponse.Builder getTask() {
       return task;
+    }
+
+    public Timestamp getDeadline() {
+      return deadline;
+    }
+
+    public void setDeadline(Timestamp deadline) {
+      this.deadline = deadline;
     }
   }
 
@@ -169,8 +180,7 @@ interface TestWorkflowStore {
   Future<PollActivityTaskQueueResponse.Builder> pollActivityTaskQueue(
       PollActivityTaskQueueRequest pollRequest);
 
-  Future<PollNexusTaskQueueResponse.Builder> pollNexusTaskQueue(
-      PollNexusTaskQueueRequest pollRequest);
+  Future<NexusTask> pollNexusTaskQueue(PollNexusTaskQueueRequest pollRequest);
 
   void sendQueryTask(
       ExecutionId executionId, TaskQueueId taskQueue, PollWorkflowTaskQueueResponse.Builder task);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -66,8 +66,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       activityTaskQueues = new HashMap<>();
   private final Map<TaskQueueId, TaskQueue<PollWorkflowTaskQueueResponse.Builder>>
       workflowTaskQueues = new HashMap<>();
-  private final Map<TaskQueueId, TaskQueue<PollNexusTaskQueueResponse.Builder>> nexusTaskQueues =
-      new HashMap<>();
+  private final Map<TaskQueueId, TaskQueue<NexusTask>> nexusTaskQueues = new HashMap<>();
   private final SelfAdvancingTimer selfAdvancingTimer;
 
   private static class HistoryStore {
@@ -233,9 +232,8 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     List<NexusTask> nexusTasks = ctx.getNexusTasks();
     if (nexusTasks != null) {
       for (NexusTask nexusTask : nexusTasks) {
-        TaskQueue<PollNexusTaskQueueResponse.Builder> nexusTaskQueue =
-            getNexusTaskQueueQueue(nexusTask.getTaskQueueId());
-        nexusTaskQueue.add(nexusTask.getTask());
+        TaskQueue<NexusTask> nexusTaskQueue = getNexusTaskQueueQueue(nexusTask.getTaskQueueId());
+        nexusTaskQueue.add(nexusTask);
       }
     }
 
@@ -310,12 +308,10 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
     }
   }
 
-  private TaskQueue<PollNexusTaskQueueResponse.Builder> getNexusTaskQueueQueue(
-      TaskQueueId taskQueueId) {
+  private TaskQueue<NexusTask> getNexusTaskQueueQueue(TaskQueueId taskQueueId) {
     lock.lock();
     try {
-      TaskQueue<PollNexusTaskQueueResponse.Builder> nexusTaskQueue =
-          nexusTaskQueues.get(taskQueueId);
+      TaskQueue<NexusTask> nexusTaskQueue = nexusTaskQueues.get(taskQueueId);
       if (nexusTaskQueue == null) {
         nexusTaskQueue = new TaskQueue<>();
         nexusTaskQueues.put(taskQueueId, nexusTaskQueue);
@@ -343,8 +339,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   }
 
   @Override
-  public Future<PollNexusTaskQueueResponse.Builder> pollNexusTaskQueue(
-      PollNexusTaskQueueRequest pollRequest) {
+  public Future<NexusTask> pollNexusTaskQueue(PollNexusTaskQueueRequest pollRequest) {
     final TaskQueueId taskQueueId =
         new TaskQueueId(pollRequest.getNamespace(), pollRequest.getTaskQueue().getName());
     return getNexusTaskQueueQueue(taskQueueId).poll();

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -521,7 +521,7 @@ public class NexusWorkflowTest {
         pollResp.getTaskToken(),
         newScheduleOperationCommand(
             defaultScheduleOperationAttributes()
-                .setScheduleToCloseTimeout(Durations.fromSeconds(7))));
+                .setScheduleToCloseTimeout(Durations.fromSeconds(8))));
     testWorkflowRule.assertHistoryEvent(
         execution.getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED);
 
@@ -602,7 +602,7 @@ public class NexusWorkflowTest {
           pollResp.getTaskToken(),
           newScheduleOperationCommand(
               defaultScheduleOperationAttributes()
-                  .setScheduleToCloseTimeout(Durations.fromSeconds(7))));
+                  .setScheduleToCloseTimeout(Durations.fromSeconds(8))));
       testWorkflowRule.assertHistoryEvent(
           execution.getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED);
 

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -147,10 +147,6 @@ public class NexusWorkflowTest {
 
     events =
         testWorkflowRule.getHistoryEvents(
-            execution.getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED);
-    Assert.assertEquals(1, events.size());
-    events =
-        testWorkflowRule.getHistoryEvents(
             execution.getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED);
     Assert.assertEquals(1, events.size());
   }

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -677,7 +677,7 @@ public class NexusWorkflowTest {
           pollResp.getTaskToken(),
           newScheduleOperationCommand(
               defaultScheduleOperationAttributes()
-                  .setScheduleToCloseTimeout(Durations.fromSeconds(10))));
+                  .setScheduleToCloseTimeout(Durations.fromSeconds(22))));
       testWorkflowRule.assertHistoryEvent(
           execution.getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED);
 
@@ -1078,15 +1078,12 @@ public class NexusWorkflowTest {
   }
 
   private void assertOperationFailureInfo(NexusOperationFailureInfo info) {
-    assertOperationFailureInfo(null, info);
+    assertOperationFailureInfo("", info);
   }
 
   private void assertOperationFailureInfo(String operationID, NexusOperationFailureInfo info) {
     Assert.assertNotNull(info);
-    if (operationID != null) {
-      // Means this was a sync operation and don't have an easy way of getting ID.
-      Assert.assertEquals(operationID, info.getOperationId());
-    }
+    Assert.assertEquals(operationID, info.getOperationId());
     Assert.assertEquals(testEndpoint.getSpec().getName(), info.getEndpoint());
     Assert.assertEquals(testService, info.getService());
     Assert.assertEquals(testOperation, info.getOperation());

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/common/TestWorkflows.java
@@ -69,4 +69,10 @@ public class TestWorkflows {
     BLOCK,
     FINISH_WORKFLOW,
   }
+
+  @WorkflowInterface
+  public interface PrimitiveNexusHandlerWorkflow {
+    @WorkflowMethod
+    Object execute(String input);
+  }
 }


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Added test server support for async Nexus operations
Refactored cancellation logic
Revised timeout / error handling
New functional tests

See also first implementation PR: https://github.com/temporalio/sdk-java/pull/2176
