### PR TITLE
Add getResult to WorkflowUpdateHandle

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
@@ -57,6 +57,7 @@ public interface WorkflowUpdateHandle<T> {
    *
    * @param timeout maximum time to wait and perform the background long polling
    * @param unit unit of timeout
+   * @throws WorkflowUpdateTimeoutOrCancelledException if the timeout is reached.
    * @return the result of the workflow update
    */
   T getResult(long timeout, TimeUnit unit);

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
@@ -46,6 +46,22 @@ public interface WorkflowUpdateHandle<T> {
   String getId();
 
   /**
+   * Returns the result of the workflow update.
+   *
+   * @return the result of the workflow update
+   */
+  T getResult();
+
+  /**
+   * Returns the result of the workflow update.
+   *
+   * @param timeout maximum time to wait and perform the background long polling
+   * @param unit unit of timeout
+   * @return the result of the workflow update
+   */
+  T getResult(long timeout, TimeUnit unit);
+
+  /**
    * Returns a {@link CompletableFuture} with the update workflow execution request result,
    * potentially waiting for the update to complete.
    *

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedWorkflowUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedWorkflowUpdateHandleImpl.java
@@ -50,6 +50,16 @@ public final class CompletedWorkflowUpdateHandleImpl<T> implements WorkflowUpdat
   }
 
   @Override
+  public T getResult() {
+    return result;
+  }
+
+  @Override
+  public T getResult(long timeout, TimeUnit unit) {
+    return result;
+  }
+
+  @Override
   public CompletableFuture<T> getResultAsync() {
     return CompletableFuture.completedFuture(result);
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -186,6 +186,14 @@ public class UpdateTest {
         WorkflowUpdateException.class,
         () -> workflowStub.update("bad_update_name", String.class, 0, "Bad Update"));
 
+    // send an update request to a bad name through the async path
+    assertThrows(
+        WorkflowUpdateException.class,
+        () ->
+            workflowStub
+                .startUpdate("bad_update_name", WorkflowUpdateStage.COMPLETED, String.class, 0, "")
+                .getResult());
+
     // send a bad update that will be rejected through the sync path
     assertThrows(
         WorkflowUpdateException.class,


### PR DESCRIPTION
Add `getResult` helper to `WorkflowUpdateHandle`

closes https://github.com/temporalio/sdk-java/issues/2212