### PR TITLE
Include failure message in Nexus exception

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/DefaultFailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/DefaultFailureConverter.java
@@ -179,6 +179,7 @@ public final class DefaultFailureConverter implements FailureConverter {
         {
           NexusOperationFailureInfo info = failure.getNexusOperationExecutionFailureInfo();
           return new NexusOperationFailure(
+              failure.getMessage(),
               info.getScheduledEventId(),
               info.getEndpoint(),
               info.getService(),

--- a/temporal-sdk/src/main/java/io/temporal/failure/NexusOperationFailure.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/NexusOperationFailure.java
@@ -38,13 +38,17 @@ public final class NexusOperationFailure extends TemporalFailure {
   private final String operationId;
 
   public NexusOperationFailure(
+      String message,
       long scheduledEventId,
       String endpoint,
       String service,
       String operation,
       String operationId,
       Throwable cause) {
-    super(getMessage(scheduledEventId, endpoint, service, operation, operationId), null, cause);
+    super(
+        getMessage(message, scheduledEventId, endpoint, service, operation, operationId),
+        message,
+        cause);
     this.scheduledEventId = scheduledEventId;
     this.endpoint = endpoint;
     this.service = service;
@@ -53,6 +57,7 @@ public final class NexusOperationFailure extends TemporalFailure {
   }
 
   public static String getMessage(
+      String originalMessage,
       long scheduledEventId,
       String endpoint,
       String service,
@@ -60,9 +65,16 @@ public final class NexusOperationFailure extends TemporalFailure {
       String operationId) {
     return "Nexus Operation with operation='"
         + operation
+        + "service='"
+        + service
+        + "' endpoint='"
+        + endpoint
+        + "' failed: '"
+        + originalMessage
         + "'. "
         + "scheduledEventId="
-        + scheduledEventId;
+        + scheduledEventId
+        + (operationId == null ? "" : ", operationId=" + operationId);
   }
 
   public long getScheduledEventId() {


### PR DESCRIPTION
Include failure message in Nexus exception. This should line up better with how the Go SDK deserializes Nexus failures