### PR TITLE
Fix inconsistency in javadoc for WorkflowInterface (#2232)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
@@ -84,7 +84,7 @@ import java.lang.annotation.Target;
  *     String d();
  *  }
  *
- *  public class CImpl implements C {
+ *  public class DImpl implements D {
  *      public void a() {}
  *      public void aa() {}
  *      public void b() {}
@@ -93,7 +93,7 @@ import java.lang.annotation.Target;
  *  }
  * </code></pre>
  *
- * When <code>CImpl</code> instance is registered with the {@link io.temporal.worker.Worker} the
+ * When <code>DImpl</code> instance is registered with the {@link io.temporal.worker.Worker} the
  * following is registered:
  *
  * <p>
@@ -107,7 +107,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * The client code can call signals through stubs to <code>B</code>, <code>C</code> and <code>D
- * </code> interfaces. A call to crate a stub to <code>A</code> interface will fail as <code>A
+ * </code> interfaces. A call to create a stub to <code>A</code> interface will fail as <code>A
  * </code> is not annotated with the WorkflowInterface.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInterface.java
@@ -64,7 +64,7 @@ import java.lang.annotation.Target;
  *     String d();
  *  }
  *
- *  public class CImpl implements C {
+ *  public class DImpl implements D {
  *      public void a() {}
  *      public void aa() {}
  *      public void b() {}
@@ -73,7 +73,7 @@ import java.lang.annotation.Target;
  *  }
  * </code></pre>
  *
- * When <code>CImpl</code> instance is registered with the {@link io.temporal.worker.Worker} the
+ * When <code>DImpl</code> instance is registered with the {@link io.temporal.worker.Worker} the
  * following is registered:
  *
  * <ul>
@@ -85,7 +85,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * The client code can call signals through stubs to <code>B</code>, <code>C</code> and <code>D
- * </code> interfaces. A call to crate a stub to <code>A</code> interface will fail as <code>A
+ * </code> interfaces. A call to create a stub to <code>A</code> interface will fail as <code>A
  * </code> is not annotated with the WorkflowInterface.
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
## What was changed

This modifies slightly the code example in the javadoc for the [@WorkflowInterface](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/WorkflowInterface.html) annotation.

## Why?

The example code had a slight inconsistency with the accompanying text describing it.

## Checklist
<!--- add/delete as needed --->

1. Closes #2232

2. How was this tested:

Inspected the documentation visually.  Neither compiled nor run.

