### PR TITLE
Add getMetricsScope interceptor

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -20,6 +20,7 @@
 
 package io.temporal.common.interceptors;
 
+import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -620,6 +621,9 @@ public interface WorkflowOutboundCallsInterceptor {
   void upsertTypedSearchAttributes(SearchAttributeUpdate<?>... searchAttributeUpdates);
 
   void upsertMemo(Map<String, Object> memo);
+
+  /** Intercepts call to get the metric scope in a workflow. */
+  Scope getMetricsScope();
 
   /**
    * Intercepts creation of a workflow child thread.

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptorBase.java
@@ -20,6 +20,7 @@
 
 package io.temporal.common.interceptors;
 
+import com.uber.m3.tally.Scope;
 import io.temporal.common.SearchAttributeUpdate;
 import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Promise;
@@ -165,6 +166,11 @@ public class WorkflowOutboundCallsInterceptorBase implements WorkflowOutboundCal
   @Override
   public void upsertMemo(Map<String, Object> memo) {
     next.upsertMemo(memo);
+  }
+
+  @Override
+  public Scope getMetricsScope() {
+    return next.getMetricsScope();
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -1210,6 +1210,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
     return new CancelWorkflowOutput(result);
   }
 
+  @Override
   public Scope getMetricsScope() {
     return replayContext.getMetricsScope();
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -640,7 +640,7 @@ public final class WorkflowInternal {
   }
 
   public static Scope getMetricsScope() {
-    return getRootWorkflowContext().getMetricsScope();
+    return getWorkflowOutboundInterceptor().getMetricsScope();
   }
 
   private static boolean isLoggingEnabledInReplay() {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -482,6 +482,11 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
     }
 
     @Override
+    public Scope getMetricsScope() {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
     public Object newChildThread(Runnable runnable, boolean detached, String name) {
       throw new UnsupportedOperationException("not implemented");
     }

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/TracingWorkerInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/TracingWorkerInterceptor.java
@@ -23,6 +23,7 @@ package io.temporal.testing.internal;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.uber.m3.tally.Scope;
 import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.common.SearchAttributeUpdate;
@@ -396,6 +397,14 @@ public class TracingWorkerInterceptor implements WorkerInterceptor {
         trace.add("upsertMemo");
       }
       next.upsertMemo(memo);
+    }
+
+    @Override
+    public Scope getMetricsScope() {
+      if (!WorkflowUnsafe.isReplaying()) {
+        trace.add("getMetricsScope");
+      }
+      return next.getMetricsScope();
     }
 
     @Override


### PR DESCRIPTION
Add `getMetricsScope` interceptor in `WorkflowOutboundCallsInterceptor`

closes https://github.com/temporalio/sdk-java/issues/2208