### PR TITLE
Support toString on workflow proxy types

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandler.java
@@ -83,4 +83,9 @@ public class ActivityInvocationHandler extends ActivityInvocationHandlerBase {
         (a) -> stub.execute(activityName, method.getReturnType(), method.getGenericReturnType(), a);
     return function;
   }
+
+  @Override
+  protected String proxyToString() {
+    return "ActivityProxy{" + "options=" + options + '}';
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandlerBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ActivityInvocationHandlerBase.java
@@ -53,6 +53,14 @@ public abstract class ActivityInvocationHandlerBase implements InvocationHandler
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) {
+    // Proxy the toString method so the stub can be inspected when debugging.
+    try {
+      if (method.equals(Object.class.getMethod("toString"))) {
+        return proxyToString();
+      }
+    } catch (NoSuchMethodException e) {
+      throw new Error("unexpected", e);
+    }
     POJOActivityMethodMetadata methodMetadata = activityMetadata.getMethodMetadata(method);
     MethodRetry methodRetry = methodMetadata.getMethod().getAnnotation(MethodRetry.class);
     String activityType = methodMetadata.getActivityTypeName();
@@ -62,4 +70,6 @@ public abstract class ActivityInvocationHandlerBase implements InvocationHandler
 
   protected abstract Function<Object[], Object> getActivityFunc(
       Method method, MethodRetry methodRetry, String activityName);
+
+  protected abstract String proxyToString();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ChildWorkflowInvocationHandler.java
@@ -71,6 +71,14 @@ class ChildWorkflowInvocationHandler implements InvocationHandler {
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) {
+    // Proxy the toString method so the stub can be inspected when debugging.
+    try {
+      if (method.equals(Object.class.getMethod("toString"))) {
+        return proxyToString();
+      }
+    } catch (NoSuchMethodException e) {
+      throw new Error("unexpected", e);
+    }
     // Implement StubMarker
     if (method.getName().equals(StubMarker.GET_UNTYPED_STUB_METHOD)) {
       return stub;
@@ -98,5 +106,15 @@ class ChildWorkflowInvocationHandler implements InvocationHandler {
               + "Use an activity that performs the update instead.");
     }
     throw new IllegalArgumentException("unreachable");
+  }
+
+  private String proxyToString() {
+    return "ChildWorkflowProxy{"
+        + "workflowType='"
+        + stub.getWorkflowType()
+        + '\''
+        + ", options="
+        + stub.getOptions()
+        + '}';
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowInvocationHandler.java
@@ -47,6 +47,14 @@ class ExternalWorkflowInvocationHandler implements InvocationHandler {
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) {
+    // Proxy the toString method so the stub can be inspected when debugging.
+    try {
+      if (method.equals(Object.class.getMethod("toString"))) {
+        return proxyToString();
+      }
+    } catch (NoSuchMethodException e) {
+      throw new Error("unexpected", e);
+    }
     // Implement StubMarker
     if (method.getName().equals(StubMarker.GET_UNTYPED_STUB_METHOD)) {
       return stub;
@@ -72,5 +80,15 @@ class ExternalWorkflowInvocationHandler implements InvocationHandler {
         throw new IllegalStateException("unreachable");
     }
     return null;
+  }
+
+  private String proxyToString() {
+    return "ExternalWorkflowProxy{"
+        + "workflowType='"
+        + workflowMetadata.getWorkflowType().orElse("")
+        + '\''
+        + ", execution="
+        + stub.getExecution()
+        + '}';
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/LocalActivityInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/LocalActivityInvocationHandler.java
@@ -79,4 +79,9 @@ public class LocalActivityInvocationHandler extends ActivityInvocationHandlerBas
         (a) -> stub.execute(activityName, method.getReturnType(), method.getGenericReturnType(), a);
     return function;
   }
+
+  @Override
+  protected String proxyToString() {
+    return "LocalActivityProxy{" + "options='" + options + '}';
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusServiceInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusServiceInvocationHandler.java
@@ -48,6 +48,15 @@ public class NexusServiceInvocationHandler implements InvocationHandler {
 
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    // Proxy the toString method so the stub can be inspected when debugging.
+    try {
+      if (method.equals(Object.class.getMethod("toString"))) {
+        return proxyToString();
+      }
+    } catch (NoSuchMethodException e) {
+      throw new Error("unexpected", e);
+    }
+
     if (method.getName().equals(StubMarker.GET_UNTYPED_STUB_METHOD)) {
       return stub;
     }
@@ -68,5 +77,15 @@ public class NexusServiceInvocationHandler implements InvocationHandler {
     return getValueOrDefault(
         this.stub.execute(opName, method.getReturnType(), method.getGenericReturnType(), arg),
         method.getReturnType());
+  }
+
+  private String proxyToString() {
+    return "NexusServiceProxy{"
+        + "serviceName="
+        + serviceDef.getName()
+        + '\''
+        + ", options="
+        + stub.getOptions()
+        + '}';
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusServiceStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusServiceStubImpl.java
@@ -28,10 +28,10 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 
 public class NexusServiceStubImpl implements NexusServiceStub {
-  final String name;
-  final NexusServiceOptions options;
-  final WorkflowOutboundCallsInterceptor outboundCallsInterceptor;
-  final Functions.Proc1<String> assertReadOnly;
+  private final String name;
+  private final NexusServiceOptions options;
+  private final WorkflowOutboundCallsInterceptor outboundCallsInterceptor;
+  private final Functions.Proc1<String> assertReadOnly;
 
   public NexusServiceStubImpl(
       String name,
@@ -118,6 +118,11 @@ public class NexusServiceStubImpl implements NexusServiceStub {
                 arg,
                 mergedOptions,
                 Collections.emptyMap()));
-    return new NexusOperationHandleImpl(result.getOperationExecution(), result.getResult());
+    return new NexusOperationHandleImpl<>(result.getOperationExecution(), result.getResult());
+  }
+
+  @Override
+  public NexusServiceOptions getOptions() {
+    return options;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/NexusServiceStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/NexusServiceStub.java
@@ -109,4 +109,9 @@ public interface NexusServiceStub {
    */
   <R> NexusOperationHandle<R> start(
       String operationName, Class<R> resultClass, Type resultType, Object arg);
+
+  /**
+   * @return Options used to create this stub.
+   */
+  NexusServiceOptions getOptions();
 }


### PR DESCRIPTION
Support `toString` on workflow proxy types.

closes https://github.com/temporalio/sdk-java/issues/1536