### PR TITLE
Add sdk name/version to task completions when unset or changed

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/Config.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/Config.java
@@ -24,7 +24,7 @@ public final class Config {
   private Config() {}
 
   /** Force new workflow task after workflow task timeout multiplied by this coefficient. */
-  public static final double WORKFLOW_TAK_HEARTBEAT_COEFFICIENT = 4d / 5d;
+  public static final double WORKFLOW_TASK_HEARTBEAT_COEFFICIENT = 4d / 5d;
 
   /**
    * Limit how many eager activities can be requested by the SDK in one workflow task completion

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -251,12 +251,17 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     String writeSdkName = result.getWriteSdkName();
     String writeSdkVersion = result.getWriteSdkVersion();
     if (!sdkFlags.isEmpty() || writeSdkName != null || writeSdkVersion != null) {
-      completedRequest.setSdkMetadata(
-          WorkflowTaskCompletedMetadata.newBuilder()
-              .addAllLangUsedFlags(sdkFlags)
-              .setSdkName(writeSdkName)
-              .setSdkVersion(writeSdkVersion)
-              .build());
+      WorkflowTaskCompletedMetadata.Builder md = WorkflowTaskCompletedMetadata.newBuilder();
+      if (!sdkFlags.isEmpty()) {
+        md.addAllLangUsedFlags(sdkFlags);
+      }
+      if (writeSdkName != null) {
+        md.setSdkName(writeSdkName);
+      }
+      if (writeSdkVersion != null) {
+        md.setSdkVersion(writeSdkVersion);
+      }
+      completedRequest.setSdkMetadata(md.build());
     }
     return new Result(
         workflowType,

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -247,12 +247,16 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       }
       completedRequest.setStickyAttributes(attributes);
     }
-    if (!result.getSdkFlags().isEmpty()) {
-      completedRequest =
-          completedRequest.setSdkMetadata(
-              WorkflowTaskCompletedMetadata.newBuilder()
-                  .addAllLangUsedFlags(result.getSdkFlags())
-                  .build());
+    List<Integer> sdkFlags = result.getSdkFlags();
+    String writeSdkName = result.getWriteSdkName();
+    String writeSdkVersion = result.getWriteSdkVersion();
+    if (!sdkFlags.isEmpty() || writeSdkName != null || writeSdkVersion != null) {
+      completedRequest.setSdkMetadata(
+          WorkflowTaskCompletedMetadata.newBuilder()
+              .addAllLangUsedFlags(sdkFlags)
+              .setSdkName(writeSdkName)
+              .setSdkVersion(writeSdkVersion)
+              .build());
     }
     return new Result(
         workflowType,

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowTaskResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowTaskResult.java
@@ -41,6 +41,8 @@ public final class WorkflowTaskResult {
     private boolean forceWorkflowTask;
     private int nonfirstLocalActivityAttempts;
     private List<Integer> sdkFlags;
+    private String writeSdkName;
+    private String writeSdkVersion;
 
     public Builder setCommands(List<Command> commands) {
       this.commands = commands;
@@ -77,6 +79,16 @@ public final class WorkflowTaskResult {
       return this;
     }
 
+    public Builder setWriteSdkName(String writeSdkName) {
+      this.writeSdkName = writeSdkName;
+      return this;
+    }
+
+    public Builder setWriteSdkVersion(String writeSdkVersion) {
+      this.writeSdkVersion = writeSdkVersion;
+      return this;
+    }
+
     public WorkflowTaskResult build() {
       return new WorkflowTaskResult(
           commands == null ? Collections.emptyList() : commands,
@@ -85,7 +97,9 @@ public final class WorkflowTaskResult {
           finalCommand,
           forceWorkflowTask,
           nonfirstLocalActivityAttempts,
-          sdkFlags == null ? Collections.emptyList() : sdkFlags);
+          sdkFlags == null ? Collections.emptyList() : sdkFlags,
+          writeSdkName,
+          writeSdkVersion);
     }
   }
 
@@ -96,6 +110,8 @@ public final class WorkflowTaskResult {
   private final boolean forceWorkflowTask;
   private final int nonfirstLocalActivityAttempts;
   private final List<Integer> sdkFlags;
+  private final String writeSdkName;
+  private final String writeSdkVersion;
 
   private WorkflowTaskResult(
       List<Command> commands,
@@ -104,7 +120,9 @@ public final class WorkflowTaskResult {
       boolean finalCommand,
       boolean forceWorkflowTask,
       int nonfirstLocalActivityAttempts,
-      List<Integer> sdkFlags) {
+      List<Integer> sdkFlags,
+      String writeSdkName,
+      String writeSdkVersion) {
     this.commands = commands;
     this.messages = messages;
     this.nonfirstLocalActivityAttempts = nonfirstLocalActivityAttempts;
@@ -115,6 +133,8 @@ public final class WorkflowTaskResult {
     this.finalCommand = finalCommand;
     this.forceWorkflowTask = forceWorkflowTask;
     this.sdkFlags = sdkFlags;
+    this.writeSdkName = writeSdkName;
+    this.writeSdkVersion = writeSdkVersion;
   }
 
   public List<Command> getCommands() {
@@ -144,5 +164,13 @@ public final class WorkflowTaskResult {
 
   public List<Integer> getSdkFlags() {
     return sdkFlags;
+  }
+
+  public String getWriteSdkName() {
+    return writeSdkName;
+  }
+
+  public String getWriteSdkVersion() {
+    return writeSdkVersion;
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -43,6 +43,7 @@ import io.temporal.internal.worker.SingleWorkerOptions;
 import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.internal.worker.WorkflowRunLockManager;
 import io.temporal.internal.worker.WorkflowTaskHandler;
+import io.temporal.serviceclient.Version;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testUtils.HistoryUtils;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
@@ -206,6 +207,34 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     StickyExecutionAttributes attributes = result.getTaskCompleted().getStickyAttributes();
     assertEquals("sticky", attributes.getWorkerTaskQueue().getName());
     assertEquals(Durations.fromSeconds(5), attributes.getScheduleToStartTimeout());
+  }
+
+  @Test
+  public void setsSdkNameAndVersionIfNotSetInHistory() throws Throwable {
+    assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
+
+    WorkflowExecutorCache cache =
+        new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope());
+    WorkflowTaskHandler taskHandler =
+        new ReplayWorkflowTaskHandler(
+            "namespace",
+            setUpMockWorkflowFactory(),
+            cache,
+            SingleWorkerOptions.newBuilder().build(),
+            InternalUtils.createStickyTaskQueue("sticky", "taskQueue"),
+            Duration.ofSeconds(5),
+            testWorkflowRule.getWorkflowServiceStubs(),
+            null);
+
+    PollWorkflowTaskQueueResponse workflowTask =
+        HistoryUtils.generateWorkflowTaskWithInitialHistory();
+
+    WorkflowTaskHandler.Result result = taskHandler.handleWorkflowTask(workflowTask);
+
+    assertTrue(result.isCompletionCommand());
+    assertEquals(Version.SDK_NAME, result.getTaskCompleted().getSdkMetadata().getSdkName());
+    assertEquals(
+        Version.LIBRARY_VERSION, result.getTaskCompleted().getSdkMetadata().getSdkVersion());
   }
 
   private ReplayWorkflowFactory setUpMockWorkflowFactory() throws Throwable {

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
@@ -616,6 +616,10 @@ class TestHistoryBuilder {
     return previousStartedEventId;
   }
 
+  public long getWorkflowTaskScheduledEventId() {
+    return workflowTaskScheduledEventId;
+  }
+
   public long getWorkflowTaskStartedEventId() {
     return workflowTaskScheduledEventId + 1;
   }

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/WorkflowStateMachinesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/WorkflowStateMachinesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.internal.statemachines;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.WorkflowTaskCompletedEventAttributes;
+import io.temporal.api.sdk.v1.WorkflowTaskCompletedMetadata;
+import io.temporal.serviceclient.Version;
+import java.util.Optional;
+import org.junit.Test;
+
+public class WorkflowStateMachinesTest {
+  private WorkflowStateMachines stateMachines;
+
+  private WorkflowStateMachines newStateMachines(TestEntityManagerListenerBase listener) {
+    return new WorkflowStateMachines(listener, m -> {});
+  }
+
+  private class TestActivityListener extends TestEntityManagerListenerBase {
+    @Override
+    public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
+      builder.add(v -> stateMachines.completeWorkflow(Optional.empty()));
+    }
+  }
+
+  private void sdkNameAndVersionTest(
+      String inputSdkVersion,
+      String inputSdkName,
+      String expectedSdkName,
+      String expectedSdkVersion) {
+    TestHistoryBuilder h = new TestHistoryBuilder();
+    TestEntityManagerListenerBase listener = new TestActivityListener();
+    stateMachines = newStateMachines(listener);
+
+    h.add(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED);
+    h.addWorkflowTaskScheduledAndStarted();
+    h.add(
+        EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+        WorkflowTaskCompletedEventAttributes.newBuilder()
+            .setScheduledEventId(h.getWorkflowTaskScheduledEventId())
+            .setSdkMetadata(
+                WorkflowTaskCompletedMetadata.newBuilder()
+                    .setSdkVersion(inputSdkVersion)
+                    .setSdkName(inputSdkName)));
+    h.addWorkflowTaskScheduledAndStarted();
+    assertEquals(2, h.getWorkflowTaskCount());
+
+    h.handleWorkflowTaskTakeCommands(stateMachines, 2);
+
+    assertEquals(expectedSdkName, stateMachines.sdkNameToWrite());
+    assertEquals(expectedSdkVersion, stateMachines.sdkVersionToWrite());
+  }
+
+  @Test
+  public void testWritesSdkNameAndVersionWhenDifferent() {
+    sdkNameAndVersionTest("hi", "skflajk", Version.SDK_NAME, Version.LIBRARY_VERSION);
+  }
+
+  @Test
+  public void doesNotWriteSdkNameAndVersionWhenSame() {
+    sdkNameAndVersionTest(Version.LIBRARY_VERSION, Version.SDK_NAME, null, null);
+  }
+
+  @Test
+  public void writesOnlyNameIfChanged() {
+    sdkNameAndVersionTest(Version.LIBRARY_VERSION, "sakflasjklf", Version.SDK_NAME, null);
+  }
+
+  @Test
+  public void writesOnlyVersionIfChanged() {
+    sdkNameAndVersionTest("safklasjf", Version.SDK_NAME, null, Version.LIBRARY_VERSION);
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WritesSDKNameVersionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WritesSDKNameVersionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.serviceclient.Version;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WritesSDKNameVersionTest {
+
+  private static boolean hasFailedWFT = false;
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowTaskFailureBackoff.class)
+          .build();
+
+  @Test
+  public void writesSdkNameAndVersion() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(10))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(1))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.getWorkflowClient().newWorkflowStub(TestWorkflow1.class, options);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("result1", result);
+
+    List<HistoryEvent> completedEvents =
+        testWorkflowRule.getHistoryEvents(
+            WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId(),
+            EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED);
+    Assert.assertEquals(
+        Version.SDK_NAME,
+        completedEvents
+            .get(0)
+            .getWorkflowTaskCompletedEventAttributes()
+            .getSdkMetadata()
+            .getSdkName());
+    Assert.assertEquals(
+        Version.LIBRARY_VERSION,
+        completedEvents
+            .get(0)
+            .getWorkflowTaskCompletedEventAttributes()
+            .getSdkMetadata()
+            .getSdkVersion());
+    Assert.assertEquals(
+        "",
+        completedEvents
+            .get(1)
+            .getWorkflowTaskCompletedEventAttributes()
+            .getSdkMetadata()
+            .getSdkName());
+    Assert.assertEquals(
+        "",
+        completedEvents
+            .get(1)
+            .getWorkflowTaskCompletedEventAttributes()
+            .getSdkMetadata()
+            .getSdkVersion());
+  }
+
+  public static class TestWorkflowTaskFailureBackoff implements TestWorkflow1 {
+    @Override
+    public String execute(String taskQueue) {
+      // Complete one wft first
+      Workflow.sleep(1);
+      if (!hasFailedWFT) {
+        hasFailedWFT = true;
+        throw new Error("fail");
+      }
+      return "result1";
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityGettingScheduledRightBeforeWorkflowTaskHeartbeatTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityGettingScheduledRightBeforeWorkflowTaskHeartbeatTest.java
@@ -88,7 +88,7 @@ public class LocalActivityGettingScheduledRightBeforeWorkflowTaskHeartbeatTest {
               VariousTestActivities.class, SDKTestOptions.newLocalActivityOptions());
 
       long firstLocalActivityDurationMs =
-          (long) (WORKFLOW_TASK_TIMEOUT.toMillis() * Config.WORKFLOW_TAK_HEARTBEAT_COEFFICIENT)
+          (long) (WORKFLOW_TASK_TIMEOUT.toMillis() * Config.WORKFLOW_TASK_HEARTBEAT_COEFFICIENT)
               - SLEEP_DURATION.toMillis() / 2;
       localActivities.sleepActivity(firstLocalActivityDurationMs, 0);
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
@@ -79,8 +79,6 @@ final class ChannelManager {
   private static final Metadata.Key<String> CLOUD_VERSION_HEADER_KEY =
       Metadata.Key.of("temporal-cloud-api-version", Metadata.ASCII_STRING_MARSHALLER);
 
-  private static final String CLIENT_NAME_HEADER_VALUE = "temporal-java";
-
   private final ServiceStubsOptions options;
 
   private final AtomicBoolean shutdownRequested = new AtomicBoolean();
@@ -169,7 +167,7 @@ final class ChannelManager {
     headers.merge(options.getHeaders());
     headers.put(LIBRARY_VERSION_HEADER_KEY, Version.LIBRARY_VERSION);
     headers.put(SUPPORTED_SERVER_VERSIONS_HEADER_KEY, Version.SUPPORTED_SERVER_VERSIONS);
-    headers.put(CLIENT_NAME_HEADER_KEY, CLIENT_NAME_HEADER_VALUE);
+    headers.put(CLIENT_NAME_HEADER_KEY, Version.SDK_NAME);
     if (options instanceof CloudServiceStubsOptions) {
       String version = ((CloudServiceStubsOptions) options).getVersion();
       if (version != null) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/Version.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/Version.java
@@ -42,6 +42,11 @@ public class Version {
   public static final String LIBRARY_VERSION;
 
   /**
+   * The named used to represent this SDK as client identities as well as worker task completions.
+   */
+  public static final String SDK_NAME = "temporal-java";
+
+  /**
    * Supported server versions defines a semver range of server versions that client is compatible
    * with.
    */


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Write name and version to task completions

## Why?
Parity 

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/1838

2. How was this tested:
Added unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
