### PR TITLE
Rename UpdateHandle to WorkflowUpdateHandle (💥 - incompatible change)

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   features-test:
-    uses: temporalio/features/.github/workflows/java.yaml@main
+    uses: temporalio/features/.github/workflows/java.yaml@WorkflowUpdateHandle # TODO: switch back to `main`
     with:
       java-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -3,8 +3,9 @@ on: [push, pull_request]
 
 jobs:
   features-test:
-    uses: temporalio/features/.github/workflows/java.yaml@WorkflowUpdateHandle # TODO: switch back to `main`
+    uses: temporalio/features/.github/workflows/java.yaml@main
     with:
       java-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+      features-repo-ref: WorkflowUpdateHandle

--- a/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
+++ b/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowClientCallsInterceptor.java
@@ -23,7 +23,7 @@ package io.temporal.opentracing.internal;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import io.temporal.client.UpdateHandle;
+import io.temporal.client.WorkflowUpdateHandle;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptorBase;
 import io.temporal.opentracing.OpenTracingOptions;
@@ -120,7 +120,7 @@ public class OpenTracingWorkflowClientCallsInterceptor extends WorkflowClientCal
   }
 
   @Override
-  public <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
+  public <R> WorkflowUpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
     Span workflowStartUpdateSpan =
         contextAccessor.writeSpanContextToHeader(
             () ->

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -105,7 +105,7 @@ public interface WorkflowStub {
    * @return update handle that can be used to get the result of the update.
    */
   @Experimental
-  <R> UpdateHandle<R> startUpdate(
+  <R> WorkflowUpdateHandle<R> startUpdate(
       String updateName, WorkflowUpdateStage waitForStage, Class<R> resultClass, Object... args);
 
   /**
@@ -118,7 +118,7 @@ public interface WorkflowStub {
    * @return update handle that can be used to get the result of the update.
    */
   @Experimental
-  <R> UpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args);
+  <R> WorkflowUpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args);
 
   /**
    * Get an update handle to a previously started update request. Getting an update handle does not
@@ -130,7 +130,7 @@ public interface WorkflowStub {
    * @return update handle that can be used to get the result of the update.
    */
   @Experimental
-  <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass);
+  <R> WorkflowUpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass);
 
   /**
    * Get an update handle to a previously started update request. Getting an update handle does not
@@ -144,7 +144,8 @@ public interface WorkflowStub {
    * @return update handle that can be used to get the result of the update.
    */
   @Experimental
-  <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass, Type resultType);
+  <R> WorkflowUpdateHandle<R> getUpdateHandle(
+      String updateId, Class<R> resultClass, Type resultType);
 
   WorkflowExecution start(Object... args);
 

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -31,7 +31,7 @@ import io.temporal.api.update.v1.WaitPolicy;
 import io.temporal.common.interceptors.Header;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.failure.CanceledFailure;
-import io.temporal.internal.client.LazyUpdateHandleImpl;
+import io.temporal.internal.client.LazyWorkflowUpdateHandleImpl;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
 import io.temporal.serviceclient.StatusUtils;
 import java.lang.reflect.Type;
