### PR TITLE
Block using conflict policy UseExisting for Nexus WorkflowRunOperation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -37,6 +37,7 @@ import io.temporal.common.metadata.WorkflowMethodType;
 import io.temporal.internal.client.NexusStartWorkflowRequest;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -155,11 +156,14 @@ public final class InternalUtils {
             .build());
 
     // TODO(klassenq) temporarily blocking conflict policy USE_EXISTING.
-    if (options.getWorkflowIdConflictPolicy().equals(WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING)) {
+    if (Objects.equals(
+        WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+        options.getWorkflowIdConflictPolicy())) {
       throw new HandlerException(
-              HandlerException.ErrorType.INTERNAL,
-              new IllegalArgumentException("Workflow ID conflict policy UseExisting is not supported for Nexus WorkflowRunOperation."),
-              HandlerException.RetryBehavior.NON_RETRYABLE);
+          HandlerException.ErrorType.INTERNAL,
+          new IllegalArgumentException(
+              "Workflow ID conflict policy UseExisting is not supported for Nexus WorkflowRunOperation."),
+          HandlerException.RetryBehavior.NON_RETRYABLE);
     }
     return stub.newInstance(nexusWorkflowOptions.build());
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -22,9 +22,11 @@ package io.temporal.internal.common;
 
 import com.google.common.base.Defaults;
 import io.nexusrpc.Header;
+import io.nexusrpc.handler.HandlerException;
 import io.nexusrpc.handler.ServiceImplInstance;
 import io.temporal.api.common.v1.Callback;
 import io.temporal.api.enums.v1.TaskQueueKind;
+import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.client.OnConflictOptions;
 import io.temporal.client.WorkflowOptions;
@@ -151,6 +153,14 @@ public final class InternalUtils {
             .setAttachLinks(true)
             .setAttachCompletionCallbacks(true)
             .build());
+
+    // TODO(klassenq) temporarily blocking conflict policy USE_EXISTING.
+    if (options.getWorkflowIdConflictPolicy().equals(WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING)) {
+      throw new HandlerException(
+              HandlerException.ErrorType.INTERNAL,
+              new IllegalArgumentException("Workflow ID conflict policy UseExisting is not supported for Nexus WorkflowRunOperation."),
+              HandlerException.RetryBehavior.NON_RETRYABLE);
+    }
     return stub.newInstance(nexusWorkflowOptions.build());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
@@ -38,7 +38,6 @@ import io.temporal.workflow.shared.TestWorkflows;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.*;
 
 @Ignore("Skipping until we can support USE_EXISTING")

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
@@ -38,11 +38,10 @@ import io.temporal.workflow.shared.TestWorkflows;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
+import org.junit.*;
+
+@Ignore("Skipping until we can support USE_EXISTING")
 public class WorkflowHandleUseExistingOnConflictCancelTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
@@ -36,11 +36,10 @@ import io.temporal.workflow.shared.TestWorkflows;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
+import org.junit.*;
+
+@Ignore("Skipping until we can support USE_EXISTING")
 public class WorkflowHandleUseExistingOnConflictTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
@@ -36,7 +36,6 @@ import io.temporal.workflow.shared.TestWorkflows;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.*;
 
 @Ignore("Skipping until we can support USE_EXISTING")


### PR DESCRIPTION
Block using conflict policy UseExisting for Nexus WorkflowRunOperation

see also https://github.com/temporalio/sdk-go/pull/1845
