### PR TITLE
Release v1.27.1

### DIFF
--- a/releases/v1.27.1
+++ b/releases/v1.27.1
@@ -1,0 +1,10 @@
+# Highlights
+
+Fixes an exception when de-serializing an exception from a Nexus operation written by Temporal Sever v1.26.2+.  
+
+# What's Changed
+
+2024-12-09 - e1bef897 - Update protocloud submodule (#2344)
+2024-12-12 - 53a8af7e - Remove Experimental annotations from Update APIs (#2347)
+2024-12-27 - c3e0e779 - Set request Id on SignalWorkflowExecutionRequest (#2352)
+2025-01-06 - 82d3c93d - Update Java SDK for Temporal Sever v1.26.2 (#2357)


### PR DESCRIPTION
Release v1.27.1, this fixes a bug prevent the Java SDK from being able to use Nexus with Temporal Server v1.26.2+
