### PR TITLE
Inject namespace header

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/NamespaceInjectWorkflowServiceStubs.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NamespaceInjectWorkflowServiceStubs.java
@@ -34,16 +34,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+/** Inject the namespace into the gRPC header */
 class NamespaceInjectWorkflowServiceStubs implements WorkflowServiceStubs {
   private static Metadata.Key<String> TEMPORAL_NAMESPACE_HEADER_KEY =
       Metadata.Key.of("temporal-namespace", Metadata.ASCII_STRING_MARSHALLER);
   private final Metadata metadata;
-  private WorkflowServiceStubs next;
-  private String namespace;
+  private final WorkflowServiceStubs next;
 
   public NamespaceInjectWorkflowServiceStubs(WorkflowServiceStubs next, String namespace) {
     this.next = next;
-    this.namespace = namespace;
     this.metadata = new Metadata();
     metadata.put(TEMPORAL_NAMESPACE_HEADER_KEY, namespace);
   }

--- a/temporal-sdk/src/main/java/io/temporal/client/NamespaceInjectWorkflowServiceStubs.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NamespaceInjectWorkflowServiceStubs.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.temporal.client;
 
 import io.grpc.ManagedChannel;

--- a/temporal-sdk/src/main/java/io/temporal/client/NamespaceInjectWorkflowServiceStubs.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NamespaceInjectWorkflowServiceStubs.java
@@ -1,0 +1,94 @@
+package io.temporal.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
+import io.temporal.serviceclient.GrpcMetadataProviderInterceptor;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+class NamespaceInjectWorkflowServiceStubs implements WorkflowServiceStubs {
+  private static Metadata.Key<String> TEMPORAL_NAMESPACE_HEADER_KEY =
+      Metadata.Key.of("temporal-namespace", Metadata.ASCII_STRING_MARSHALLER);
+  private final Metadata metadata;
+  private WorkflowServiceStubs next;
+  private String namespace;
+
+  public NamespaceInjectWorkflowServiceStubs(WorkflowServiceStubs next, String namespace) {
+    this.next = next;
+    this.namespace = namespace;
+    this.metadata = new Metadata();
+    metadata.put(TEMPORAL_NAMESPACE_HEADER_KEY, namespace);
+  }
+
+  @Override
+  public WorkflowServiceStubsOptions getOptions() {
+    return next.getOptions();
+  }
+
+  @Override
+  public WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub() {
+    return next.blockingStub()
+        .withInterceptors(
+            new GrpcMetadataProviderInterceptor(Collections.singleton(() -> metadata)));
+  }
+
+  @Override
+  public WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub() {
+    return next.futureStub()
+        .withInterceptors(
+            new GrpcMetadataProviderInterceptor(Collections.singleton(() -> metadata)));
+  }
+
+  @Override
+  public ManagedChannel getRawChannel() {
+    return next.getRawChannel();
+  }
+
+  @Override
+  public void shutdown() {
+    next.shutdown();
+  }
+
+  @Override
+  public void shutdownNow() {
+    next.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return next.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return next.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) {
+    return next.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public void connect(@Nullable Duration timeout) {
+    next.connect(timeout);
+  }
+
+  @Override
+  public HealthCheckResponse healthCheck() {
+    return next.healthCheck();
+  }
+
+  @Override
+  public Supplier<GetSystemInfoResponse.Capabilities> getServerCapabilities() {
+    return next.getServerCapabilities();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowClientInternalImpl.java
@@ -89,6 +89,8 @@ final class WorkflowClientInternalImpl implements WorkflowClient, WorkflowClient
   WorkflowClientInternalImpl(
       WorkflowServiceStubs workflowServiceStubs, WorkflowClientOptions options) {
     options = WorkflowClientOptions.newBuilder(options).validateAndBuildWithDefaults();
+    workflowServiceStubs =
+        new NamespaceInjectWorkflowServiceStubs(workflowServiceStubs, options.getNamespace());
     this.options = options;
     this.workflowServiceStubs = workflowServiceStubs;
     this.metricsScope =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateWithStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateWithStartTest.java
@@ -396,6 +396,7 @@ public class UpdateWithStartTest {
     WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
         mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
     when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+    when(blockingStub.withInterceptors(any())).thenReturn(blockingStub);
     when(blockingStub.withDeadline(any())).thenReturn(blockingStub);
 
     Scope scope = mock(Scope.class);
@@ -457,6 +458,7 @@ public class UpdateWithStartTest {
     WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
         mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
     when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+    when(blockingStub.withInterceptors(any())).thenReturn(blockingStub);
     when(blockingStub.withDeadline(any())).thenReturn(blockingStub);
 
     Scope scope = mock(Scope.class);

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -634,10 +634,7 @@ public class ServiceStubsOptions {
      */
     public T addApiKey(AuthorizationTokenSupplier apiKey) {
       addGrpcMetadataProvider(
-          new AuthorizationGrpcMetadataProvider(
-              () -> {
-                return "Bearer " + apiKey.supply();
-              }));
+          new AuthorizationGrpcMetadataProvider(() -> "Bearer " + apiKey.supply()));
       return self();
     }
 


### PR DESCRIPTION
Inject Namespace in grpc headers. Unfortunately I couldn't use gRPC interceptors as originally proposed because java's gRPC interceptors cannot modify the header based of the content of the message https://github.com/grpc/grpc-java/issues/4684#issuecomment-410315965

closes https://github.com/temporalio/sdk-java/issues/2058