### PR TITLE
mark the nexus sdk as an api dep.

### DIFF
--- a/temporal-kotlin/build.gradle
+++ b/temporal-kotlin/build.gradle
@@ -20,7 +20,6 @@ dependencies {
 
     // this module shouldn't carry temporal-sdk with it, especially for situations when users may be using a shaded artifact
     compileOnly project(':temporal-sdk')
-    implementation "io.nexusrpc:nexus-sdk:$nexusVersion"
 
     implementation "org.jetbrains.kotlin:kotlin-reflect"
 

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api project(':temporal-serviceclient')
     api "com.google.code.gson:gson:$gsonVersion"
     api "io.micrometer:micrometer-core"
-    implementation "io.nexusrpc:nexus-sdk:$nexusVersion"
+    api "io.nexusrpc:nexus-sdk:$nexusVersion"
 
     implementation "com.google.guava:guava:$guavaVersion"
     api "com.fasterxml.jackson.core:jackson-databind"

--- a/temporal-shaded/build.gradle
+++ b/temporal-shaded/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     shadow "com.google.guava:failureaccess:1.0.1"
     shadow "com.google.guava:guava:$guavaVersion"
 
+    // nexus
+    shadow "io.nexusrpc:nexus-sdk:$nexusVersion"
+
     // grpc
     shadow "io.grpc:grpc-protobuf-lite:$grpcVersion"
     shadow "io.grpc:grpc-protobuf:$grpcVersion"

--- a/temporal-spring-boot-autoconfigure/build.gradle
+++ b/temporal-spring-boot-autoconfigure/build.gradle
@@ -8,7 +8,6 @@ ext {
 dependencies {
     api(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     api(platform("io.opentelemetry:opentelemetry-bom:$otelVersion"))
-    implementation "io.nexusrpc:nexus-sdk:$nexusVersion"
 
     compileOnly project(':temporal-sdk')
     compileOnly project(':temporal-testing')

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -21,7 +21,6 @@ dependencies {
         //needed for the generated grpc stubs and is not a part of JDK since java 9
         compileOnly "javax.annotation:javax.annotation-api:$annotationApiVersion"
     }
-    implementation "io.nexusrpc:nexus-sdk:$nexusVersion"
 
     implementation "com.google.guava:guava:$guavaVersion"
     implementation("com.cronutils:cron-utils:${cronUtilsVersion}") {

--- a/temporal-testing/build.gradle
+++ b/temporal-testing/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     implementation("com.jayway.jsonpath:json-path:$jsonPathVersion"){
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
-    implementation "io.nexusrpc:nexus-sdk:$nexusVersion"
-
 
     junit4Api 'junit:junit:4.13.2'
 


### PR DESCRIPTION
mark the Nexus SDK as an `API` dep. instead of `implementation` since the SDK takes and returns types from the Nexus SDK
