### PR TITLE
Make headers in ExecuteNexusOperationInput case insensitive

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -285,7 +286,13 @@ public interface WorkflowOutboundCallsInterceptor {
       this.resultType = resultType;
       this.arg = arg;
       this.options = options;
-      this.headers = headers;
+      this.headers = headers.entrySet().stream()
+              .collect(
+                      Collectors.toMap(
+                              (k) -> k.getKey().toLowerCase(),
+                              Map.Entry::getValue,
+                              (a, b) -> a,
+                              () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
     }
 
     public String getService() {
@@ -316,6 +323,10 @@ public interface WorkflowOutboundCallsInterceptor {
       return options;
     }
 
+    /**
+     * Get headers that will be sent with the request. The returned map operates without regard to
+     * case.
+     */
     public Map<String, String> getHeaders() {
       return headers;
     }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowOutboundCallsInterceptor.java
@@ -286,13 +286,14 @@ public interface WorkflowOutboundCallsInterceptor {
       this.resultType = resultType;
       this.arg = arg;
       this.options = options;
-      this.headers = headers.entrySet().stream()
+      this.headers =
+          headers.entrySet().stream()
               .collect(
-                      Collectors.toMap(
-                              (k) -> k.getKey().toLowerCase(),
-                              Map.Entry::getValue,
-                              (a, b) -> a,
-                              () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
+                  Collectors.toMap(
+                      (k) -> k.getKey().toLowerCase(),
+                      Map.Entry::getValue,
+                      (a, b) -> a,
+                      () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
     }
 
     public String getService() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -816,7 +816,8 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
     attributes.setOperation(input.getOperation());
     attributes.setService(input.getService());
     attributes.setEndpoint(input.getEndpoint());
-    attributes.putAllNexusHeader(input.getHeaders());
+    // Ensure that the headers are lowercase
+    input.getHeaders().forEach((k, v) -> attributes.putNexusHeader(k.toLowerCase(), v));
     attributes.setScheduleToCloseTimeout(
         ProtobufTimeUtils.toProtoDuration(input.getOptions().getScheduleToCloseTimeout()));
 


### PR DESCRIPTION
Make headers in ExecuteNexusOperationInput case insensitive, this will align with other Nexus headers that are all case insensitive.
