### PR TITLE
Test server support for Nexus operation complete before start

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableState.java
@@ -28,6 +28,7 @@ import io.temporal.api.enums.v1.SignalExternalWorkflowExecutionFailedCause;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.*;
+import io.temporal.api.nexus.v1.Link;
 import io.temporal.api.nexus.v1.StartOperationResponse;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.workflowservice.v1.*;
@@ -115,6 +116,9 @@ interface TestWorkflowMutableState {
   void cancelNexusOperation(NexusOperationRef ref, Failure failure);
 
   void completeNexusOperation(NexusOperationRef ref, Payload result);
+
+  void completeAsyncNexusOperation(
+      NexusOperationRef ref, Payload result, String operationID, Link startLink);
 
   void failNexusOperation(NexusOperationRef ref, Failure failure);
 

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -50,10 +50,7 @@ import io.temporal.api.failure.v1.MultiOperationExecutionAborted;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.WorkflowExecutionContinuedAsNewEventAttributes;
 import io.temporal.api.namespace.v1.NamespaceInfo;
-import io.temporal.api.nexus.v1.HandlerError;
-import io.temporal.api.nexus.v1.Request;
-import io.temporal.api.nexus.v1.StartOperationResponse;
-import io.temporal.api.nexus.v1.UnsuccessfulOperationError;
+import io.temporal.api.nexus.v1.*;
 import io.temporal.api.testservice.v1.LockTimeSkippingRequest;
 import io.temporal.api.testservice.v1.SleepRequest;
 import io.temporal.api.testservice.v1.TestServiceGrpc;
@@ -899,7 +896,8 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     }
   }
 
-  public void completeNexusOperation(NexusOperationRef ref, HistoryEvent completionEvent) {
+  public void completeNexusOperation(
+      NexusOperationRef ref, String operationID, Link startLink, HistoryEvent completionEvent) {
     TestWorkflowMutableState target = getMutableState(ref.getExecutionId());
 
     switch (completionEvent.getEventType()) {
@@ -912,7 +910,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
         // Nexus does not support it.
         Payload p =
             (result.getPayloadsCount() > 0) ? result.getPayloads(0) : Payload.getDefaultInstance();
-        target.completeNexusOperation(ref, p);
+        target.completeAsyncNexusOperation(ref, p, operationID, startLink);
         break;
       case EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
         Failure f =


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added support to the test server for completing Nexus operations before the start response is received.

