### PR TITLE
Fix unbalanced locks in test server for Nexus

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -62,6 +62,7 @@ import io.temporal.internal.testservice.StateMachines.Action;
 import io.temporal.internal.testservice.StateMachines.ActivityTaskData;
 import io.temporal.internal.testservice.StateMachines.CancelExternalData;
 import io.temporal.internal.testservice.StateMachines.ChildWorkflowData;
+import io.temporal.internal.testservice.StateMachines.NexusOperationData;
 import io.temporal.internal.testservice.StateMachines.SignalExternalData;
 import io.temporal.internal.testservice.StateMachines.State;
 import io.temporal.internal.testservice.StateMachines.TimerData;
@@ -782,11 +783,11 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     nexusOperations.put(scheduleEventId, operation);
 
     operation.action(Action.INITIATE, ctx, attr, workflowTaskCompletedId);
+    // Record the current attempt of this
+    int attempt = operation.getData().getAttempt();
     ctx.addTimer(
         ProtobufTimeUtils.toJavaDuration(operation.getData().requestTimeout),
-        () ->
-            timeoutNexusRequest(
-                scheduleEventId, "StartNexusOperation", operation.getData().getAttempt()),
+        () -> timeoutNexusRequest(scheduleEventId, "StartNexusOperation", attempt),
         "StartNexusOperation request timeout");
     if (attr.hasScheduleToCloseTimeout()
         && Durations.toMillis(attr.getScheduleToCloseTimeout()) > 0) {


### PR DESCRIPTION
Fix unbalanced locks in test server for Nexus. The issue was the attempt of the task was always using the current attempt not the attempt when the timer was creates as intended. 

```
08:43:47.767 [Timer task] ERROR i.t.i.t.SelfAdvancingTimerImpl - Failed to unlock the timer
java.lang.IllegalStateException: Unbalanced lock and unlock calls: 
Self Advancing Timer Lock Events:
2024-12-03 08:43:47.273	L	  1	TestService constructor
2024-12-03 08:43:47.629	L	    2	scheduleWorkflowTask
2024-12-03 08:43:47.642	L	      3	scheduleWorkflowTask
2024-12-03 08:43:47.645	U	    2	External Caller
2024-12-03 08:43:47.704	U	  1	completeWorkflowTask
2024-12-03 08:43:47.725	L	    2	processScheduleNexusOperation
2024-12-03 08:43:47.725	U	  1	completeWorkflowTask
2024-12-03 08:43:47.755	U	0	failNexusOperation
2024-12-03 08:43:47.755	L	  1	nexusOperationRetryTimer 
2024-12-03 08:43:47.758	U	0	failNexusOperation
2024-12-03 08:43:47.758	L	  1	nexusOperationRetryTimer 
2024-12-03 08:43:47.76	U	0	failNexusOperation
2024-12-03 08:43:47.761	L	  1	nexusOperationRetryTimer 
2024-12-03 08:43:47.764	U	0	failNexusOperation
2024-12-03 08:43:47.765	U	-1	timeoutNexusOperation: 5
```