### PR TITLE
Avoid lock up on unexpected ExecutorService errors while executing Local Activities

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -104,7 +104,6 @@ final class ActivityWorker implements SuspendableWorker {
               new TaskHandlerImpl(handler),
               pollerOptions,
               slotSupplier.maximumSlots().orElse(Integer.MAX_VALUE),
-              true,
               options.isUsingVirtualThreads());
       poller =
           new Poller<>(

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
@@ -109,7 +109,8 @@ class LocalActivitySlotSupplierQueue implements Shutdownable {
         if (request != null) {
           LocalActivityExecutionContext executionContext = request.task.getExecutionContext();
           executionContext.callback(
-              LocalActivityResult.processingFailed(executionContext.getActivityId(), 1, e));
+              LocalActivityResult.processingFailed(
+                  executionContext.getActivityId(), request.task.getAttemptTask().getAttempt(), e));
         }
       }
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
@@ -102,7 +102,7 @@ class LocalActivitySlotSupplierQueue implements Shutdownable {
       } catch (Throwable e) {
         // Fail the workflow task if something went wrong executing the local activity (at the
         // executor level, otherwise, the LA handler itself should be handling errors)
-        log.error("Unexpected error executing local activity", e);
+        log.error("Unexpected error submitting local activity task to worker", e);
         if (slotPermit != null) {
           slotSupplier.releaseSlot(SlotReleaseReason.error(new RuntimeException(e)), slotPermit);
         }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
@@ -22,6 +22,7 @@ package io.temporal.internal.worker;
 
 import io.temporal.worker.tuning.LocalActivitySlotInfo;
 import io.temporal.worker.tuning.SlotPermit;
+import io.temporal.worker.tuning.SlotReleaseReason;
 import io.temporal.workflow.Functions;
 import java.util.concurrent.*;
 import javax.annotation.Nullable;
@@ -77,10 +78,11 @@ class LocalActivitySlotSupplierQueue implements Shutdownable {
   }
 
   private void processQueue() {
-    try {
-      while (running || !requestQueue.isEmpty()) {
-        QueuedLARequest request = requestQueue.take();
-        SlotPermit slotPermit;
+    while (running || !requestQueue.isEmpty()) {
+      SlotPermit slotPermit = null;
+      QueuedLARequest request = null;
+      try {
+        request = requestQueue.take();
         try {
           slotPermit = slotSupplier.reserveSlot(request.data);
         } catch (InterruptedException e) {
@@ -95,9 +97,21 @@ class LocalActivitySlotSupplierQueue implements Shutdownable {
         }
         request.task.getExecutionContext().setPermit(slotPermit);
         afterReservedCallback.apply(request.task);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (Throwable e) {
+        // Fail the workflow task if something went wrong executing the local activity (at the
+        // executor level, otherwise, the LA handler itself should be handling errors)
+        log.error("Unexpected error executing local activity", e);
+        if (slotPermit != null) {
+          slotSupplier.releaseSlot(SlotReleaseReason.error(new RuntimeException(e)), slotPermit);
+        }
+        if (request != null) {
+          LocalActivityExecutionContext executionContext = request.task.getExecutionContext();
+          executionContext.callback(
+              LocalActivityResult.processingFailed(executionContext.getActivityId(), 1, e));
+        }
       }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivityWorker.java
@@ -688,7 +688,6 @@ final class LocalActivityWorker implements Startable, Shutdownable {
               new AttemptTaskHandlerImpl(handler),
               pollerOptions,
               slotSupplier.maximumSlots().orElse(Integer.MAX_VALUE),
-              false,
               options.isUsingVirtualThreads());
 
       this.workerMetricsScope.counter(MetricsType.WORKER_START_COUNTER).inc(1);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -102,7 +102,6 @@ final class NexusWorker implements SuspendableWorker {
               new TaskHandlerImpl(handler),
               pollerOptions,
               slotSupplier.maximumSlots().orElse(Integer.MAX_VALUE),
-              true,
               options.isUsingVirtualThreads());
       poller =
           new Poller<>(

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollTaskExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollTaskExecutor.java
@@ -52,8 +52,7 @@ final class PollTaskExecutor<T> implements ShutdownableTaskExecutor<T> {
       @Nonnull String identity,
       @Nonnull TaskHandler<T> handler,
       @Nonnull PollerOptions pollerOptions,
-      int workerTaskSlots,
-      boolean synchronousQueue,
+      int threadPoolMax,
       boolean useVirtualThreads) {
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
@@ -76,16 +75,7 @@ final class PollTaskExecutor<T> implements ShutdownableTaskExecutor<T> {
               });
     } else {
       ThreadPoolExecutor threadPoolTaskExecutor =
-          new ThreadPoolExecutor(
-              // for SynchronousQueue we can afford to set it to 0, because the queue is always full
-              // or empty for LinkedBlockingQueue we have to set slots to workerTaskSlots to avoid
-              // situation when the queue grows, but the amount of threads is not, because the queue
-              // is not (and never) full
-              synchronousQueue ? 0 : workerTaskSlots,
-              workerTaskSlots,
-              10,
-              TimeUnit.SECONDS,
-              synchronousQueue ? new SynchronousQueue<>() : new LinkedBlockingQueue<>());
+          new ThreadPoolExecutor(0, threadPoolMax, 10, TimeUnit.SECONDS, new SynchronousQueue<>());
       threadPoolTaskExecutor.allowCoreThreadTimeOut(true);
       threadPoolTaskExecutor.setThreadFactory(
           new ExecutorThreadFactory(

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/Poller.java
@@ -342,7 +342,7 @@ final class Poller<T> implements SuspendableWorker {
 
     /**
      * Some exceptions are considered normal during shutdown {@link #shouldIgnoreDuringShutdown} and
-     * we log them in the most quite manner.
+     * we log them in the most quiet manner.
      *
      * @param t thread where the exception happened
      * @param e the exception itself

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -120,7 +120,6 @@ final class WorkflowWorker implements SuspendableWorker {
               new TaskHandlerImpl(handler),
               pollerOptions,
               this.slotSupplier.maximumSlots().orElse(Integer.MAX_VALUE),
-              true,
               options.isUsingVirtualThreads());
       stickyQueueBalancer =
           new StickyQueueBalancer(

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -632,7 +632,12 @@ public final class Worker {
       List<ContextPropagator> contextPropagators,
       Scope metricsScope) {
     return toSingleWorkerOptions(factoryOptions, options, clientOptions, contextPropagators)
-        .setPollerOptions(PollerOptions.newBuilder().setPollThreadCount(1).build())
+        .setPollerOptions(
+            PollerOptions.newBuilder()
+                .setPollThreadCount(1)
+                .setPollerTaskExecutorOverride(
+                    factoryOptions.getOverrideLocalActivityTaskExecutor())
+                .build())
         .setMetricsScope(metricsScope)
         .setUsingVirtualThreads(options.isUsingVirtualThreadsOnLocalActivityWorker())
         .build();

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.WorkerInterceptor;
 import java.time.Duration;
+import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 
 public class WorkerFactoryOptions {
@@ -57,6 +58,7 @@ public class WorkerFactoryOptions {
     private WorkerInterceptor[] workerInterceptors;
     private boolean enableLoggingInReplay;
     private boolean usingVirtualWorkflowThreads;
+    private ExecutorService overrideLocalActivityTaskExecutor;
 
     private Builder() {}
 
@@ -71,6 +73,7 @@ public class WorkerFactoryOptions {
       this.workerInterceptors = options.workerInterceptors;
       this.enableLoggingInReplay = options.enableLoggingInReplay;
       this.usingVirtualWorkflowThreads = options.usingVirtualWorkflowThreads;
+      this.overrideLocalActivityTaskExecutor = options.overrideLocalActivityTaskExecutor;
     }
 
     /**
@@ -143,6 +146,13 @@ public class WorkerFactoryOptions {
       return this;
     }
 
+    /** For internal use only. Overrides the local activity task ExecutorService. */
+    Builder setOverrideLocalActivityTaskExecutor(
+        ExecutorService overrideLocalActivityTaskExecutor) {
+      this.overrideLocalActivityTaskExecutor = overrideLocalActivityTaskExecutor;
+      return this;
+    }
+
     public WorkerFactoryOptions build() {
       return new WorkerFactoryOptions(
           workflowCacheSize,
@@ -151,6 +161,7 @@ public class WorkerFactoryOptions {
           workerInterceptors,
           enableLoggingInReplay,
           usingVirtualWorkflowThreads,
+          overrideLocalActivityTaskExecutor,
           false);
     }
 
@@ -162,6 +173,7 @@ public class WorkerFactoryOptions {
           workerInterceptors == null ? new WorkerInterceptor[0] : workerInterceptors,
           enableLoggingInReplay,
           usingVirtualWorkflowThreads,
+          overrideLocalActivityTaskExecutor,
           true);
     }
   }
@@ -172,6 +184,7 @@ public class WorkerFactoryOptions {
   private final WorkerInterceptor[] workerInterceptors;
   private final boolean enableLoggingInReplay;
   private final boolean usingVirtualWorkflowThreads;
+  private final ExecutorService overrideLocalActivityTaskExecutor;
 
   private WorkerFactoryOptions(
       int workflowCacheSize,
@@ -180,6 +193,7 @@ public class WorkerFactoryOptions {
       WorkerInterceptor[] workerInterceptors,
       boolean enableLoggingInReplay,
       boolean usingVirtualWorkflowThreads,
+      ExecutorService overrideLocalActivityTaskExecutor,
       boolean validate) {
     if (validate) {
       Preconditions.checkState(workflowCacheSize >= 0, "negative workflowCacheSize");
@@ -207,6 +221,7 @@ public class WorkerFactoryOptions {
     this.workerInterceptors = workerInterceptors;
     this.enableLoggingInReplay = enableLoggingInReplay;
     this.usingVirtualWorkflowThreads = usingVirtualWorkflowThreads;
+    this.overrideLocalActivityTaskExecutor = overrideLocalActivityTaskExecutor;
   }
 
   public int getWorkflowCacheSize() {
@@ -233,6 +248,16 @@ public class WorkerFactoryOptions {
   @Experimental
   public boolean isUsingVirtualWorkflowThreads() {
     return usingVirtualWorkflowThreads;
+  }
+
+  /**
+   * For internal use only.
+   *
+   * @return the ExecutorService to use for local activity tasks, or null if the default should be
+   *     used
+   */
+  ExecutorService getOverrideLocalActivityTaskExecutor() {
+    return overrideLocalActivityTaskExecutor;
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -20,6 +20,7 @@
 
 package io.temporal.worker;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.WorkerInterceptor;
@@ -147,6 +148,7 @@ public class WorkerFactoryOptions {
     }
 
     /** For internal use only. Overrides the local activity task ExecutorService. */
+    @VisibleForTesting
     Builder setOverrideLocalActivityTaskExecutor(
         ExecutorService overrideLocalActivityTaskExecutor) {
       this.overrideLocalActivityTaskExecutor = overrideLocalActivityTaskExecutor;

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
@@ -30,7 +30,8 @@ import java.util.Optional;
  * at once.
  *
  * @param <SI> The type of information that will be used to reserve a slot. The three info types are
- *     {@link WorkflowSlotInfo}, {@link ActivitySlotInfo}, and {@link LocalActivitySlotInfo}.
+ *     {@link WorkflowSlotInfo}, {@link ActivitySlotInfo}, {@link LocalActivitySlotInfo}, and {@link
+ *     NexusSlotInfo}.
  */
 @Experimental
 public interface SlotSupplier<SI extends SlotInfo> {
@@ -77,11 +78,11 @@ public interface SlotSupplier<SI extends SlotInfo> {
   void releaseSlot(SlotReleaseContext<SI> ctx);
 
   /**
-   * Because we currently use thread pools to execute tasks, there must be *some* defined
-   * upper-limit on the size of the thread pool for each kind of task. You must not hand out more
-   * permits than this number. If unspecified, the default is {@link Integer#MAX_VALUE}. Be aware
-   * that if your implementation hands out unreasonable numbers of permits, you could easily
-   * oversubscribe the worker, and cause it to run out of resources.
+   * Because we use thread pools to execute tasks when virtual threads are not enabled, there must
+   * be *some* defined upper-limit on the size of the thread pool for each kind of task. You must
+   * not hand out more permits than this number. If unspecified, the default is {@link
+   * Integer#MAX_VALUE}. Be aware that if your implementation hands out unreasonable numbers of
+   * permits, you could easily oversubscribe the worker, and cause it to run out of resources.
    *
    * <p>If a non-empty value is returned, it is assumed to be meaningful, and the worker will emit
    * {@link io.temporal.worker.MetricsType#WORKER_TASK_SLOTS_AVAILABLE} metrics based on this value.

--- a/temporal-sdk/src/test/java/io/temporal/worker/LocalActivitySlotThreadPoolTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/LocalActivitySlotThreadPoolTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.LocalActivityOptions;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.tuning.*;
+import io.temporal.workflow.*;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LocalActivitySlotThreadPoolTests {
+  private final int MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE = 2;
+  private final int MAX_CONCURRENT_ACTIVITY_EXECUTION_SIZE = 2;
+  private final int MAX_CONCURRENT_LOCAL_ACTIVITY_EXECUTION_SIZE = 100;
+  private final int MAX_CONCURRENT_NEXUS_EXECUTION_SIZE = 2;
+  private final FixedSizeSlotSupplier<WorkflowSlotInfo> workflowTaskSlotSupplier =
+      new FixedSizeSlotSupplier<>(MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE);
+  private final FixedSizeSlotSupplier<ActivitySlotInfo> activityTaskSlotSupplier =
+      new FixedSizeSlotSupplier<>(MAX_CONCURRENT_ACTIVITY_EXECUTION_SIZE);
+  private final FixedSizeSlotSupplier<LocalActivitySlotInfo> localActivitySlotSupplier =
+      new FixedSizeSlotSupplier<>(MAX_CONCURRENT_LOCAL_ACTIVITY_EXECUTION_SIZE);
+  private final FixedSizeSlotSupplier<NexusSlotInfo> nexusSlotSupplier =
+      new FixedSizeSlotSupplier<>(MAX_CONCURRENT_NEXUS_EXECUTION_SIZE);
+
+  class ExplodingExecutor extends ThreadPoolExecutor {
+    AtomicInteger submitted = new AtomicInteger(0);
+
+    public ExplodingExecutor(
+        int corePoolSize,
+        int maximumPoolSize,
+        long keepAliveTime,
+        TimeUnit unit,
+        BlockingQueue<Runnable> workQueue) {
+      super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    @Override
+    public void execute(@Nonnull Runnable command) {
+      int newval = submitted.incrementAndGet();
+      // Blow up for a while and then recover
+      if (newval > 2 && newval < 10) {
+        throw new OutOfMemoryError("boom");
+      }
+      super.execute(command);
+    }
+  }
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkerOptions(
+              WorkerOptions.newBuilder()
+                  .setWorkerTuner(
+                      new CompositeTuner(
+                          workflowTaskSlotSupplier,
+                          activityTaskSlotSupplier,
+                          localActivitySlotSupplier,
+                          nexusSlotSupplier))
+                  .build())
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setOverrideLocalActivityTaskExecutor(
+                      new ExplodingExecutor(
+                          1, 10, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>()))
+                  .build())
+          .setActivityImplementations(new TestActivitySemaphoreImpl())
+          .setWorkflowTypes(ParallelActivities.class)
+          .setDoNotStart(true)
+          .build();
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String workflow();
+  }
+
+  public static class ParallelActivities implements TestWorkflow {
+    private final TestActivity localActivity =
+        Workflow.newLocalActivityStub(
+            TestActivity.class,
+            LocalActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(10))
+                .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
+                .validateAndBuildWithDefaults());
+
+    @Override
+    public String workflow() {
+      List<Promise<String>> laResults = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        laResults.add(Async.function(localActivity::activity, String.valueOf(i)));
+      }
+      Promise.allOf(laResults).get();
+      return "ok";
+    }
+  }
+
+  @ActivityInterface
+  public interface TestActivity {
+
+    @ActivityMethod
+    String activity(String input);
+  }
+
+  public static class TestActivitySemaphoreImpl implements TestActivity {
+    @Override
+    public String activity(String input) {
+      return "";
+    }
+  }
+
+  @Test
+  public void TestLAExecutorServiceThrowsOOM() throws InterruptedException {
+    testWorkflowRule.getTestEnvironment().start();
+    WorkflowClient client = testWorkflowRule.getWorkflowClient();
+    TestWorkflow workflow =
+        client.newWorkflowStub(
+            TestWorkflow.class,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(testWorkflowRule.getTaskQueue())
+                .validateBuildWithDefaults());
+    workflow.workflow();
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ParallelLocalActivitiesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ParallelLocalActivitiesTest.java
@@ -24,6 +24,7 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.testing.internal.TracingWorkerInterceptor;
+import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Async;
 import io.temporal.workflow.Promise;
 import io.temporal.workflow.Workflow;
@@ -48,6 +49,10 @@ public class ParallelLocalActivitiesTest {
           .setWorkflowTypes(TestParallelLocalActivitiesWorkflowImpl.class)
           .setActivityImplementations(activitiesImpl)
           .setTestTimeoutSeconds(20)
+          // Use a number lower than the number of concurrent activities to ensure that the
+          // queueing of LAs when task executor is full works
+          .setWorkerOptions(
+              WorkerOptions.newBuilder().setMaxConcurrentLocalActivityExecutionSize(50).build())
           .build();
 
   @Test


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Avoid putting the worker into a useless state if submitting a local activity for execution fails (ex: OOM / other thread starting problems). 

## Why?
Bad times when you don't know why your worker is stuck

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/2349

2. How was this tested:
Added an integration test with an executor service that fails intentionally

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
