### PR TITLE
:boom: [Breaking] Asyncify slot suppliers

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
@@ -98,12 +98,18 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
     PollActivityTaskQueueResponse response;
     SlotPermit permit;
     boolean isSuccessful = false;
-    CompletableFuture<SlotPermit> future =
-        slotSupplier.reserveSlot(
-            new SlotReservationData(
-                pollRequest.getTaskQueue().getName(),
-                pollRequest.getIdentity(),
-                pollRequest.getWorkerVersionCapabilities().getBuildId()));
+    CompletableFuture<SlotPermit> future;
+    try {
+      future =
+          slotSupplier.reserveSlot(
+              new SlotReservationData(
+                  pollRequest.getTaskQueue().getName(),
+                  pollRequest.getIdentity(),
+                  pollRequest.getWorkerVersionCapabilities().getBuildId()));
+    } catch (Exception e) {
+      log.warn("Error while trying to reserve a slot for an activity", e.getCause());
+      return null;
+    }
     try {
       permit = future.get();
     } catch (InterruptedException e) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
@@ -35,8 +35,8 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.tuning.*;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -98,7 +98,7 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
     PollActivityTaskQueueResponse response;
     SlotPermit permit;
     boolean isSuccessful = false;
-    CompletableFuture<SlotPermit> future;
+    Future<SlotPermit> future;
     try {
       future =
           slotSupplier.reserveSlot(

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/LocalActivitySlotSupplierQueue.java
@@ -84,7 +84,7 @@ class LocalActivitySlotSupplierQueue implements Shutdownable {
       try {
         request = requestQueue.take();
 
-        CompletableFuture<SlotPermit> future = slotSupplier.reserveSlot(request.data);
+        Future<SlotPermit> future = slotSupplier.reserveSlot(request.data);
         try {
           slotPermit = future.get();
         } catch (InterruptedException e) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusPollTask.java
@@ -32,8 +32,8 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.tuning.*;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,7 +88,7 @@ final class NexusPollTask implements Poller.PollTask<NexusTask> {
     PollNexusTaskQueueResponse response;
     SlotPermit permit;
     boolean isSuccessful = false;
-    CompletableFuture<SlotPermit> future =
+    Future<SlotPermit> future =
         slotSupplier.reserveSlot(
             new SlotReservationData(
                 pollRequest.getTaskQueue().getName(),

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusPollTask.java
@@ -32,6 +32,8 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.tuning.*;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -86,18 +88,19 @@ final class NexusPollTask implements Poller.PollTask<NexusTask> {
     PollNexusTaskQueueResponse response;
     SlotPermit permit;
     boolean isSuccessful = false;
-
+    CompletableFuture<SlotPermit> future =
+        slotSupplier.reserveSlot(
+            new SlotReservationData(
+                pollRequest.getTaskQueue().getName(),
+                pollRequest.getIdentity(),
+                pollRequest.getWorkerVersionCapabilities().getBuildId()));
     try {
-      permit =
-          slotSupplier.reserveSlot(
-              new SlotReservationData(
-                  pollRequest.getTaskQueue().getName(),
-                  pollRequest.getIdentity(),
-                  pollRequest.getWorkerVersionCapabilities().getBuildId()));
+      permit = future.get();
     } catch (InterruptedException e) {
+      future.cancel(true);
       Thread.currentThread().interrupt();
       return null;
-    } catch (Exception e) {
+    } catch (ExecutionException e) {
       log.warn("Error while trying to reserve a slot for a nexus task", e.getCause());
       return null;
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/TrackingSlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/TrackingSlotSupplier.java
@@ -26,6 +26,7 @@ import io.temporal.worker.tuning.*;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -48,10 +49,10 @@ public class TrackingSlotSupplier<SI extends SlotInfo> {
     publishSlotsMetric();
   }
 
-  public SlotPermit reserveSlot(SlotReservationData dat) throws InterruptedException {
-    SlotPermit p = inner.reserveSlot(createCtx(dat));
-    issuedSlots.incrementAndGet();
-    return p;
+  public CompletableFuture<SlotPermit> reserveSlot(SlotReservationData dat) {
+    CompletableFuture<SlotPermit> future = inner.reserveSlot(createCtx(dat));
+    future.thenAccept(permit -> issuedSlots.incrementAndGet());
+    return future;
   }
 
   public Optional<SlotPermit> tryReserveSlot(SlotReservationData dat) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/TrackingSlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/TrackingSlotSupplier.java
@@ -50,7 +50,12 @@ public class TrackingSlotSupplier<SI extends SlotInfo> {
   }
 
   public CompletableFuture<SlotPermit> reserveSlot(SlotReservationData dat) {
-    CompletableFuture<SlotPermit> future = inner.reserveSlot(createCtx(dat));
+    CompletableFuture<SlotPermit> future = null;
+    try {
+      future = inner.reserveSlot(createCtx(dat));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
     future.thenAccept(permit -> issuedSlots.incrementAndGet());
     return future;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -39,8 +39,8 @@ import io.temporal.worker.tuning.SlotPermit;
 import io.temporal.worker.tuning.SlotReleaseReason;
 import io.temporal.worker.tuning.WorkflowSlotInfo;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -127,7 +127,7 @@ final class WorkflowPollTask implements Poller.PollTask<WorkflowTask> {
   public WorkflowTask poll() {
     boolean isSuccessful = false;
     SlotPermit permit;
-    CompletableFuture<SlotPermit> future =
+    Future<SlotPermit> future =
         slotSupplier.reserveSlot(
             new SlotReservationData(
                 pollRequest.getTaskQueue().getName(),

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/FixedSizeSlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/FixedSizeSlotSupplier.java
@@ -110,7 +110,7 @@ public class FixedSizeSlotSupplier<SI extends SlotInfo> implements SlotSupplier<
   }
 
   @Override
-  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) {
+  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception {
     return executorSlotsSemaphore.acquire().thenApply(ignored -> new SlotPermit());
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/FixedSizeSlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/FixedSizeSlotSupplier.java
@@ -21,8 +21,11 @@
 package io.temporal.worker.tuning;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayDeque;
 import java.util.Optional;
-import java.util.concurrent.*;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This implementation of {@link SlotSupplier} provides a fixed number of slots backed by a
@@ -32,18 +35,83 @@ import java.util.concurrent.*;
  */
 public class FixedSizeSlotSupplier<SI extends SlotInfo> implements SlotSupplier<SI> {
   private final int numSlots;
-  private final Semaphore executorSlotsSemaphore;
+  private final AsyncSemaphore executorSlotsSemaphore;
+
+  /**
+   * A simple version of an async semaphore. Unfortunately there's not any readily available
+   * properly licensed library I could find for this which is a bit shocking, but this
+   * implementation should be suitable for our needs
+   */
+  static class AsyncSemaphore {
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Queue<CompletableFuture<Void>> waiters = new ArrayDeque<>();
+    private int permits;
+
+    AsyncSemaphore(int initialPermits) {
+      this.permits = initialPermits;
+    }
+
+    /**
+     * Acquire a permit asynchronously. If a permit is available, returns a completed future,
+     * otherwise returns a future that will be completed when a permit is released.
+     */
+    public CompletableFuture<Void> acquire() {
+      lock.lock();
+      try {
+        if (permits > 0) {
+          permits--;
+          return CompletableFuture.completedFuture(null);
+        } else {
+          CompletableFuture<Void> waiter = new CompletableFuture<>();
+          waiters.add(waiter);
+          return waiter;
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    public boolean tryAcquire() {
+      lock.lock();
+      try {
+        if (permits > 0) {
+          permits--;
+          return true;
+        }
+        return false;
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    /**
+     * Release a permit. If there are waiting futures, completes the next one instead of
+     * incrementing the permit count.
+     */
+    public void release() {
+      lock.lock();
+      try {
+        CompletableFuture<Void> waiter = waiters.poll();
+        if (waiter != null) {
+          waiter.complete(null);
+        } else {
+          permits++;
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
 
   public FixedSizeSlotSupplier(int numSlots) {
     Preconditions.checkArgument(numSlots > 0, "FixedSizeSlotSupplier must have at least one slot");
     this.numSlots = numSlots;
-    executorSlotsSemaphore = new Semaphore(numSlots);
+    executorSlotsSemaphore = new AsyncSemaphore(numSlots);
   }
 
   @Override
-  public SlotPermit reserveSlot(SlotReserveContext<SI> ctx) throws InterruptedException {
-    executorSlotsSemaphore.acquire();
-    return new SlotPermit();
+  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) {
+    return executorSlotsSemaphore.acquire().thenApply(ignored -> new SlotPermit());
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/FixedSizeSlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/FixedSizeSlotSupplier.java
@@ -25,6 +25,7 @@ import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -110,7 +111,7 @@ public class FixedSizeSlotSupplier<SI extends SlotInfo> implements SlotSupplier<
   }
 
   @Override
-  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception {
+  public Future<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception {
     return executorSlotsSemaphore.acquire().thenApply(ignored -> new SlotPermit());
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/ResourceBasedSlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/ResourceBasedSlotSupplier.java
@@ -202,7 +202,7 @@ public class ResourceBasedSlotSupplier<SI extends SlotInfo> implements SlotSuppl
   }
 
   @Override
-  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception {
+  public Future<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception {
     if (ctx.getNumIssuedSlots() < options.getMinimumSlots()) {
       return CompletableFuture.completedFuture(new SlotPermit());
     }

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
@@ -43,13 +43,13 @@ public interface SlotSupplier<SI extends SlotInfo> {
    * <p>These futures may be cancelled if the worker is shutting down or otherwise abandons the
    * reservation. This can cause an {@link InterruptedException} to be thrown, in the thread running
    * your implementation. You may want to catch it to perform any necessary cleanup, and then you
-   * should rethrow the exception.
+   * should rethrow the exception. Other thrown exceptions will be logged.
    *
    * @param ctx The context for slot reservation.
    * @return A future that will be completed with a permit to use the slot when one becomes
    *     available. Never return null, or complete the future with null.
    */
-  CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx);
+  CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception;
 
   /**
    * This function is called when trying to reserve slots for "eager" workflow and activity tasks.

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 public interface SlotSupplier<SI extends SlotInfo> {
   /**
    * This function is called before polling for new tasks. Your implementation should return a
-   * Promise that is completed with a {@link SlotPermit} when one becomes available.
+   * future that is completed with a {@link SlotPermit} when one becomes available.
    *
    * <p>These futures may be cancelled if the worker is shutting down or otherwise abandons the
    * reservation. This can cause an {@link InterruptedException} to be thrown, in the thread running

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
@@ -22,6 +22,7 @@ package io.temporal.worker.tuning;
 
 import io.temporal.common.Experimental;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A SlotSupplier is responsible for managing the number of slots available for a given type of
@@ -36,16 +37,19 @@ import java.util.Optional;
 @Experimental
 public interface SlotSupplier<SI extends SlotInfo> {
   /**
-   * This function is called before polling for new tasks. Your implementation should block until a
-   * slot is available then return a permit to use that slot.
+   * This function is called before polling for new tasks. Your implementation should return a
+   * Promise that is completed with a {@link SlotPermit} when one becomes available.
+   *
+   * <p>These futures may be cancelled if the worker is shutting down or otherwise abandons the
+   * reservation. This can cause an {@link InterruptedException} to be thrown, in the thread running
+   * your implementation. You may want to catch it to perform any necessary cleanup, and then you
+   * should rethrow the exception.
    *
    * @param ctx The context for slot reservation.
-   * @return A permit to use the slot which may be populated with your own data.
-   * @throws InterruptedException The worker may choose to interrupt the thread in order to cancel
-   *     the reservation, or during shutdown. You may perform cleanup, and then should rethrow the
-   *     exception.
+   * @return A future that will be completed with a permit to use the slot when one becomes
+   *     available. Never return null, or complete the future with null.
    */
-  SlotPermit reserveSlot(SlotReserveContext<SI> ctx) throws InterruptedException;
+  CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx);
 
   /**
    * This function is called when trying to reserve slots for "eager" workflow and activity tasks.

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
@@ -22,7 +22,6 @@ package io.temporal.worker.tuning;
 
 import io.temporal.common.Experimental;
 import java.util.Optional;
-import java.util.concurrent.Future;
 
 /**
  * A SlotSupplier is responsible for managing the number of slots available for a given type of
@@ -49,7 +48,7 @@ public interface SlotSupplier<SI extends SlotInfo> {
    * @return A future that will be completed with a permit to use the slot when one becomes
    *     available. Never return null, or complete the future with null.
    */
-  Future<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception;
+  SlotSupplierFuture reserveSlot(SlotReserveContext<SI> ctx) throws Exception;
 
   /**
    * This function is called when trying to reserve slots for "eager" workflow and activity tasks.

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplier.java
@@ -22,7 +22,7 @@ package io.temporal.worker.tuning;
 
 import io.temporal.common.Experimental;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 /**
  * A SlotSupplier is responsible for managing the number of slots available for a given type of
@@ -49,7 +49,7 @@ public interface SlotSupplier<SI extends SlotInfo> {
    * @return A future that will be completed with a permit to use the slot when one becomes
    *     available. Never return null, or complete the future with null.
    */
-  CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception;
+  Future<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception;
 
   /**
    * This function is called when trying to reserve slots for "eager" workflow and activity tasks.

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplierFuture.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/SlotSupplierFuture.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.worker.tuning;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a future that will be completed with a {@link SlotPermit} when a slot is available.
+ *
+ * <p>This class exists to provide a reliable cancellation mechanism, since {@link
+ * CompletableFuture} does not provide cancellations that properly propagate up the chain.
+ */
+public abstract class SlotSupplierFuture extends CompletableFuture<SlotPermit> {
+  /**
+   * Abort the reservation attempt. Direct implementations should cancel or interrupt any underlying
+   * processes that are attempting to reserve a slot.
+   */
+  @Nullable
+  @CheckReturnValue
+  public abstract SlotPermit abortReservation();
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    throw new UnsupportedOperationException(
+        "Do not call cancel on SlotSupplierFuture, use abortReservation");
+  }
+
+  /** See {@link CompletableFuture#completedFuture(Object)} */
+  public static SlotSupplierFuture completedFuture(SlotPermit permit) {
+    return new SlotSupplierFuture() {
+      @Override
+      public SlotPermit abortReservation() {
+        return permit;
+      }
+
+      {
+        complete(permit);
+      }
+    };
+  }
+
+  /**
+   * Create a new {@link SlotSupplierFuture} from a {@link CompletableFuture}
+   *
+   * @param abortHandler The handler to call when the reservation is aborted. This should abort the
+   *     furthest-upstream future, or call being waited on, in order to properly propagate
+   *     cancellation downstream.
+   */
+  public static SlotSupplierFuture fromCompletableFuture(
+      CompletableFuture<SlotPermit> future, Runnable abortHandler) {
+    SlotSupplierFuture wrapper =
+        new SlotSupplierFuture() {
+          @Override
+          public SlotPermit abortReservation() {
+            // Try to force the future into an exceptional state.
+            // completeExceptionally returns true only if it successfully transitions.
+            boolean abortedNow =
+                this.completeExceptionally(new CancellationException("Reservation aborted"));
+            if (abortedNow) {
+              abortHandler.run();
+              future.cancel(true);
+              return null;
+            } else {
+              // The future has already completed normally so return the permit.
+              return this.join();
+            }
+          }
+        };
+
+    // Propagate the delegate future’s outcome to our wrapper
+    future.whenComplete(
+        (result, throwable) -> {
+          // If our wrapper isn’t already completed (via abortReservation), complete it.
+          if (!wrapper.isDone()) {
+            if (throwable != null) {
+              wrapper.completeExceptionally(throwable);
+            } else {
+              wrapper.complete(result);
+            }
+          }
+        });
+
+    return wrapper;
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotSupplierTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotSupplierTest.java
@@ -37,7 +37,7 @@ import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.tuning.*;
 import java.util.Objects;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,7 +60,7 @@ public class SlotSupplierTest {
   }
 
   @Test
-  public void supplierIsCalledAppropriately() throws InterruptedException, TimeoutException {
+  public void supplierIsCalledAppropriately() {
     WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
     when(client.getServerCapabilities())
         .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
@@ -77,7 +77,7 @@ public class SlotSupplierTest {
                   usedSlotsWhenCalled.set(src.getUsedSlots().size());
                   return true;
                 })))
-        .thenReturn(new SlotPermit());
+        .thenReturn(CompletableFuture.completedFuture(new SlotPermit()));
 
     StickyQueueBalancer stickyQueueBalancer = new StickyQueueBalancer(5, true);
     Scope metricsScope =

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotSupplierTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotSupplierTest.java
@@ -37,7 +37,6 @@ import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.tuning.*;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,7 +77,7 @@ public class SlotSupplierTest {
                     usedSlotsWhenCalled.set(src.getUsedSlots().size());
                     return true;
                   })))
-          .thenReturn(CompletableFuture.completedFuture(new SlotPermit()));
+          .thenReturn(SlotSupplierFuture.completedFuture(new SlotPermit()));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotsSmallSizeTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotsSmallSizeTests.java
@@ -22,7 +22,6 @@ package io.temporal.internal.worker;
 
 import static org.junit.Assert.assertEquals;
 
-import com.uber.m3.util.ImmutableMap;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.ActivityOptions;
@@ -38,7 +37,6 @@ import io.temporal.workflow.*;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -181,20 +179,9 @@ public class WorkflowSlotsSmallSizeTests {
     }
   }
 
-  private Map<String, String> getWorkerTags(String workerType) {
-    return ImmutableMap.of(
-        "worker_type",
-        workerType,
-        "task_queue",
-        testWorkflowRule.getTaskQueue(),
-        "namespace",
-        "UnitTest");
-  }
-
   private void assertIntraWFTSlotCount(int allowedToRun) {
     int runningLAs = activitiesAreLocal ? allowedToRun : 0;
     int runningAs = activitiesAreLocal ? 0 : allowedToRun;
-    int runningWFTs = activitiesAreLocal ? 1 : 0;
     assertCurrentUsedCount(runningAs, runningLAs);
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/testUtils/CountingSlotSupplier.java
+++ b/temporal-sdk/src/test/java/io/temporal/testUtils/CountingSlotSupplier.java
@@ -22,6 +22,7 @@ package io.temporal.testUtils;
 
 import io.temporal.worker.tuning.*;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -37,10 +38,13 @@ public class CountingSlotSupplier<SI extends SlotInfo> extends FixedSizeSlotSupp
   }
 
   @Override
-  public SlotPermit reserveSlot(SlotReserveContext<SI> ctx) throws InterruptedException {
-    SlotPermit p = super.reserveSlot(ctx);
-    reservedCount.incrementAndGet();
-    return p;
+  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) {
+    CompletableFuture<SlotPermit> p = super.reserveSlot(ctx);
+    return p.thenApply(
+        permit -> {
+          reservedCount.incrementAndGet();
+          return permit;
+        });
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/testUtils/CountingSlotSupplier.java
+++ b/temporal-sdk/src/test/java/io/temporal/testUtils/CountingSlotSupplier.java
@@ -38,7 +38,7 @@ public class CountingSlotSupplier<SI extends SlotInfo> extends FixedSizeSlotSupp
   }
 
   @Override
-  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) {
+  public CompletableFuture<SlotPermit> reserveSlot(SlotReserveContext<SI> ctx) throws Exception {
     CompletableFuture<SlotPermit> p = super.reserveSlot(ctx);
     return p.thenApply(
         permit -> {

--- a/temporal-sdk/src/test/java/io/temporal/worker/tuning/FixedSizeSlotSupplierTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/tuning/FixedSizeSlotSupplierTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.worker.tuning;
+
+import static org.junit.Assert.*;
+
+import com.uber.m3.tally.NoopScope;
+import io.temporal.internal.worker.SlotReservationData;
+import io.temporal.internal.worker.TrackingSlotSupplier;
+import org.junit.Test;
+
+public class FixedSizeSlotSupplierTest {
+
+  @Test
+  public void ensureInterruptingReservationWorksWhenWaitingOnSemaphoreInQueue() throws Exception {
+    FixedSizeSlotSupplier<WorkflowSlotInfo> supplier = new FixedSizeSlotSupplier<>(1);
+    TrackingSlotSupplier<WorkflowSlotInfo> trackingSS =
+        new TrackingSlotSupplier<>(supplier, new NoopScope());
+    // Reserve one slot and don't release
+    SlotPermit firstPermit =
+        trackingSS.reserveSlot(new SlotReservationData("bla", "blah", "bla")).get();
+
+    // Try to reserve another slot
+    SlotSupplierFuture secondSlotFuture =
+        trackingSS.reserveSlot(new SlotReservationData("bla", "blah", "bla"));
+    // Try to reserve a third
+    SlotSupplierFuture thirdSlotFuture =
+        trackingSS.reserveSlot(new SlotReservationData("bla", "blah", "bla"));
+
+    // Cancel second reservation & release first permit, which should allow third to be acquired
+    SlotPermit maybePermit = secondSlotFuture.abortReservation();
+    assertNull(maybePermit);
+    trackingSS.releaseSlot(SlotReleaseReason.neverUsed(), firstPermit);
+
+    SlotPermit p = thirdSlotFuture.get();
+    assertNotNull(p);
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Made the `reserveSlot` method on `SlotSupplier` interface async.

Note that, as it stands, this can actually slightly _increase_ the number of threads used because the slot suppliers have been changed in a way that they will not block the caller (which is the whole point) but in order to do that, the resource based one at least needs a couple threads that it didn't before. 

For the fixed size supplier, I think I've managed to come up with something that should always be non-blocking.

## Why?
This is to support https://github.com/temporalio/sdk-java/issues/1456 where the pollers themselves will be made async, and thus will be able to take advantage of async slot reservation as well.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
