### PR TITLE
Add support for user meta data 

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
@@ -23,10 +23,7 @@ package io.temporal.client;
 import com.google.common.base.Objects;
 import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
-import io.temporal.common.CronSchedule;
-import io.temporal.common.MethodRetry;
-import io.temporal.common.RetryOptions;
-import io.temporal.common.SearchAttributes;
+import io.temporal.common.*;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.internal.common.OptionsUtils;
 import io.temporal.worker.WorkerFactory;
@@ -79,6 +76,8 @@ public final class WorkflowOptions {
         .setDisableEagerExecution(o.isDisableEagerExecution())
         .setStartDelay(o.getStartDelay())
         .setWorkflowIdConflictPolicy(o.getWorkflowIdConflictPolicy())
+        .setStaticSummary(o.getStaticSummary())
+        .setStaticDetails(o.getStaticDetails())
         .validateBuildWithDefaults();
   }
 
@@ -114,6 +113,10 @@ public final class WorkflowOptions {
 
     private WorkflowIdConflictPolicy workflowIdConflictpolicy;
 
+    private String staticSummary;
+
+    private String staticDetails;
+
     private Builder() {}
 
     private Builder(WorkflowOptions options) {
@@ -135,6 +138,8 @@ public final class WorkflowOptions {
       this.disableEagerExecution = options.disableEagerExecution;
       this.startDelay = options.startDelay;
       this.workflowIdConflictpolicy = options.workflowIdConflictpolicy;
+      this.staticSummary = options.staticSummary;
+      this.staticDetails = options.staticDetails;
     }
 
     /**
@@ -382,6 +387,31 @@ public final class WorkflowOptions {
       return this;
     }
 
+    /**
+     * Single-line fixed summary for this workflow execution that will appear in UI/CLI. This can be
+     * in single-line Temporal Markdown format.
+     *
+     * <p>Default is none/empty.
+     */
+    @Experimental
+    public Builder setStaticSummary(String staticSummary) {
+      this.staticSummary = staticSummary;
+      return this;
+    }
+
+    /**
+     * General fixed details for this workflow execution that will appear in UI/CLI. This can be in
+     * Temporal Markdown format and can span multiple lines. This is a fixed value on the workflow
+     * that cannot be updated.
+     *
+     * <p>Default is none/empty.
+     */
+    @Experimental
+    public Builder setStaticDetails(String staticDetails) {
+      this.staticDetails = staticDetails;
+      return this;
+    }
+
     public WorkflowOptions build() {
       return new WorkflowOptions(
           workflowId,
@@ -398,7 +428,9 @@ public final class WorkflowOptions {
           contextPropagators,
           disableEagerExecution,
           startDelay,
-          workflowIdConflictpolicy);
+          workflowIdConflictpolicy,
+          staticSummary,
+          staticDetails);
     }
 
     /**
@@ -420,7 +452,9 @@ public final class WorkflowOptions {
           contextPropagators,
           disableEagerExecution,
           startDelay,
-          workflowIdConflictpolicy);
+          workflowIdConflictpolicy,
+          staticSummary,
+          staticDetails);
     }
   }
 
@@ -454,6 +488,10 @@ public final class WorkflowOptions {
 
   private final WorkflowIdConflictPolicy workflowIdConflictpolicy;
 
+  private final String staticSummary;
+
+  private final String staticDetails;
+
   private WorkflowOptions(
       String workflowId,
       WorkflowIdReusePolicy workflowIdReusePolicy,
@@ -469,7 +507,9 @@ public final class WorkflowOptions {
       List<ContextPropagator> contextPropagators,
       boolean disableEagerExecution,
       Duration startDelay,
-      WorkflowIdConflictPolicy workflowIdConflictpolicy) {
+      WorkflowIdConflictPolicy workflowIdConflictpolicy,
+      String staticSummary,
+      String staticDetails) {
     this.workflowId = workflowId;
     this.workflowIdReusePolicy = workflowIdReusePolicy;
     this.workflowRunTimeout = workflowRunTimeout;
@@ -485,6 +525,8 @@ public final class WorkflowOptions {
     this.disableEagerExecution = disableEagerExecution;
     this.startDelay = startDelay;
     this.workflowIdConflictpolicy = workflowIdConflictpolicy;
+    this.staticSummary = staticSummary;
+    this.staticDetails = staticDetails;
   }
 
   public String getWorkflowId() {
@@ -556,6 +598,14 @@ public final class WorkflowOptions {
     return workflowIdConflictpolicy;
   }
 
+  public String getStaticSummary() {
+    return staticSummary;
+  }
+
+  public String getStaticDetails() {
+    return staticDetails;
+  }
+
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -579,7 +629,9 @@ public final class WorkflowOptions {
         && Objects.equal(contextPropagators, that.contextPropagators)
         && Objects.equal(disableEagerExecution, that.disableEagerExecution)
         && Objects.equal(startDelay, that.startDelay)
-        && Objects.equal(workflowIdConflictpolicy, that.workflowIdConflictpolicy);
+        && Objects.equal(workflowIdConflictpolicy, that.workflowIdConflictpolicy)
+        && Objects.equal(staticSummary, that.staticSummary)
+        && Objects.equal(staticDetails, that.staticDetails);
   }
 
   @Override
@@ -599,7 +651,9 @@ public final class WorkflowOptions {
         contextPropagators,
         disableEagerExecution,
         startDelay,
-        workflowIdConflictpolicy);
+        workflowIdConflictpolicy,
+        staticSummary,
+        staticDetails);
   }
 
   @Override
@@ -638,6 +692,10 @@ public final class WorkflowOptions {
         + startDelay
         + ", workflowIdConflictpolicy="
         + workflowIdConflictpolicy
+        + ", staticSummary="
+        + staticSummary
+        + ", staticDetails="
+        + staticDetails
         + '}';
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -588,6 +588,8 @@ public interface WorkflowOutboundCallsInterceptor {
 
   Promise<Void> newTimer(Duration duration);
 
+  Promise<Void> newTimer(Duration duration, TimerOptions options);
+
   <R> R sideEffect(Class<R> resultClass, Type resultType, Func<R> func);
 
   <R> R mutableSideEffect(

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
@@ -23,6 +23,7 @@ package io.temporal.common.interceptors;
 import io.temporal.common.SearchAttributeUpdate;
 import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Promise;
+import io.temporal.workflow.TimerOptions;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.Map;
@@ -88,6 +89,11 @@ public class WorkflowOutboundCallsInterceptorBase implements WorkflowOutboundCal
   @Override
   public Promise<Void> newTimer(Duration duration) {
     return next.newTimer(duration);
+  }
+
+  @Override
+  public Promise<Void> newTimer(Duration duration, TimerOptions options) {
+    return next.newTimer(duration, options);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -21,6 +21,7 @@
 package io.temporal.internal.client;
 
 import static io.temporal.internal.common.HeaderUtils.intoPayloadMap;
+import static io.temporal.internal.common.WorkflowExecutionUtils.makeUserMetaData;
 
 import io.grpc.Deadline;
 import io.grpc.Status;
@@ -29,6 +30,7 @@ import io.temporal.api.common.v1.*;
 import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.query.v1.WorkflowQuery;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.update.v1.*;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.client.*;
@@ -86,6 +88,13 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                 .build()
             : null;
 
+    @Nullable
+    UserMetadata userMetadata =
+        makeUserMetaData(
+            input.getOptions().getStaticSummary(),
+            input.getOptions().getStaticDetails(),
+            dataConverterWithWorkflowContext);
+
     StartWorkflowExecutionRequest.Builder request =
         requestsHelper.newStartWorkflowExecutionRequest(
             input.getWorkflowId(),
@@ -93,7 +102,8 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
             input.getHeader(),
             input.getOptions(),
             inputArgs.orElse(null),
-            memo);
+            memo,
+            userMetadata);
     try (@Nullable WorkflowTaskDispatchHandle eagerDispatchHandle = obtainDispatchHandle(input)) {
       boolean requestEagerExecution = eagerDispatchHandle != null;
       request.setRequestEagerExecution(requestEagerExecution);
@@ -173,6 +183,13 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                 .build()
             : null;
 
+    @Nullable
+    UserMetadata userMetadata =
+        makeUserMetaData(
+            workflowStartInput.getOptions().getStaticSummary(),
+            workflowStartInput.getOptions().getStaticDetails(),
+            dataConverterWithWorkflowContext);
+
     StartWorkflowExecutionRequestOrBuilder startRequest =
         requestsHelper.newStartWorkflowExecutionRequest(
             workflowStartInput.getWorkflowId(),
@@ -180,7 +197,8 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
             workflowStartInput.getHeader(),
             workflowStartInput.getOptions(),
             workflowInput.orElse(null),
-            memo);
+            memo,
+            userMetadata);
 
     Optional<Payloads> signalInput =
         dataConverterWithWorkflowContext.toPayloads(input.getSignalArguments());

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientRequestFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientRequestFactory.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import io.temporal.api.common.v1.*;
 import io.temporal.api.enums.v1.HistoryEventFilterType;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest;
@@ -59,7 +60,8 @@ final class WorkflowClientRequestFactory {
       @Nonnull io.temporal.common.interceptors.Header header,
       @Nonnull WorkflowOptions options,
       @Nullable Payloads inputArgs,
-      @Nullable Memo memo) {
+      @Nullable Memo memo,
+      @Nullable UserMetadata userMetadata) {
     StartWorkflowExecutionRequest.Builder request =
         StartWorkflowExecutionRequest.newBuilder()
             .setNamespace(clientOptions.getNamespace())
@@ -106,6 +108,10 @@ final class WorkflowClientRequestFactory {
 
     if (options.getStartDelay() != null) {
       request.setWorkflowStartDelay(ProtobufTimeUtils.toProtoDuration(options.getStartDelay()));
+    }
+
+    if (userMetadata != null) {
+      request.setUserMetadata(userMetadata);
     }
 
     if (options.getSearchAttributes() != null && !options.getSearchAttributes().isEmpty()) {
@@ -181,6 +187,10 @@ final class WorkflowClientRequestFactory {
 
     if (startParameters.hasWorkflowStartDelay()) {
       request.setWorkflowStartDelay(startParameters.getWorkflowStartDelay());
+    }
+
+    if (startParameters.hasUserMetadata()) {
+      request.setUserMetadata(startParameters.getUserMetadata());
     }
 
     return request;

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -33,6 +33,7 @@ import io.temporal.api.enums.v1.RetryState;
 import io.temporal.api.enums.v1.TimeoutType;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.history.v1.*;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.common.converter.DataConverter;
@@ -238,6 +239,21 @@ public class WorkflowExecutionUtils {
       default:
         throw new IllegalArgumentException("Not a close event: " + event);
     }
+  }
+
+  public static UserMetadata makeUserMetaData(String summary, String details, DataConverter dc) {
+    if (summary == null && details == null) {
+      return null;
+    }
+
+    UserMetadata.Builder builder = UserMetadata.newBuilder();
+    if (summary != null) {
+      builder.setSummary(dc.toPayload(summary).get());
+    }
+    if (details != null) {
+      builder.setDetails(dc.toPayload(details).get());
+    }
+    return builder.build();
   }
 
   public static String prettyPrintCommands(Iterable<Command> commands) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -25,6 +25,7 @@ import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttribute
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
 import io.temporal.api.common.v1.*;
 import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.common.RetryOptions;
 import io.temporal.internal.common.SdkFlag;
@@ -205,13 +206,14 @@ public interface ReplayWorkflowContext extends ReplayAware {
    * Create a Value that becomes ready after the specified delay.
    *
    * @param delay time-interval after which the Value becomes ready.
+   * @param metadata user metadata to be associated with the timer.
    * @param callback Callback that is called with null parameter after the specified delay.
    *     CanceledException is passed as a parameter in case of a cancellation.
    * @return cancellation handle. Invoke {@link io.temporal.workflow.Functions.Proc1#apply(Object)}
    *     to cancel timer.
    */
   Functions.Proc1<RuntimeException> newTimer(
-      Duration delay, Functions.Proc1<RuntimeException> callback);
+      Duration delay, UserMetadata metadata, Functions.Proc1<RuntimeException> callback);
 
   /**
    * Executes the provided function once, records its result into the workflow history. The recorded

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -30,6 +30,7 @@ import io.temporal.api.common.v1.*;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.common.ProtobufTimeUtils;
@@ -268,7 +269,7 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
 
   @Override
   public Functions.Proc1<RuntimeException> newTimer(
-      Duration delay, Functions.Proc1<RuntimeException> callback) {
+      Duration delay, UserMetadata metadata, Functions.Proc1<RuntimeException> callback) {
     if (delay.compareTo(Duration.ZERO) <= 0) {
       callback.apply(null);
       return (e) -> {};
@@ -279,7 +280,8 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
             .setTimerId(workflowStateMachines.randomUUID().toString())
             .build();
     Functions.Proc cancellationHandler =
-        workflowStateMachines.newTimer(attributes, (event) -> handleTimerCallback(callback, event));
+        workflowStateMachines.newTimer(
+            attributes, metadata, (event) -> handleTimerCallback(callback, event));
     return (e) -> cancellationHandler.apply();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StartChildWorkflowExecutionParameters.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StartChildWorkflowExecutionParameters.java
@@ -21,18 +21,23 @@
 package io.temporal.internal.statemachines;
 
 import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.workflow.ChildWorkflowCancellationType;
+import javax.annotation.Nullable;
 
 public final class StartChildWorkflowExecutionParameters {
 
   private final StartChildWorkflowExecutionCommandAttributes.Builder request;
   private final ChildWorkflowCancellationType cancellationType;
+  private final UserMetadata metadata;
 
   public StartChildWorkflowExecutionParameters(
       StartChildWorkflowExecutionCommandAttributes.Builder request,
-      ChildWorkflowCancellationType cancellationType) {
+      ChildWorkflowCancellationType cancellationType,
+      @Nullable UserMetadata metadata) {
     this.request = request;
     this.cancellationType = cancellationType;
+    this.metadata = metadata;
   }
 
   public StartChildWorkflowExecutionCommandAttributes.Builder getRequest() {
@@ -41,5 +46,9 @@ public final class StartChildWorkflowExecutionParameters {
 
   public ChildWorkflowCancellationType getCancellationType() {
     return cancellationType;
+  }
+
+  public @Nullable UserMetadata getMetadata() {
+    return metadata;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -848,10 +848,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
 
     @Nullable
     UserMetadata userMetadata =
-        makeUserMetaData(
-            options.getStaticSummary(),
-            options.getStaticDetails(),
-            dataConverterWithCurrentWorkflowContext);
+        makeUserMetaData(options.getStaticSummary(), null, dataConverterWithCurrentWorkflowContext);
 
     Functions.Proc1<RuntimeException> cancellationHandler =
         replayContext.newTimer(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -23,6 +23,7 @@ package io.temporal.internal.sync;
 import static io.temporal.internal.common.HeaderUtils.intoPayloadMap;
 import static io.temporal.internal.common.HeaderUtils.toHeaderGrpc;
 import static io.temporal.internal.common.RetryOptionsUtils.toRetryPolicy;
+import static io.temporal.internal.common.WorkflowExecutionUtils.makeUserMetaData;
 import static io.temporal.internal.sync.WorkflowInternal.DEFAULT_VERSION;
 
 import com.google.common.base.MoreObjects;
@@ -44,6 +45,7 @@ import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.enums.v1.ParentClosePolicy;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.client.WorkflowException;
@@ -649,6 +651,13 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
                 .build()
             : null;
 
+    @Nullable
+    UserMetadata userMetadata =
+        makeUserMetaData(
+            input.getOptions().getStaticSummary(),
+            input.getOptions().getStaticDetails(),
+            dataConverterWithChildWorkflowContext);
+
     StartChildWorkflowExecutionParameters parameters =
         createChildWorkflowParameters(
             input.getWorkflowId(),
@@ -656,7 +665,8 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
             input.getOptions(),
             input.getHeader(),
             payloads,
-            memo);
+            memo,
+            userMetadata);
 
     Functions.Proc1<Exception> cancellationCallback =
         replayContext.startChildWorkflow(
@@ -713,7 +723,8 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
       ChildWorkflowOptions options,
       Header header,
       Optional<Payloads> input,
-      @Nullable Memo memo) {
+      @Nullable Memo memo,
+      @Nullable UserMetadata metadata) {
     final StartChildWorkflowExecutionCommandAttributes.Builder attributes =
         StartChildWorkflowExecutionCommandAttributes.newBuilder()
             .setWorkflowType(WorkflowType.newBuilder().setName(name).build());
@@ -775,7 +786,8 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
               .determineUseCompatibleFlag(
                   replayContext.getTaskQueue().equals(options.getTaskQueue())));
     }
-    return new StartChildWorkflowExecutionParameters(attributes, options.getCancellationType());
+    return new StartChildWorkflowExecutionParameters(
+        attributes, options.getCancellationType(), metadata);
   }
 
   private static Header extractContextsAndConvertToBytes(
@@ -827,10 +839,24 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
 
   @Override
   public Promise<Void> newTimer(Duration delay) {
+    return newTimer(delay, TimerOptions.newBuilder().build());
+  }
+
+  @Override
+  public Promise<Void> newTimer(Duration delay, TimerOptions options) {
     CompletablePromise<Void> p = Workflow.newPromise();
+
+    @Nullable
+    UserMetadata userMetadata =
+        makeUserMetaData(
+            options.getStaticSummary(),
+            options.getStaticDetails(),
+            dataConverterWithCurrentWorkflowContext);
+
     Functions.Proc1<RuntimeException> cancellationHandler =
         replayContext.newTimer(
             delay,
+            userMetadata,
             (e) ->
                 runner.executeInWorkflowThread(
                     "timer-callback",

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -848,7 +848,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
 
     @Nullable
     UserMetadata userMetadata =
-        makeUserMetaData(options.getStaticSummary(), null, dataConverterWithCurrentWorkflowContext);
+        makeUserMetaData(options.getSummary(), null, dataConverterWithCurrentWorkflowContext);
 
     Functions.Proc1<RuntimeException> cancellationHandler =
         replayContext.newTimer(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -89,6 +89,11 @@ public final class WorkflowInternal {
     return getWorkflowOutboundInterceptor().newTimer(duration);
   }
 
+  public static Promise<Void> newTimer(Duration duration, TimerOptions options) {
+    assertNotReadOnly("schedule timer");
+    return getWorkflowOutboundInterceptor().newTimer(duration, options);
+  }
+
   /**
    * @param capacity the maximum size of the queue
    * @return new instance of {@link WorkflowQueue}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowOptions.java
@@ -73,6 +73,8 @@ public final class ChildWorkflowOptions {
     private List<ContextPropagator> contextPropagators;
     private ChildWorkflowCancellationType cancellationType;
     private VersioningIntent versioningIntent;
+    private String staticSummary;
+    private String staticDetails;
 
     private Builder() {}
 
@@ -96,6 +98,8 @@ public final class ChildWorkflowOptions {
       this.contextPropagators = options.getContextPropagators();
       this.cancellationType = options.getCancellationType();
       this.versioningIntent = options.getVersioningIntent();
+      this.staticSummary = options.getStaticSummary();
+      this.staticDetails = options.getStaticDetails();
     }
 
     /**
@@ -303,6 +307,31 @@ public final class ChildWorkflowOptions {
       return this;
     }
 
+    /**
+     * Single-line fixed summary for this workflow execution that will appear in UI/CLI. This can be
+     * in single-line Temporal Markdown format.
+     *
+     * <p>Default is none/empty.
+     */
+    @Experimental
+    public Builder setStaticSummary(String staticSummary) {
+      this.staticSummary = staticSummary;
+      return this;
+    }
+
+    /**
+     * General fixed details for this workflow execution that will appear in UI/CLI. This can be in
+     * Temporal Markdown format and can span multiple lines. This is a fixed value on the workflow
+     * that cannot be updated.
+     *
+     * <p>Default is none/empty.
+     */
+    @Experimental
+    public Builder setStaticDetails(String staticDetails) {
+      this.staticDetails = staticDetails;
+      return this;
+    }
+
     public ChildWorkflowOptions build() {
       return new ChildWorkflowOptions(
           namespace,
@@ -320,7 +349,9 @@ public final class ChildWorkflowOptions {
           typedSearchAttributes,
           contextPropagators,
           cancellationType,
-          versioningIntent);
+          versioningIntent,
+          staticSummary,
+          staticDetails);
     }
 
     public ChildWorkflowOptions validateAndBuildWithDefaults() {
@@ -344,7 +375,9 @@ public final class ChildWorkflowOptions {
               : cancellationType,
           versioningIntent == null
               ? VersioningIntent.VERSIONING_INTENT_UNSPECIFIED
-              : versioningIntent);
+              : versioningIntent,
+          staticSummary,
+          staticDetails);
     }
   }
 
