### PR TITLE
Add type safe API to execute an async update workflow request

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -794,7 +794,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> renameUpdate(
+  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func4<A1, A2, A3, A4, R> updateMethod,
       A1 arg1,
       A2 arg2,

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -580,7 +580,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static WorkflowUpdateHandle<Void> update(
+  static WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc updateMethod, @Nonnull UpdateOptions<Void> options) {
     return WorkflowClientInternalImpl.update(updateMethod, options);
   }
@@ -594,7 +594,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1> WorkflowUpdateHandle<Void> update(
+  static <A1> WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc1<A1> updateMethod, A1 arg1, @Nonnull UpdateOptions<Void> options) {
     return WorkflowClientInternalImpl.update(updateMethod, arg1, options);
   }
@@ -609,7 +609,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2> WorkflowUpdateHandle<Void> update(
+  static <A1, A2> WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc2<A1, A2> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -628,7 +628,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3> WorkflowUpdateHandle<Void> update(
+  static <A1, A2, A3> WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc3<A1, A2, A3> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -649,7 +649,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> update(
+  static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc4<A1, A2, A3, A4> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -672,7 +672,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> update(
+  static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -697,7 +697,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> update(
+  static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> executeUpdate(
       Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -719,7 +719,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R> WorkflowUpdateHandle<R> update(
+  static <R> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func<R> updateMethod, @Nonnull UpdateOptions<R> options) {
     return WorkflowClientInternalImpl.update(updateMethod, options);
   }
@@ -734,7 +734,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1> WorkflowUpdateHandle<R> update(
+  static <R, A1> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func1<A1, R> updateMethod, A1 arg1, @Nonnull UpdateOptions<R> options) {
     return WorkflowClientInternalImpl.update(updateMethod, arg1, options);
   }
@@ -750,7 +750,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2> WorkflowUpdateHandle<R> update(
+  static <R, A1, A2> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func2<A1, A2, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -770,7 +770,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3> WorkflowUpdateHandle<R> update(
+  static <R, A1, A2, A3> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func3<A1, A2, A3, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -792,7 +792,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> update(
+  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func4<A1, A2, A3, A4, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -816,7 +816,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4, A5> WorkflowUpdateHandle<R> update(
+  static <R, A1, A2, A3, A4, A5> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -842,7 +842,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<R> update(
+  static <R, A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<R> executeUpdate(
       Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
       A1 arg1,
       A2 arg2,

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -308,11 +308,10 @@ public interface WorkflowClient {
   WorkflowExecutionHistory fetchHistory(@Nonnull String workflowId, @Nullable String runId);
 
   /**
-   * Allows you to startUpdate the worker-build-id based version sets for a particular task queue.
-   * This is used in conjunction with workers who specify their build id and thus opt into the
-   * feature.
+   * Allows you to update the worker-build-id based version sets for a particular task queue. This
+   * is used in conjunction with workers who specify their build id and thus opt into the feature.
    *
-   * @param taskQueue The task queue to startUpdate the version set(s) of.
+   * @param taskQueue The task queue to update the version set(s) of.
    * @param operation The operation to perform. See {@link BuildIdOperation} for more.
    * @throws WorkflowServiceException for any failures including networking and service availability
    *     issues.

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -573,7 +573,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a zero argument workflow update with a void return type
+   * Start a zero argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -586,7 +586,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a one argument workflow update with a void return type
+   * Start a one argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -600,7 +600,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a two argument workflow update with a void return type
+   * Start a two argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -618,7 +618,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a three argument workflow update with a void return type
+   * Start a three argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -638,7 +638,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a four argument workflow update with a void return type
+   * Start a four argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -660,7 +660,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a five argument workflow update with a void return type
+   * Start a five argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -685,7 +685,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a six argument workflow update with a void return type
+   * Start a six argument workflow update with a void return type
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -712,7 +712,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a zero argument update workflow request asynchronously.
+   * Start a zero argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -726,7 +726,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a one argument update workflow request asynchronously.
+   * Start a one argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -741,7 +741,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a two argument update workflow request asynchronously.
+   * Start a two argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -760,7 +760,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a three argument update workflow request asynchronously.
+   * Start a three argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -781,7 +781,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a four argument update workflow request asynchronously.
+   * Start a four argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -804,7 +804,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a five argument update workflow request asynchronously.
+   * Start a five argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
@@ -830,7 +830,7 @@ public interface WorkflowClient {
   }
 
   /**
-   * Executes a six argument update workflow request asynchronously.
+   * Start a six argument update workflow request asynchronously.
    *
    * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
    *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -308,10 +308,11 @@ public interface WorkflowClient {
   WorkflowExecutionHistory fetchHistory(@Nonnull String workflowId, @Nullable String runId);
 
   /**
-   * Allows you to update the worker-build-id based version sets for a particular task queue. This
-   * is used in conjunction with workers who specify their build id and thus opt into the feature.
+   * Allows you to startUpdate the worker-build-id based version sets for a particular task queue.
+   * This is used in conjunction with workers who specify their build id and thus opt into the
+   * feature.
    *
-   * @param taskQueue The task queue to update the version set(s) of.
+   * @param taskQueue The task queue to startUpdate the version set(s) of.
    * @param operation The operation to perform. See {@link BuildIdOperation} for more.
    * @throws WorkflowServiceException for any failures including networking and service availability
    *     issues.
@@ -580,9 +581,9 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static WorkflowUpdateHandle<Void> executeUpdate(
+  static WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc updateMethod, @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, options);
   }
 
   /**
@@ -594,9 +595,9 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1> WorkflowUpdateHandle<Void> executeUpdate(
+  static <A1> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc1<A1> updateMethod, A1 arg1, @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, options);
   }
 
   /**
@@ -609,12 +610,12 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2> WorkflowUpdateHandle<Void> executeUpdate(
+  static <A1, A2> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc2<A1, A2> updateMethod,
       A1 arg1,
       A2 arg2,
       @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, arg2, options);
   }
 
   /**
@@ -628,13 +629,13 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3> WorkflowUpdateHandle<Void> executeUpdate(
+  static <A1, A2, A3> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc3<A1, A2, A3> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, arg2, arg3, options);
   }
 
   /**
@@ -649,14 +650,14 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> executeUpdate(
+  static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc4<A1, A2, A3, A4> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       A4 arg4,
       @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, arg2, arg3, arg4, options);
   }
 
   /**
@@ -672,7 +673,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> executeUpdate(
+  static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -680,7 +681,8 @@ public interface WorkflowClient {
       A4 arg4,
       A5 arg5,
       @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, arg5, options);
+    return WorkflowClientInternalImpl.startUpdate(
+        updateMethod, arg1, arg2, arg3, arg4, arg5, options);
   }
 
   /**
@@ -697,7 +699,7 @@ public interface WorkflowClient {
    * @param options update options
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
-  static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> executeUpdate(
+  static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -706,7 +708,7 @@ public interface WorkflowClient {
       A5 arg5,
       A6 arg6,
       @Nonnull UpdateOptions<Void> options) {
-    return WorkflowClientInternalImpl.update(
+    return WorkflowClientInternalImpl.startUpdate(
         updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, options);
   }
 
@@ -719,9 +721,9 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R> WorkflowUpdateHandle<R> executeUpdate(
+  static <R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func<R> updateMethod, @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, options);
   }
 
   /**
@@ -734,9 +736,9 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1> WorkflowUpdateHandle<R> executeUpdate(
+  static <R, A1> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func1<A1, R> updateMethod, A1 arg1, @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, options);
   }
 
   /**
@@ -750,12 +752,12 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2> WorkflowUpdateHandle<R> executeUpdate(
+  static <R, A1, A2> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func2<A1, A2, R> updateMethod,
       A1 arg1,
       A2 arg2,
       @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, arg2, options);
   }
 
   /**
@@ -770,13 +772,13 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3> WorkflowUpdateHandle<R> executeUpdate(
+  static <R, A1, A2, A3> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func3<A1, A2, A3, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, arg2, arg3, options);
   }
 
   /**
@@ -792,14 +794,14 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> executeUpdate(
+  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> renameUpdate(
       Functions.Func4<A1, A2, A3, A4, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       A4 arg4,
       @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, options);
+    return WorkflowClientInternalImpl.startUpdate(updateMethod, arg1, arg2, arg3, arg4, options);
   }
 
   /**
@@ -816,7 +818,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4, A5> WorkflowUpdateHandle<R> executeUpdate(
+  static <R, A1, A2, A3, A4, A5> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -824,7 +826,8 @@ public interface WorkflowClient {
       A4 arg4,
       A5 arg5,
       @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, arg5, options);
+    return WorkflowClientInternalImpl.startUpdate(
+        updateMethod, arg1, arg2, arg3, arg4, arg5, options);
   }
 
   /**
@@ -842,7 +845,7 @@ public interface WorkflowClient {
    * @return WorkflowUpdateHandle that can be used to get the result of the update
    */
   @Experimental
-  static <R, A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<R> executeUpdate(
+  static <R, A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -851,7 +854,7 @@ public interface WorkflowClient {
       A5 arg5,
       A6 arg6,
       @Nonnull UpdateOptions<R> options) {
-    return WorkflowClientInternalImpl.update(
+    return WorkflowClientInternalImpl.startUpdate(
         updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, options);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java
@@ -573,6 +573,289 @@ public interface WorkflowClient {
   }
 
   /**
+   * Executes a zero argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static WorkflowUpdateHandle<Void> update(
+      Functions.Proc updateMethod, @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, options);
+  }
+
+  /**
+   * Executes a one argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static <A1> WorkflowUpdateHandle<Void> update(
+      Functions.Proc1<A1> updateMethod, A1 arg1, @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, options);
+  }
+
+  /**
+   * Executes a two argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static <A1, A2> WorkflowUpdateHandle<Void> update(
+      Functions.Proc2<A1, A2> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, options);
+  }
+
+  /**
+   * Executes a three argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static <A1, A2, A3> WorkflowUpdateHandle<Void> update(
+      Functions.Proc3<A1, A2, A3> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, options);
+  }
+
+  /**
+   * Executes a four argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param arg4 fourth update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> update(
+      Functions.Proc4<A1, A2, A3, A4> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, options);
+  }
+
+  /**
+   * Executes a five argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param arg4 fourth update method parameter
+   * @param arg5 fifth update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> update(
+      Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, arg5, options);
+  }
+
+  /**
+   * Executes a six argument workflow update with a void return type
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param arg4 fourth update method parameter
+   * @param arg5 fifth update method parameter
+   * @param arg6 sixth update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> update(
+      Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      @Nonnull UpdateOptions<Void> options) {
+    return WorkflowClientInternalImpl.update(
+        updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, options);
+  }
+
+  /**
+   * Executes a zero argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R> WorkflowUpdateHandle<R> update(
+      Functions.Func<R> updateMethod, @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, options);
+  }
+
+  /**
+   * Executes a one argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R, A1> WorkflowUpdateHandle<R> update(
+      Functions.Func1<A1, R> updateMethod, A1 arg1, @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, options);
+  }
+
+  /**
+   * Executes a two argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R, A1, A2> WorkflowUpdateHandle<R> update(
+      Functions.Func2<A1, A2, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, options);
+  }
+
+  /**
+   * Executes a three argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R, A1, A2, A3> WorkflowUpdateHandle<R> update(
+      Functions.Func3<A1, A2, A3, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, options);
+  }
+
+  /**
+   * Executes a four argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param arg4 fourth update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R, A1, A2, A3, A4> WorkflowUpdateHandle<R> update(
+      Functions.Func4<A1, A2, A3, A4, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, options);
+  }
+
+  /**
+   * Executes a five argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param arg4 fourth update method parameter
+   * @param arg5 firth update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R, A1, A2, A3, A4, A5> WorkflowUpdateHandle<R> update(
+      Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(updateMethod, arg1, arg2, arg3, arg4, arg5, options);
+  }
+
+  /**
+   * Executes a six argument update workflow request asynchronously.
+   *
+   * @param updateMethod method reference annotated with @UpdateMethod of a proxy created through
+   *     {@link WorkflowClient#newWorkflowStub(Class, WorkflowOptions)}.
+   * @param arg1 first update method parameter
+   * @param arg2 second update method parameter
+   * @param arg3 third update method parameter
+   * @param arg4 fourth update method parameter
+   * @param arg5 firth update method parameter
+   * @param arg6 sixth update method parameter
+   * @param options update options
+   * @return WorkflowUpdateHandle that can be used to get the result of the update
+   */
+  @Experimental
+  static <R, A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<R> update(
+      Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      @Nonnull UpdateOptions<R> options) {
+    return WorkflowClientInternalImpl.update(
+        updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, options);
+  }
+
+  /**
    * Executes zero argument workflow with void return type together with an update workflow request.
    *
    * @param workflow The only supported value is method reference to a proxy created through {@link

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
@@ -537,7 +537,7 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
     return execute(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
   }
 
-  public static WorkflowUpdateHandle<Void> update(
+  public static WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc updateMethod, UpdateOptions<?> options) {
     enforceNonWorkflowThread();
     WorkflowInvocationHandler.initAsyncInvocation(InvocationType.UPDATE, options);
@@ -549,36 +549,36 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
     }
   }
 
-  public static <A1> WorkflowUpdateHandle<Void> update(
+  public static <A1> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc1<A1> updateMethod, A1 arg1, UpdateOptions<Void> options) {
-    return update(() -> updateMethod.apply(arg1), options);
+    return startUpdate(() -> updateMethod.apply(arg1), options);
   }
 
-  public static <A1, A2> WorkflowUpdateHandle<Void> update(
+  public static <A1, A2> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc2<A1, A2> updateMethod, A1 arg1, A2 arg2, UpdateOptions<Void> options) {
-    return update(() -> updateMethod.apply(arg1, arg2), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2), options);
   }
 
-  public static <A1, A2, A3> WorkflowUpdateHandle<Void> update(
+  public static <A1, A2, A3> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc3<A1, A2, A3> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       UpdateOptions<Void> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3), options);
   }
 
-  public static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> update(
+  public static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc4<A1, A2, A3, A4> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       A4 arg4,
       UpdateOptions<Void> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3, arg4), options);
   }
 
-  public static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> update(
+  public static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -586,10 +586,10 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
       A4 arg4,
       A5 arg5,
       UpdateOptions<Void> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5), options);
   }
 
-  public static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> update(
+  public static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> startUpdate(
       Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -598,44 +598,44 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
       A5 arg5,
       A6 arg6,
       UpdateOptions<Void> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5, arg6), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5, arg6), options);
   }
 
-  public static <R> WorkflowUpdateHandle<R> update(
+  public static <R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func<R> updateMethod, UpdateOptions<R> options) {
-    return (WorkflowUpdateHandle<R>) update((Functions.Proc) updateMethod::apply, options);
+    return (WorkflowUpdateHandle<R>) startUpdate((Functions.Proc) updateMethod::apply, options);
   }
 
-  public static <A1, R> WorkflowUpdateHandle<R> update(
+  public static <A1, R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func1<A1, R> updateMethod, A1 arg1, UpdateOptions<R> options) {
-    return update(() -> updateMethod.apply(arg1), options);
+    return startUpdate(() -> updateMethod.apply(arg1), options);
   }
 
-  public static <A1, A2, R> WorkflowUpdateHandle<R> update(
+  public static <A1, A2, R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func2<A1, A2, R> updateMethod, A1 arg1, A2 arg2, UpdateOptions<R> options) {
-    return update(() -> updateMethod.apply(arg1, arg2), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2), options);
   }
 
-  public static <A1, A2, A3, R> WorkflowUpdateHandle<R> update(
+  public static <A1, A2, A3, R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func3<A1, A2, A3, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       UpdateOptions<R> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3), options);
   }
 
-  public static <A1, A2, A3, A4, R> WorkflowUpdateHandle<R> update(
+  public static <A1, A2, A3, A4, R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func4<A1, A2, A3, A4, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       A4 arg4,
       UpdateOptions<R> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3, arg4), options);
   }
 
-  public static <A1, A2, A3, A4, A5, R> WorkflowUpdateHandle<R> update(
+  public static <A1, A2, A3, A4, A5, R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -643,10 +643,10 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
       A4 arg4,
       A5 arg5,
       UpdateOptions<R> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5), options);
   }
 
-  public static <A1, A2, A3, A4, A5, A6, R> WorkflowUpdateHandle<R> update(
+  public static <A1, A2, A3, A4, A5, A6, R> WorkflowUpdateHandle<R> startUpdate(
       Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
       A1 arg1,
       A2 arg2,
@@ -655,7 +655,7 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
       A5 arg5,
       A6 arg6,
       UpdateOptions<R> options) {
-    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5, arg6), options);
+    return startUpdate(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5, arg6), options);
   }
 
   Stream<HistoryEvent> streamHistory(WorkflowExecution execution) {

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
@@ -537,6 +537,127 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
     return execute(() -> workflow.apply(arg1, arg2, arg3, arg4, arg5, arg6));
   }
 
+  public static WorkflowUpdateHandle<Void> update(
+      Functions.Proc updateMethod, UpdateOptions<?> options) {
+    enforceNonWorkflowThread();
+    WorkflowInvocationHandler.initAsyncInvocation(InvocationType.UPDATE, options);
+    try {
+      updateMethod.apply();
+      return WorkflowInvocationHandler.getAsyncInvocationResult(WorkflowUpdateHandle.class);
+    } finally {
+      WorkflowInvocationHandler.closeAsyncInvocation();
+    }
+  }
+
+  public static <A1> WorkflowUpdateHandle<Void> update(
+      Functions.Proc1<A1> updateMethod, A1 arg1, UpdateOptions<Void> options) {
+    return update(() -> updateMethod.apply(arg1), options);
+  }
+
+  public static <A1, A2> WorkflowUpdateHandle<Void> update(
+      Functions.Proc2<A1, A2> updateMethod, A1 arg1, A2 arg2, UpdateOptions<Void> options) {
+    return update(() -> updateMethod.apply(arg1, arg2), options);
+  }
+
+  public static <A1, A2, A3> WorkflowUpdateHandle<Void> update(
+      Functions.Proc3<A1, A2, A3> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<Void> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3), options);
+  }
+
+  public static <A1, A2, A3, A4> WorkflowUpdateHandle<Void> update(
+      Functions.Proc4<A1, A2, A3, A4> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<Void> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4), options);
+  }
+
+  public static <A1, A2, A3, A4, A5> WorkflowUpdateHandle<Void> update(
+      Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<Void> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5), options);
+  }
+
+  public static <A1, A2, A3, A4, A5, A6> WorkflowUpdateHandle<Void> update(
+      Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<Void> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5, arg6), options);
+  }
+
+  public static <R> WorkflowUpdateHandle<R> update(
+      Functions.Func<R> updateMethod, UpdateOptions<R> options) {
+    return (WorkflowUpdateHandle<R>) update((Functions.Proc) updateMethod::apply, options);
+  }
+
+  public static <A1, R> WorkflowUpdateHandle<R> update(
+      Functions.Func1<A1, R> updateMethod, A1 arg1, UpdateOptions<R> options) {
+    return update(() -> updateMethod.apply(arg1), options);
+  }
+
+  public static <A1, A2, R> WorkflowUpdateHandle<R> update(
+      Functions.Func2<A1, A2, R> updateMethod, A1 arg1, A2 arg2, UpdateOptions<R> options) {
+    return update(() -> updateMethod.apply(arg1, arg2), options);
+  }
+
+  public static <A1, A2, A3, R> WorkflowUpdateHandle<R> update(
+      Functions.Func3<A1, A2, A3, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<R> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3), options);
+  }
+
+  public static <A1, A2, A3, A4, R> WorkflowUpdateHandle<R> update(
+      Functions.Func4<A1, A2, A3, A4, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<R> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4), options);
+  }
+
+  public static <A1, A2, A3, A4, A5, R> WorkflowUpdateHandle<R> update(
+      Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<R> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5), options);
+  }
+
+  public static <A1, A2, A3, A4, A5, A6, R> WorkflowUpdateHandle<R> update(
+      Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<R> options) {
+    return update(() -> updateMethod.apply(arg1, arg2, arg3, arg4, arg5, arg6), options);
+  }
+
   Stream<HistoryEvent> streamHistory(WorkflowExecution execution) {
     Preconditions.checkNotNull(execution, "execution is required");
 

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowInvocationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowInvocationHandler.java
@@ -23,6 +23,7 @@ package io.temporal.client;
 import static io.temporal.internal.common.InternalUtils.createNexusBoundStub;
 
 import com.google.common.base.Defaults;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
@@ -396,6 +397,9 @@ class WorkflowInvocationHandler implements InvocationHandler {
         case QUERY:
           throw new IllegalArgumentException(
               "SignalWithStart batch doesn't accept methods annotated with @QueryMethod");
+        case UPDATE:
+          throw new IllegalArgumentException(
+              "SignalWithStart batch doesn't accept methods annotated with @UpdateMethod");
         case WORKFLOW:
           batch.start(untyped, args);
           break;
@@ -451,6 +455,7 @@ class WorkflowInvocationHandler implements InvocationHandler {
     private Object result;
 
     public UpdateInvocationHandler(UpdateOptions<?> options) {
+      Preconditions.checkNotNull(options, "options");
       this.options = options;
     }
 
@@ -468,7 +473,7 @@ class WorkflowInvocationHandler implements InvocationHandler {
       UpdateMethod updateMethod = method.getAnnotation(UpdateMethod.class);
       if (updateMethod == null) {
         throw new IllegalArgumentException(
-            "Only a method annotated with @UpdateMethod can be used to start a Update.");
+            "Only a method annotated with @UpdateMethod can be used to start an Update.");
       }
       POJOWorkflowMethodMetadata methodMetadata = workflowMetadata.getMethodMetadata(method);
       UpdateOptions.Builder builder = UpdateOptions.newBuilder(options);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestMultiArgWorkflowUpdateFunctions.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestMultiArgWorkflowUpdateFunctions.java
@@ -1,0 +1,204 @@
+package io.temporal.workflow.shared;
+
+import io.temporal.workflow.*;
+
+public class TestMultiArgWorkflowUpdateFunctions {
+
+  @WorkflowInterface
+  public interface TestMultiArgUpdateWorkflow
+      extends TestNoArgsUpdateFunc,
+          Test1ArgUpdateFunc,
+          Test2ArgUpdateFunc,
+          Test3ArgUpdateFunc,
+          Test4ArgUpdateFunc,
+          Test5ArgUpdateFunc,
+          Test6ArgUpdateFunc,
+          TestNoArgsUpdateProc,
+          Test1ArgUpdateProc,
+          Test2ArgUpdateProc,
+          Test3ArgUpdateProc,
+          Test4ArgUpdateProc,
+          Test5ArgUpdateProc,
+          Test6ArgUpdateProc {
+    @WorkflowMethod
+    String execute();
+
+    @SignalMethod
+    void complete();
+  }
+
+  public interface TestNoArgsUpdateFunc {
+    @UpdateMethod
+    String func();
+  }
+
+  public interface Test1ArgUpdateFunc {
+    @UpdateMethod
+    String func1(String input);
+  }
+
+  public interface Test2ArgUpdateFunc {
+
+    @UpdateMethod
+    String func2(String a1, int a2);
+  }
+
+  public interface Test3ArgUpdateFunc {
+
+    @UpdateMethod
+    String func3(String a1, int a2, int a3);
+  }
+
+  public interface Test4ArgUpdateFunc {
+
+    @UpdateMethod
+    String func4(String a1, int a2, int a3, int a4);
+  }
+
+  public interface Test5ArgUpdateFunc {
+
+    @UpdateMethod
+    String func5(String a1, int a2, int a3, int a4, int a5);
+  }
+
+  public interface Test6ArgUpdateFunc {
+
+    @UpdateMethod
+    String func6(String a1, int a2, int a3, int a4, int a5, int a6);
+  }
+
+  public interface ProcInvocationQueryable {
+
+    @QueryMethod(name = "getTrace")
+    String query();
+  }
+
+  public interface TestNoArgsUpdateProc {
+
+    @UpdateMethod
+    void proc();
+  }
+
+  public interface Test1ArgUpdateProc {
+
+    @UpdateMethod
+    void proc1(String input);
+  }
+
+  public interface Test2ArgUpdateProc {
+
+    @UpdateMethod
+    void proc2(String a1, int a2);
+  }
+
+  public interface Test3ArgUpdateProc {
+
+    @UpdateMethod
+    void proc3(String a1, int a2, int a3);
+  }
+
+  public interface Test4ArgUpdateProc {
+
+    @UpdateMethod
+    void proc4(String a1, int a2, int a3, int a4);
+  }
+
+  public interface Test5ArgUpdateProc {
+
+    @UpdateMethod
+    void proc5(String a1, int a2, int a3, int a4, int a5);
+  }
+
+  public interface Test6ArgUpdateProc {
+
+    @UpdateMethod
+    void proc6(String a1, int a2, int a3, int a4, int a5, int a6);
+  }
+
+  public static class TestMultiArgUpdateWorkflowImpl implements TestMultiArgUpdateWorkflow {
+
+    private String procResult = "";
+    private boolean signaled;
+
+    @Override
+    public String func() {
+      return "func";
+    }
+
+    @Override
+    public String func1(String a1) {
+      return a1;
+    }
+
+    @Override
+    public String func2(String a1, int a2) {
+      return a1 + a2;
+    }
+
+    @Override
+    public String func3(String a1, int a2, int a3) {
+      return a1 + a2 + a3;
+    }
+
+    @Override
+    public String func4(String a1, int a2, int a3, int a4) {
+      return a1 + a2 + a3 + a4;
+    }
+
+    @Override
+    public String func5(String a1, int a2, int a3, int a4, int a5) {
+      return a1 + a2 + a3 + a4 + a5;
+    }
+
+    @Override
+    public String func6(String a1, int a2, int a3, int a4, int a5, int a6) {
+      return a1 + a2 + a3 + a4 + a5 + a6;
+    }
+
+    @Override
+    public void proc() {
+      procResult += "proc";
+    }
+
+    @Override
+    public void proc1(String a1) {
+      procResult += a1;
+    }
+
+    @Override
+    public void proc2(String a1, int a2) {
+      procResult += a1 + a2;
+    }
+
+    @Override
+    public void proc3(String a1, int a2, int a3) {
+      procResult += a1 + a2 + a3;
+    }
+
+    @Override
+    public void proc4(String a1, int a2, int a3, int a4) {
+      procResult += a1 + a2 + a3 + a4;
+    }
+
+    @Override
+    public void proc5(String a1, int a2, int a3, int a4, int a5) {
+      procResult += a1 + a2 + a3 + a4 + a5;
+    }
+
+    @Override
+    public void proc6(String a1, int a2, int a3, int a4, int a5, int a6) {
+      procResult += a1 + a2 + a3 + a4 + a5 + a6;
+    }
+
+    @Override
+    public String execute() {
+      Workflow.await(() -> signaled);
+      return procResult;
+    }
+
+    @Override
+    public void complete() {
+      signaled = true;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestMultiArgWorkflowUpdateFunctions.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestMultiArgWorkflowUpdateFunctions.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.workflow.shared;
 
 import io.temporal.workflow.*;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
@@ -98,57 +98,53 @@ public class TypedUpdateTest {
         UpdateOptions.<String>newBuilder().setWaitForStage(WorkflowUpdateStage.COMPLETED).build();
 
     Assert.assertEquals(
-        "func", WorkflowClient.executeUpdate(workflow::func, updateOptions).getResultAsync().get());
+        "func", WorkflowClient.startUpdate(workflow::func, updateOptions).getResultAsync().get());
     Assert.assertEquals(
         "input",
-        WorkflowClient.executeUpdate(workflow::func1, "input", updateOptions)
-            .getResultAsync()
-            .get());
+        WorkflowClient.startUpdate(workflow::func1, "input", updateOptions).getResultAsync().get());
     Assert.assertEquals(
         "input2",
-        WorkflowClient.executeUpdate(workflow::func2, "input", 2, updateOptions)
+        WorkflowClient.startUpdate(workflow::func2, "input", 2, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input23",
-        WorkflowClient.executeUpdate(workflow::func3, "input", 2, 3, updateOptions)
+        WorkflowClient.startUpdate(workflow::func3, "input", 2, 3, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input234",
-        WorkflowClient.executeUpdate(workflow::func4, "input", 2, 3, 4, updateOptions)
+        WorkflowClient.renameUpdate(workflow::func4, "input", 2, 3, 4, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input2345",
-        WorkflowClient.executeUpdate(workflow::func5, "input", 2, 3, 4, 5, updateOptions)
+        WorkflowClient.startUpdate(workflow::func5, "input", 2, 3, 4, 5, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input23456",
-        WorkflowClient.executeUpdate(workflow::func6, "input", 2, 3, 4, 5, 6, updateOptions)
+        WorkflowClient.startUpdate(workflow::func6, "input", 2, 3, 4, 5, 6, updateOptions)
             .getResultAsync()
             .get());
 
     UpdateOptions<Void> updateVoidOptions =
         UpdateOptions.<Void>newBuilder().setWaitForStage(WorkflowUpdateStage.COMPLETED).build();
-    WorkflowClient.executeUpdate(workflow::proc, updateVoidOptions).getResultAsync().get();
-    WorkflowClient.executeUpdate(workflow::proc1, "input", updateVoidOptions)
+    WorkflowClient.startUpdate(workflow::proc, updateVoidOptions).getResultAsync().get();
+    WorkflowClient.startUpdate(workflow::proc1, "input", updateVoidOptions).getResultAsync().get();
+    WorkflowClient.startUpdate(workflow::proc2, "input", 2, updateVoidOptions)
         .getResultAsync()
         .get();
-    WorkflowClient.executeUpdate(workflow::proc2, "input", 2, updateVoidOptions)
+    WorkflowClient.startUpdate(workflow::proc3, "input", 2, 3, updateVoidOptions)
         .getResultAsync()
         .get();
-    WorkflowClient.executeUpdate(workflow::proc3, "input", 2, 3, updateVoidOptions)
+    WorkflowClient.startUpdate(workflow::proc4, "input", 2, 3, 4, updateVoidOptions)
         .getResultAsync()
         .get();
-    WorkflowClient.executeUpdate(workflow::proc4, "input", 2, 3, 4, updateVoidOptions)
+    WorkflowClient.startUpdate(workflow::proc5, "input", 2, 3, 4, 5, updateVoidOptions)
         .getResultAsync()
         .get();
-    WorkflowClient.executeUpdate(workflow::proc5, "input", 2, 3, 4, 5, updateVoidOptions)
-        .getResultAsync()
-        .get();
-    WorkflowClient.executeUpdate(workflow::proc6, "input", 2, 3, 4, 5, 6, updateVoidOptions)
+    WorkflowClient.startUpdate(workflow::proc6, "input", 2, 3, 4, 5, 6, updateVoidOptions)
         .getResultAsync()
         .get();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
@@ -114,7 +114,7 @@ public class TypedUpdateTest {
             .get());
     Assert.assertEquals(
         "input234",
-        WorkflowClient.renameUpdate(workflow::func4, "input", 2, 3, 4, updateOptions)
+        WorkflowClient.startUpdate(workflow::func4, "input", 2, 3, 4, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
@@ -98,47 +98,57 @@ public class TypedUpdateTest {
         UpdateOptions.<String>newBuilder().setWaitForStage(WorkflowUpdateStage.COMPLETED).build();
 
     Assert.assertEquals(
-        "func", WorkflowClient.update(workflow::func, updateOptions).getResultAsync().get());
+        "func", WorkflowClient.executeUpdate(workflow::func, updateOptions).getResultAsync().get());
     Assert.assertEquals(
         "input",
-        WorkflowClient.update(workflow::func1, "input", updateOptions).getResultAsync().get());
+        WorkflowClient.executeUpdate(workflow::func1, "input", updateOptions)
+            .getResultAsync()
+            .get());
     Assert.assertEquals(
         "input2",
-        WorkflowClient.update(workflow::func2, "input", 2, updateOptions).getResultAsync().get());
+        WorkflowClient.executeUpdate(workflow::func2, "input", 2, updateOptions)
+            .getResultAsync()
+            .get());
     Assert.assertEquals(
         "input23",
-        WorkflowClient.update(workflow::func3, "input", 2, 3, updateOptions)
+        WorkflowClient.executeUpdate(workflow::func3, "input", 2, 3, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input234",
-        WorkflowClient.update(workflow::func4, "input", 2, 3, 4, updateOptions)
+        WorkflowClient.executeUpdate(workflow::func4, "input", 2, 3, 4, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input2345",
-        WorkflowClient.update(workflow::func5, "input", 2, 3, 4, 5, updateOptions)
+        WorkflowClient.executeUpdate(workflow::func5, "input", 2, 3, 4, 5, updateOptions)
             .getResultAsync()
             .get());
     Assert.assertEquals(
         "input23456",
-        WorkflowClient.update(workflow::func6, "input", 2, 3, 4, 5, 6, updateOptions)
+        WorkflowClient.executeUpdate(workflow::func6, "input", 2, 3, 4, 5, 6, updateOptions)
             .getResultAsync()
             .get());
 
     UpdateOptions<Void> updateVoidOptions =
         UpdateOptions.<Void>newBuilder().setWaitForStage(WorkflowUpdateStage.COMPLETED).build();
-    WorkflowClient.update(workflow::proc, updateVoidOptions).getResultAsync().get();
-    WorkflowClient.update(workflow::proc1, "input", updateVoidOptions).getResultAsync().get();
-    WorkflowClient.update(workflow::proc2, "input", 2, updateVoidOptions).getResultAsync().get();
-    WorkflowClient.update(workflow::proc3, "input", 2, 3, updateVoidOptions).getResultAsync().get();
-    WorkflowClient.update(workflow::proc4, "input", 2, 3, 4, updateVoidOptions)
+    WorkflowClient.executeUpdate(workflow::proc, updateVoidOptions).getResultAsync().get();
+    WorkflowClient.executeUpdate(workflow::proc1, "input", updateVoidOptions)
         .getResultAsync()
         .get();
-    WorkflowClient.update(workflow::proc5, "input", 2, 3, 4, 5, updateVoidOptions)
+    WorkflowClient.executeUpdate(workflow::proc2, "input", 2, updateVoidOptions)
         .getResultAsync()
         .get();
-    WorkflowClient.update(workflow::proc6, "input", 2, 3, 4, 5, 6, updateVoidOptions)
+    WorkflowClient.executeUpdate(workflow::proc3, "input", 2, 3, updateVoidOptions)
+        .getResultAsync()
+        .get();
+    WorkflowClient.executeUpdate(workflow::proc4, "input", 2, 3, 4, updateVoidOptions)
+        .getResultAsync()
+        .get();
+    WorkflowClient.executeUpdate(workflow::proc5, "input", 2, 3, 4, 5, updateVoidOptions)
+        .getResultAsync()
+        .get();
+    WorkflowClient.executeUpdate(workflow::proc6, "input", 2, 3, 4, 5, 6, updateVoidOptions)
         .getResultAsync()
         .get();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/TypedUpdateTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow.updateTest;
+
+import static org.junit.Assert.*;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.*;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.workflow.shared.TestMultiArgWorkflowUpdateFunctions;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TypedUpdateTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkerOptions(WorkerOptions.newBuilder().build())
+          .setWorkflowTypes(
+              TestMultiArgWorkflowUpdateFunctions.TestMultiArgUpdateWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testTypedStubSync() {
+    String workflowId = UUID.randomUUID().toString();
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .setWorkflowId(workflowId)
+            .build();
+    TestMultiArgWorkflowUpdateFunctions.TestMultiArgUpdateWorkflow workflow =
+        workflowClient.newWorkflowStub(
+            TestMultiArgWorkflowUpdateFunctions.TestMultiArgUpdateWorkflow.class, options);
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+
+    Assert.assertEquals("func", workflow.func());
+    Assert.assertEquals("input", workflow.func1("input"));
+    Assert.assertEquals("input2", workflow.func2("input", 2));
+    Assert.assertEquals("input23", workflow.func3("input", 2, 3));
+    Assert.assertEquals("input234", workflow.func4("input", 2, 3, 4));
+    Assert.assertEquals("input2345", workflow.func5("input", 2, 3, 4, 5));
+    Assert.assertEquals("input23456", workflow.func6("input", 2, 3, 4, 5, 6));
+
+    workflow.proc();
+    workflow.proc1("input");
+    workflow.proc2("input", 2);
+    workflow.proc3("input", 2, 3);
+    workflow.proc4("input", 2, 3, 4);
+    workflow.proc5("input", 2, 3, 4, 5);
+    workflow.proc6("input", 2, 3, 4, 5, 6);
+
+    workflow.complete();
+    String result =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(execution, Optional.empty())
+            .getResult(String.class);
+    assertEquals("procinputinput2input23input234input2345input23456", result);
+  }
+
+  @Test
+  public void testTypedAsync() throws ExecutionException, InterruptedException {
+    String workflowId = UUID.randomUUID().toString();
+    WorkflowClient workflowClient = testWorkflowRule.getWorkflowClient();
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .setWorkflowId(workflowId)
+            .build();
+    TestMultiArgWorkflowUpdateFunctions.TestMultiArgUpdateWorkflow workflow =
+        workflowClient.newWorkflowStub(
+            TestMultiArgWorkflowUpdateFunctions.TestMultiArgUpdateWorkflow.class, options);
+    WorkflowExecution execution = WorkflowClient.start(workflow::execute);
+    UpdateOptions<String> updateOptions =
+        UpdateOptions.<String>newBuilder().setWaitForStage(WorkflowUpdateStage.COMPLETED).build();
+
+    Assert.assertEquals(
+        "func", WorkflowClient.update(workflow::func, updateOptions).getResultAsync().get());
+    Assert.assertEquals(
+        "input",
+        WorkflowClient.update(workflow::func1, "input", updateOptions).getResultAsync().get());
+    Assert.assertEquals(
+        "input2",
+        WorkflowClient.update(workflow::func2, "input", 2, updateOptions).getResultAsync().get());
+    Assert.assertEquals(
+        "input23",
+        WorkflowClient.update(workflow::func3, "input", 2, 3, updateOptions)
+            .getResultAsync()
+            .get());
+    Assert.assertEquals(
+        "input234",
+        WorkflowClient.update(workflow::func4, "input", 2, 3, 4, updateOptions)
+            .getResultAsync()
+            .get());
+    Assert.assertEquals(
+        "input2345",
+        WorkflowClient.update(workflow::func5, "input", 2, 3, 4, 5, updateOptions)
+            .getResultAsync()
+            .get());
+    Assert.assertEquals(
+        "input23456",
+        WorkflowClient.update(workflow::func6, "input", 2, 3, 4, 5, 6, updateOptions)
+            .getResultAsync()
+            .get());
+
+    UpdateOptions<Void> updateVoidOptions =
+        UpdateOptions.<Void>newBuilder().setWaitForStage(WorkflowUpdateStage.COMPLETED).build();
+    WorkflowClient.update(workflow::proc, updateVoidOptions).getResultAsync().get();
+    WorkflowClient.update(workflow::proc1, "input", updateVoidOptions).getResultAsync().get();
+    WorkflowClient.update(workflow::proc2, "input", 2, updateVoidOptions).getResultAsync().get();
+    WorkflowClient.update(workflow::proc3, "input", 2, 3, updateVoidOptions).getResultAsync().get();
+    WorkflowClient.update(workflow::proc4, "input", 2, 3, 4, updateVoidOptions)
+        .getResultAsync()
+        .get();
+    WorkflowClient.update(workflow::proc5, "input", 2, 3, 4, 5, updateVoidOptions)
+        .getResultAsync()
+        .get();
+    WorkflowClient.update(workflow::proc6, "input", 2, 3, 4, 5, 6, updateVoidOptions)
+        .getResultAsync()
+        .get();
+
+    workflow.complete();
+    String result =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(execution, Optional.empty())
+            .getResult(String.class);
+    assertEquals("procinputinput2input23input234input2345input23456", result);
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -227,7 +227,7 @@ public class UpdateTest {
         workflowClient.newWorkflowStub(
             TestWorkflows.WorkflowWithUpdate.class, workflowStub.getExecution().getWorkflowId());
     WorkflowUpdateHandle<String> updateRef =
-        WorkflowClient.update(
+        WorkflowClient.executeUpdate(
             workflow::update, 0, "World", UpdateOptions.<String>newBuilder().build());
     assertEquals("Execute-World", updateRef.getResultAsync().get());
     // send a bad update that will be rejected through the sync path

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -223,7 +223,7 @@ public class UpdateTest {
             TestWorkflows.WorkflowWithUpdate.class, workflowStub.getExecution().getWorkflowId());
 
     WorkflowUpdateHandle<String> handle =
-        WorkflowClient.executeUpdate(
+        WorkflowClient.startUpdate(
             workflow::update,
             0,
             "Hello",
@@ -232,7 +232,7 @@ public class UpdateTest {
 
     assertEquals(
         "Execute-World",
-        WorkflowClient.executeUpdate(
+        WorkflowClient.startUpdate(
                 workflow::update,
                 0,
                 "World",
@@ -242,7 +242,7 @@ public class UpdateTest {
 
     assertEquals(
         "Execute-Hello",
-        WorkflowClient.executeUpdate(
+        WorkflowClient.startUpdate(
                 workflow::update,
                 0,
                 "World",
@@ -255,7 +255,7 @@ public class UpdateTest {
 
     assertEquals(
         null,
-        WorkflowClient.executeUpdate(
+        WorkflowClient.startUpdate(
                 workflow::complete,
                 UpdateOptions.<Void>newBuilder().setWaitForStage(COMPLETED).build())
             .getResultAsync()


### PR DESCRIPTION
Add type safe API to execute an async update workflow request.

Open questions we should resolve:
1. Is the name `executeUpdate` acceptable? We could also use `update` or `startUpdate` the Java SDK is not very consistent here
2. Is taking `UpdateOptions` OK or do we want a new type here? Reusing is nice since it reduces the number of types, but has some redundant fields like `name`, and type.

closes https://github.com/temporalio/sdk-java/issues/2181