@@ -313,7 +313,7 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   @Override
-  public <R> UpdateHandle<R> startUpdate(
+  public <R> WorkflowUpdateHandle<R> startUpdate(
       String updateName, WorkflowUpdateStage waitForStage, Class<R> resultClass, Object... args) {
     UpdateOptions<R> options =
         UpdateOptions.<R>newBuilder()
@@ -327,7 +327,7 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   @Override
-  public <R> UpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args) {
+  public <R> WorkflowUpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args) {
     checkStarted();
     options.validate();
     WorkflowExecution targetExecution = execution.get();
@@ -353,8 +353,8 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   @Override
-  public <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass) {
-    return new LazyUpdateHandleImpl<>(
+  public <R> WorkflowUpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass) {
+    return new LazyWorkflowUpdateHandleImpl<>(
         workflowClientInvoker,
         workflowType.orElse(null),
         "",
@@ -365,9 +365,9 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   @Override
-  public <R> UpdateHandle<R> getUpdateHandle(
+  public <R> WorkflowUpdateHandle<R> getUpdateHandle(
       String updateId, Class<R> resultClass, Type resultType) {
-    return new LazyUpdateHandleImpl<>(
+    return new LazyWorkflowUpdateHandleImpl<>(
         workflowClientInvoker,
         workflowType.orElse(null),
         "",

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
@@ -26,11 +26,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * UpdateHandle is a handle to an update workflow execution request that can be used to get the
- * status of that update request.
+ * WorkflowUpdateHandle is a handle to an update workflow execution request that can be used to get
+ * the status of that update request.
  */
 @Experimental
-public interface UpdateHandle<T> {
+public interface WorkflowUpdateHandle<T> {
   /**
    * Gets the workflow execution this update request was sent to.
    *

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptor.java
@@ -23,8 +23,8 @@ package io.temporal.common.interceptors;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.update.v1.WaitPolicy;
-import io.temporal.client.UpdateHandle;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowUpdateHandle;
 import io.temporal.common.Experimental;
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -78,7 +78,7 @@ public interface WorkflowClientCallsInterceptor {
   <R> QueryOutput<R> query(QueryInput<R> input);
 
   @Experimental
-  <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input);
+  <R> WorkflowUpdateHandle<R> startUpdate(StartUpdateInput<R> input);
 
   @Experimental
   <R> PollWorkflowUpdateOutput<R> pollWorkflowUpdate(PollWorkflowUpdateInput<R> input);

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptorBase.java
@@ -20,7 +20,7 @@
 
 package io.temporal.common.interceptors;
 
-import io.temporal.client.UpdateHandle;
+import io.temporal.client.WorkflowUpdateHandle;
 import java.util.concurrent.TimeoutException;
 
 /** Convenience base class for {@link WorkflowClientCallsInterceptor} implementations. */
@@ -63,7 +63,7 @@ public class WorkflowClientCallsInterceptorBase implements WorkflowClientCallsIn
   }
 
   @Override
-  public <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
+  public <R> WorkflowUpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
     return next.startUpdate(input);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedWorkflowUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedWorkflowUpdateHandleImpl.java
@@ -21,19 +21,19 @@
 package io.temporal.internal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.client.UpdateHandle;
+import io.temporal.client.WorkflowUpdateHandle;
 import io.temporal.common.Experimental;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 @Experimental
-public final class CompletedUpdateHandleImpl<T> implements UpdateHandle<T> {
+public final class CompletedWorkflowUpdateHandleImpl<T> implements WorkflowUpdateHandle<T> {
 
   private final String id;
   private final WorkflowExecution execution;
   private final T result;
 
-  public CompletedUpdateHandleImpl(String id, WorkflowExecution execution, T result) {
+  public CompletedWorkflowUpdateHandleImpl(String id, WorkflowExecution execution, T result) {
     this.id = id;
     this.execution = execution;
     this.result = result;

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/LazyWorkflowUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/LazyWorkflowUpdateHandleImpl.java
@@ -23,9 +23,9 @@ package io.temporal.internal.client;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.client.UpdateHandle;
 import io.temporal.client.WorkflowException;
 import io.temporal.client.WorkflowServiceException;
+import io.temporal.client.WorkflowUpdateHandle;
 import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 @Experimental
-public final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
+public final class LazyWorkflowUpdateHandleImpl<T> implements WorkflowUpdateHandle<T> {
 
   private final WorkflowClientCallsInterceptor workflowClientInvoker;
   private final String workflowType;
@@ -47,7 +47,7 @@ public final class LazyUpdateHandleImpl<T> implements UpdateHandle<T> {
   private final Type resultType;
   private WorkflowClientCallsInterceptor.PollWorkflowUpdateOutput<T> waitCompletedPollCall;
 
-  public LazyUpdateHandleImpl(
+  public LazyWorkflowUpdateHandleImpl(
       WorkflowClientCallsInterceptor workflowClientInvoker,
       String workflowType,
       String updateName,

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -297,7 +297,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
   }
 
   @Override
-  public <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
+  public <R> WorkflowUpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
     DataConverter dataConverterWithWorkflowContext =
         clientOptions
             .getDataConverter()
@@ -366,7 +366,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                   input.getResultClass(),
                   input.getResultType(),
                   dataConverterWithWorkflowContext);
-          return new CompletedUpdateHandleImpl<>(
+          return new CompletedWorkflowUpdateHandleImpl<>(
               result.getUpdateRef().getUpdateId(),
               result.getUpdateRef().getWorkflowExecution(),
               resultValue);
@@ -383,8 +383,8 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                   + result.getOutcome().getValueCase());
       }
     } else {
-      LazyUpdateHandleImpl<R> handle =
-          new LazyUpdateHandleImpl<>(
+      LazyWorkflowUpdateHandleImpl<R> handle =
+          new LazyWorkflowUpdateHandleImpl<>(
               this,
               input.getWorkflowType().orElse(null),
               input.getUpdateName(),

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTest.java
@@ -56,7 +56,7 @@ public class UpdateTest {
     WorkflowStub workflowStub =
         testWorkflowRule.getWorkflowClient().newUntypedWorkflowStub("non-existing-id");
     // Getting the update handle to a nonexistent workflow is fine
-    UpdateHandle<String> handle = workflowStub.getUpdateHandle("update-id", String.class);
+    WorkflowUpdateHandle<String> handle = workflowStub.getUpdateHandle("update-id", String.class);
     assertThrows(Exception.class, () -> handle.getResultAsync().get());
   }
 
@@ -124,7 +124,7 @@ public class UpdateTest {
     String updateId = "update-id";
 
     // Try to get the result of an invalid update
-    UpdateHandle<String> handle = workflowStub.getUpdateHandle(updateId, String.class);
+    WorkflowUpdateHandle<String> handle = workflowStub.getUpdateHandle(updateId, String.class);
     assertThrows(Exception.class, () -> handle.getResultAsync().get());
 
     assertEquals(

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTestTimeout.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/UpdateTestTimeout.java
@@ -58,7 +58,7 @@ public class UpdateTestTimeout {
     workflowStub.start();
     SDKTestWorkflowRule.waitForOKQuery(workflowStub);
     // Send an update that is accepted, but will not complete.
-    UpdateHandle<String> handle =
+    WorkflowUpdateHandle<String> handle =
         workflowStub.startUpdate(
             "update", WorkflowUpdateStage.ACCEPTED, String.class, 10_000, "some-value");
 
@@ -78,7 +78,7 @@ public class UpdateTestTimeout {
 
     workflowStub.start();
     SDKTestWorkflowRule.waitForOKQuery(workflowStub);
-    UpdateHandle<String> handle =
+    WorkflowUpdateHandle<String> handle =
         workflowStub.startUpdate(
             "update", WorkflowUpdateStage.ACCEPTED, String.class, 65_000, "some-value");
 
@@ -99,7 +99,7 @@ public class UpdateTestTimeout {
     workflowStub.start();
     SDKTestWorkflowRule.waitForOKQuery(workflowStub);
 
-    UpdateHandle<String> handle =
+    WorkflowUpdateHandle<String> handle =
         workflowStub.startUpdate(
             "update", WorkflowUpdateStage.ACCEPTED, String.class, 10_000, "some-value");
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateAllHandlersFinished.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateAllHandlersFinished.java
@@ -53,7 +53,7 @@ public class UpdateAllHandlersFinished {
     WorkflowExecution execution = WorkflowClient.start(workflow::execute);
 
     WorkflowStub untypedStub = workflowClient.newUntypedWorkflowStub(execution.getWorkflowId());
-    List<UpdateHandle<String>> updateHandles = new ArrayList<>();
+    List<WorkflowUpdateHandle<String>> updateHandles = new ArrayList<>();
     // Send a bunch of update requests
     for (int i = 0; i < 5; i++) {
       updateHandles.add(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateInfoTest.java
@@ -60,11 +60,11 @@ public class UpdateInfoTest {
             .setUpdateName("update")
             .setWaitForStage(WorkflowUpdateStage.COMPLETED);
 
-    UpdateHandle handle1 =
+    WorkflowUpdateHandle handle1 =
         stub.startUpdate(updateOptionsBuilder.setUpdateId("update id 1").build(), 0, "");
     assertEquals("update:update id 1", handle1.getResultAsync().get());
 
-    UpdateHandle handle2 =
+    WorkflowUpdateHandle handle2 =
         stub.startUpdate(updateOptionsBuilder.setUpdateId("update id 2").build(), 0, "");
     assertEquals("update:update id 2", handle2.getResultAsync().get());
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -34,7 +34,7 @@ import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptorBase;
 import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
 import io.temporal.failure.ApplicationFailure;
-import io.temporal.internal.client.CompletedUpdateHandleImpl;
+import io.temporal.internal.client.CompletedWorkflowUpdateHandleImpl;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
@@ -113,9 +113,9 @@ public class UpdateTest {
         WorkflowClientCallsInterceptor next) {
       return new WorkflowClientCallsInterceptorBase(next) {
         @Override
-        public <R> UpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
+        public <R> WorkflowUpdateHandle<R> startUpdate(StartUpdateInput<R> input) {
           super.startUpdate(input);
-          return new CompletedUpdateHandleImpl<>(
+          return new CompletedWorkflowUpdateHandleImpl<>(
               "someid", input.getWorkflowExecution(), (R) "fake");
         }
       };
@@ -173,7 +173,7 @@ public class UpdateTest {
     // send an update through the sync path
     assertEquals("Execute-Hello", workflowStub.update("update", String.class, 0, "Hello"));
     // send an update through the async path
-    UpdateHandle<String> updateRef =
+    WorkflowUpdateHandle<String> updateRef =
         workflowStub.startUpdate("update", WorkflowUpdateStage.ACCEPTED, String.class, 0, "World");
     assertEquals("Execute-World", updateRef.getResultAsync().get());
     // send a bad update that will be rejected through the sync path
@@ -266,7 +266,7 @@ public class UpdateTest {
         Executors.newSingleThreadExecutor()
             .submit(
                 () -> {
-                  UpdateHandle<String> handle =
+                  WorkflowUpdateHandle<String> handle =
                       workflowStub.startUpdate(
                           UpdateOptions.newBuilder(String.class)
                               .setUpdateName("update")

--- a/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
@@ -236,23 +236,23 @@ class TimeLockingInterceptor extends WorkflowClientInterceptorBase {
     }
 
     @Override
-    public <R> UpdateHandle<R> startUpdate(
+    public <R> WorkflowUpdateHandle<R> startUpdate(
         String updateName, WorkflowUpdateStage waitForStage, Class<R> resultClass, Object... args) {
       return next.startUpdate(updateName, waitForStage, resultClass, args);
     }
 
     @Override
-    public <R> UpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args) {
+    public <R> WorkflowUpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args) {
       return next.startUpdate(options, args);
     }
 
     @Override
-    public <R> UpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass) {
+    public <R> WorkflowUpdateHandle<R> getUpdateHandle(String updateId, Class<R> resultClass) {
       return next.getUpdateHandle(updateId, resultClass);
     }
 
     @Override
-    public <R> UpdateHandle<R> getUpdateHandle(
+    public <R> WorkflowUpdateHandle<R> getUpdateHandle(
         String updateId, Class<R> resultClass, Type resultType) {
       return next.getUpdateHandle(updateId, resultClass, resultType);
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Renamed `UpdateHandle` to `WorkflowUpdateHandle`.

This is a breaking change.

⚠️ Feature tests are failing; I can update them as a fast follow-up.

## Why?
<!-- Tell your future self why have you made these changes -->

Consistency. (as discussed previously)

## Checklist
<!--- add/delete as needed --->

**How was this tested:**

Existing tests.

**Any docs updates needed?**

I checked https://docs.temporal.io/develop/java/message-passing and the `UpdateHandle` type isn't mentioned anywhere.

I also cannot see it in the samples repo ([search](https://github.com/search?q=repo%3Atemporalio%2Fsamples-java%20UpdateHandle&type=code))

The release docs will need to mention this change, though.