### PR TITLE
Support Proto 3 and 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ or to *build.gradle*:
 
     compile group: 'io.temporal', name: 'temporal-sdk', version: 'N.N.N'
 
+## Protobuf 3.x vs 4.x
+
+The Temporal Java SDK currently supports `protobuf-java` 3.x and 4.x. To support these, the Temporal Java SDK allows any protobuf library >= 3.25.
+Temporal strongly recommends using the latest `protobuf-java` 4.x library unless you absolutely cannot. 
+If you cannot use protobuf-java 3.25 >=, you can try `temporal-shaded` which includes a shaded version of the `protobuf-java` library.
+
 ## Contributing
 
 We'd love your help in improving the Temporal Java SDK. Please review our [contribution guidelines](CONTRIBUTING.md).

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.54.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.58.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     nexusVersion = '0.3.0-alpha'
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,12 @@ ext {
     // also slf4j 2.x is not compatible with spring boot 2.x
     slf4jVersion = project.hasProperty("edgeDepsTest") ? '2.0.16' : '1.7.36' // [1.4.0,)
     // [3.25.5,)
-    // 3.12 is brought by min gRPC 1.38.
-    // We can't move pass 3.22.0 because 3.22.2 deprecates some methods used by generated code produced by
-    // the old protoc we keep for compatibility of our generated code with old protobuf-java versions.
-    // Which leads to build failure because of -Werror.
-    protoVersion = project.hasProperty("edgeDepsTest") ? '4.29.3' : '3.25.5'
+    // 3.25.5 is required because of our protoc compiler 25.x. The proto version must be the same or greater then the protoc version.
+    // We use this version of protoc because it will generate code that is compatible with protobuf-java 3.x and 4.x.
+    // We don't move past 3.25.x because the next version is a major version bump and we don't want to break our users.
+    //
+    // For more information see: https://github.com/grpc/grpc-java/issues/11015#issuecomment-2560196695
+    protoVersion = '3.25.5'
     annotationApiVersion = '1.3.2'
     guavaVersion = '32.0.1-jre' // [10.0,)
     tallyVersion = '0.13.0' // [0.4.0,)

--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,12 @@ ext {
     // stay on 1.x for a while to don't use any APIs from 2.x which may break our users which still stay on 1.x
     // also slf4j 2.x is not compatible with spring boot 2.x
     slf4jVersion = project.hasProperty("edgeDepsTest") ? '2.0.16' : '1.7.36' // [1.4.0,)
-    // [3.12.0,)
+    // [3.25.5,)
     // 3.12 is brought by min gRPC 1.38.
     // We can't move pass 3.22.0 because 3.22.2 deprecates some methods used by generated code produced by
     // the old protoc we keep for compatibility of our generated code with old protobuf-java versions.
     // Which leads to build failure because of -Werror.
-    protoVersion = '3.22.0'
+    protoVersion = project.hasProperty("edgeDepsTest") ? '4.29.3' : '3.25.5'
     annotationApiVersion = '1.3.2'
     guavaVersion = '32.0.1-jre' // [10.0,)
     tallyVersion = '0.13.0' // [0.4.0,)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id 'net.ltgt.errorprone' version '4.0.1' apply false
+    id 'net.ltgt.errorprone' version '4.1.0' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'com.palantir.git-version' version "${palantirGitVersionVersion}" apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -14,7 +14,7 @@ subprojects {
 
     compileJava {
         options.encoding = 'UTF-8'
-        options.compilerArgs << '-Xlint:none' << '-Werror' << '-parameters'
+        options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror' << '-parameters'
         if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
             // https://stackoverflow.com/a/43103115/525203
             options.compilerArgs.addAll(['--release', '8'])

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -14,7 +14,7 @@ subprojects {
 
     compileJava {
         options.encoding = 'UTF-8'
-        options.compilerArgs << '-Xlint:none' << '-Xlint:deprecation' << '-Werror' << '-parameters'
+        options.compilerArgs << '-Xlint:none' << '-Werror' << '-parameters'
         if (JavaVersion.current().isJava9Compatible() && !project.hasProperty("edgeDepsTest")) {
             // https://stackoverflow.com/a/43103115/525203
             options.compilerArgs.addAll(['--release', '8'])

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: "${logbackVersion}"
+    if (project.hasProperty("edgeDepsTest")) {
+        testRuntimeOnly "com.google.protobuf:protobuf-java:4.29.3"
+        testRuntimeOnly "com.google.protobuf:protobuf-java-util:4.29.3"
+    }
 }
 
 // Temporal SDK supports Java 8 or later so to support virtual threads

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -501,8 +501,6 @@ class WorkflowStubImpl implements WorkflowStub {
   private void checkStarted() {
     if (execution.get() == null) {
       throw new IllegalStateException("Null workflowId. Was workflow started?");
-    } else {
-      execution.get().getWorkflowId();
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -499,8 +499,10 @@ class WorkflowStubImpl implements WorkflowStub {
   }
 
   private void checkStarted() {
-    if (execution.get() == null || execution.get().getWorkflowId() == null) {
+    if (execution.get() == null) {
       throw new IllegalStateException("Null workflowId. Was workflow started?");
+    } else {
+      execution.get().getWorkflowId();
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
@@ -451,7 +451,7 @@ public class ScheduleProtoUtil {
 
       if (startWfAction.hasRetryPolicy()) {
         wfOptionsBuilder.setRetryOptions(
-                RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
+            RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
       }
 
       if (startWfAction.hasMemo()) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
@@ -449,8 +449,10 @@ public class ScheduleProtoUtil {
       wfOptionsBuilder.setWorkflowTaskTimeout(
           ProtobufTimeUtils.toJavaDuration(startWfAction.getWorkflowTaskTimeout()));
 
-      wfOptionsBuilder.setRetryOptions(
-          RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
+      if (startWfAction.hasRetryPolicy()) {
+        wfOptionsBuilder.setRetryOptions(
+                RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
+      }
 
       if (startWfAction.hasMemo()) {
         Map<String, Object> memos = new HashMap<>();

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
@@ -339,10 +339,11 @@ public class ScheduleProtoUtil {
   public io.temporal.client.schedules.ScheduleSpec protoToScheduleSpec(
       @Nonnull ScheduleSpec scheduleSpec) {
     Objects.requireNonNull(scheduleSpec);
+    scheduleSpec.getTimezoneName();
     io.temporal.client.schedules.ScheduleSpec.Builder specBuilder =
         io.temporal.client.schedules.ScheduleSpec.newBuilder()
             .setTimeZoneName(
-                scheduleSpec.getTimezoneName() == null ? "" : scheduleSpec.getTimezoneName());
+                    scheduleSpec.getTimezoneName());
 
     if (scheduleSpec.hasJitter()) {
       specBuilder.setJitter(ProtobufTimeUtils.toJavaDuration(scheduleSpec.getJitter()));
@@ -450,10 +451,8 @@ public class ScheduleProtoUtil {
       wfOptionsBuilder.setWorkflowTaskTimeout(
           ProtobufTimeUtils.toJavaDuration(startWfAction.getWorkflowTaskTimeout()));
 
-      if (startWfAction.getRetryPolicy() != null) {
-        wfOptionsBuilder.setRetryOptions(
-            RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
-      }
+      wfOptionsBuilder.setRetryOptions(
+              RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
 
       if (startWfAction.hasMemo()) {
         Map<String, Object> memos = new HashMap<>();

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/ScheduleProtoUtil.java
@@ -339,11 +339,9 @@ public class ScheduleProtoUtil {
   public io.temporal.client.schedules.ScheduleSpec protoToScheduleSpec(
       @Nonnull ScheduleSpec scheduleSpec) {
     Objects.requireNonNull(scheduleSpec);
-    scheduleSpec.getTimezoneName();
     io.temporal.client.schedules.ScheduleSpec.Builder specBuilder =
         io.temporal.client.schedules.ScheduleSpec.newBuilder()
-            .setTimeZoneName(
-                    scheduleSpec.getTimezoneName());
+            .setTimeZoneName(scheduleSpec.getTimezoneName());
 
     if (scheduleSpec.hasJitter()) {
       specBuilder.setJitter(ProtobufTimeUtils.toJavaDuration(scheduleSpec.getJitter()));
@@ -452,7 +450,7 @@ public class ScheduleProtoUtil {
           ProtobufTimeUtils.toJavaDuration(startWfAction.getWorkflowTaskTimeout()));
 
       wfOptionsBuilder.setRetryOptions(
-              RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
+          RetryOptionsUtils.toRetryOptions(startWfAction.getRetryPolicy()));
 
       if (startWfAction.hasMemo()) {
         Map<String, Object> memos = new HashMap<>();

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionHistory.java
@@ -71,7 +71,7 @@ public class WorkflowExecutionHistory {
 
   private static void checkHistory(History history) {
     List<HistoryEvent> events = history.getEventsList();
-    if (events == null || events.size() == 0) {
+    if (events.size() == 0) {
       throw new IllegalArgumentException("Empty history");
     }
     HistoryEvent startedEvent = events.get(0);

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/WorkflowExecutionUtils.java
@@ -265,9 +265,8 @@ public class WorkflowExecutionUtils {
   }
 
   /** Pretty prints a proto message. */
-  @SuppressWarnings("deprecation")
   public static String prettyPrintObject(MessageOrBuilder object) {
-    return TextFormat.printToString(object);
+    return TextFormat.printer().printToString(object);
   }
 
   public static boolean containsEvent(List<HistoryEvent> history, EventType eventType) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowExecutor.java
@@ -217,7 +217,7 @@ final class ReplayWorkflowExecutor {
       Message protocolMessage = updateMessage.getMessage();
       Request update = protocolMessage.getBody().unpack(Request.class);
       Input input = update.getInput();
-      Optional<Payloads> args = Optional.ofNullable(input.getArgs());
+      Optional<Payloads> args = Optional.of(input.getArgs());
       this.workflow.handleUpdate(
           input.getName(),
           update.getMeta().getUpdateId(),

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -385,8 +385,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
     WorkflowMetadata.Builder workflowMetadata = WorkflowMetadata.newBuilder();
     WorkflowDefinition.Builder workflowDefinition = WorkflowDefinition.newBuilder();
     // Set the workflow type
-    if (replayContext.getWorkflowType() != null
-        && replayContext.getWorkflowType().getName() != null) {
+    if (replayContext.getWorkflowType() != null) {
       workflowDefinition.setType(replayContext.getWorkflowType().getName());
     }
     // Set built in queries

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
@@ -434,8 +434,8 @@ class TestHistoryBuilder {
     } else if (attributes instanceof Number) {
       attributes = newAttributes(type, ((Number) attributes).intValue());
     }
-    if (attributes instanceof com.google.protobuf.GeneratedMessageV3.Builder) {
-      attributes = ((com.google.protobuf.GeneratedMessageV3.Builder) attributes).build();
+    if (attributes instanceof com.google.protobuf.Message.Builder) {
+      attributes = ((com.google.protobuf.Message.Builder) attributes).build();
     }
     HistoryEvent.Builder result =
         HistoryEvent.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/UpdateProtocolStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/UpdateProtocolStateMachineTest.java
@@ -941,7 +941,7 @@ public class UpdateProtocolStateMachineTest {
                 (r) -> {
                   message.getCallbacks().complete(converter.toPayloads("update result"), null);
                 });
-        if (message.getMessage().getProtocolInstanceId() == "message_update") {
+        if (message.getMessage().getProtocolInstanceId().equals("message_update")) {
           builder.add((r) -> stateMachines.completeWorkflow(Optional.empty()));
         }
       }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/DynamicUpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/DynamicUpdateTest.java
@@ -88,8 +88,7 @@ public class DynamicUpdateTest {
     CompletablePromise<Void> promise = Workflow.newPromise();
     List<String> updates = new ArrayList<>();
 
-    @Override
-    public String execute(String input) {
+    public TestDynamicUpdateWorkflowImpl() {
       Workflow.registerListener(
           new DynamicUpdateHandler() {
             @Override
@@ -109,6 +108,10 @@ public class DynamicUpdateTest {
               return "update:" + args.get(0, String.class);
             }
           });
+    }
+
+    @Override
+    public String execute(String input) {
       promise.get();
       return updates.stream().reduce("", (a, b) -> a + " " + b);
     }

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -29,8 +29,10 @@ dependencies {
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 
-    testRuntimeOnly "com.google.protobuf:protobuf-java:4.29.3"
-    testRuntimeOnly "com.google.protobuf:protobuf-java-util:4.29.3"
+    if (project.hasProperty("edgeDepsTest")) {
+        testRuntimeOnly "com.google.protobuf:protobuf-java:4.29.3"
+        testRuntimeOnly "com.google.protobuf:protobuf-java-util:4.29.3"
+    }
     testRuntimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 }
 

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     api "io.grpc:grpc-stub" //Part of WorkflowServiceStubs API
     api "io.grpc:grpc-netty-shaded" //Part of WorkflowServiceStubs API, specifically SslContext
     api "io.grpc:grpc-services" //Standard gRPC HealthCheck Response class
+    api "io.grpc:grpc-inprocess" //For the in-process time skipping test server
     api "com.google.protobuf:protobuf-java-util:$protoVersion" //proto request and response objects are a part of this module's API
     if (JavaVersion.current().isJava9Compatible()) {
         //needed for the generated grpc stubs and is not a part of JDK since java 9

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -72,7 +72,7 @@ protobuf {
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
     // with the oldest supported versions of protoc and grpc artifacts.
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.10.1' + (System.getProperty("os.arch") == 'aarch64' && System.getProperty("os.name") == 'Mac OS X' ? ':osx-x86_64' : '')
+        artifact = 'com.google.protobuf:protoc:3.25.5' + (System.getProperty("os.arch") == 'aarch64' && System.getProperty("os.name") == 'Mac OS X' ? ':osx-x86_64' : '')
     }
     plugins {
         grpc {

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 
+    testRuntimeOnly "com.google.protobuf:protobuf-java:4.29.3"
+    testRuntimeOnly "com.google.protobuf:protobuf-java-util:4.29.3"
     testRuntimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 }
 

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/common/ProtoUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/common/ProtoUtils.java
@@ -28,8 +28,7 @@ public class ProtoUtils {
    * This method does exactly what {@link Any#pack(Message)} does. But it doesn't go into reflection
    * to fetch the {@code descriptor}, which allows us to avoid a bunch of Graal reflection configs.
    */
-  public static <T extends GeneratedMessageV3> Any packAny(
-      T details, Descriptors.Descriptor descriptor) {
+  public static <T extends Message> Any packAny(T details, Descriptors.Descriptor descriptor) {
     return Any.newBuilder()
         .setTypeUrl("type.googleapis.com/" + descriptor.getFullName())
         .setValue(details.toByteString())

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -24,7 +24,7 @@ import static io.temporal.serviceclient.rpcretry.DefaultStubServiceOperationRpcR
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.Message;
 import io.grpc.Status;
 import io.temporal.internal.common.OptionsUtils;
 import java.time.Duration;
@@ -57,7 +57,7 @@ public final class RpcRetryOptions {
 
   public static class DoNotRetryItem {
     private final Status.Code code;
-    private final Class<? extends GeneratedMessageV3> detailsClass;
+    private final Class<? extends Message> detailsClass;
 
     /**
      * @param code errors with this code will be considered non retryable. {@link
@@ -68,7 +68,7 @@ public final class RpcRetryOptions {
      *     retryable.
      */
     public DoNotRetryItem(
-        @Nonnull Status.Code code, @Nullable Class<? extends GeneratedMessageV3> detailsClass) {
+        @Nonnull Status.Code code, @Nullable Class<? extends Message> detailsClass) {
       this.code = Preconditions.checkNotNull(code, "code");
       this.detailsClass = detailsClass;
     }
@@ -77,7 +77,7 @@ public final class RpcRetryOptions {
       return code;
     }
 
-    public Class<? extends GeneratedMessageV3> getDetailsClass() {
+    public Class<? extends Message> getDetailsClass() {
       return detailsClass;
     }
   }
@@ -252,7 +252,7 @@ public final class RpcRetryOptions {
      *     with the {@code code} code are non retryable.
      */
     public Builder addDoNotRetry(
-        Status.Code code, @Nullable Class<? extends GeneratedMessageV3> detailsClass) {
+        Status.Code code, @Nullable Class<? extends Message> detailsClass) {
       doNotRetry.add(new DoNotRetryItem(code, detailsClass));
       return this;
     }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/StatusUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/StatusUtils.java
@@ -39,7 +39,7 @@ public class StatusUtils {
    * @return true if the given failure is found, false otherwise
    */
   public static boolean hasFailure(
-      StatusRuntimeException exception, Class<? extends GeneratedMessageV3> failureType) {
+      StatusRuntimeException exception, Class<? extends Message> failureType) {
     Preconditions.checkNotNull(exception, "exception cannot be null");
     com.google.rpc.Status status = StatusProto.fromThrowable(exception);
     if (status.getDetailsCount() == 0) {
@@ -52,7 +52,7 @@ public class StatusUtils {
   /**
    * @return a failure of a given type from the StatusRuntimeException object
    */
-  public static <T extends GeneratedMessageV3> T getFailure(
+  public static <T extends Message> T getFailure(
       StatusRuntimeException exception, Class<T> failureType) {
     Preconditions.checkNotNull(exception, "exception cannot be null");
     com.google.rpc.Status status = StatusProto.fromThrowable(exception);
@@ -72,7 +72,7 @@ public class StatusUtils {
   }
 
   /** Create StatusRuntimeException with given details. */
-  public static <T extends GeneratedMessageV3> StatusRuntimeException newException(
+  public static <T extends Message> StatusRuntimeException newException(
       io.grpc.Status status, T details, Descriptors.Descriptor detailsDescriptor) {
     Preconditions.checkNotNull(status, "status cannot be null");
     Status protoStatus =

--- a/temporal-test-server/build.gradle
+++ b/temporal-test-server/build.gradle
@@ -62,7 +62,7 @@ protobuf {
     // protoc and protoc-gen-grpc-java versions are selected to be compatible
     // with the oldest supported versions of protoc and grpc artifacts.
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.10.1' + (System.getProperty("os.arch") == 'aarch64' && System.getProperty("os.name") == 'Mac OS X' ? ':osx-x86_64' : '')
+        artifact = 'com.google.protobuf:protoc:3.25.5' + (System.getProperty("os.arch") == 'aarch64' && System.getProperty("os.name") == 'Mac OS X' ? ':osx-x86_64' : '')
     }
     plugins {
         grpc {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServiceRetryState.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestServiceRetryState.java
@@ -104,7 +104,7 @@ final class TestServiceRetryState {
     RetryPolicy retryPolicy = getRetryPolicy();
     // check if error is non-retryable
     List<String> nonRetryableErrorTypes = retryPolicy.getNonRetryableErrorTypesList();
-    if (nonRetryableErrorTypes != null && errorType.isPresent()) {
+    if (errorType.isPresent()) {
       String type = errorType.get();
       for (String err : nonRetryableErrorTypes) {
         if (type.equals(err)) {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -3396,7 +3396,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       RequestContext ctx, SignalWorkflowExecutionRequest signalRequest) {
     WorkflowExecutionSignaledEventAttributes.Builder a =
         WorkflowExecutionSignaledEventAttributes.newBuilder()
-            .setInput(startRequest.getInput())
             .setIdentity(signalRequest.getIdentity())
             .setInput(signalRequest.getInput())
             .setSignalName(signalRequest.getSignalName());
@@ -3412,7 +3411,6 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
       RequestContext ctx, SignalExternalWorkflowExecutionCommandAttributes d) {
     WorkflowExecutionSignaledEventAttributes.Builder a =
         WorkflowExecutionSignaledEventAttributes.newBuilder()
-            .setInput(startRequest.getInput())
             .setInput(d.getInput())
             .setSignalName(d.getSignalName());
     HistoryEvent executionSignaled =

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1348,8 +1348,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
               .setWorkflowIdReusePolicy(r.getWorkflowIdReusePolicy())
               .setIdentity(r.getIdentity())
               .setWorkflowType(r.getWorkflowType())
-              .setCronSchedule(r.getCronSchedule())
-              .setRequestId(r.getRequestId());
+              .setCronSchedule(r.getCronSchedule());
       if (r.hasRetryPolicy()) {
         startRequest.setRetryPolicy(r.getRetryPolicy());
       }

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -453,7 +453,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("operation terminated", cause.getMessage());
-      Assert.assertNotNull(cause.getApplicationFailureInfo());
+      Assert.assertTrue(cause.hasApplicationFailureInfo());
       Assert.assertTrue(cause.getApplicationFailureInfo().getNonRetryable());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
@@ -531,7 +531,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("operation exceeded internal timeout", cause.getMessage());
-      Assert.assertNotNull(cause.getApplicationFailureInfo());
+      Assert.assertTrue(cause.hasApplicationFailureInfo());
       Assert.assertTrue(cause.getApplicationFailureInfo().getNonRetryable());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
@@ -657,7 +657,7 @@ public class NexusWorkflowTest {
     Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
     io.temporal.api.failure.v1.Failure cause = failure.getCause();
     Assert.assertEquals("operation canceled before it was started", cause.getMessage());
-    Assert.assertNotNull(cause.getCanceledFailureInfo());
+    Assert.assertTrue(cause.hasCanceledFailureInfo());
   }
 
   @Test(timeout = 15000)
@@ -706,7 +706,7 @@ public class NexusWorkflowTest {
     Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
     io.temporal.api.failure.v1.Failure cause = failure.getCause();
     Assert.assertEquals("operation timed out", cause.getMessage());
-    Assert.assertNotNull(cause.getTimeoutFailureInfo());
+    Assert.assertTrue(cause.hasTimeoutFailureInfo());
     Assert.assertEquals(
         TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, cause.getTimeoutFailureInfo().getTimeoutType());
   }
@@ -754,7 +754,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("operation timed out", cause.getMessage());
-      Assert.assertNotNull(cause.getTimeoutFailureInfo());
+      Assert.assertTrue(cause.hasTimeoutFailureInfo());
       Assert.assertEquals(
           TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
           cause.getTimeoutFailureInfo().getTimeoutType());
@@ -838,7 +838,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("operation timed out", cause.getMessage());
-      Assert.assertNotNull(cause.getTimeoutFailureInfo());
+      Assert.assertTrue(cause.hasTimeoutFailureInfo());
       Assert.assertEquals(
           TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
           cause.getTimeoutFailureInfo().getTimeoutType());
@@ -889,7 +889,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("deliberate test failure", cause.getMessage());
-      Assert.assertNotNull(cause.getApplicationFailureInfo());
+      Assert.assertTrue(cause.hasApplicationFailureInfo());
       Assert.assertEquals("NexusOperationFailure", cause.getApplicationFailureInfo().getType());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
@@ -952,7 +952,7 @@ public class NexusWorkflowTest {
       Assert.assertEquals("nexus operation completed unsuccessfully", failure.getMessage());
       io.temporal.api.failure.v1.Failure cause = failure.getCause();
       Assert.assertEquals("deliberate terminal error", cause.getMessage());
-      Assert.assertNotNull(cause.getApplicationFailureInfo());
+      Assert.assertTrue(cause.hasApplicationFailureInfo());
       Assert.assertEquals("INVALID_ARGUMENT", cause.getApplicationFailureInfo().getType());
     } catch (Exception e) {
       Assert.fail(e.getMessage());

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowCachingTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowCachingTest.java
@@ -23,7 +23,6 @@ package io.temporal.testserver.functional;
 import static io.temporal.internal.common.InternalUtils.createNormalTaskQueue;
 import static io.temporal.internal.common.InternalUtils.createStickyTaskQueue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import io.temporal.api.enums.v1.EventType;

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowCachingTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowCachingTest.java
@@ -170,7 +170,7 @@ public class WorkflowCachingTest {
 
     // Assert Full history
     // Make sure first is workflow execution started
-    assertNotNull(response.getHistory().getEvents(0).getWorkflowExecutionStartedEventAttributes());
+    assertTrue(response.getHistory().getEvents(0).hasWorkflowExecutionStartedEventAttributes());
     // 10 is the expected number of events for the full history.
     assertEquals(
         "Expected 10 events, but got: " + new WorkflowExecutionHistory(response.getHistory()),


### PR DESCRIPTION
Update the Java SDK protoc and protobuf dependency to support proto-java 3.x and 4.x

See also: https://github.com/grpc/grpc-java/issues/11015#issuecomment-2560196695

closes https://github.com/temporalio/sdk-java/issues/2006
