### PR TITLE
Fix test server operation timeout

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
@@ -30,7 +30,6 @@ import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
 import io.temporal.workflow.shared.TestWorkflows;
-import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,10 +64,7 @@ public class AsyncWorkflowOperationTest extends BaseNexusTest {
   public static class TestNexus implements TestWorkflows.TestWorkflow1 {
     @Override
     public String execute(String input) {
-      NexusOperationOptions options =
-          NexusOperationOptions.newBuilder()
-              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
-              .build();
+      NexusOperationOptions options = NexusOperationOptions.newBuilder().build();
       NexusServiceOptions serviceOptions =
           NexusServiceOptions.newBuilder()
               .setEndpoint(getEndpointName())

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -661,7 +661,8 @@ class StateMachines {
       long workflowTaskCompletedId) {
     Duration expirationInterval = attr.getScheduleToCloseTimeout();
     Timestamp expirationTime =
-        (attr.hasScheduleToCloseTimeout())
+        (attr.hasScheduleToCloseTimeout()
+                && Durations.toMillis(attr.getScheduleToCloseTimeout()) > 0)
             ? Timestamps.add(ctx.currentTime(), expirationInterval)
             : Timestamp.getDefaultInstance();
     TestServiceRetryState retryState = new TestServiceRetryState(data.retryPolicy, expirationTime);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -786,7 +786,8 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             timeoutNexusRequest(
                 scheduleEventId, "StartNexusOperation", operation.getData().getAttempt()),
         "StartNexusOperation request timeout");
-    if (attr.hasScheduleToCloseTimeout()) {
+    if (attr.hasScheduleToCloseTimeout()
+        && Durations.toMillis(attr.getScheduleToCloseTimeout()) > 0) {
       ctx.addTimer(
           ProtobufTimeUtils.toJavaDuration(attr.getScheduleToCloseTimeout()),
           () ->


### PR DESCRIPTION
Fix test server operation timeout. Previously the test server was inconsistent with the real server an treated a zero timeout as immediate where the real server treats it as infinite.