### PR TITLE
Add workflow init support (💥 - incompatible change)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -131,7 +131,7 @@ class SyncWorkflow implements ReplayWorkflow {
             workflowThreadExecutor,
             workflowContext,
             () -> {
-              workflow.initialize();
+              workflowProc.runConstructor();
               WorkflowInternal.newWorkflowMethodThread(
                       () -> workflowProc.runWorkflowMethod(),
                       workflowMethodThreadNameStrategy.createThreadName(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 interface SyncWorkflowDefinition {
 
   /** Always called first. */
-  void initialize();
+  void initialize(Optional<Payloads> input);
 
   Optional<Payloads> execute(Header header, Optional<Payloads> input);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowExecutionHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowExecutionHandler.java
@@ -76,6 +76,17 @@ class WorkflowExecutionHandler {
     }
   }
 
+  /** Runs the workflow class constructor. */
+  public void runConstructor() {
+    try {
+      workflow.initialize(
+          attributes.hasInput() ? Optional.of(attributes.getInput()) : Optional.empty());
+    } catch (Throwable e) {
+      applyWorkflowFailurePolicyAndRethrow(e);
+      done = true;
+    }
+  }
+
   public void cancel(String reason) {}
 
   public boolean isDone() {

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
@@ -1,0 +1,20 @@
+package io.temporal.workflow;
+
+import io.temporal.common.Experimental;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the constructor should be used as a workflow initialization method. The method
+ * annotated with this annotation is called when a new workflow instance is created. The method must
+ * be public and take no arguments or take the same arguments as the workflow method. All the same
+ * constraints as for workflow methods apply to workflow initialization methods.
+ *
+ * <p>This annotation applies only to workflow implementation constructors.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.CONSTRUCTOR)
+@Experimental
+public @interface WorkflowInit {}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
@@ -47,6 +47,12 @@ import java.lang.annotation.Target;
  * <p>A workflow implementation object must have <b>exactly one</b> method annotated with
  * {@literal @}WorkflowMethod inherited from all the interfaces it implements.
  *
+ * <p>A workflow implementation may have a no-arg constructor or a constructor that takes the same
+ * set of arguments as the workflow interface method annotated with {@literal @}WorkflowMethod.
+ * Users should avoid blocking operations in the constructor as the constructor must be called
+ * before the workflow method is invoked and before any Signal, Update, or Queries handlers are
+ * registered.
+ *
  * <p>Example:
  *
  * <pre><code>

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
@@ -259,6 +259,12 @@ public class POJOWorkflowInterfaceMetadataTest {
     void g();
   }
 
+  @WorkflowInterface
+  public interface H {
+    @WorkflowMethod
+    void h(Integer i);
+  }
+
   public interface DE extends D, E {}
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.common.converter.EncodedValues;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DynamicWorkflowInitTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestInitWorkflow.class).build();
+
+  @Test
+  public void testInit() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(testWorkflowRule.getTaskQueue(), result);
+  }
+
+  @Test
+  public void testInitThrowApplicationFailure() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    WorkflowFailedException failure =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(""));
+    Assert.assertTrue(failure.getCause() instanceof ApplicationFailure);
+    ApplicationFailure applicationFailure = (ApplicationFailure) failure.getCause();
+    assertEquals("Empty taskQueue", applicationFailure.getOriginalMessage());
+  }
+
+  public static class TestInitWorkflow implements DynamicWorkflow {
+    private final String taskQueue;
+
+    public TestInitWorkflow(EncodedValues args) {
+      String taskQueue = args.get(0, String.class);
+      if (taskQueue.isEmpty()) {
+        throw ApplicationFailure.newFailure("Empty taskQueue", "TestFailure");
+      }
+      this.taskQueue = taskQueue;
+    }
+
+    @Override
+    public Object execute(EncodedValues args) {
+      String taskQueue = args.get(0, String.class);
+      if (!taskQueue.equals(this.taskQueue)) {
+        throw new IllegalArgumentException("Unexpected taskQueue: " + taskQueue);
+      }
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
@@ -59,6 +59,7 @@ public class DynamicWorkflowInitTest {
   public static class TestInitWorkflow implements DynamicWorkflow {
     private final String taskQueue;
 
+    @WorkflowInit
     public TestInitWorkflow(EncodedValues args) {
       String taskQueue = args.get(0, String.class);
       if (taskQueue.isEmpty()) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitConstructorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitConstructorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowInitConstructorTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestInitWorkflow.class).build();
+
+  @Test
+  public void testInit() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(testWorkflowRule.getTaskQueue(), result);
+  }
+
+  public static class TestInitWorkflow implements TestWorkflow1 {
+
+    public TestInitWorkflow() {}
+
+    public TestInitWorkflow(String taskQueue) {
+      Assert.fail();
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
@@ -58,6 +58,8 @@ public class WorkflowInitRetryTest {
   }
 
   public static class TestInitWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @WorkflowInit
     public TestInitWorkflow(String testName) {
       AtomicInteger count = retryCount.get(testName);
       if (count == null) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowException;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class WorkflowInitRetryTest {
+  private static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(IllegalArgumentException.class)
+                  .build(),
+              TestInitWorkflow.class)
+          .build();
+
+  @Test
+  public void testInitFailsRuntimeException() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    WorkflowException exception =
+        Assert.assertThrows(
+            WorkflowException.class, () -> workflowStub.execute(testName.getMethodName()));
+    System.out.println(exception);
+  }
+
+  public static class TestInitWorkflow implements TestWorkflows.TestWorkflow1 {
+    public TestInitWorkflow(String testName) {
+      AtomicInteger count = retryCount.get(testName);
+      if (count == null) {
+        count = new AtomicInteger();
+        retryCount.put(testName, count);
+      }
+      int c = count.incrementAndGet();
+      if (c < 3) {
+        throw new IllegalStateException("simulated " + c);
+      } else {
+        throw new IllegalArgumentException("simulated " + c);
+      }
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowInitTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestInitWorkflow.class).build();
+
+  @Test
+  public void testInit() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(testWorkflowRule.getTaskQueue(), result);
+  }
+
+  @Test
+  public void testInitThrowApplicationFailure() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    WorkflowFailedException failure =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(""));
+    Assert.assertTrue(failure.getCause() instanceof ApplicationFailure);
+    ApplicationFailure applicationFailure = (ApplicationFailure) failure.getCause();
+    assertEquals("Empty taskQueue", applicationFailure.getOriginalMessage());
+  }
+
+  public static class TestInitWorkflow implements TestWorkflow1 {
+    private final String taskQueue;
+
+    public TestInitWorkflow(String taskQueue) {
+      if (taskQueue.isEmpty()) {
+        throw ApplicationFailure.newFailure("Empty taskQueue", "TestFailure");
+      }
+      this.taskQueue = taskQueue;
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      if (!taskQueue.equals(this.taskQueue)) {
+        throw new IllegalArgumentException("Unexpected taskQueue: " + taskQueue);
+      }
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
@@ -58,6 +58,7 @@ public class WorkflowInitTest {
   public static class TestInitWorkflow implements TestWorkflow1 {
     private final String taskQueue;
 
+    @WorkflowInit
     public TestInitWorkflow(String taskQueue) {
       if (taskQueue.isEmpty()) {
         throw ApplicationFailure.newFailure("Empty taskQueue", "TestFailure");


### PR DESCRIPTION
Add workflow init support to allow users to run code before signal/update handlers:
* If the workflow implementation defines a no-arg constructor that is used to maintain backwards compatibility
* If the workflow does not, the SDK checks if a constructor with the same args as the main workflow method exists
* 💥 Exceptions throw from constructors now behave the same as normal workflow code

closes https://github.com/temporalio/sdk-java/issues/865