### PR TITLE
Align root workflow execution with real server

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
@@ -127,15 +127,19 @@ final class WorkflowInfoImpl implements WorkflowInfo {
         : Optional.of(parentWorkflowExecution.getRunId());
   }
 
-  public String getRootWorkflowId() {
+  public Optional<String> getRootWorkflowId() {
     WorkflowExecution rootWorkflowExecution = context.getRootWorkflowExecution();
-    return rootWorkflowExecution == null ? null : rootWorkflowExecution.getWorkflowId();
+    return rootWorkflowExecution == null
+        ? Optional.empty()
+        : Optional.of(rootWorkflowExecution.getWorkflowId());
   }
 
   @Override
-  public String getRootRunId() {
+  public Optional<String> getRootRunId() {
     WorkflowExecution rootWorkflowExecution = context.getRootWorkflowExecution();
-    return rootWorkflowExecution == null ? null : rootWorkflowExecution.getRunId();
+    return rootWorkflowExecution == null
+        ? Optional.empty()
+        : Optional.of(rootWorkflowExecution.getRunId());
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -140,19 +140,17 @@ public interface WorkflowInfo {
 
   /**
    * @return Workflow ID of the root Workflow
-   * @apiNote On server versions prior to v1.27.0, this method will return null. Otherwise, it will
-   *     always return a non-null value.
+   * @apiNote On server versions prior to v1.27.0, this method will be empty. Otherwise, it will be
+   *     empty if the workflow is its own root.
    */
-  @Nullable
-  String getRootWorkflowId();
+  Optional<String> getRootWorkflowId();
 
   /**
    * @return Run ID of the root Workflow
-   * @apiNote On server versions prior to v1.27.0, this method will return null. Otherwise, it will
-   *     always return a non-null value.
+   * @apiNote On server versions prior to v1.27.0, this method will be empty. Otherwise, it will be
+   *     empty if the workflow is its own root.
    */
-  @Nullable
-  String getRootRunId();
+  Optional<String> getRootRunId();
 
   /**
    * @return Workflow retry attempt handled by this Workflow code execution. Starts on "1".

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetRootWorkflowExecutionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetRootWorkflowExecutionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GetRootWorkflowExecutionTest {
+  private static final TestActivities.VariousTestActivities activitiesImpl =
+      new TestActivities.TestActivitiesImpl();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(activitiesImpl)
+          .build();
+
+  @Test
+  public void getRootWorkflowExecution() {
+    TestWorkflows.TestWorkflowReturnString workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(
+            TestWorkflows.TestWorkflowReturnString.class);
+    String workflowId = workflowStub.execute();
+    assertEquals(
+        "empty " + WorkflowStub.fromTyped(workflowStub).getExecution().getWorkflowId(), workflowId);
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.TestWorkflowReturnString {
+
+    @Override
+    public String execute() {
+      String result = Workflow.getInfo().getRootWorkflowId().orElse("empty");
+      if (!Workflow.getInfo().getParentWorkflowId().isPresent()) {
+        result += " ";
+        result +=
+            Workflow.newChildWorkflowStub(TestWorkflows.TestWorkflowReturnString.class).execute();
+      }
+      return result;
+    }
+  }
+}

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1351,9 +1351,11 @@ class StateMachines {
       ExecutionId parentExecutionId = parent.get().getExecutionId();
       a.setParentWorkflowNamespace(parentExecutionId.getNamespace());
       a.setParentWorkflowExecution(parentExecutionId.getExecution());
+      // This mimics the real server behaviour where the root execution is only set in history
+      // if the workflow has a parent.
+      ExecutionId rootExecutionId = ctx.getWorkflowMutableState().getRoot().getExecutionId();
+      a.setRootWorkflowExecution(rootExecutionId.getExecution());
     }
-    ExecutionId rootExecutionId = ctx.getWorkflowMutableState().getRoot().getExecutionId();
-    a.setRootWorkflowExecution(rootExecutionId.getExecution());
     HistoryEvent.Builder event =
         HistoryEvent.newBuilder()
             .setEventType(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED)


### PR DESCRIPTION
Align root workflow execution with real server. The real server does not set `rootWorkflowExecution` if a workflow is its own root in history. This change makes sure the test server respects that behaviour. Also change the API since it is more likely for a `null` value to be present. No backwards compatibility concerns since this API has not been release yet.  