### PR TITLE
[WIP] Fix CI after GHA's drop of node16 actions

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: buildjet-2vcpu-ubuntu-1804
+          - runner: ubuntu-latest
             os_family: linux
             arch: amd64
           - runner: macos-13
@@ -138,16 +138,9 @@ jobs:
             os_family: windows
             arch: amd64
     runs-on: ${{ matrix.runner }}
-    env:
-      # This is required to allow continuing usage of Node 16 for actions,
-      # as Node 20 won't run on the builder we use for linux builds
-      # (Node 20 require glibc 2.28+, but ubuntu-1804 has glibc 2.27).
-      # https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout repo
-        # FIXME: v4+ requires Node 20
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.INPUT_REF }}
 
@@ -156,25 +149,20 @@ jobs:
       - name: Temporary tag
         run: git tag "$INPUT_TAG"
 
-      - name: Set up Java
-        # FIXME: v4+ requires Node 20
-        uses: actions/setup-java@v3
-        with:
-          java-version: "11"
-          distribution: "temurin"
-
-      - name: Set up Gradle
-        # FIXME: v3+ requires Node 20
-        uses: gradle/gradle-build-action@v2
-      
       - name: Build native test server
-        run: ./gradlew :temporal-test-server:build
+        run: |
+          docker run \
+            --rm -v "$(pwd):/workspace" -w /workspace \
+            ghcr.io/graalvm/graalvm-community:21-ol7 \
+            sh -c '
+              yum install -y git && \
+              ./gradlew -x :temporal-serviceclient:updateSubmodules :temporal-test-server:build
+            '
 
       # path ends in a wildcard because on windows the file ends in '.exe'
       # path excludes *.txt because native-image also writes a build manifest txt file
       - name: Upload executable to workflow
-        # FIXME: v4+ requires Node 20
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os_family }}_${{ matrix.arch }}
           path: |
@@ -193,8 +181,7 @@ jobs:
 
       # when no artifact is specified, all artifacts are downloaded and expanded into CWD
       - name: Fetch executables
-        # Need v3 here to stay compatible with the build_native_images job.
-        uses: actions/download-artifact@v3-node20
+        uses: actions/download-artifact@v4
 
       # example: linux_amd64/ -> temporal-test-server_1.2.3_linux_amd64
       # the name of the directory created becomes the basename of the archive (*.tar.gz or *.zip) and

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -156,14 +156,10 @@ jobs:
 
       - name: Build native test server (Docker)
         if: matrix.os_family == 'Linux'
-        run: |
-          docker run \
-            --rm -v "$(pwd):/workspace" -w /workspace \
-            ghcr.io/graalvm/graalvm-community:21-ol7 \
-            sh -c '
-              yum install -y git && \
-              ./gradlew -x :temporal-serviceclient:updateSubmodules :temporal-test-server:build
-            '
+        uses: docker://openjdk:21-jdk-oraclelinux7
+        with:
+          args: |
+            sh -c 'yum install -y git && ./gradlew -x :temporal-serviceclient:updateSubmodules :temporal-test-server:build'
 
       # path ends in a wildcard because on windows the file ends in '.exe'
       # path excludes *.txt because native-image also writes a build manifest txt file

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -149,7 +149,13 @@ jobs:
       - name: Temporary tag
         run: git tag "$INPUT_TAG"
 
-      - name: Build native test server
+      - name: Build native test server (non-Docker)
+        if: matrix.os_family != 'Linux'
+        run: |
+          ./gradlew -x :temporal-serviceclient:updateSubmodules :temporal-test-server:build
+
+      - name: Build native test server (Docker)
+        if: matrix.os_family == 'Linux'
         run: |
           docker run \
             --rm -v "$(pwd):/workspace" -w /workspace \


### PR DESCRIPTION
## What was changed

- Modified our GHA workflows so that when building the native executable of the Test Server on Linux targets, only the actual compilation step runs inside an older GLIBC 2.17-based Docker container; all other operations are performed directly on the runner, which can now be any recent Ubuntu.  

  This was required because GHA no longer allows actions based on Node16 (i.e. actions are forced to use Node20 instead), but Node20 requires at least GLIBC 2.28. It is therefore not possible to have a single execution environment that can both execute Node20-based actions, yet produces native binaries that can then execute on the GLIBC 2.17-based environments that some of our users have.

  Fixes #2331.