### PR TITLE
Add workflow init support 

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowImplMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowImplMetadata.java
@@ -166,7 +166,6 @@ public final class POJOWorkflowImplMetadata {
     this.queryMethods = ImmutableList.copyOf(queryMethods.values());
     this.updateMethods = ImmutableList.copyOf(updateMethods.values());
     this.updateValidatorMethods = ImmutableList.copyOf(updateValidatorMethods.values());
-    //
     if (!listener) {
       this.workflowInit =
           ReflectionUtils.getConstructor(

--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowImplMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowImplMetadata.java
@@ -22,10 +22,11 @@ package io.temporal.common.metadata;
 
 import com.google.common.collect.ImmutableList;
 import io.temporal.common.Experimental;
-import io.temporal.workflow.WorkflowInit;
+import io.temporal.internal.common.env.ReflectionUtils;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Rules:
@@ -72,9 +73,7 @@ public final class POJOWorkflowImplMetadata {
   private final List<POJOWorkflowMethodMetadata> queryMethods;
   private final List<POJOWorkflowMethodMetadata> updateMethods;
   private final List<POJOWorkflowMethodMetadata> updateValidatorMethods;
-  private Constructor<?> defaultConstructors;
-
-  private final Constructor<?> constructor;
+  private final Constructor<?> workflowInit;
 
   /**
    * Create POJOWorkflowImplMetadata for a workflow implementation class. The object must implement
@@ -169,50 +168,15 @@ public final class POJOWorkflowImplMetadata {
     this.updateValidatorMethods = ImmutableList.copyOf(updateValidatorMethods.values());
     //
     if (!listener) {
-      Optional<Constructor<?>> constructors = Optional.empty();
-      for (Constructor<?> ctor : implClass.getDeclaredConstructors()) {
-        WorkflowInit wfInit = ctor.getAnnotation(WorkflowInit.class);
-        if (wfInit == null) {
-          if (ctor.getParameterCount() == 0) {
-            if (constructors.isPresent() || this.defaultConstructors != null) {
-              throw new IllegalArgumentException(
-                  "Multiple constructors annotated with @WorkflowInit or a default constructor found.");
-            }
-            this.defaultConstructors = ctor;
-            continue;
-          }
-          continue;
-        }
-        if (constructors.isPresent() || this.defaultConstructors != null) {
-          throw new IllegalArgumentException(
-              "Multiple constructors annotated with @WorkflowInit or a default constructor found.");
-        }
-        if (!Modifier.isPublic(ctor.getModifiers())) {
-          throw new IllegalArgumentException(
-              "Constructor with @WorkflowInit annotation must be public");
-        }
-        if (this.workflowInterfaces.size() != 1) {
-          throw new IllegalArgumentException(
-              "Multiple interfaces implemented by "
-                  + implClass.getName()
-                  + " using a @WorkflowInit annotation. Only one is allowed.");
-        }
-        if (!Arrays.equals(
-            ctor.getParameterTypes(),
-            this.workflowMethods.get(0).getWorkflowMethod().getParameterTypes())) {
-          throw new IllegalArgumentException(
-              "Constructor annotated with @WorkflowInit must have the same parameters as the workflow method.");
-        }
-        constructors = Optional.of(ctor);
-      }
-      this.constructor = constructors.orElse(null);
-      if (this.constructor == null && this.defaultConstructors == null) {
-        throw new IllegalArgumentException(
-            "No default constructor or constructor annotated with @WorkflowInit found in "
-                + implClass.getName());
-      }
+      this.workflowInit =
+          ReflectionUtils.getConstructor(
+                  implClass,
+                  this.workflowMethods.stream()
+                      .map(POJOWorkflowMethodMetadata::getWorkflowMethod)
+                      .collect(Collectors.toList()))
+              .orElse(null);
     } else {
-      this.constructor = null;
+      this.workflowInit = null;
     }
   }
 
@@ -248,11 +212,8 @@ public final class POJOWorkflowImplMetadata {
     return updateValidatorMethods;
   }
 
-  public Constructor<?> getDefaultConstructors() {
-    return defaultConstructors;
-  }
-
-  public Constructor<?> getConstructor() {
-    return constructor;
+  @Experimental
+  public @Nullable Constructor<?> getWorkflowInit() {
+    return workflowInit;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/env/ReflectionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/env/ReflectionUtils.java
@@ -44,10 +44,11 @@ public final class ReflectionUtils {
     for (Constructor<?> ctor : clazz.getDeclaredConstructors()) {
       WorkflowInit wfInit = ctor.getAnnotation(WorkflowInit.class);
       if (wfInit == null) {
-        if (ctor.getParameterCount() == 0) {
+        if (ctor.getParameterCount() == 0 && Modifier.isPublic(ctor.getModifiers())) {
           if (workflowInit.isPresent() || defaultConstructors != null) {
             throw new IllegalArgumentException(
-                "Multiple constructors annotated with @WorkflowInit or a default constructor found.");
+                "Multiple constructors annotated with @WorkflowInit or a default constructor found: "
+                    + clazz.getName());
           }
           defaultConstructors = ctor;
           continue;
@@ -56,19 +57,22 @@ public final class ReflectionUtils {
       }
       if (workflowMethod.size() != 1) {
         throw new IllegalArgumentException(
-            "Multiple interfaces implemented while using @WorkflowInit annotation. Only one is allowed.");
+            "Multiple interfaces implemented while using @WorkflowInit annotation. Only one is allowed: "
+                + clazz.getName());
       }
       if (workflowInit.isPresent() || defaultConstructors != null) {
         throw new IllegalArgumentException(
-            "Multiple constructors annotated with @WorkflowInit or a default constructor found.");
+            "Multiple constructors annotated with @WorkflowInit or a default constructor found: "
+                + clazz.getName());
       }
       if (!Modifier.isPublic(ctor.getModifiers())) {
         throw new IllegalArgumentException(
-            "Constructor with @WorkflowInit annotation must be public");
+            "Constructor with @WorkflowInit annotation must be public: " + clazz.getName());
       }
       if (!Arrays.equals(ctor.getParameterTypes(), workflowMethod.get(0).getParameterTypes())) {
         throw new IllegalArgumentException(
-            "Constructor annotated with @WorkflowInit must have the same parameters as the workflow method.");
+            "Constructor annotated with @WorkflowInit must have the same parameters as the workflow method: "
+                + clazz.getName());
       }
       workflowInit = Optional.of(ctor);
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/env/ReflectionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/env/ReflectionUtils.java
@@ -21,9 +21,64 @@
 package io.temporal.internal.common.env;
 
 import com.google.common.base.Joiner;
+import io.temporal.workflow.WorkflowInit;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 public final class ReflectionUtils {
   private ReflectionUtils() {}
+
+  public static Optional<Constructor<?>> getConstructor(
+      Class<?> clazz, List<Method> workflowMethod) {
+    // We iterate through all constructors to find the one annotated with @WorkflowInit
+    // and check if it has the same parameters as the workflow method.
+    // We check all declared constructors to find any constructors that are annotated with
+    // @WorkflowInit, but not public,
+    // to give a more informative error message.
+    Optional<Constructor<?>> workflowInit = Optional.empty();
+    Constructor<?> defaultConstructors = null;
+    for (Constructor<?> ctor : clazz.getDeclaredConstructors()) {
+      WorkflowInit wfInit = ctor.getAnnotation(WorkflowInit.class);
+      if (wfInit == null) {
+        if (ctor.getParameterCount() == 0) {
+          if (workflowInit.isPresent() || defaultConstructors != null) {
+            throw new IllegalArgumentException(
+                "Multiple constructors annotated with @WorkflowInit or a default constructor found.");
+          }
+          defaultConstructors = ctor;
+          continue;
+        }
+        continue;
+      }
+      if (workflowMethod.size() != 1) {
+        throw new IllegalArgumentException(
+            "Multiple interfaces implemented while using @WorkflowInit annotation. Only one is allowed.");
+      }
+      if (workflowInit.isPresent() || defaultConstructors != null) {
+        throw new IllegalArgumentException(
+            "Multiple constructors annotated with @WorkflowInit or a default constructor found.");
+      }
+      if (!Modifier.isPublic(ctor.getModifiers())) {
+        throw new IllegalArgumentException(
+            "Constructor with @WorkflowInit annotation must be public");
+      }
+      if (!Arrays.equals(ctor.getParameterTypes(), workflowMethod.get(0).getParameterTypes())) {
+        throw new IllegalArgumentException(
+            "Constructor annotated with @WorkflowInit must have the same parameters as the workflow method.");
+      }
+      workflowInit = Optional.of(ctor);
+    }
+    if (!workflowInit.isPresent() && defaultConstructors == null) {
+      throw new IllegalArgumentException(
+          "No default constructor or constructor annotated with @WorkflowInit found: "
+              + clazz.getName());
+    }
+    return workflowInit;
+  }
 
   public static String getMethodNameForStackTraceCutoff(
       Class<?> clazz, String methodName, Class<?>... parameterTypes) throws RuntimeException {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -131,7 +131,7 @@ class SyncWorkflow implements ReplayWorkflow {
             workflowThreadExecutor,
             workflowContext,
             () -> {
-              workflow.initialize();
+              workflowProc.runConstructor();
               WorkflowInternal.newWorkflowMethodThread(
                       () -> workflowProc.runWorkflowMethod(),
                       workflowMethodThreadNameStrategy.createThreadName(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 interface SyncWorkflowDefinition {
 
   /** Always called first. */
-  void initialize();
+  void initialize(Optional<Payloads> input);
 
   Optional<Payloads> execute(Header header, Optional<Payloads> input);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowExecutionHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowExecutionHandler.java
@@ -76,6 +76,17 @@ class WorkflowExecutionHandler {
     }
   }
 
+  /** Runs the workflow class constructor. */
+  public void runConstructor() {
+    try {
+      workflow.initialize(
+          attributes.hasInput() ? Optional.of(attributes.getInput()) : Optional.empty());
+    } catch (Throwable e) {
+      applyWorkflowFailurePolicyAndRethrow(e);
+      done = true;
+    }
+  }
+
   public void cancel(String reason) {}
 
   public boolean isDone() {

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow;
 
 import io.temporal.common.Experimental;
@@ -7,10 +27,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the constructor should be used as a workflow initialization method. The method
- * annotated with this annotation is called when a new workflow instance is created. The method must
- * be public and take no arguments or take the same arguments as the workflow method. All the same
- * constraints as for workflow methods apply to workflow initialization methods.
+ * Indicates that the constructor should be used as a workflow initialization method. The
+ * constructor annotated with this annotation is called when a new workflow instance is created. The
+ * method must be public and take no arguments or take the same arguments as the workflow method.
+ * All the same constraints as for workflow methods apply to workflow initialization methods.
+ *
+ * <p>Workflow initialization methods are called before the workflow method, signal handlers, update
+ * handlers or query handlers.
  *
  * <p>This annotation applies only to workflow implementation constructors.
  */

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
@@ -1,0 +1,20 @@
+package io.temporal.workflow;
+
+import io.temporal.common.Experimental;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the constructor should be used as a workflow initialization method. The method
+ * annotated with this annotation is called when a new workflow instance is created. The method must
+ * be public and take no arguments or take the same arguments as the workflow method. All the same
+ * constraints as for workflow methods apply to workflow initialization methods.
+ *
+ * <p>This annotation applies only to workflow implementation constructors.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.CONSTRUCTOR)
+@Experimental
+public @interface WorkflowInit {}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInit.java
@@ -29,8 +29,9 @@ import java.lang.annotation.Target;
 /**
  * Indicates that the constructor should be used as a workflow initialization method. The
  * constructor annotated with this annotation is called when a new workflow instance is created. The
- * method must be public and take no arguments or take the same arguments as the workflow method.
- * All the same constraints as for workflow methods apply to workflow initialization methods.
+ * method must be public and take the same arguments as the workflow method. All the same
+ * constraints as for workflow methods apply to workflow initialization methods. Any exceptions
+ * thrown by the constructor are treated the same as exceptions thrown by the workflow method.
  *
  * <p>Workflow initialization methods are called before the workflow method, signal handlers, update
  * handlers or query handlers.

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
@@ -47,6 +47,12 @@ import java.lang.annotation.Target;
  * <p>A workflow implementation object must have <b>exactly one</b> method annotated with
  * {@literal @}WorkflowMethod inherited from all the interfaces it implements.
  *
+ * <p>A workflow implementation may have a no-arg constructor or a constructor that takes the same
+ * set of arguments as the workflow interface method annotated with {@literal @}WorkflowMethod.
+ * Users should avoid blocking operations in the constructor as the constructor must be called
+ * before the workflow method is invoked and before any Signal, Update, or Queries handlers are
+ * registered.
+ *
  * <p>Example:
  *
  * <pre><code>

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
@@ -47,11 +47,11 @@ import java.lang.annotation.Target;
  * <p>A workflow implementation object must have <b>exactly one</b> method annotated with
  * {@literal @}WorkflowMethod inherited from all the interfaces it implements.
  *
- * <p>A workflow implementation may have a no-arg constructor or a constructor that takes the same
- * set of arguments as the workflow interface method annotated with {@literal @}WorkflowMethod.
- * Users should avoid blocking operations in the constructor as the constructor must be called
- * before the workflow method is invoked and before any Signal, Update, or Queries handlers are
- * registered.
+ * <p>A workflow implementation may have a no-arg constructor or a constructor annotated with
+ * {@literal @}WorkflowInit that takes the same set of arguments as the workflow interface method
+ * annotated with {@literal @}WorkflowMethod. Users should avoid blocking operations in the
+ * constructor as the constructor must be called before the workflow method is invoked and before
+ * any Signal, Update, or Queries handlers are registered.
  *
  * <p>Example:
  *

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowImplMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowImplMetadataTest.java
@@ -159,7 +159,7 @@ public class POJOWorkflowImplMetadataTest {
       assertTrue(
           e.getMessage()
               .contains(
-                  "Multiple interfaces implemented while using @WorkflowInit annotation. Only one is allowed."));
+                  "Multiple interfaces implemented while using @WorkflowInit annotation. Only one is allowed:"));
     }
   }
 
@@ -172,7 +172,7 @@ public class POJOWorkflowImplMetadataTest {
       assertTrue(
           e.getMessage()
               .contains(
-                  "Constructor annotated with @WorkflowInit must have the same parameters as the workflow method."));
+                  "Constructor annotated with @WorkflowInit must have the same parameters as the workflow method"));
     }
   }
 
@@ -196,7 +196,7 @@ public class POJOWorkflowImplMetadataTest {
       assertTrue(
           e.getMessage()
               .contains(
-                  "Multiple constructors annotated with @WorkflowInit or a default constructor found."));
+                  "Multiple constructors annotated with @WorkflowInit or a default constructor found:"));
     }
   }
 
@@ -229,12 +229,12 @@ public class POJOWorkflowImplMetadataTest {
     Assert.assertNull(meta.getWorkflowInit());
   }
 
-  static class GImpl implements POJOWorkflowInterfaceMetadataTest.G {
+  public static class GImpl implements POJOWorkflowInterfaceMetadataTest.G {
     @Override
     public void g() {}
   }
 
-  static class DImpl
+  public static class DImpl
       implements POJOWorkflowInterfaceMetadataTest.D, POJOWorkflowInterfaceMetadataTest.E {
 
     @Override
@@ -255,13 +255,13 @@ public class POJOWorkflowImplMetadataTest {
     public void d() {}
   }
 
-  static class DWithAdditionalInterface extends DImpl
+  public static class DWithAdditionalInterface extends DImpl
       implements POJOWorkflowInterfaceMetadataTest.O {
     @Override
     public void someMethod() {}
   }
 
-  static class DuplicatedName1Impl implements POJOWorkflowInterfaceMetadataTest.DE {
+  public static class DuplicatedName1Impl implements POJOWorkflowInterfaceMetadataTest.DE {
 
     @Override
     public void a() {}
@@ -281,7 +281,7 @@ public class POJOWorkflowImplMetadataTest {
     public void d() {}
   }
 
-  static class DuplicatedName2Impl
+  public static class DuplicatedName2Impl
       implements POJOWorkflowInterfaceMetadataTest.F, POJOWorkflowInterfaceMetadataTest.C {
 
     @Override
@@ -302,11 +302,11 @@ public class POJOWorkflowImplMetadataTest {
     public void f() {}
   }
 
-  static class EmptyImpl implements POJOWorkflowInterfaceMetadataTest.Empty {
+  public static class EmptyImpl implements POJOWorkflowInterfaceMetadataTest.Empty {
     public void foo() {}
   }
 
-  static class NoWorkflowImpl implements POJOWorkflowInterfaceMetadataTest.A {
+  public static class NoWorkflowImpl implements POJOWorkflowInterfaceMetadataTest.A {
 
     @Override
     public void a() {}
@@ -370,9 +370,9 @@ public class POJOWorkflowImplMetadataTest {
     public void someMethod() {}
   }
 
-  static class WorkflowWithConstructor implements POJOWorkflowInterfaceMetadataTest.I {
+  public static class WorkflowWithConstructor implements POJOWorkflowInterfaceMetadataTest.I {
 
-    WorkflowWithConstructor() {}
+    public WorkflowWithConstructor() {}
 
     @Override
     public void i() {}

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowImplMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowImplMetadataTest.java
@@ -150,9 +150,17 @@ public class POJOWorkflowImplMetadataTest {
     POJOWorkflowImplMetadata.newInstance(EmptyImpl.class);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testImplementingMultipleWorkflowInterfaceWithInit() {
-    POJOWorkflowImplMetadata.newInstance(MultipleWorkflowWithInit.class);
+    try {
+      POJOWorkflowImplMetadata.newInstance(MultipleWorkflowWithInit.class);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Multiple interfaces implemented while using @WorkflowInit annotation. Only one is allowed."));
+    }
   }
 
   @Test
@@ -194,9 +202,31 @@ public class POJOWorkflowImplMetadataTest {
 
   @Test
   public void testWorkflowInheritWithInit() {
+    try {
+      POJOWorkflowImplMetadata.newInstance(WorkflowInheritWithInit.class);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "No default constructor or constructor annotated with @WorkflowInit found:"));
+    }
+  }
+
+  @Test
+  public void testWorkflowInit() {
+    POJOWorkflowImplMetadata meta = POJOWorkflowImplMetadata.newInstance(WorkflowWithInit.class);
+    Assert.assertNotNull(meta.getWorkflowInit());
+    Assert.assertEquals(1, meta.getWorkflowInit().getParameterCount());
+    Assert.assertEquals(Integer.class, meta.getWorkflowInit().getParameterTypes()[0]);
+    Assert.assertEquals(WorkflowWithInit.class, meta.getWorkflowInit().getDeclaringClass());
+  }
+
+  @Test
+  public void testWorkflowWithConstructor() {
     POJOWorkflowImplMetadata meta =
-        POJOWorkflowImplMetadata.newInstance(WorkflowInheritWithInit.class);
-    System.out.println(meta);
+        POJOWorkflowImplMetadata.newInstance(WorkflowWithConstructor.class);
+    Assert.assertNull(meta.getWorkflowInit());
   }
 
   static class GImpl implements POJOWorkflowInterfaceMetadataTest.G {
@@ -283,12 +313,12 @@ public class POJOWorkflowImplMetadataTest {
   }
 
   static class MultipleWorkflowWithInit
-      implements POJOWorkflowInterfaceMetadataTest.F, POJOWorkflowInterfaceMetadataTest.G {
+      implements POJOWorkflowInterfaceMetadataTest.F, POJOWorkflowInterfaceMetadataTest.I {
     @WorkflowInit
     public MultipleWorkflowWithInit() {}
 
     @Override
-    public void g() {}
+    public void i() {}
 
     @Override
     public void f() {}
@@ -338,5 +368,13 @@ public class POJOWorkflowImplMetadataTest {
 
     @Override
     public void someMethod() {}
+  }
+
+  static class WorkflowWithConstructor implements POJOWorkflowInterfaceMetadataTest.I {
+
+    WorkflowWithConstructor() {}
+
+    @Override
+    public void i() {}
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
@@ -259,6 +259,12 @@ public class POJOWorkflowInterfaceMetadataTest {
     void g();
   }
 
+  @WorkflowInterface
+  public interface H {
+    @WorkflowMethod
+    void h(Integer i);
+  }
+
   public interface DE extends D, E {}
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
@@ -265,6 +265,12 @@ public class POJOWorkflowInterfaceMetadataTest {
     void h(Integer i);
   }
 
+  @WorkflowInterface
+  public interface I {
+    @WorkflowMethod
+    void i();
+  }
+
   public interface DE extends D, E {}
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.common.converter.EncodedValues;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DynamicWorkflowInitTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestInitWorkflow.class).build();
+
+  @Test
+  public void testInit() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(testWorkflowRule.getTaskQueue(), result);
+  }
+
+  @Test
+  public void testInitThrowApplicationFailure() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    WorkflowFailedException failure =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(""));
+    Assert.assertTrue(failure.getCause() instanceof ApplicationFailure);
+    ApplicationFailure applicationFailure = (ApplicationFailure) failure.getCause();
+    assertEquals("Empty taskQueue", applicationFailure.getOriginalMessage());
+  }
+
+  public static class TestInitWorkflow implements DynamicWorkflow {
+    private final String taskQueue;
+
+    public TestInitWorkflow(EncodedValues args) {
+      String taskQueue = args.get(0, String.class);
+      if (taskQueue.isEmpty()) {
+        throw ApplicationFailure.newFailure("Empty taskQueue", "TestFailure");
+      }
+      this.taskQueue = taskQueue;
+    }
+
+    @Override
+    public Object execute(EncodedValues args) {
+      String taskQueue = args.get(0, String.class);
+      if (!taskQueue.equals(this.taskQueue)) {
+        throw new IllegalArgumentException("Unexpected taskQueue: " + taskQueue);
+      }
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/DynamicWorkflowInitTest.java
@@ -59,6 +59,7 @@ public class DynamicWorkflowInitTest {
   public static class TestInitWorkflow implements DynamicWorkflow {
     private final String taskQueue;
 
+    @WorkflowInit
     public TestInitWorkflow(EncodedValues args) {
       String taskQueue = args.get(0, String.class);
       if (taskQueue.isEmpty()) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitConstructorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitConstructorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowInitConstructorTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestInitWorkflow.class).build();
+
+  @Test
+  public void testInit() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(testWorkflowRule.getTaskQueue(), result);
+  }
+
+  public static class TestInitWorkflow implements TestWorkflow1 {
+
+    public TestInitWorkflow() {}
+
+    public TestInitWorkflow(String taskQueue) {
+      Assert.fail();
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
@@ -58,6 +58,8 @@ public class WorkflowInitRetryTest {
   }
 
   public static class TestInitWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @WorkflowInit
     public TestInitWorkflow(String testName) {
       AtomicInteger count = retryCount.get(testName);
       if (count == null) {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitRetryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.client.WorkflowException;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class WorkflowInitRetryTest {
+  private static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              WorkflowImplementationOptions.newBuilder()
+                  .setFailWorkflowExceptionTypes(IllegalArgumentException.class)
+                  .build(),
+              TestInitWorkflow.class)
+          .build();
+
+  @Test
+  public void testInitFailsRuntimeException() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    WorkflowException exception =
+        Assert.assertThrows(
+            WorkflowException.class, () -> workflowStub.execute(testName.getMethodName()));
+    System.out.println(exception);
+  }
+
+  public static class TestInitWorkflow implements TestWorkflows.TestWorkflow1 {
+    public TestInitWorkflow(String testName) {
+      AtomicInteger count = retryCount.get(testName);
+      if (count == null) {
+        count = new AtomicInteger();
+        retryCount.put(testName, count);
+      }
+      int c = count.incrementAndGet();
+      if (c < 3) {
+        throw new IllegalStateException("simulated " + c);
+      } else {
+        throw new IllegalArgumentException("simulated " + c);
+      }
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowInitTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestInitWorkflow.class).build();
+
+  @Test
+  public void testInit() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    assertEquals(testWorkflowRule.getTaskQueue(), result);
+  }
+
+  @Test
+  public void testInitThrowApplicationFailure() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    WorkflowFailedException failure =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(""));
+    Assert.assertTrue(failure.getCause() instanceof ApplicationFailure);
+    ApplicationFailure applicationFailure = (ApplicationFailure) failure.getCause();
+    assertEquals("Empty taskQueue", applicationFailure.getOriginalMessage());
+  }
+
+  public static class TestInitWorkflow implements TestWorkflow1 {
+    private final String taskQueue;
+
+    public TestInitWorkflow(String taskQueue) {
+      if (taskQueue.isEmpty()) {
+        throw ApplicationFailure.newFailure("Empty taskQueue", "TestFailure");
+      }
+      this.taskQueue = taskQueue;
+    }
+
+    @Override
+    public String execute(String taskQueue) {
+      if (!taskQueue.equals(this.taskQueue)) {
+        throw new IllegalArgumentException("Unexpected taskQueue: " + taskQueue);
+      }
+      return taskQueue;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowInitTest.java
@@ -58,6 +58,7 @@ public class WorkflowInitTest {
   public static class TestInitWorkflow implements TestWorkflow1 {
     private final String taskQueue;
 
+    @WorkflowInit
     public TestInitWorkflow(String taskQueue) {
       if (taskQueue.isEmpty()) {
         throw ApplicationFailure.newFailure("Empty taskQueue", "TestFailure");


### PR DESCRIPTION
Add workflow init support to allow users to run code before signal/update handlers:
* If the workflow implementation defines a no-arg constructor that is used to maintain backwards compatibility
* SDK checks if the workflow implementation defines a constructor annotated with `@WorkflowInit`
* SDK validates at registration time the constructor meets all requirments.
* If a constructor is  annotated with `@WorkflowInit` we treat exceptions thrown by as if they are thrown from the main workflow method

closes https://github.com/temporalio/sdk-java/issues/865