### PR TITLE
Unblock UseExisting conflict policy for Nexux WorkflowRunOperation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -22,11 +22,9 @@ package io.temporal.internal.common;
 
 import com.google.common.base.Defaults;
 import io.nexusrpc.Header;
-import io.nexusrpc.handler.HandlerException;
 import io.nexusrpc.handler.ServiceImplInstance;
 import io.temporal.api.common.v1.Callback;
 import io.temporal.api.enums.v1.TaskQueueKind;
-import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.client.OnConflictOptions;
 import io.temporal.client.WorkflowOptions;
@@ -37,7 +35,6 @@ import io.temporal.common.metadata.WorkflowMethodType;
 import io.temporal.internal.client.NexusStartWorkflowRequest;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -155,16 +152,6 @@ public final class InternalUtils {
             .setAttachCompletionCallbacks(true)
             .build());
 
-    // TODO(klassenq) temporarily blocking conflict policy USE_EXISTING.
-    if (Objects.equals(
-        WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
-        options.getWorkflowIdConflictPolicy())) {
-      throw new HandlerException(
-          HandlerException.ErrorType.INTERNAL,
-          new IllegalArgumentException(
-              "Workflow ID conflict policy UseExisting is not supported for Nexus WorkflowRunOperation."),
-          HandlerException.RetryBehavior.NON_RETRYABLE);
-    }
     return stub.newInstance(nexusWorkflowOptions.build());
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.*;
 
-@Ignore("Skipping until we can support USE_EXISTING")
 public class WorkflowHandleUseExistingOnConflictCancelTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.*;
 
-@Ignore("Skipping until we can support USE_EXISTING")
 public class WorkflowHandleUseExistingOnConflictTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Unblock `UseExisting` conflict policy for Nexus `WorkflowRunOperation` (revert https://github.com/temporalio/sdk-java/pull/2428).

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
