### PR TITLE
Fix memory leak of command inputs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ActivityStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ActivityStateMachine.java
@@ -275,6 +275,7 @@ final class ActivityStateMachine
             .setCommandType(CommandType.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK)
             .setScheduleActivityTaskCommandAttributes(parameters.getAttributes())
             .build());
+    parameters = null; // avoiding retaining large input for the duration of the activity
   }
 
   private void setStartedCommandEventId() {
@@ -455,7 +456,6 @@ final class ActivityStateMachine
                 RequestCancelActivityTaskCommandAttributes.newBuilder()
                     .setScheduledEventId(getInitialCommandEventId()))
             .build());
-    parameters = null; // avoid retaining large input for the duration of the activity
   }
 
   public static class FailureResult {


### PR DESCRIPTION
Fix memory leak of command inputs. Before this change the Java SDK was holding onto the input of various operations (activities, local activities, child workflow) after the operation had already started for two reasons: 
* The state machine was holding a strong reference to the command even after it had been sent to the server
* The output handle needed some of the type informations from the input, but that kept a reference to the input parameters as well

This could cause an OOM error if a lot of async operations were started in a specific workflow.

There is another memory leak in the SDK where the JVM cannot garbage collect complete state machines because they are being held by the cancellation callback in the CancellationScope. This PR does not address this issue because it is significantly more complicated, given the above fixes the impact is much less since only the relatively small amount of data for the statemachine is retained

closes https://github.com/temporalio/sdk-java/issues/2203
