### PR TITLE
Fix NPE for async activity testing

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/ActivityTestingTest.java
@@ -76,12 +76,35 @@ public class ActivityTestingTest {
     }
   }
 
+  @ActivityInterface
+  public interface TestAsyncActivity {
+
+    void asyncActivity(String input);
+  }
+
+  private static class AsyncActivityImpl implements TestAsyncActivity {
+
+    @Override
+    public void asyncActivity(String input) {
+      ActivityExecutionContext executionContext = Activity.getExecutionContext();
+      executionContext.doNotCompleteOnReturn();
+    }
+  }
+
   @Test
   public void testSuccess() {
     testEnvironment.registerActivitiesImplementations(new ActivityImpl());
     TestActivity activity = testEnvironment.newActivityStub(TestActivity.class);
     String result = activity.activity1("input1");
     assertEquals("Activity1-input1", result);
+  }
+
+  @Test
+  public void testAsyncActivity() {
+    testEnvironment.registerActivitiesImplementations(new AsyncActivityImpl());
+    TestAsyncActivity activity = testEnvironment.newActivityStub(TestAsyncActivity.class);
+
+    activity.asyncActivity("input1");
   }
 
   private static class AngryActivityImpl implements TestActivity {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -518,7 +518,10 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
         return dataConverter.fromPayloads(0, result, resultClass, resultType);
       } else {
         RespondActivityTaskFailedRequest taskFailed =
-            response.getTaskFailed().getTaskFailedRequest();
+            Optional.ofNullable(response.getTaskFailed())
+                .map(Result.TaskFailedResult::getTaskFailedRequest)
+                .orElse(null);
+
         if (taskFailed != null) {
           Exception cause = dataConverter.failureToException(taskFailed.getFailure());
           throw new ActivityFailure(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Null-safe navigation for response.getTaskFailed was implemented
## Why?
because taskFaild is null for async activities
## Checklist
<!--- add/delete as needed --->

1. Closes [2097](https://github.com/temporalio/sdk-java/issues/2097)

2. How was this tested:
with a unit test.
3. Any docs updates needed?
No
