### PR TITLE
Add Workflow Info on activity cancellation and failure logs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
@@ -117,15 +117,23 @@ final class ActivityTaskExecutors {
         boolean local = info.isLocal();
         if (ex instanceof ActivityCanceledException) {
           log.info(
-              "{} canceled. ActivityId={}, activityType={}, attempt={}",
+              "{} canceled. Namespace={}, TaskQueue={}, WorkflowId={}, RunId={}, ActivityId={}, activityType={}, attempt={}",
               local ? "Local activity" : "Activity",
+              info.getNamespace(),
+              info.getActivityTaskQueue(),
+              info.getWorkflowId(),
+              info.getRunId(),
               info.getActivityId(),
               info.getActivityType(),
               info.getAttempt());
         } else {
           log.warn(
-              "{} failure. ActivityId={}, activityType={}, attempt={}",
+              "{} failure. Namespace={}, TaskQueue={}, WorkflowId={}, RunId={}, ActivityId={}, activityType={}, attempt={}",
               local ? "Local activity" : "Activity",
+              info.getNamespace(),
+              info.getActivityTaskQueue(),
+              info.getWorkflowId(),
+              info.getRunId(),
               info.getActivityId(),
               info.getActivityType(),
               info.getAttempt(),


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
Add the WorkflowId on activity cancelled and failure logs to make it easier to find the effected workflow.


## Why?
Users can quickly identify which workflow an activity failure belongs to.

This also is inline with [Go's version](https://github.com/temporalio/sdk-go/blob/master/internal/internal_task_handlers.go#L2286-L2288) and other SDKs.
