### PR TITLE
Avoid warning from un-accessed operation promise

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -817,6 +817,11 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
                     ? dataConverter.fromPayload(
                         b.get(), input.getResultClass(), input.getResultType())
                     : null);
+    // We register an empty handler to make sure that this promise is always "accessed" and never
+    // leads to a log about it being completed exceptionally and non-accessed.
+    // The "main" operation promise is the one returned from the execute method and that
+    // promise will always be logged if not accessed.
+    operationPromise.handle((ex, failure) -> null);
     return new ExecuteNexusOperationOutput<>(result, operationPromise);
   }
 


### PR DESCRIPTION
Avoid warning from un-accessed operation promise. Currently the SDK will log a warning if the nexus operations promise is not accessed in some cases, even if the result promise is accessed. This PR will prevent the warning. We have similar logic for the child workflow execution promise.
