### PR TITLE
Add cancel async operation tests

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelAsyncOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelAsyncOperationTest.java
@@ -34,7 +34,6 @@ import io.temporal.workflow.shared.TestNexusServices;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,9 +62,6 @@ public class CancelAsyncOperationTest {
 
   @Test
   public void asyncOperationCancelled() {
-    Assume.assumeTrue(
-        "Test server does not return correct error", testWorkflowRule.isUseExternalService());
-
     TestWorkflows.TestWorkflow1 workflowStub =
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     WorkflowFailedException exception =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelAsyncOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelAsyncOperationTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.failure.NexusOperationFailure;
+import io.temporal.nexus.WorkflowClientOperationHandlers;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestNexusServices;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CancelAsyncOperationTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestNexus.class, AsyncWorkflowOperationTest.TestOperationWorkflow.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  @Test
+  public void asyncOperationImmediatelyCancelled() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    WorkflowFailedException exception =
+        Assert.assertThrows(
+            WorkflowFailedException.class, () -> workflowStub.execute("immediately"));
+    Assert.assertTrue(exception.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) exception.getCause();
+    Assert.assertTrue(nexusFailure.getCause() instanceof CanceledFailure);
+    CanceledFailure canceledFailure = (CanceledFailure) nexusFailure.getCause();
+    Assert.assertEquals(
+        "operation canceled before it was started", canceledFailure.getOriginalMessage());
+  }
+
+  @Test
+  public void asyncOperationCancelled() {
+    Assume.assumeTrue(
+        "Test server does not return correct error", testWorkflowRule.isUseExternalService());
+
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    WorkflowFailedException exception =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(""));
+    Assert.assertTrue(exception.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) exception.getCause();
+    Assert.assertTrue(nexusFailure.getCause() instanceof CanceledFailure);
+  }
+
+  public static class TestNexus implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
+      TestNexusServices.TestNexusService1 serviceStub =
+          Workflow.newNexusServiceStub(TestNexusServices.TestNexusService1.class, serviceOptions);
+      Workflow.newCancellationScope(
+              () -> {
+                NexusOperationHandle<String> handle =
+                    Workflow.startNexusOperation(serviceStub::operation, "block");
+                if (input.isEmpty()) {
+                  handle.getExecution().get();
+                }
+                CancellationScope.current().cancel();
+                handle.getResult().get();
+              })
+          .run();
+      return "Should not get here";
+    }
+  }
+
+  @ServiceImpl(service = TestNexusServices.TestNexusService1.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, String> operation() {
+      return WorkflowClientOperationHandlers.fromWorkflowMethod(
+          (context, details, client, input) ->
+              client.newWorkflowStub(
+                      AsyncWorkflowOperationTest.OperationWorkflow.class,
+                      WorkflowOptions.newBuilder().setWorkflowId(details.getRequestId()).build())
+                  ::execute);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncClientOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncClientOperationTest.java
@@ -42,7 +42,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class SyncClientOperationTest extends BaseNexusTest {
+public class SyncClientOperationTest {
   private final TestStatsReporter reporter = new TestStatsReporter();
 
   @Rule
@@ -55,11 +55,6 @@ public class SyncClientOperationTest extends BaseNexusTest {
                   .reportEvery(com.uber.m3.util.Duration.ofMillis(10)))
           .setNexusServiceImplementation(new TestNexusServiceImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void syncClientOperation() {
@@ -105,10 +100,7 @@ public class SyncClientOperationTest extends BaseNexusTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(1))
               .build();
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
       // Try to call a synchronous operation in a blocking way
       TestNexusServices.TestNexusService1 serviceStub =
           Workflow.newNexusServiceStub(TestNexusServices.TestNexusService1.class, serviceOptions);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleFuncTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleFuncTest.java
@@ -37,7 +37,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class WorkflowHandleFuncTest extends BaseNexusTest {
+public class WorkflowHandleFuncTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
@@ -45,11 +45,6 @@ public class WorkflowHandleFuncTest extends BaseNexusTest {
               TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
           .setNexusServiceImplementation(new TestNexusServiceFuncImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void handleTests() {
@@ -67,10 +62,7 @@ public class WorkflowHandleFuncTest extends BaseNexusTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(10))
               .build();
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
 
       TestNexusServiceFunc serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceFunc.class, serviceOptions);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleProcTest.java
@@ -39,7 +39,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class WorkflowHandleProcTest extends BaseNexusTest {
+public class WorkflowHandleProcTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
@@ -47,11 +47,6 @@ public class WorkflowHandleProcTest extends BaseNexusTest {
               TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
           .setNexusServiceImplementation(new TestNexusServiceFuncImpl())
           .build();
-
-  @Override
-  protected SDKTestWorkflowRule getTestWorkflowRule() {
-    return testWorkflowRule;
-  }
 
   @Test
   public void handleTests() {
@@ -69,10 +64,7 @@ public class WorkflowHandleProcTest extends BaseNexusTest {
               .setScheduleToCloseTimeout(Duration.ofSeconds(10))
               .build();
       NexusServiceOptions serviceOptions =
-          NexusServiceOptions.newBuilder()
-              .setEndpoint(getEndpointName())
-              .setOperationOptions(options)
-              .build();
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
 
       TestNexusServiceProc serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceProc.class, serviceOptions);


### PR DESCRIPTION
Add test coverage for cancelling an async operation. I also moved a few tests off of `BaseNexusTest`, hope to move all tests off but there is some challenges around replay.