### PR TITLE
Standardized update failure exception

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -83,10 +83,11 @@ public interface WorkflowStub {
    * @param <R> type of the update return value
    * @param args update method arguments
    * @return update result
-   * @throws WorkflowNotFoundException if the workflow execution doesn't exist or completed and
-   *     can't be signalled
+   * @throws WorkflowUpdateException if the update is rejected or failed during it's execution by
+   *     the workflow.
+   * @throws WorkflowNotFoundException if the workflow execution doesn't exist or is completed.
    * @throws WorkflowServiceException for all other failures including networking and service
-   *     availability issues
+   *     availability issues.
    */
   @Experimental
   <R> R update(String updateName, Class<R> resultClass, Object... args);
@@ -103,6 +104,9 @@ public interface WorkflowStub {
    * @param <R> type of the update return value
    * @param args update method arguments
    * @return update handle that can be used to get the result of the update.
+   * @throws WorkflowNotFoundException if the workflow execution doesn't exist or completed.
+   * @throws WorkflowServiceException for all other failures including networking and service
+   *     availability issues.
    */
   @Experimental
   <R> WorkflowUpdateHandle<R> startUpdate(
@@ -116,6 +120,9 @@ public interface WorkflowStub {
    * @param options options that will be used to configure and start a new update request.
    * @param args update method arguments
    * @return update handle that can be used to get the result of the update.
+   * @throws WorkflowNotFoundException if the workflow execution doesn't exist or completed.
+   * @throws WorkflowServiceException for all other failures including networking and service
+   *     availability issues.
    */
   @Experimental
   <R> WorkflowUpdateHandle<R> startUpdate(UpdateOptions<R> options, Object... args);

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowUpdateHandle.java
@@ -49,6 +49,7 @@ public interface WorkflowUpdateHandle<T> {
    * Returns the result of the workflow update.
    *
    * @return the result of the workflow update
+   * @throws WorkflowUpdateException if the update was rejected or failed by the workflow.
    */
   T getResult();
 
@@ -58,6 +59,7 @@ public interface WorkflowUpdateHandle<T> {
    * @param timeout maximum time to wait and perform the background long polling
    * @param unit unit of timeout
    * @throws WorkflowUpdateTimeoutOrCancelledException if the timeout is reached.
+   * @throws WorkflowUpdateException if the update was rejected or failed by the workflow.
    * @return the result of the workflow update
    */
   T getResult(long timeout, TimeUnit unit);

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedWorkflowUpdateHandleImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/CompletedWorkflowUpdateHandleImpl.java
@@ -21,6 +21,7 @@
 package io.temporal.internal.client;
 
 import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowUpdateException;
 import io.temporal.client.WorkflowUpdateHandle;
 import io.temporal.common.Experimental;
 import java.util.concurrent.CompletableFuture;
@@ -31,12 +32,22 @@ public final class CompletedWorkflowUpdateHandleImpl<T> implements WorkflowUpdat
 
   private final String id;
   private final WorkflowExecution execution;
+  private final WorkflowUpdateException exception;
   private final T result;
 
   public CompletedWorkflowUpdateHandleImpl(String id, WorkflowExecution execution, T result) {
     this.id = id;
     this.execution = execution;
     this.result = result;
+    this.exception = null;
+  }
+
+  public CompletedWorkflowUpdateHandleImpl(
+      String id, WorkflowExecution execution, WorkflowUpdateException ex) {
+    this.id = id;
+    this.execution = execution;
+    this.exception = ex;
+    this.result = null;
   }
 
   @Override
@@ -51,21 +62,29 @@ public final class CompletedWorkflowUpdateHandleImpl<T> implements WorkflowUpdat
 
   @Override
   public T getResult() {
+    if (exception != null) {
+      throw exception;
+    }
     return result;
   }
 
   @Override
   public T getResult(long timeout, TimeUnit unit) {
-    return result;
+    return getResult();
   }
 
   @Override
   public CompletableFuture<T> getResultAsync() {
+    if (exception != null) {
+      CompletableFuture<T> result = new CompletableFuture<>();
+      result.completeExceptionally(exception);
+      return result;
+    }
     return CompletableFuture.completedFuture(result);
   }
 
   @Override
   public CompletableFuture<T> getResultAsync(long timeout, TimeUnit unit) {
-    return CompletableFuture.completedFuture(result);
+    return getResultAsync();
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -533,12 +533,15 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
               result.getUpdateRef().getWorkflowExecution(),
               resultValue);
         case FAILURE:
-          throw new WorkflowUpdateException(
-              result.getUpdateRef().getWorkflowExecution(),
+          return new CompletedWorkflowUpdateHandleImpl<>(
               result.getUpdateRef().getUpdateId(),
-              input.getUpdateName(),
-              dataConverterWithWorkflowContext.failureToException(
-                  result.getOutcome().getFailure()));
+              result.getUpdateRef().getWorkflowExecution(),
+              new WorkflowUpdateException(
+                  result.getUpdateRef().getWorkflowExecution(),
+                  result.getUpdateRef().getUpdateId(),
+                  input.getUpdateName(),
+                  dataConverterWithWorkflowContext.failureToException(
+                      result.getOutcome().getFailure())));
         default:
           throw new RuntimeException(
               "Received unexpected outcome from update request: "

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/DynamicUpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/DynamicUpdateTest.java
@@ -72,7 +72,7 @@ public class DynamicUpdateTest {
         WorkflowUpdateException.class,
         () ->
             stub.startUpdate("reject", WorkflowUpdateStage.COMPLETED, String.class, "update input")
-                .getResultAsync());
+                .getResult());
 
     stub.startUpdate("complete", WorkflowUpdateStage.COMPLETED, Void.class).getResultAsync().get();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateInfoTest.java
@@ -72,8 +72,7 @@ public class UpdateInfoTest {
         WorkflowUpdateException.class,
         () ->
             stub.startUpdate(updateOptionsBuilder.setUpdateId("reject").build(), 0, "")
-                .getResultAsync());
-
+                .getResult());
     workflow.complete();
     String result =
         testWorkflowRule

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -199,7 +199,10 @@ public class UpdateTest {
     // send a bad update that will be rejected through the sync path
     assertThrows(
         WorkflowUpdateException.class,
-        () -> workflowStub.startUpdate("update", ACCEPTED, String.class, 0, "Bad Update"));
+        () ->
+            workflowStub
+                .startUpdate("update", ACCEPTED, String.class, 0, "Bad Update")
+                .getResult());
 
     workflowStub.update("complete", void.class);
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateWithStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateWithStartTest.java
@@ -478,8 +478,8 @@ public class UpdateWithStartTest {
             .build();
 
     assertThrows(
-        WorkflowServiceException.class,
-        () -> WorkflowClient.updateWithStart(workflow::execute, updateOp));
+        WorkflowUpdateException.class,
+        () -> WorkflowClient.updateWithStart(workflow::execute, updateOp).getResult());
   }
 
   @Test


### PR DESCRIPTION
While reviewing update with start I noticed that the Java SDK was handling update failures a bit different then other SDKs. Other SDKs always return an update rejection or failure through the update handle. The Java SDK may have returned the update failure (as an exception) on `startUpdate` or `getResult` depending on the exact timing and `waitStage` the user selected. After this PR the Java SDK will always return the update failure by getting the result from the handle.