### PR TITLE
Access to workflow/activity instance from context

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityExecutionContext.java
@@ -147,4 +147,7 @@ public interface ActivityExecutionContext {
    * an activity.
    */
   WorkflowClient getWorkflowClient();
+
+  /** Get the currently running activity instance. */
+  Object getInstance();
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityExecutionContextBase.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/ActivityExecutionContextBase.java
@@ -91,4 +91,9 @@ public class ActivityExecutionContextBase implements ActivityExecutionContext {
   public WorkflowClient getWorkflowClient() {
     return next.getWorkflowClient();
   }
+
+  @Override
+  public Object getInstance() {
+    return next.getInstance();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactory.java
@@ -23,5 +23,6 @@ package io.temporal.internal.activity;
 import com.uber.m3.tally.Scope;
 
 public interface ActivityExecutionContextFactory {
-  InternalActivityExecutionContext createContext(ActivityInfoInternal info, Scope metricsScope);
+  InternalActivityExecutionContext createContext(
+      ActivityInfoInternal info, Object activity, Scope metricsScope);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextFactoryImpl.java
@@ -61,10 +61,11 @@ public class ActivityExecutionContextFactoryImpl implements ActivityExecutionCon
 
   @Override
   public InternalActivityExecutionContext createContext(
-      ActivityInfoInternal info, Scope metricsScope) {
+      ActivityInfoInternal info, Object activity, Scope metricsScope) {
     return new ActivityExecutionContextImpl(
         client,
         namespace,
+        activity,
         info,
         dataConverter,
         heartbeatExecutor,

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextImpl.java
@@ -48,6 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
 class ActivityExecutionContextImpl implements InternalActivityExecutionContext {
   private final Lock lock = new ReentrantLock();
   private final WorkflowClient client;
+  private final Object activity;
   private final ManualActivityCompletionClientFactory manualCompletionClientFactory;
   private final Functions.Proc completionHandle;
   private final HeartbeatContext heartbeatContext;
@@ -61,6 +62,7 @@ class ActivityExecutionContextImpl implements InternalActivityExecutionContext {
   ActivityExecutionContextImpl(
       WorkflowClient client,
       String namespace,
+      Object activity,
       ActivityInfo info,
       DataConverter dataConverter,
       ScheduledExecutorService heartbeatExecutor,
@@ -71,6 +73,7 @@ class ActivityExecutionContextImpl implements InternalActivityExecutionContext {
       Duration maxHeartbeatThrottleInterval,
       Duration defaultHeartbeatThrottleInterval) {
     this.client = client;
+    this.activity = activity;
     this.metricsScope = metricsScope;
     this.info = info;
     this.completionHandle = completionHandle;
@@ -176,5 +179,10 @@ class ActivityExecutionContextImpl implements InternalActivityExecutionContext {
   @Override
   public WorkflowClient getWorkflowClient() {
     return client;
+  }
+
+  @Override
+  public Object getInstance() {
+    return activity;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
@@ -76,7 +76,7 @@ final class ActivityTaskExecutors {
     @Override
     public ActivityTaskHandler.Result execute(ActivityInfoInternal info, Scope metricsScope) {
       InternalActivityExecutionContext context =
-          executionContextFactory.createContext(info, metricsScope);
+          executionContextFactory.createContext(info, getActivity(), metricsScope);
       ActivityInfo activityInfo = context.getInfo();
       ActivitySerializationContext serializationContext =
           new ActivitySerializationContext(
@@ -144,6 +144,8 @@ final class ActivityTaskExecutors {
 
     abstract ActivityInboundCallsInterceptor createRootInboundInterceptor();
 
+    abstract Object getActivity();
+
     abstract Object[] provideArgs(
         Optional<Payloads> input, DataConverter dataConverterWithActivityContext);
 
@@ -204,6 +206,11 @@ final class ActivityTaskExecutors {
     }
 
     @Override
+    Object getActivity() {
+      return activity;
+    }
+
+    @Override
     Object[] provideArgs(Optional<Payloads> input, DataConverter dataConverterWithActivityContext) {
       return dataConverterWithActivityContext.fromPayloads(
           input, method.getParameterTypes(), method.getGenericParameterTypes());
@@ -239,6 +246,11 @@ final class ActivityTaskExecutors {
     ActivityInboundCallsInterceptor createRootInboundInterceptor() {
       return new RootActivityInboundCallsInterceptor.DynamicActivityInboundCallsInterceptor(
           activity);
+    }
+
+    @Override
+    Object getActivity() {
+      return activity;
     }
 
     @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextFactoryImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextFactoryImpl.java
@@ -32,7 +32,7 @@ public class LocalActivityExecutionContextFactoryImpl implements ActivityExecuti
 
   @Override
   public InternalActivityExecutionContext createContext(
-      ActivityInfoInternal info, Scope metricsScope) {
-    return new LocalActivityExecutionContextImpl(client, info, metricsScope);
+      ActivityInfoInternal info, Object activity, Scope metricsScope) {
+    return new LocalActivityExecutionContextImpl(client, activity, info, metricsScope);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextImpl.java
@@ -30,11 +30,14 @@ import java.util.Optional;
 
 class LocalActivityExecutionContextImpl implements InternalActivityExecutionContext {
   private final WorkflowClient client;
+  private final Object activity;
   private final ActivityInfo info;
   private final Scope metricsScope;
 
-  LocalActivityExecutionContextImpl(WorkflowClient client, ActivityInfo info, Scope metricsScope) {
+  LocalActivityExecutionContextImpl(
+      WorkflowClient client, Object activity, ActivityInfo info, Scope metricsScope) {
     this.client = client;
+    this.activity = activity;
     this.info = info;
     this.metricsScope = metricsScope;
   }
@@ -99,5 +102,10 @@ class LocalActivityExecutionContextImpl implements InternalActivityExecutionCont
   @Override
   public WorkflowClient getWorkflowClient() {
     return client;
+  }
+
+  @Override
+  public Object getInstance() {
+    return activity;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -101,6 +101,7 @@ class SyncWorkflow implements ReplayWorkflow {
         new SyncWorkflowContext(
             namespace,
             workflowExecution,
+            workflow,
             signalDispatcher,
             queryDispatcher,
             updateDispatcher,

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -101,6 +101,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
 
   private final String namespace;
   private final WorkflowExecution workflowExecution;
+  private final SyncWorkflowDefinition workflowDefinition;
   private final WorkflowImplementationOptions workflowImplementationOptions;
   private final DataConverter dataConverter;
   // to be used in this class, should not be passed down. Pass the original #dataConverter instead
@@ -125,15 +126,16 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
   private Map<String, NexusServiceOptions> nexusServiceOptionsMap;
   private boolean readOnly = false;
   private final WorkflowThreadLocal<UpdateInfo> currentUpdateInfo = new WorkflowThreadLocal<>();
-  // Map of all running update handlers. Key is the update Id of the update request.
+  // Map of all running update handlers. Key is the update ID of the update request.
   private Map<String, UpdateHandlerInfo> runningUpdateHandlers = new HashMap<>();
-  // Map of all running signal handlers. Key is the event Id of the signal event.
+  // Map of all running signal handlers. Key is the event ID of the signal event.
   private Map<Long, SignalHandlerInfo> runningSignalHandlers = new HashMap<>();
   @Nullable private String currentDetails;
 
   public SyncWorkflowContext(
       @Nonnull String namespace,
       @Nonnull WorkflowExecution workflowExecution,
+      @Nullable SyncWorkflowDefinition workflowDefinition,
       SignalDispatcher signalDispatcher,
       QueryDispatcher queryDispatcher,
       UpdateDispatcher updateDispatcher,
@@ -142,6 +144,7 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
       List<ContextPropagator> contextPropagators) {
     this.namespace = namespace;
     this.workflowExecution = workflowExecution;
+    this.workflowDefinition = workflowDefinition;
     this.dataConverter = dataConverter;
     this.dataConverterWithCurrentWorkflowContext =
         dataConverter.withContext(
@@ -1490,6 +1493,11 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
 
   public void setCurrentDetails(String details) {
     currentDetails = details;
+  }
+
+  @Nullable
+  public Object getInstance() {
+    return workflowDefinition.getInstance();
   }
 
   @Nullable

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowDefinition.java
@@ -23,12 +23,20 @@ package io.temporal.internal.sync;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.common.interceptors.Header;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** Workflow wrapper used by the workflow thread to start a workflow */
 interface SyncWorkflowDefinition {
 
   /** Always called first. */
   void initialize(Optional<Payloads> input);
+
+  /**
+   * Returns the workflow instance that is executing this code. Must be called after {@link
+   * #initialize(Optional)}.
+   */
+  @Nullable
+  Object getInstance();
 
   Optional<Payloads> execute(Header header, Optional<Payloads> input);
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -837,6 +837,11 @@ public final class WorkflowInternal {
     return getRootWorkflowContext().getCurrentDetails();
   }
 
+  @Nullable
+  public static Object getInstance() {
+    return getRootWorkflowContext().getInstance();
+  }
+
   static WorkflowOutboundCallsInterceptor getWorkflowOutboundInterceptor() {
     return getRootWorkflowContext().getWorkflowOutboundInterceptor();
   }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -29,6 +29,7 @@ import io.temporal.common.RetryOptions;
 import io.temporal.common.SearchAttributeUpdate;
 import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.WorkflowOutboundCallsInterceptor;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.ChildWorkflowFailure;
@@ -1383,6 +1384,20 @@ public final class Workflow {
   @Nullable
   public static String getCurrentDetails() {
     return WorkflowInternal.getCurrentDetails();
+  }
+
+  /**
+   * Get the currently running workflow instance.
+   *
+   * @apiNote The instance is only available after it has been initialized. This function will
+   *     return null if called before the workflow has been initialized. For example, this could
+   *     happen if the function is called from a {@link WorkflowInit} constructor or {@link
+   *     io.temporal.common.interceptors.WorkflowInboundCallsInterceptor#init(WorkflowOutboundCallsInterceptor)}.
+   */
+  @Experimental
+  @Nullable
+  public static Object getInstance() {
+    return WorkflowInternal.getInstance();
   }
 
   /** Prohibit instantiation. */

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetInstanceTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetInstanceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.activity.Activity;
+import io.temporal.common.interceptors.*;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerFactoryOptions;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetInstanceTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkerFactoryOptions(
+              WorkerFactoryOptions.newBuilder()
+                  .setWorkerInterceptors(new WorkerInterceptor())
+                  .build())
+          .setWorkflowTypes(TestWorkflow1Impl.class)
+          .setActivityImplementations(new TestActivity1Impl())
+          .build();
+
+  @Test
+  public void testGetInstance() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("TestWorkflow1Impl called TestActivity1Impl and TestActivity1Impl", result);
+  }
+
+  public static class TestActivity1Impl implements TestActivities.TestActivity1 {
+    @Override
+    public String execute(String input) {
+      return Activity.getExecutionContext().getInstance().getClass().getSimpleName();
+    }
+  }
+
+  public static class TestWorkflow1Impl implements TestWorkflow1 {
+
+    private final TestActivities.TestActivity1 activities =
+        Workflow.newActivityStub(
+            TestActivities.TestActivity1.class,
+            SDKTestOptions.newActivityOptions20sScheduleToClose());
+
+    private final TestActivities.TestActivity1 localActivities =
+        Workflow.newLocalActivityStub(
+            TestActivities.TestActivity1.class,
+            SDKTestOptions.newLocalActivityOptions20sScheduleToClose());
+
+    @Override
+    public String execute(String testName) {
+      return Workflow.getInstance().getClass().getSimpleName()
+          + " called "
+          + activities.execute("")
+          + " and "
+          + localActivities.execute("");
+    }
+  }
+
+  private static class WorkerInterceptor extends WorkerInterceptorBase {
+    @Override
+    public WorkflowInboundCallsInterceptor interceptWorkflow(WorkflowInboundCallsInterceptor next) {
+      return new WorkflowInboundCallsInterceptorBase(next) {
+        @Override
+        public void init(WorkflowOutboundCallsInterceptor outboundCalls) {
+          // Assert that Workflow.getInstance() is null when the interceptor is initialized
+          Assert.assertNull(Workflow.getInstance());
+          next.init(new WorkflowOutboundCallsInterceptorBase(outboundCalls));
+        }
+
+        @Override
+        public WorkflowOutput execute(WorkflowInput input) {
+          // Assert that Workflow.getInstance() is not null when the workflow is executed
+          Assert.assertNotNull(Workflow.getInstance());
+          return next.execute(input);
+        }
+      };
+    }
+  }
+}

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -49,6 +49,7 @@ public class DummySyncWorkflowContext {
         new SyncWorkflowContext(
             "dummy",
             WorkflowExecution.newBuilder().setWorkflowId("dummy").setRunId("dummy").build(),
+            null,
             new SignalDispatcher(DefaultDataConverter.STANDARD_INSTANCE),
             new QueryDispatcher(DefaultDataConverter.STANDARD_INSTANCE),
             new UpdateDispatcher(DefaultDataConverter.STANDARD_INSTANCE),


### PR DESCRIPTION
Provide access to workflow/activity instance from their context. There is some subtly around when the workflow instance is created, I tried to document this in the user visible method.

Note: I did not do anything for Nexus here because the `OperationHandler` is already passed to the interceptor.

closes: https://github.com/temporalio/sdk-java/issues/2361