@@ -364,6 +397,8 @@ public final class ChildWorkflowOptions {
   private final List<ContextPropagator> contextPropagators;
   private final ChildWorkflowCancellationType cancellationType;
   private final VersioningIntent versioningIntent;
+  private final String staticSummary;
+  private final String staticDetails;
 
   private ChildWorkflowOptions(
       String namespace,
@@ -381,7 +416,9 @@ public final class ChildWorkflowOptions {
       SearchAttributes typedSearchAttributes,
       List<ContextPropagator> contextPropagators,
       ChildWorkflowCancellationType cancellationType,
-      VersioningIntent versioningIntent) {
+      VersioningIntent versioningIntent,
+      String staticSummary,
+      String staticDetails) {
     this.namespace = namespace;
     this.workflowId = workflowId;
     this.workflowIdReusePolicy = workflowIdReusePolicy;
@@ -398,6 +435,8 @@ public final class ChildWorkflowOptions {
     this.contextPropagators = contextPropagators;
     this.cancellationType = cancellationType;
     this.versioningIntent = versioningIntent;
+    this.staticSummary = staticSummary;
+    this.staticDetails = staticDetails;
   }
 
   public String getNamespace() {
@@ -468,6 +507,14 @@ public final class ChildWorkflowOptions {
     return versioningIntent;
   }
 
+  public String getStaticSummary() {
+    return staticSummary;
+  }
+
+  public String getStaticDetails() {
+    return staticDetails;
+  }
+
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -492,7 +539,9 @@ public final class ChildWorkflowOptions {
         && Objects.equal(typedSearchAttributes, that.typedSearchAttributes)
         && Objects.equal(contextPropagators, that.contextPropagators)
         && cancellationType == that.cancellationType
-        && versioningIntent == that.versioningIntent;
+        && versioningIntent == that.versioningIntent
+        && Objects.equal(staticSummary, that.staticSummary)
+        && Objects.equal(staticDetails, that.staticDetails);
   }
 
   @Override
@@ -513,7 +562,9 @@ public final class ChildWorkflowOptions {
         typedSearchAttributes,
         contextPropagators,
         cancellationType,
-        versioningIntent);
+        versioningIntent,
+        staticSummary,
+        staticDetails);
   }
 
   @Override
@@ -555,6 +606,10 @@ public final class ChildWorkflowOptions {
         + cancellationType
         + ", versioningIntent="
         + versioningIntent
+        + ", staticSummary="
+        + staticSummary
+        + ", staticDetails="
+        + staticDetails
         + '}';
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
@@ -102,6 +102,6 @@ public final class TimerOptions {
 
   @Override
   public int hashCode() {
-    return Objects.hash(staticSummary);
+    return Objects.hash(summary);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
@@ -53,7 +53,7 @@ public final class TimerOptions {
       if (options == null) {
         return;
       }
-      this.summary = options.staticSummary;
+      this.summary = options.summary;
     }
 
     /**
@@ -73,14 +73,14 @@ public final class TimerOptions {
     }
   }
 
-  private final String staticSummary;
+  private final String summary;
 
-  private TimerOptions(String staticSummary) {
-    this.staticSummary = staticSummary;
+  private TimerOptions(String summary) {
+    this.summary = summary;
   }
 
-  public String getStaticSummary() {
-    return staticSummary;
+  public String getSummary() {
+    return summary;
   }
 
   public Builder toBuilder() {
@@ -89,7 +89,7 @@ public final class TimerOptions {
 
   @Override
   public String toString() {
-    return "TimerOptions{" + "summary='" + staticSummary + '\'' + '}';
+    return "TimerOptions{" + "summary='" + summary + '\'' + '}';
   }
 
   @Override
@@ -97,7 +97,7 @@ public final class TimerOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     TimerOptions that = (TimerOptions) o;
-    return Objects.equals(staticSummary, that.staticSummary);
+    return Objects.equals(summary, that.summary);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.common.Experimental;
+import java.util.Objects;
+
+/** TimerOptions is used to specify options for a timer. */
+public final class TimerOptions {
+
+  public static TimerOptions.Builder newBuilder() {
+    return new TimerOptions.Builder();
+  }
+
+  public static TimerOptions.Builder newBuilder(TimerOptions options) {
+    return new TimerOptions.Builder(options);
+  }
+
+  public static TimerOptions getDefaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+
+  private static final TimerOptions DEFAULT_INSTANCE;
+
+  static {
+    DEFAULT_INSTANCE = TimerOptions.newBuilder().build();
+  }
+
+  public static final class Builder {
+    private String staticSummary;
+    private String staticDetails;
+
+    private Builder() {}
+
+    private Builder(TimerOptions options) {
+      if (options == null) {
+        return;
+      }
+      this.staticSummary = options.staticSummary;
+      this.staticDetails = options.staticDetails;
+    }
+
+    /**
+     * Single-line fixed summary for this timer that will appear in UI/CLI. This can be in
+     * single-line Temporal Markdown format.
+     *
+     * <p>Default is none/empty.
+     */
+    @Experimental
+    public Builder setStaticSummary(String staticSummary) {
+      this.staticSummary = staticSummary;
+      return this;
+    }
+
+    /**
+     * General fixed details for this timer that will appear in UI/CLI. This can be in Temporal
+     * Markdown format and can span multiple lines. This is a fixed value on the workflow that
+     * cannot be updated.
+     *
+     * <p>Default is none/empty.
+     */
+    @Experimental
+    public Builder setStaticDetails(String staticDetails) {
+      this.staticDetails = staticDetails;
+      return this;
+    }
+
+    public TimerOptions build() {
+      return new TimerOptions(staticSummary, staticDetails);
+    }
+  }
+
+  private final String staticSummary;
+  private final String staticDetails;
+
+  public TimerOptions(String staticSummary, String staticDetails) {
+    this.staticSummary = staticSummary;
+    this.staticDetails = staticDetails;
+  }
+
+  public String getStaticSummary() {
+    return staticSummary;
+  }
+
+  public String getStaticDetails() {
+    return staticDetails;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public String toString() {
+    return "TimerOptions{"
+        + "staticSummary='"
+        + staticSummary
+        + '\''
+        + ", staticDetails='"
+        + staticDetails
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TimerOptions that = (TimerOptions) o;
+    return Objects.equals(staticSummary, that.staticSummary)
+        && Objects.equals(staticDetails, that.staticDetails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(staticSummary, staticDetails);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
@@ -45,8 +45,7 @@ public final class TimerOptions {
   }
 
   public static final class Builder {
-    private String staticSummary;
-    private String staticDetails;
+    private String summary;
 
     private Builder() {}
 
@@ -54,8 +53,7 @@ public final class TimerOptions {
       if (options == null) {
         return;
       }
-      this.staticSummary = options.staticSummary;
-      this.staticDetails = options.staticDetails;
+      this.summary = options.staticSummary;
     }
 
     /**
@@ -65,43 +63,24 @@ public final class TimerOptions {
      * <p>Default is none/empty.
      */
     @Experimental
-    public Builder setStaticSummary(String staticSummary) {
-      this.staticSummary = staticSummary;
-      return this;
-    }
-
-    /**
-     * General fixed details for this timer that will appear in UI/CLI. This can be in Temporal
-     * Markdown format and can span multiple lines. This is a fixed value on the workflow that
-     * cannot be updated.
-     *
-     * <p>Default is none/empty.
-     */
-    @Experimental
-    public Builder setStaticDetails(String staticDetails) {
-      this.staticDetails = staticDetails;
+    public Builder setSummary(String summary) {
+      this.summary = summary;
       return this;
     }
 
     public TimerOptions build() {
-      return new TimerOptions(staticSummary, staticDetails);
+      return new TimerOptions(summary);
     }
   }
 
   private final String staticSummary;
-  private final String staticDetails;
 
-  public TimerOptions(String staticSummary, String staticDetails) {
+  private TimerOptions(String staticSummary) {
     this.staticSummary = staticSummary;
-    this.staticDetails = staticDetails;
   }
 
   public String getStaticSummary() {
     return staticSummary;
-  }
-
-  public String getStaticDetails() {
-    return staticDetails;
   }
 
   public Builder toBuilder() {
@@ -110,14 +89,7 @@ public final class TimerOptions {
 
   @Override
   public String toString() {
-    return "TimerOptions{"
-        + "staticSummary='"
-        + staticSummary
-        + '\''
-        + ", staticDetails='"
-        + staticDetails
-        + '\''
-        + '}';
+    return "TimerOptions{" + "summary='" + staticSummary + '\'' + '}';
   }
 
   @Override
@@ -125,12 +97,11 @@ public final class TimerOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     TimerOptions that = (TimerOptions) o;
-    return Objects.equals(staticSummary, that.staticSummary)
-        && Objects.equals(staticDetails, that.staticDetails);
+    return Objects.equals(staticSummary, that.staticSummary);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(staticSummary, staticDetails);
+    return Objects.hash(staticSummary);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -493,7 +493,18 @@ public final class Workflow {
    *     failed with {@link CanceledFailure} if enclosing scope is canceled.
    */
   public static Promise<Void> newTimer(Duration delay) {
-    return WorkflowInternal.newTimer(delay);
+    return WorkflowInternal.newTimer(delay, null);
+  }
+
+  /**
+   * Create new timer with options. Note that Temporal service time resolution is in seconds. So all
+   * durations are rounded <b>up</b> to the nearest second.
+   *
+   * @return feature that becomes ready when at least specified number of seconds passes. promise is
+   *     failed with {@link CanceledFailure} if enclosing scope is canceled.
+   */
+  public static Promise<Void> newTimer(Duration delay, TimerOptions options) {
+    return WorkflowInternal.newTimer(delay, options);
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -493,7 +493,7 @@ public final class Workflow {
    *     failed with {@link CanceledFailure} if enclosing scope is canceled.
    */
   public static Promise<Void> newTimer(Duration delay) {
-    return WorkflowInternal.newTimer(delay, null);
+    return WorkflowInternal.newTimer(delay);
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
@@ -133,6 +133,7 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
                               .getTimerStartedEventAttributes()
                               .getTimerId())
                       .build(),
+                  null,
                   historyEvent -> {});
               return false;
             })

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/LocalActivityStateMachineTest.java
@@ -357,7 +357,8 @@ public class LocalActivityStateMachineTest {
         StartChildWorkflowExecutionParameters childRequest =
             new StartChildWorkflowExecutionParameters(
                 StartChildWorkflowExecutionCommandAttributes.newBuilder(),
-                ChildWorkflowCancellationType.WAIT_CANCELLATION_REQUESTED);
+                ChildWorkflowCancellationType.WAIT_CANCELLATION_REQUESTED,
+                null);
         ExecuteLocalActivityParameters parameters1 =
             new ExecuteLocalActivityParameters(
                 PollActivityTaskQueueResponse.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/MutableSideEffectStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/MutableSideEffectStateMachineTest.java
@@ -234,6 +234,7 @@ public class MutableSideEffectStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .<HistoryEvent>add1(
                 (v, c) ->
@@ -241,6 +242,7 @@ public class MutableSideEffectStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .<Optional<Payloads>>add1(
                 (v, c) -> stateMachines.mutableSideEffect("id1", (p) -> Optional.empty(), c))

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TimerStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TimerStateMachineTest.java
@@ -87,6 +87,7 @@ public class TimerStateMachineTest {
                             .setStartToFireTimeout(
                                 ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                             .build(),
+                        null,
                         c))
             .add((firedEvent) -> stateMachines.completeWorkflow(Optional.empty()));
       }
@@ -158,6 +159,7 @@ public class TimerStateMachineTest {
                                 .setStartToFireTimeout(
                                     ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                                 .build(),
+                            null,
                             c))
             .add(
                 (firedEvent) ->
@@ -171,6 +173,7 @@ public class TimerStateMachineTest {
                             .setStartToFireTimeout(
                                 ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                             .build(),
+                        null,
                         c))
             .add((firedEvent) -> stateMachines.completeWorkflow(converter.toPayloads("result1")));
 
@@ -232,6 +235,7 @@ public class TimerStateMachineTest {
                                 .setStartToFireTimeout(
                                     ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                                 .build(),
+                            null,
                             c))
             .add(
                 (firedEvent) -> {
@@ -247,6 +251,7 @@ public class TimerStateMachineTest {
                             .setStartToFireTimeout(
                                 ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                             .build(),
+                        null,
                         c))
             .add(
                 (firedEvent) -> {

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/UpdateProtocolStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/UpdateProtocolStateMachineTest.java
@@ -107,6 +107,7 @@ public class UpdateProtocolStateMachineTest {
                             .setStartToFireTimeout(
                                 ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                             .build(),
+                        null,
                         c))
             .add(
                 (r) -> {
@@ -465,6 +466,7 @@ public class UpdateProtocolStateMachineTest {
                         .setStartToFireTimeout(
                             ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                         .build(),
+                    null,
                     c));
       }
 
@@ -488,6 +490,7 @@ public class UpdateProtocolStateMachineTest {
                         .setStartToFireTimeout(
                             ProtobufTimeUtils.toProtoDuration(Duration.ofHours(1)))
                         .build(),
+                    null,
                     c));
       }
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/VersionStateMachineTest.java
@@ -384,6 +384,7 @@ public class VersionStateMachineTest {
                       StartTimerCommandAttributes.newBuilder()
                           .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                           .build(),
+                      null,
                       c);
                 })
             .add((v) -> stateMachines.completeWorkflow(converter.toPayloads(v)));
@@ -496,6 +497,7 @@ public class VersionStateMachineTest {
                       StartTimerCommandAttributes.newBuilder()
                           .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                           .build(),
+                      null,
                       c);
                 })
             .<HistoryEvent>add1(
@@ -504,6 +506,7 @@ public class VersionStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .<Integer, RuntimeException>add2(
                 (v, c) -> stateMachines.getVersion("id1", maxSupported - 3, maxSupported + 10, c))
@@ -635,6 +638,7 @@ public class VersionStateMachineTest {
                       StartTimerCommandAttributes.newBuilder()
                           .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                           .build(),
+                      null,
                       c);
                 })
             .<HistoryEvent>add1(
@@ -643,6 +647,7 @@ public class VersionStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .<Integer, RuntimeException>add2(
                 (v, c) -> stateMachines.getVersion("id1", maxSupported - 3, maxSupported + 10, c))
@@ -743,6 +748,7 @@ public class VersionStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .add((v) -> stateMachines.completeWorkflow(converter.toPayloads(v)));
       }
@@ -841,6 +847,7 @@ public class VersionStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .<HistoryEvent>add1(
                 (v, c) ->
@@ -848,6 +855,7 @@ public class VersionStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             /*.<Integer>add(
             (v, c) -> stateMachines.getVersion("id1", maxSupported - 3, maxSupported + 10, c))*/
@@ -950,6 +958,7 @@ public class VersionStateMachineTest {
                   StartTimerCommandAttributes.newBuilder()
                       .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                       .build(),
+                  null,
                   c);
               stateMachines.completeWorkflow(converter.toPayloads(v));
             });
@@ -1009,6 +1018,7 @@ public class VersionStateMachineTest {
                         StartTimerCommandAttributes.newBuilder()
                             .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                             .build(),
+                        null,
                         c))
             .add(
                 (v) -> {
@@ -1080,6 +1090,7 @@ public class VersionStateMachineTest {
                       StartTimerCommandAttributes.newBuilder()
                           .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                           .build(),
+                      null,
                       c);
                 })
             .<Integer, RuntimeException>add2(
@@ -1181,6 +1192,7 @@ public class VersionStateMachineTest {
                                 .setStartToFireTimeout(
                                     Duration.newBuilder().setSeconds(100).build())
                                 .build(),
+                            null,
                             ignore -> {})))
             .add((v) -> cancelTimerProc.get().apply())
             .<Integer, RuntimeException>add2(
@@ -1193,6 +1205,7 @@ public class VersionStateMachineTest {
                       StartTimerCommandAttributes.newBuilder()
                           .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                           .build(),
+                      null,
                       c);
                 })
             .add((v) -> stateMachines.completeWorkflow(converter.toPayloads(null)));
@@ -1265,6 +1278,7 @@ public class VersionStateMachineTest {
                       StartTimerCommandAttributes.newBuilder()
                           .setStartToFireTimeout(Duration.newBuilder().setSeconds(100).build())
                           .build(),
+                      null,
                       c);
                 })
             .<Integer, RuntimeException>add2(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
@@ -55,7 +55,6 @@ public class ChildWorkflowMetadataTest {
   static final String details = "my-wf-details";
   static final String childSummary = "child-summary";
   static final String childDetails = "child-details";
-  static final String childTimerDetails = "child-timer-details";
   static final String childTimerSummary = "child-timer-summary";
 
   @Before
@@ -87,7 +86,7 @@ public class ChildWorkflowMetadataTest {
         workflowExecutionHistory.getEvents().stream()
             .filter(HistoryEvent::hasTimerStartedEventAttributes)
             .collect(Collectors.toList());
-    assertEventMetadata(timerStartedEvents.get(0), childTimerSummary, childTimerDetails);
+    assertEventMetadata(timerStartedEvents.get(0), childTimerSummary, null);
   }
 
   private void assertWorkflowMetadata(String workflowId, String summary, String details) {
@@ -116,14 +115,18 @@ public class ChildWorkflowMetadataTest {
   }
 
   private void assertEventMetadata(HistoryEvent event, String summary, String details) {
-    String describedSummary =
-        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
-            event.getUserMetadata().getSummary(), String.class, String.class);
-    String describedDetails =
-        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
-            event.getUserMetadata().getDetails(), String.class, String.class);
-    assertEquals(summary, describedSummary);
-    assertEquals(details, describedDetails);
+    if (details != null) {
+      String describedSummary =
+          DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+              event.getUserMetadata().getSummary(), String.class, String.class);
+      assertEquals(summary, describedSummary);
+    }
+    if (summary != null) {
+      String describedDetails =
+          DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+              event.getUserMetadata().getDetails(), String.class, String.class);
+      assertEquals(details, describedDetails);
+    }
   }
 
   public static class TestParentWorkflow implements TestWorkflow1 {
@@ -149,10 +152,7 @@ public class ChildWorkflowMetadataTest {
     public String execute(String arg, int delay) {
       Workflow.newTimer(
               Duration.ofMillis(delay),
-              TimerOptions.newBuilder()
-                  .setStaticDetails(childTimerDetails)
-                  .setStaticSummary(childTimerSummary)
-                  .build())
+              TimerOptions.newBuilder().setSummary(childTimerSummary).build())
           .get();
       return arg.toUpperCase();
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
@@ -115,13 +115,13 @@ public class ChildWorkflowMetadataTest {
   }
 
   private void assertEventMetadata(HistoryEvent event, String summary, String details) {
-    if (details != null) {
+    if (summary != null) {
       String describedSummary =
           DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
               event.getUserMetadata().getSummary(), String.class, String.class);
       assertEquals(summary, describedSummary);
     }
-    if (summary != null) {
+    if (details != null) {
       String describedDetails =
           DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
               event.getUserMetadata().getDetails(), String.class, String.class);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
@@ -21,6 +21,7 @@
 package io.temporal.workflow.childWorkflowTests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.history.v1.HistoryEvent;
@@ -38,6 +39,7 @@ import io.temporal.workflow.shared.TestWorkflows.*;
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -47,7 +49,6 @@ public class ChildWorkflowMetadataTest {
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestParentWorkflow.class, TestChild.class)
-          .setUseExternalService(true)
           .build();
 
   static final String summary = "my-wf-summary";
@@ -56,6 +57,11 @@ public class ChildWorkflowMetadataTest {
   static final String childDetails = "child-details";
   static final String childTimerDetails = "child-timer-details";
   static final String childTimerSummary = "child-timer-summary";
+
+  @Before
+  public void checkRealServer() {
+    assumeTrue("skipping for test server", SDKTestWorkflowRule.useExternalService);
+  }
 
   @Test
   public void testChildWorkflowWithMetaData() {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.childWorkflowTests;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.ChildWorkflowOptions;
+import io.temporal.workflow.TimerOptions;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows.*;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ChildWorkflowMetadataTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestParentWorkflow.class, TestChild.class)
+          .setUseExternalService(true)
+          .build();
+
+  static final String summary = "my-wf-summary";
+  static final String details = "my-wf-details";
+  static final String childSummary = "child-summary";
+  static final String childDetails = "child-details";
+  static final String childTimerDetails = "child-timer-details";
+  static final String childTimerSummary = "child-timer-summary";
+
+  @Test
+  public void testChildWorkflowWithMetaData() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(20))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .setStaticSummary(summary)
+            .setStaticDetails(details)
+            .build();
+    TestWorkflow1 stub =
+        testWorkflowRule.getWorkflowClient().newWorkflowStub(TestWorkflow1.class, options);
+
+    String childWorkflowId = stub.execute(testWorkflowRule.getTaskQueue());
+
+    WorkflowExecution exec = WorkflowStub.fromTyped(stub).getExecution();
+    assertWorkflowMetadata(exec.getWorkflowId(), summary, details);
+    assertWorkflowMetadata(childWorkflowId, childSummary, childDetails);
+
+    WorkflowExecutionHistory workflowExecutionHistory =
+        testWorkflowRule.getWorkflowClient().fetchHistory(childWorkflowId);
+    List<HistoryEvent> timerStartedEvents =
+        workflowExecutionHistory.getEvents().stream()
+            .filter(HistoryEvent::hasTimerStartedEventAttributes)
+            .collect(Collectors.toList());
+    assertEventMetadata(timerStartedEvents.get(0), childTimerSummary, childTimerDetails);
+  }
+
+  private void assertWorkflowMetadata(String workflowId, String summary, String details) {
+    DescribeWorkflowExecutionResponse describe =
+        testWorkflowRule
+            .getWorkflowClient()
+            .getWorkflowServiceStubs()
+            .blockingStub()
+            .describeWorkflowExecution(
+                DescribeWorkflowExecutionRequest.newBuilder()
+                    .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                    .setExecution(WorkflowExecution.newBuilder().setWorkflowId(workflowId).build())
+                    .build());
+    String describedSummary =
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            describe.getExecutionConfig().getUserMetadata().getSummary(),
+            String.class,
+            String.class);
+    String describedDetails =
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            describe.getExecutionConfig().getUserMetadata().getDetails(),
+            String.class,
+            String.class);
+    assertEquals(summary, describedSummary);
+    assertEquals(details, describedDetails);
+  }
+
+  private void assertEventMetadata(HistoryEvent event, String summary, String details) {
+    String describedSummary =
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            event.getUserMetadata().getSummary(), String.class, String.class);
+    String describedDetails =
+        DefaultDataConverter.STANDARD_INSTANCE.fromPayload(
+            event.getUserMetadata().getDetails(), String.class, String.class);
+    assertEquals(summary, describedSummary);
+    assertEquals(details, describedDetails);
+  }
+
+  public static class TestParentWorkflow implements TestWorkflow1 {
+
+    private final ITestChild child1 =
+        Workflow.newChildWorkflowStub(
+            ITestChild.class,
+            ChildWorkflowOptions.newBuilder()
+                .setStaticDetails(childDetails)
+                .setStaticSummary(childSummary)
+                .build());
+
+    @Override
+    public String execute(String taskQueue) {
+      child1.execute("World!", 1);
+      return Workflow.getWorkflowExecution(child1).get().getWorkflowId();
+    }
+  }
+
+  public static class TestChild implements ITestChild {
+
+    @Override
+    public String execute(String arg, int delay) {
+      Workflow.newTimer(
+              Duration.ofMillis(delay),
+              TimerOptions.newBuilder()
+                  .setStaticDetails(childTimerDetails)
+                  .setStaticSummary(childTimerSummary)
+                  .build())
+          .get();
+      return arg.toUpperCase();
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -26,6 +26,7 @@ import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttribute
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
 import io.temporal.api.common.v1.*;
 import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.CanceledFailure;
@@ -243,7 +244,7 @@ public class DummySyncWorkflowContext {
 
     @Override
     public Functions.Proc1<RuntimeException> newTimer(
-        Duration delay, Functions.Proc1<RuntimeException> callback) {
+        Duration delay, UserMetadata metadata, Functions.Proc1<RuntimeException> callback) {
       timer.schedule(
           new TimerTask() {
             @Override

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -60,6 +60,7 @@ import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Functions;
 import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Promise;
+import io.temporal.workflow.TimerOptions;
 import io.temporal.workflow.Workflow;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Type;
@@ -411,6 +412,11 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
 
     @Override
     public Promise<Void> newTimer(Duration duration) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Promise<Void> newTimer(Duration duration, TimerOptions options) {
       throw new UnsupportedOperationException("not implemented");
     }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/TracingWorkerInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/TracingWorkerInterceptor.java
@@ -28,10 +28,7 @@ import io.temporal.client.ActivityCompletionException;
 import io.temporal.common.SearchAttributeUpdate;
 import io.temporal.common.interceptors.*;
 import io.temporal.internal.sync.WorkflowMethodThreadNameStrategy;
-import io.temporal.workflow.Functions;
-import io.temporal.workflow.Promise;
-import io.temporal.workflow.Workflow;
-import io.temporal.workflow.WorkflowInfo;
+import io.temporal.workflow.*;
 import io.temporal.workflow.unsafe.WorkflowUnsafe;
 import java.lang.reflect.Type;
 import java.time.Duration;
@@ -245,6 +242,14 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
         trace.add("newTimer " + duration);
       }
       return next.newTimer(duration);
+    }
+
+    @Override
+    public Promise<Void> newTimer(Duration duration, TimerOptions options) {
+      if (!WorkflowUnsafe.isReplaying()) {
+        trace.add("newTimer " + duration);
+      }
+      return next.newTimer(duration, options);
     }
 
     @Override


### PR DESCRIPTION
Add support for user metadata on workflows and timer events. Other events can be added in the future, just picked these events to match the Go SDK.

Note: This does NOT cover `__temporal_workflow_metadata`, that feature is tracked [here](https://github.com/temporalio/sdk-java/issues/2217) 

closes https://github.com/temporalio/sdk-java/issues/2216
