### PR TITLE
fix: Nexus operation headers should be modifiable

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusServiceStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusServiceStubImpl.java
@@ -26,6 +26,7 @@ import io.temporal.failure.TemporalFailure;
 import io.temporal.workflow.*;
 import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashMap;
 
 public class NexusServiceStubImpl implements NexusServiceStub {
   private final String name;
@@ -90,7 +91,7 @@ public class NexusServiceStubImpl implements NexusServiceStub {
                 resultType,
                 arg,
                 mergedOptions,
-                Collections.emptyMap()));
+                new HashMap<>()));
     return result.getResult();
   }
 
@@ -117,7 +118,7 @@ public class NexusServiceStubImpl implements NexusServiceStub {
                 resultType,
                 arg,
                 mergedOptions,
-                Collections.emptyMap()));
+                new HashMap<>()));
     return new NexusOperationHandleImpl<>(result.getOperationExecution(), result.getResult());
   }
 


### PR DESCRIPTION
## What was changed
Changes Nexus start/execute operation headers from an immutable empty map to an empty HashMap.

## Why?
Changing headers as part of a `WorkerInterceptor` is not currently possible.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Not manually tested.
