### PR TITLE
Make nexus header check case-insensitive

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
@@ -96,7 +96,9 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
     ScheduledFuture<?> timeoutTask = null;
     AtomicBoolean timedOut = new AtomicBoolean(false);
     try {
-      String timeoutString = headers.get(Header.REQUEST_TIMEOUT);
+      // Parse request timeout, use the context headers to get the timeout
+      // since they are case-insensitive.
+      String timeoutString = ctx.getHeaders().get(Header.REQUEST_TIMEOUT);
       if (timeoutString != null) {
         try {
           Duration timeout = NexusUtil.parseRequestTimeout(timeoutString);


### PR DESCRIPTION
Make nexus header check case-insensitive. Nexus headers should be case insensitive so we use the map from the context that is case insensitive. 