### PR TITLE
Add Nexus support to TestWorkflowExtension

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkflowImplementationOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkflowImplementationOptions.java
@@ -43,6 +43,14 @@ public final class WorkflowImplementationOptions {
     return new Builder();
   }
 
+  public static Builder newBuilder(WorkflowImplementationOptions options) {
+    return new Builder(options);
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
   public static final class Builder {
 
     private Class<? extends Throwable>[] failWorkflowExceptionTypes;
@@ -54,6 +62,19 @@ public final class WorkflowImplementationOptions {
     private NexusServiceOptions defaultNexusServiceOptions;
 
     private Builder() {}
+
+    private Builder(WorkflowImplementationOptions options) {
+      if (options == null) {
+        return;
+      }
+      this.failWorkflowExceptionTypes = options.getFailWorkflowExceptionTypes();
+      this.activityOptions = options.getActivityOptions();
+      this.defaultActivityOptions = options.getDefaultActivityOptions();
+      this.localActivityOptions = options.getLocalActivityOptions();
+      this.defaultLocalActivityOptions = options.getDefaultLocalActivityOptions();
+      this.nexusServiceOptions = options.getNexusServiceOptions();
+      this.defaultNexusServiceOptions = options.getDefaultNexusServiceOptions();
+    }
 
     /**
      * Optional: Sets how workflow worker deals with exceptions thrown from the workflow code which

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotTests.java
@@ -39,7 +39,6 @@ import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.tuning.*;
 import io.temporal.workflow.*;
-import io.temporal.workflow.nexus.BaseNexusTest;
 import io.temporal.workflow.shared.TestNexusServices;
 import java.time.Duration;
 import java.util.Map;
@@ -49,7 +48,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class WorkflowSlotTests extends BaseNexusTest {
+public class WorkflowSlotTests {
   private final int MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE = 100;
   private final int MAX_CONCURRENT_ACTIVITY_EXECUTION_SIZE = 1000;
   private final int MAX_CONCURRENT_LOCAL_ACTIVITY_EXECUTION_SIZE = 10000;
@@ -96,11 +95,6 @@ public class WorkflowSlotTests extends BaseNexusTest {
     runningLatch = new CountDownLatch(1);
     localActivitySlotSupplier.usedCount.set(0);
     didFail = false;
-  }
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
   }
 
   @After
@@ -181,7 +175,6 @@ public class WorkflowSlotTests extends BaseNexusTest {
         Workflow.newNexusServiceStub(
             TestNexusServices.TestNexusService1.class,
             NexusServiceOptions.newBuilder()
-                .setEndpoint(getEndpointName())
                 .setOperationOptions(
                     NexusOperationOptions.newBuilder()
                         .setScheduleToCloseTimeout(Duration.ofSeconds(10))

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanNexusWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanNexusWorkerShutdownTest.java
@@ -37,7 +37,6 @@ import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.NexusOperationOptions;
 import io.temporal.workflow.NexusServiceOptions;
 import io.temporal.workflow.Workflow;
-import io.temporal.workflow.nexus.BaseNexusTest;
 import io.temporal.workflow.shared.TestNexusServices;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
@@ -47,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class CleanNexusWorkerShutdownTest extends BaseNexusTest {
+public class CleanNexusWorkerShutdownTest {
 
   private static final String COMPLETED = "Completed";
   private static final String INTERRUPTED = "Interrupted";
@@ -114,18 +113,12 @@ public class CleanNexusWorkerShutdownTest extends BaseNexusTest {
     assertTrue("Contains NexusOperationCompleted", found);
   }
 
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
-
   public static class TestWorkflowImpl implements TestWorkflow1 {
 
     private final TestNexusServices.TestNexusService1 service =
         Workflow.newNexusServiceStub(
             TestNexusServices.TestNexusService1.class,
             NexusServiceOptions.newBuilder()
-                .setEndpoint(getEndpointName())
                 .setOperationOptions(
                     NexusOperationOptions.newBuilder()
                         .setScheduleToCloseTimeout(Duration.ofSeconds(10))

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationCancelledTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationCancelledTest.java
@@ -35,18 +35,13 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class SyncOperationCancelledTest extends BaseNexusTest {
+public class SyncOperationCancelledTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestNexus.class)
           .setNexusServiceImplementation(new TestNexusServiceImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void syncOperationImmediatelyCancelled() {
@@ -82,10 +77,7 @@ public class SyncOperationCancelledTest extends BaseNexusTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(10))
               .build();
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
       TestNexusServices.TestNexusService1 serviceStub =
           Workflow.newNexusServiceStub(TestNexusServices.TestNexusService1.class, serviceOptions);
       Workflow.newCancellationScope(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationFailTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationFailTest.java
@@ -34,7 +34,7 @@ import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
 import org.junit.*;
 
-public class SyncOperationFailTest extends BaseNexusTest {
+public class SyncOperationFailTest {
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -56,11 +56,6 @@ public class SyncOperationFailTest extends BaseNexusTest {
     Assert.assertEquals("failed to call operation", applicationFailure.getOriginalMessage());
   }
 
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
-
   public static class TestNexus implements TestWorkflow1 {
     @Override
     public String execute(String endpoint) {
@@ -70,10 +65,7 @@ public class SyncOperationFailTest extends BaseNexusTest {
               .build();
 
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
       TestNexusServices.TestNexusService1 testNexusService =
           Workflow.newNexusServiceStub(TestNexusServices.TestNexusService1.class, serviceOptions);
       try {

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationStubTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationStubTest.java
@@ -32,18 +32,13 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class SyncOperationStubTest extends BaseNexusTest {
+public class SyncOperationStubTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestNexus.class)
           .setNexusServiceImplementation(new TestNexusServiceImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void typedNexusServiceStub() {
@@ -61,10 +56,7 @@ public class SyncOperationStubTest extends BaseNexusTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(5))
               .build();
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
       // Try to call a synchronous operation in a blocking way
       TestNexusServices.TestNexusService1 serviceStub =
           Workflow.newNexusServiceStub(TestNexusServices.TestNexusService1.class, serviceOptions);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationTimeoutTest.java
@@ -35,18 +35,13 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class SyncOperationTimeoutTest extends BaseNexusTest {
+public class SyncOperationTimeoutTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestNexus.class)
           .setNexusServiceImplementation(new TestNexusServiceImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void typedOperationTimeout() {
@@ -69,10 +64,7 @@ public class SyncOperationTimeoutTest extends BaseNexusTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(1))
               .build();
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
       // Try to call a synchronous operation in a blocking way
       TestNexusServices.TestNexusService1 serviceStub =
           Workflow.newNexusServiceStub(TestNexusServices.TestNexusService1.class, serviceOptions);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UntypedSyncOperationStubTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UntypedSyncOperationStubTest.java
@@ -29,21 +29,16 @@ import io.temporal.workflow.shared.TestNexusServices;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
 import org.junit.Assert;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 
-public class UntypedSyncOperationStubTest extends BaseNexusTest {
-  @Rule
-  public SDKTestWorkflowRule testWorkflowRule =
+public class UntypedSyncOperationStubTest {
+  @ClassRule
+  public static SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestNexus.class)
           .setNexusServiceImplementation(new TestNexusServiceImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void untypedNexusServiceStub() {
@@ -62,7 +57,7 @@ public class UntypedSyncOperationStubTest extends BaseNexusTest {
               .build();
       NexusServiceOptions serviceOptions =
           NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
+              .setEndpoint(testWorkflowRule.getNexusEndpoint().getSpec().getName())
               .setOperationOptions(options)
               .build();
       NexusServiceStub serviceStub =
@@ -90,7 +85,7 @@ public class UntypedSyncOperationStubTest extends BaseNexusTest {
   }
 
   @ServiceImpl(service = TestNexusServices.TestNexusService1.class)
-  public class TestNexusServiceImpl {
+  public static class TestNexusServiceImpl {
     @OperationImpl
     public OperationHandler<String, String> operation() {
       // Implemented inline

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation("com.jayway.jsonpath:json-path:$jsonPathVersion"){
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+    implementation "io.nexusrpc:nexus-sdk:$nexusVersion"
+
 
     junit4Api 'junit:junit:4.13.2'
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -24,6 +24,7 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.IndexedValueType;
 import io.temporal.api.nexus.v1.Endpoint;
 import io.temporal.client.WorkflowClient;
+import io.temporal.common.Experimental;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.serviceclient.OperatorServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -167,13 +168,15 @@ public interface TestWorkflowEnvironment extends Closeable {
    * @param taskQueue Task Queue to be used for the endpoint
    * @return Endpoint object
    */
+  @Experimental
   Endpoint createNexusEndpoint(String name, String taskQueue);
 
   /**
    * Delete a Nexus Endpoint on the server.
    *
-   * @param Endpoint current endpoint to be deleted
+   * @param endpoint current endpoint to be deleted
    */
+  @Experimental
   void deleteNexusEndpoint(Endpoint endpoint);
 
   /**

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironment.java
@@ -22,6 +22,7 @@ package io.temporal.testing;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.IndexedValueType;
+import io.temporal.api.nexus.v1.Endpoint;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.serviceclient.OperatorServiceStubs;
@@ -158,6 +159,22 @@ public interface TestWorkflowEnvironment extends Closeable {
    *     a Custom Search Attribute Using tctl</a>
    */
   boolean registerSearchAttribute(String name, IndexedValueType type);
+
+  /**
+   * Register a Nexus Endpoint with the server.
+   *
+   * @param name Nexus Endpoint name
+   * @param taskQueue Task Queue to be used for the endpoint
+   * @return Endpoint object
+   */
+  Endpoint createNexusEndpoint(String name, String taskQueue);
+
+  /**
+   * Delete a Nexus Endpoint on the server.
+   *
+   * @param Endpoint current endpoint to be deleted
+   */
+  void deleteNexusEndpoint(Endpoint endpoint);
 
   /**
    * @return the in-memory test Temporal service that is owned by this.

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -477,6 +477,7 @@ public class TestWorkflowExtension
      * When set to true the {@link TestWorkflowEnvironment} will not automatically create a Nexus
      * Endpoint. This is useful when you want to manually create a Nexus Endpoint for your test.
      */
+    @Experimental
     public Builder setDoNotSetupNexusEndpoint(boolean doNotSetupNexusEndpoint) {
       this.doNotSetupNexusEndpoint = doNotSetupNexusEndpoint;
       return this;

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -260,7 +260,7 @@ public class TestWorkflowExtension
   public void afterEach(ExtensionContext context) {
     Endpoint endpoint = getNexusEndpoint(context);
     TestWorkflowEnvironment testEnvironment = getTestEnvironment(context);
-    if (endpoint != null) {
+    if (endpoint != null && !testEnvironment.getOperatorServiceStubs().isShutdown()) {
       testEnvironment.deleteNexusEndpoint(endpoint);
     }
     testEnvironment.close();

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -400,8 +400,8 @@ public class TestWorkflowExtension
     /**
      * Specify Nexus service implementations to register with the Temporal workerIf any Nexus
      * services are registered with the worker, the extension will automatically create a Nexus
-     * Endpoint for the test and the endpoint will be set on the per-service options in {@link
-     * WorkflowImplementationOptions} if none are provided.
+     * Endpoint for the test and the endpoint will be set on the per-service options and default
+     * options in {@link WorkflowImplementationOptions} if none are provided.
      *
      * <p>This can be disabled by setting {@link #setDoNotSetupNexusEndpoint(boolean)} to true.
      *

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -398,7 +398,12 @@ public class TestWorkflowExtension
     }
 
     /**
-     * Specify Nexus service implementations to register with the Temporal worker
+     * Specify Nexus service implementations to register with the Temporal workerIf any Nexus
+     * services are registered with the worker, the extension will automatically create a Nexus
+     * Endpoint for the test and the endpoint will be set on the per-service options in {@link
+     * WorkflowImplementationOptions} if none are provided.
+     *
+     * <p>This can be disabled by setting {@link #setDoNotSetupNexusEndpoint(boolean)} to true.
      *
      * @see Worker#registerNexusServiceImplementation(Object...)
      */

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -20,11 +20,15 @@
 
 package io.temporal.testing;
 
+import static io.temporal.testing.internal.TestServiceUtils.applyNexusServiceOptions;
+
 import com.uber.m3.tally.Scope;
 import io.temporal.api.enums.v1.IndexedValueType;
+import io.temporal.api.nexus.v1.Endpoint;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.common.Experimental;
 import io.temporal.common.metadata.POJOWorkflowImplMetadata;
 import io.temporal.common.metadata.POJOWorkflowInterfaceMetadata;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
@@ -36,11 +40,7 @@ import io.temporal.workflow.DynamicWorkflow;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Parameter;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -89,15 +89,18 @@ public class TestWorkflowExtension
   private static final String TEST_ENVIRONMENT_KEY = "testEnvironment";
   private static final String WORKER_KEY = "worker";
   private static final String WORKFLOW_OPTIONS_KEY = "workflowOptions";
+  private static final String NEXUS_ENDPOINT_KEY = "nexusEndpoint";
 
   private final WorkerOptions workerOptions;
   private final WorkflowClientOptions workflowClientOptions;
   private final WorkerFactoryOptions workerFactoryOptions;
   private final Map<Class<?>, WorkflowImplementationOptions> workflowTypes;
   private final Object[] activityImplementations;
+  private final Object[] nexusServiceImplementations;
   private final boolean useExternalService;
   private final String target;
   private final boolean doNotStart;
+  private final boolean doNotSetupNexusEndpoint;
   private final long initialTimeMillis;
   private final boolean useTimeskipping;
   @Nonnull private final Map<String, IndexedValueType> searchAttributes;
@@ -117,9 +120,11 @@ public class TestWorkflowExtension
     workerFactoryOptions = builder.workerFactoryOptions;
     workflowTypes = builder.workflowTypes;
     activityImplementations = builder.activityImplementations;
+    nexusServiceImplementations = builder.nexusServiceImplementations;
     useExternalService = builder.useExternalService;
     target = builder.target;
     doNotStart = builder.doNotStart;
+    doNotSetupNexusEndpoint = builder.doNotSetupNexusEndpoint;
     initialTimeMillis = builder.initialTimeMillis;
     useTimeskipping = builder.useTimeskipping;
     this.searchAttributes = builder.searchAttributes;
@@ -212,12 +217,25 @@ public class TestWorkflowExtension
 
     String taskQueue =
         String.format("WorkflowTest-%s-%s", context.getDisplayName(), context.getUniqueId());
+    String nexusEndpointName = String.format("WorkflowTestNexusEndpoint-%s", UUID.randomUUID());
+    boolean createNexusEndpoint =
+        !doNotSetupNexusEndpoint && nexusServiceImplementations.length > 0;
     Worker worker = testEnvironment.newWorker(taskQueue, workerOptions);
-    workflowTypes.forEach((wft, o) -> worker.registerWorkflowImplementationTypes(o, wft));
+    workflowTypes.forEach(
+        (wft, o) -> {
+          if (createNexusEndpoint) {
+            o = applyNexusServiceOptions(o, nexusServiceImplementations, nexusEndpointName);
+          }
+          worker.registerWorkflowImplementationTypes(o, wft);
+        });
     worker.registerActivitiesImplementations(activityImplementations);
+    worker.registerNexusServiceImplementation(nexusServiceImplementations);
 
     if (!doNotStart) {
       testEnvironment.start();
+    }
+    if (createNexusEndpoint) {
+      setNexusEndpoint(context, testEnvironment.createNexusEndpoint(nexusEndpointName, taskQueue));
     }
 
     setTestEnvironment(context, testEnvironment);
@@ -239,8 +257,12 @@ public class TestWorkflowExtension
   }
 
   @Override
-  public void afterEach(ExtensionContext context) throws Exception {
+  public void afterEach(ExtensionContext context) {
+    Endpoint endpoint = getNexusEndpoint(context);
     TestWorkflowEnvironment testEnvironment = getTestEnvironment(context);
+    if (endpoint != null) {
+      testEnvironment.deleteNexusEndpoint(endpoint);
+    }
     testEnvironment.close();
   }
 
@@ -267,6 +289,14 @@ public class TestWorkflowExtension
     getStore(context).put(WORKER_KEY, worker);
   }
 
+  private Endpoint getNexusEndpoint(ExtensionContext context) {
+    return getStore(context).get(NEXUS_ENDPOINT_KEY, Endpoint.class);
+  }
+
+  private void setNexusEndpoint(ExtensionContext context, Endpoint endpoint) {
+    getStore(context).put(NEXUS_ENDPOINT_KEY, endpoint);
+  }
+
   private WorkflowOptions getWorkflowOptions(ExtensionContext context) {
     return getStore(context).get(WORKFLOW_OPTIONS_KEY, WorkflowOptions.class);
   }
@@ -284,6 +314,7 @@ public class TestWorkflowExtension
   public static class Builder {
 
     private static final Object[] NO_ACTIVITIES = new Object[0];
+    private static final Object[] NO_NEXUS_SERVICES = new Object[0];
 
     private WorkerOptions workerOptions = WorkerOptions.getDefaultInstance();
     private WorkflowClientOptions workflowClientOptions;
@@ -291,9 +322,11 @@ public class TestWorkflowExtension
     private String namespace = "UnitTest";
     private Map<Class<?>, WorkflowImplementationOptions> workflowTypes = new HashMap<>();
     private Object[] activityImplementations = NO_ACTIVITIES;
+    private Object[] nexusServiceImplementations = NO_NEXUS_SERVICES;
     private boolean useExternalService = false;
     private String target = null;
     private boolean doNotStart = false;
+    private boolean doNotSetupNexusEndpoint = false;
     private long initialTimeMillis;
     // Default to TestEnvironmentOptions isUseTimeskipping
     private boolean useTimeskipping =
@@ -365,6 +398,17 @@ public class TestWorkflowExtension
     }
 
     /**
+     * Specify Nexus service implementations to register with the Temporal worker
+     *
+     * @see Worker#registerNexusServiceImplementation(Object...)
+     */
+    @Experimental
+    public Builder setNexusServiceImplementation(Object... nexusServiceImplementations) {
+      this.nexusServiceImplementations = nexusServiceImplementations;
+      return this;
+    }
+
+    /**
      * Specify workflow implementation types to register with the Temporal worker.
      *
      * @see Worker#registerWorkflowImplementationTypes(Class[])
@@ -426,6 +470,15 @@ public class TestWorkflowExtension
      */
     public Builder setDoNotStart(boolean doNotStart) {
       this.doNotStart = doNotStart;
+      return this;
+    }
+
+    /**
+     * When set to true the {@link TestWorkflowEnvironment} will not automatically create a Nexus
+     * Endpoint. This is useful when you want to manually create a Nexus Endpoint for your test.
+     */
+    public Builder setDoNotSetupNexusEndpoint(boolean doNotSetupNexusEndpoint) {
+      this.doNotSetupNexusEndpoint = doNotSetupNexusEndpoint;
       return this;
     }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -338,6 +338,7 @@ public class TestWorkflowRule implements TestRule {
      * When set to true the {@link TestWorkflowEnvironment} will not automatically create a Nexus
      * Endpoint. This is useful when you want to manually create a Nexus Endpoint for your test.
      */
+    @Experimental
     public Builder setDoNotSetupNexusEndpoint(boolean doNotSetupNexusEndpoint) {
       this.doNotSetupNexusEndpoint = doNotSetupNexusEndpoint;
       return this;

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -450,7 +450,7 @@ public class TestWorkflowRule implements TestRule {
   }
 
   protected void shutdown() {
-    if (nexusEndpoint != null) {
+    if (nexusEndpoint != null && !testEnvironment.getOperatorServiceStubs().isShutdown()) {
       testEnvironment.deleteNexusEndpoint(nexusEndpoint);
     }
     testEnvironment.close();
@@ -474,6 +474,13 @@ public class TestWorkflowRule implements TestRule {
    */
   public String getTaskQueue() {
     return taskQueue;
+  }
+
+  /**
+   * @return endpoint of the nexus service created for the test.
+   */
+  public Endpoint getNexusEndpoint() {
+    return nexusEndpoint;
   }
 
   /**

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -252,8 +252,8 @@ public class TestWorkflowRule implements TestRule {
     /**
      * Specify Nexus service implementations to register with the Temporal worker. If any Nexus
      * services are registered with the worker, the rule will automatically create a Nexus Endpoint
-     * for the test and the endpoint will be set on the per-service options in {@link
-     * WorkflowImplementationOptions} if none are provided.
+     * for the test and the endpoint will be set on the per-service options and default options in
+     * {@link WorkflowImplementationOptions} if none are provided.
      *
      * <p>This can be disabled by setting {@link #setDoNotSetupNexusEndpoint(boolean)} to true.
      *

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -249,6 +249,16 @@ public class TestWorkflowRule implements TestRule {
       return this;
     }
 
+    /**
+     * Specify Nexus service implementations to register with the Temporal worker. If any Nexus
+     * services are registered with the worker, the rule will automatically create a Nexus Endpoint
+     * for the test and the endpoint will be set on the per-service options in {@link
+     * WorkflowImplementationOptions} if none are provided.
+     *
+     * <p>This can be disabled by setting {@link #setDoNotSetupNexusEndpoint(boolean)} to true.
+     *
+     * @see Worker#registerNexusServiceImplementation(Object...)
+     */
     @Experimental
     public Builder setNexusServiceImplementation(Object... nexusServiceImplementations) {
       this.nexusServiceImplementations = nexusServiceImplementations;

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -32,6 +32,7 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.enums.v1.IndexedValueType;
 import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.nexus.v1.Endpoint;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowQueryException;
@@ -254,6 +255,10 @@ public class SDKTestWorkflowRule implements TestRule {
 
   public String getTaskQueue() {
     return testWorkflowRule.getTaskQueue();
+  }
+
+  public Endpoint getNexusEndpoint() {
+    return testWorkflowRule.getNexusEndpoint();
   }
 
   public Worker getWorker() {

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/TestServiceUtils.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/TestServiceUtils.java
@@ -67,11 +67,15 @@ public class TestServiceUtils {
               : serviceOptionWithEndpoint;
       newNexusServiceOptions.put(serviceName, serviceOptionWithEndpoint);
     }
-    if (options.getDefaultNexusServiceOptions().getEndpoint() == null) {
+    NexusServiceOptions defaultServiceOptions =
+        options.getDefaultNexusServiceOptions() == null
+            ? NexusServiceOptions.newBuilder().build()
+            : options.getDefaultNexusServiceOptions();
+    if (defaultServiceOptions.getEndpoint() == null) {
       options =
           options.toBuilder()
               .setDefaultNexusServiceOptions(
-                  NexusServiceOptions.newBuilder(options.getDefaultNexusServiceOptions())
+                  NexusServiceOptions.newBuilder(defaultServiceOptions)
                       .setEndpoint(endpoint)
                       .build())
               .build();

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/TestServiceUtils.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/TestServiceUtils.java
@@ -67,6 +67,15 @@ public class TestServiceUtils {
               : serviceOptionWithEndpoint;
       newNexusServiceOptions.put(serviceName, serviceOptionWithEndpoint);
     }
+    if (options.getDefaultNexusServiceOptions().getEndpoint() == null) {
+      options =
+          options.toBuilder()
+              .setDefaultNexusServiceOptions(
+                  NexusServiceOptions.newBuilder(options.getDefaultNexusServiceOptions())
+                      .setEndpoint(endpoint)
+                      .build())
+              .build();
+    }
     return options.toBuilder().setNexusServiceOptions(newNexusServiceOptions).build();
   }
 


### PR DESCRIPTION
Add Nexus support to TestWorkflowExtension. This PR also adds support to automatically create a Nexus Endpoint in the `TestWorkflowExtension` to make testing easier.

closes: https://github.com/temporalio/sdk-java/issues/2235