### PR TITLE
Test Server: Fix Nexus operation cancel before start

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -608,13 +608,12 @@ class StateMachines {
         .add(NONE, INITIATE, INITIATED, StateMachines::scheduleNexusOperation)
         .add(INITIATED, START, STARTED, StateMachines::startNexusOperation)
         .add(INITIATED, TIME_OUT, TIMED_OUT, StateMachines::timeoutNexusOperation)
-        // Transitions directly to CANCELED if operation has not been started
         // TODO: properly support cancel before start
-        .add(
-            INITIATED,
-            REQUEST_CANCELLATION,
-            CANCELED,
-            StateMachines::reportNexusOperationCancellation)
+        // .add(
+        //     INITIATED,
+        //     REQUEST_CANCELLATION,
+        //     INITIATED,
+        //     StateMachines::requestCancelNexusOperation)
         .add(INITIATED, CANCEL, CANCELED, StateMachines::reportNexusOperationCancellation)
         // Transitions directly from INITIATED to COMPLETE for sync completions
         .add(INITIATED, COMPLETE, COMPLETED, StateMachines::completeNexusOperation)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updated the test server to always record expected `NexusOperationCancelRequested` history events.

The logic is now consistent with server version `v1.25.0`
NOTE: this logic was changed in https://github.com/temporalio/temporal/pull/6483 which is not in an official server release yet.
This logic will be updated again once the server properly supports cancel before start.
