### PR TITLE
Fix API key auth

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -216,7 +216,9 @@ public final class WorkerFactory {
 
     // Workers check and require that Temporal Server is available during start to fail-fast in case
     // of configuration issues.
-    workflowClient.getWorkflowServiceStubs().connect(null);
+    // TODO(https://github.com/temporalio/sdk-java/issues/2060) consider using describeNamespace as
+    // a connection check.
+    workflowClient.getWorkflowServiceStubs().getServerCapabilities();
 
     for (Worker worker : workers.values()) {
       worker.start();

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/ServiceStubOptionsTemplate.java
@@ -64,7 +64,7 @@ public class ServiceStubOptionsTemplate {
 
     stubsOptionsBuilder.setEnableHttps(Boolean.TRUE.equals(connectionProperties.isEnableHttps()));
 
-    if (connectionProperties.getApiKey() != null && connectionProperties.getApiKey().isEmpty()) {
+    if (connectionProperties.getApiKey() != null && !connectionProperties.getApiKey().isEmpty()) {
       stubsOptionsBuilder.addApiKey(() -> connectionProperties.getApiKey());
       // Unless HTTPS is explicitly disabled, enable it by default for API keys
       if (connectionProperties.isEnableHttps() == null) {

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/ApiKeyAuthTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/ApiKeyAuthTest.java
@@ -20,7 +20,9 @@
 
 package io.temporal.spring.boot.autoconfigure;
 
+import io.temporal.authorization.AuthorizationGrpcMetadataProvider;
 import io.temporal.client.WorkflowClient;
+import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +40,7 @@ public class ApiKeyAuthTest {
 
   @Autowired TemporalProperties temporalProperties;
   @Autowired WorkflowClient workflowClient;
+  @Autowired WorkflowServiceStubs workflowServiceStubs;
 
   @BeforeEach
   void setUp() {
@@ -47,6 +50,15 @@ public class ApiKeyAuthTest {
   @Test
   public void testProperties() {
     Assertions.assertEquals("my-api-key", temporalProperties.getConnection().getApiKey());
+    Assertions.assertEquals(1, workflowServiceStubs.getOptions().getGrpcMetadataProviders().size());
+    Assertions.assertTrue(
+        workflowServiceStubs.getOptions().getGrpcMetadataProviders().stream()
+            .allMatch(
+                provider ->
+                    provider
+                        .getMetadata()
+                        .get(AuthorizationGrpcMetadataProvider.AUTHORIZATION_HEADER_KEY)
+                        .equals("Bearer my-api-key")));
   }
 
   @ComponentScan(


### PR DESCRIPTION
Fix some issues with API key auth:
* If the worker was not connected the SDK would try to make a health check call which is not namespaced so doesn't work well with API keys
* typo in the spring auto config
