### PR TITLE
fix documentation in CapacityConfigurationProperties

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
@@ -114,7 +114,7 @@ public class WorkerProperties {
 
     /**
      * @param maxConcurrentWorkflowTaskExecutors defines {@link
-     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers(int)}
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentWorkflowTaskExecutionSize(int)}
      * @param maxConcurrentActivityExecutors defines {@link
      *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentActivityExecutionSize(int)}
      * @param maxConcurrentLocalActivityExecutors defines {@link


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Java doc in CapacityConfigurationProperties

## Why?
```
maxConcurrentWorkflowTaskExecutors defines {@link
     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentWorkflowTaskPollers(int)
```

But it is incorrect

https://github.com/temporalio/sdk-java/blob/49bd366af37343f1cba2bbec0fc7f61718fd5bb1/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerOptionsTemplate.java#L56

