### PR TITLE
Increase timeout of canRunWithResourceBasedTuner

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/worker/ResourceBasedTunerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/ResourceBasedTunerTests.java
@@ -65,7 +65,7 @@ public class ResourceBasedTunerTests {
                   .reportEvery(com.uber.m3.util.Duration.ofMillis(10)))
           .build();
 
-  @Test
+  @Test(timeout = 300 * 1000)
   public void canRunWithResourceBasedTuner() throws InterruptedException {
     ResourceTunerWorkflow workflow = testWorkflowRule.newWorkflowStub(ResourceTunerWorkflow.class);
     workflow.execute(5, 5, 1000);


### PR DESCRIPTION
Increase timeout of canRunWithResourceBasedTuner to try to fix flakes like seen here https://github.com/temporalio/sdk-java/actions/runs/11802877846/job/32883424690