### PR TITLE
Make sure user metadata is set on WorkflowExecutionStartedEvent

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowMetadataTest.java
@@ -70,12 +70,27 @@ public class ChildWorkflowMetadataTest {
 
     WorkflowExecution exec = WorkflowStub.fromTyped(stub).getExecution();
     assertWorkflowMetadata(exec.getWorkflowId(), summary, details);
-    assertWorkflowMetadata(childWorkflowId, childSummary, childDetails);
 
     WorkflowExecutionHistory workflowExecutionHistory =
-        testWorkflowRule.getWorkflowClient().fetchHistory(childWorkflowId);
-    List<HistoryEvent> timerStartedEvents =
+        testWorkflowRule.getWorkflowClient().fetchHistory(exec.getWorkflowId());
+    List<HistoryEvent> workflowStartedEvents =
         workflowExecutionHistory.getEvents().stream()
+            .filter(HistoryEvent::hasWorkflowExecutionStartedEventAttributes)
+            .collect(Collectors.toList());
+    assertEventMetadata(workflowStartedEvents.get(0), summary, details);
+
+    assertWorkflowMetadata(childWorkflowId, childSummary, childDetails);
+
+    WorkflowExecutionHistory childWorkflowExecutionHistory =
+        testWorkflowRule.getWorkflowClient().fetchHistory(childWorkflowId);
+    List<HistoryEvent> childWorkflowStartedEvents =
+        childWorkflowExecutionHistory.getEvents().stream()
+            .filter(HistoryEvent::hasWorkflowExecutionStartedEventAttributes)
+            .collect(Collectors.toList());
+    assertEventMetadata(childWorkflowStartedEvents.get(0), childSummary, childDetails);
+
+    List<HistoryEvent> timerStartedEvents =
+        childWorkflowExecutionHistory.getEvents().stream()
             .filter(HistoryEvent::hasTimerStartedEventAttributes)
             .collect(Collectors.toList());
     assertEventMetadata(timerStartedEvents.get(0), childTimerSummary, null);

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1363,6 +1363,9 @@ class StateMachines {
     if (request.getLinksCount() > 0) {
       event.addAllLinks(request.getLinksList());
     }
+    if (request.hasUserMetadata()) {
+      event.setUserMetadata(request.getUserMetadata());
+    }
     ctx.addEvent(event.build());
   }
 


### PR DESCRIPTION
Make sure user metadata is set on WorkflowExecutionStartedEvent

closes https://github.com/temporalio/sdk-java/issues/2494