### PR TITLE
Update max task timeout in Test Server

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -91,7 +91,7 @@ class StateMachines {
   public static final long DEFAULT_WORKFLOW_EXECUTION_TIMEOUT_MILLISECONDS =
       10L * 365 * 24 * 3600 * 1000;
   public static final long DEFAULT_WORKFLOW_TASK_TIMEOUT_MILLISECONDS = 10L * 1000;
-  public static final long MAX_WORKFLOW_TASK_TIMEOUT_MILLISECONDS = 60L * 1000;
+  public static final long MAX_WORKFLOW_TASK_TIMEOUT_MILLISECONDS = 2 * 60L * 1000;
   static final Duration DEFAULT_ACTIVITY_RETRY_INITIAL_INTERVAL = Durations.fromSeconds(1);
   static final double DEFAULT_ACTIVITY_RETRY_BACKOFF_COEFFICIENT = 2.0;
   static final int DEFAULT_ACTIVITY_RETRY_MAXIMUM_ATTEMPTS = 0;


### PR DESCRIPTION
Update max task timeout in the test server to match docs 

see also https://github.com/temporalio/sdk-java/commit/de33b3adeefbc0d605094657ee78867d49150bae