### PR TITLE
Test Server: Fix Nexus operation timeout during retry

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -789,7 +789,12 @@ class StateMachines {
   private static State failNexusOperation(
       RequestContext ctx, NexusOperationData data, Failure failure, long notUsed) {
     RetryState retryState = attemptNexusOperationRetry(ctx, Optional.of(failure), data);
-    if (retryState == RetryState.RETRY_STATE_IN_PROGRESS) {
+    if (retryState == RetryState.RETRY_STATE_IN_PROGRESS
+        || retryState == RetryState.RETRY_STATE_TIMEOUT) {
+      // RETRY_STATE_TIMEOUT indicates that the next attempt schedule time would exceed the
+      // operation's schedule-to-close timeout, so do not fail the operation here and allow
+      // it to be timed out by the timer set in
+      // io.temporal.internal.testservice.TestWorkflowMutableStateImpl.timeoutNexusOperation
       return (Strings.isNullOrEmpty(data.operationId)) ? INITIATED : STARTED;
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Changed test server logic to not immediately record a failure if the next attempt schedule time would exceed an operation's schedule to close timeout.

## Why?
<!-- Tell your future self why have you made these changes -->
Closes https://github.com/temporalio/sdk-java/issues/2215

