### PR TITLE
Test Server: Set CanceledFailureInfo for all canceled Nexus outcomes

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -813,7 +813,12 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       }
 
       if (request.getResponse().hasCancelOperation()) {
-        mutableState.cancelNexusOperation(tt.getOperationRef(), null);
+        Failure canceled =
+            Failure.newBuilder()
+                .setMessage("operation canceled")
+                .setCanceledFailureInfo(CanceledFailureInfo.getDefaultInstance())
+                .build();
+        mutableState.cancelNexusOperation(tt.getOperationRef(), canceled);
       } else if (request.getResponse().hasStartOperation()) {
         StartOperationResponse startResp = request.getResponse().getStartOperation();
         if (startResp.hasOperationError()) {
@@ -913,8 +918,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         Failure canceled =
             Failure.newBuilder()
                 .setMessage("operation canceled")
-                .setApplicationFailureInfo(
-                    ApplicationFailureInfo.newBuilder().setNonRetryable(true))
+                .setCanceledFailureInfo(CanceledFailureInfo.getDefaultInstance())
                 .build();
         target.cancelNexusOperation(ref, canceled);
         break;

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -528,7 +528,9 @@ public class NexusWorkflowTest {
           events.get(0).getNexusOperationCanceledEventAttributes().getFailure();
       assertOperationFailureInfo(operationId, failure.getNexusOperationExecutionFailureInfo());
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
-      Assert.assertFalse(failure.hasCause());
+      io.temporal.api.failure.v1.Failure cause = failure.getCause();
+      Assert.assertEquals("operation canceled", cause.getMessage());
+      Assert.assertTrue(cause.hasCanceledFailureInfo());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     } finally {

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -287,8 +287,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("operation canceled", cause.getMessage());
-      Assert.assertNotNull(cause.getApplicationFailureInfo());
-      Assert.assertTrue(cause.getApplicationFailureInfo().getNonRetryable());
+      Assert.assertTrue(cause.hasCanceledFailureInfo());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     } finally {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Making sure canceled failures have the correct cause for Nexus operations in the test server
