### PR TITLE
Do runtime check to ensure update validator has the same parameters as the update it validates

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadata.java
@@ -210,17 +210,15 @@ public final class POJOWorkflowInterfaceMetadata {
                   + methodMetadata.getWorkflowMethod().getName()
                   + "\"");
         }
-        if (Arrays.equals(
-                update.getWorkflowMethod().getGenericParameterTypes(),
-                methodMetadata.getWorkflowMethod().getGenericParameterTypes())
-            || update.getWorkflowMethod().getGenericReturnType()
-                == methodMetadata.getWorkflowMethod().getGenericReturnType()) {
+        if (!Arrays.equals(
+            update.getWorkflowMethod().getGenericParameterTypes(),
+            methodMetadata.getWorkflowMethod().getGenericParameterTypes())) {
           throw new IllegalArgumentException(
               "Update method \""
                   + update.getWorkflowMethod().getName()
-                  + "\" and validator method \""
+                  + "\" and Validator method \""
                   + methodMetadata.getWorkflowMethod().getName()
-                  + "\" have the same signature");
+                  + "\" do not have the same parameters");
         }
       }
     }

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
@@ -211,6 +211,34 @@ public class POJOWorkflowInterfaceMetadataTest {
     return methodDefinition.make().load(this.getClass().getClassLoader()).getLoaded();
   }
 
+  @Test
+  public void workflowInterfaceWithUpdateValidator() {
+    POJOWorkflowInterfaceMetadata metadata =
+        POJOWorkflowInterfaceMetadata.newInstance(GUpdate.class);
+    System.out.println(metadata);
+  }
+
+  @Test
+  public void workflowInterfaceWithBadUpdateValidator() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> POJOWorkflowInterfaceMetadata.newInstance(GUpdateBadValidator.class));
+  }
+
+  @Test
+  public void workflowInterfaceValidatorWithNoUpdate() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> POJOWorkflowInterfaceMetadata.newInstance(GUpdateValidatorWithNoUpdate.class));
+  }
+
+  @Test
+  public void interfaceWithInvalidValidator() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> POJOWorkflowInterfaceMetadata.newImplementationInstance(J.class, true));
+  }
+
   public interface O {
     void someMethod();
   }
@@ -255,9 +283,36 @@ public class POJOWorkflowInterfaceMetadataTest {
   }
 
   @WorkflowInterface
-  interface G {
+  public interface G {
     @WorkflowMethod
     void g();
+  }
+
+  @WorkflowInterface
+  public interface GUpdate extends G {
+    @UpdateMethod
+    void update(Map<String, Integer> input);
+
+    @UpdateValidatorMethod(updateName = "update")
+    void validate(Map<String, Integer> input);
+  }
+
+  @WorkflowInterface
+  public interface GUpdateBadValidator extends G {
+    @UpdateMethod
+    void update(Map<String, Integer> input);
+
+    @UpdateValidatorMethod(updateName = "update")
+    void validate(Map<String, String> input);
+  }
+
+  @WorkflowInterface
+  public interface GUpdateValidatorWithNoUpdate extends G {
+    @UpdateMethod
+    void update(Map<String, Integer> input);
+
+    @UpdateValidatorMethod(updateName = "wrongUpdate")
+    void validate(Map<String, Integer> input);
   }
 
   @WorkflowInterface
@@ -270,6 +325,11 @@ public class POJOWorkflowInterfaceMetadataTest {
   public interface I {
     @WorkflowMethod
     void i();
+  }
+
+  public interface J {
+    @UpdateValidatorMethod(updateName = "update")
+    void validate(String input);
   }
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
@@ -215,7 +215,6 @@ public class POJOWorkflowInterfaceMetadataTest {
   public void workflowInterfaceWithUpdateValidator() {
     POJOWorkflowInterfaceMetadata metadata =
         POJOWorkflowInterfaceMetadata.newInstance(GUpdate.class);
-    System.out.println(metadata);
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/metadata/POJOWorkflowInterfaceMetadataTest.java
@@ -214,21 +214,21 @@ public class POJOWorkflowInterfaceMetadataTest {
   @Test
   public void workflowInterfaceWithUpdateValidator() {
     POJOWorkflowInterfaceMetadata metadata =
-        POJOWorkflowInterfaceMetadata.newInstance(GUpdate.class);
+        POJOWorkflowInterfaceMetadata.newInstance(LUpdate.class);
   }
 
   @Test
   public void workflowInterfaceWithBadUpdateValidator() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> POJOWorkflowInterfaceMetadata.newInstance(GUpdateBadValidator.class));
+        () -> POJOWorkflowInterfaceMetadata.newInstance(LUpdateBadValidator.class));
   }
 
   @Test
   public void workflowInterfaceValidatorWithNoUpdate() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> POJOWorkflowInterfaceMetadata.newInstance(GUpdateValidatorWithNoUpdate.class));
+        () -> POJOWorkflowInterfaceMetadata.newInstance(LUpdateValidatorWithNoUpdate.class));
   }
 
   @Test
@@ -282,36 +282,9 @@ public class POJOWorkflowInterfaceMetadataTest {
   }
 
   @WorkflowInterface
-  public interface G {
+  interface G {
     @WorkflowMethod
     void g();
-  }
-
-  @WorkflowInterface
-  public interface GUpdate extends G {
-    @UpdateMethod
-    void update(Map<String, Integer> input);
-
-    @UpdateValidatorMethod(updateName = "update")
-    void validate(Map<String, Integer> input);
-  }
-
-  @WorkflowInterface
-  public interface GUpdateBadValidator extends G {
-    @UpdateMethod
-    void update(Map<String, Integer> input);
-
-    @UpdateValidatorMethod(updateName = "update")
-    void validate(Map<String, String> input);
-  }
-
-  @WorkflowInterface
-  public interface GUpdateValidatorWithNoUpdate extends G {
-    @UpdateMethod
-    void update(Map<String, Integer> input);
-
-    @UpdateValidatorMethod(updateName = "wrongUpdate")
-    void validate(Map<String, Integer> input);
   }
 
   @WorkflowInterface
@@ -335,6 +308,39 @@ public class POJOWorkflowInterfaceMetadataTest {
   public interface K {
     @WorkflowMethod
     void f(Map<String, EncodedValuesTest.Pair> input);
+  }
+
+  @WorkflowInterface
+  public interface L {
+    @WorkflowMethod
+    void l();
+  }
+
+  @WorkflowInterface
+  public interface LUpdate extends L {
+    @UpdateMethod
+    void update(Map<String, Integer> input);
+
+    @UpdateValidatorMethod(updateName = "update")
+    void validate(Map<String, Integer> input);
+  }
+
+  @WorkflowInterface
+  public interface LUpdateBadValidator extends L {
+    @UpdateMethod
+    void update(Map<String, Integer> input);
+
+    @UpdateValidatorMethod(updateName = "update")
+    void validate(Map<String, String> input);
+  }
+
+  @WorkflowInterface
+  public interface LUpdateValidatorWithNoUpdate extends L {
+    @UpdateMethod
+    void update(Map<String, Integer> input);
+
+    @UpdateValidatorMethod(updateName = "wrongUpdate")
+    void validate(Map<String, Integer> input);
   }
 
   public interface DE extends D, E {}


### PR DESCRIPTION
Do runtime check to ensure update validator has the same parameters as the update it validates.

closes https://github.com/temporalio/sdk-java/issues/2317