### PR TITLE
Add interceptor support to springboot integration

### DIFF
--- a/temporal-spring-boot-autoconfigure/README.md
+++ b/temporal-spring-boot-autoconfigure/README.md
@@ -184,8 +184,9 @@ Note: Worker whose name is not explicitly specified is named after it's Task Que
 
 ## Interceptors
 
-To enable interceptors create beans implementing the `io.temporal.common.interceptors.WorkflowClientInterceptor` interface or `io.temporal.common.interceptors.WorkerInterceptor` interface. 
-Interceptors will be registered in the order specified by the `@Order` annotation.
+To enable interceptors users can create beans implementing the `io.temporal.common.interceptors.WorkflowClientInterceptor`
+, `io.temporal.common.interceptors.ScheduleClientInterceptor`, or `io.temporal.common.interceptors.WorkerInterceptor` 
+interface. Interceptors will be registered in the order specified by the `@Order` annotation.
 
 ## Customization of `*Options`
 
@@ -288,7 +289,7 @@ spring.temporal:
 ## Customization
 
 All customization points for the root namespace also exist for the non-root namespaces. To specify for a particular 
-namespace users just need to append the alias/namespace to the bean. Currently interceptors are not supported.
+namespace users just need to append the alias/namespace to the bean. Currently, interceptors are not supported.
 
 ```java
     // TemporalOptionsCustomizer type beans must start with the namespace/alias you defined and end with function class 

--- a/temporal-spring-boot-autoconfigure/README.md
+++ b/temporal-spring-boot-autoconfigure/README.md
@@ -182,6 +182,11 @@ Task Queue names directly for simplicity.
 
 Note: Worker whose name is not explicitly specified is named after it's Task Queue.
 
+## Interceptors
+
+To enable interceptors create beans implementing the `io.temporal.common.interceptors.WorkflowClientInterceptor` interface or `io.temporal.common.interceptors.WorkerInterceptor` interface. 
+Interceptors will be registered in the order specified by the `@Order` annotation.
+
 ## Customization of `*Options`
 
 To provide freedom in customization of `*Options` instances that are created by this module,
@@ -283,7 +288,7 @@ spring.temporal:
 ## Customization
 
 All customization points for the root namespace also exist for the non-root namespaces. To specify for a particular 
-namespace users just need to append the alias/namespace to the bean.
+namespace users just need to append the alias/namespace to the bean. Currently interceptors are not supported.
 
 ```java
     // TemporalOptionsCustomizer type beans must start with the namespace/alias you defined and end with function class 

--- a/temporal-spring-boot-autoconfigure/README.md
+++ b/temporal-spring-boot-autoconfigure/README.md
@@ -289,7 +289,8 @@ spring.temporal:
 ## Customization
 
 All customization points for the root namespace also exist for the non-root namespaces. To specify for a particular 
-namespace users just need to append the alias/namespace to the bean. Currently, interceptors are not supported.
+namespace users just need to append the alias/namespace to the bean. Currently, auto registered interceptors are not 
+supported, but `WorkerFactoryOptions` can always be used to customize it per namespace.
 
 ```java
     // TemporalOptionsCustomizer type beans must start with the namespace/alias you defined and end with function class 

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/AutoConfigurationUtils.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/AutoConfigurationUtils.java
@@ -2,6 +2,9 @@ package io.temporal.spring.boot.autoconfigure;
 
 import com.google.common.base.MoreObjects;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
+import io.temporal.common.interceptors.WorkerInterceptor;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.NonRootNamespaceProperties;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
@@ -17,7 +20,7 @@ import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 class AutoConfigurationUtils {
 
   @Nullable
-  static DataConverter choseDataConverter(
+  static DataConverter chooseDataConverter(
       List<DataConverter> dataConverters, DataConverter mainDataConverter) {
     DataConverter chosenDataConverter = null;
     if (dataConverters.size() == 1) {
@@ -38,7 +41,7 @@ class AutoConfigurationUtils {
   }
 
   @Nullable
-  static DataConverter choseDataConverter(
+  static DataConverter chooseDataConverter(
       Map<String, DataConverter> dataConverters,
       DataConverter mainDataConverter,
       TemporalProperties properties) {
@@ -47,7 +50,7 @@ class AutoConfigurationUtils {
     }
     List<NonRootNamespaceProperties> nonRootNamespaceProperties = properties.getNamespaces();
     if (Objects.isNull(nonRootNamespaceProperties) || nonRootNamespaceProperties.isEmpty()) {
-      return choseDataConverter(new ArrayList<>(dataConverters.values()), mainDataConverter);
+      return chooseDataConverter(new ArrayList<>(dataConverters.values()), mainDataConverter);
     } else {
       List<DataConverter> dataConverterList = new ArrayList<>();
       List<String> nonRootBeanNames =
@@ -69,8 +72,26 @@ class AutoConfigurationUtils {
         }
         dataConverterList.add(dataConverter);
       }
-      return choseDataConverter(dataConverterList, mainDataConverter);
+      return chooseDataConverter(dataConverterList, mainDataConverter);
     }
+  }
+
+  @Nullable
+  static List<WorkflowClientInterceptor> chooseWorkflowClientInterceptors(
+      List<WorkflowClientInterceptor> workflowClientInterceptors, TemporalProperties properties) {
+    return workflowClientInterceptors;
+  }
+
+  @Nullable
+  static List<ScheduleClientInterceptor> chooseScheduleClientInterceptors(
+      List<ScheduleClientInterceptor> scheduleClientInterceptor, TemporalProperties properties) {
+    return scheduleClientInterceptor;
+  }
+
+  @Nullable
+  static List<WorkerInterceptor> chooseWorkerInterceptors(
+      List<WorkerInterceptor> workerInterceptor, TemporalProperties properties) {
+    return workerInterceptor;
   }
 
   static <T> TemporalOptionsCustomizer<T> chooseTemporalCustomizerBean(

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NonRootBeanPostProcessor.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NonRootBeanPostProcessor.java
@@ -109,6 +109,9 @@ public class NonRootBeanPostProcessor implements BeanPostProcessor, BeanFactoryA
             ns,
             workflowServiceStubs,
             dataConverterByNamespace,
+            null, // Currently interceptors are not supported in non-root namespace
+            null,
+            null,
             tracer,
             testWorkflowEnvironment,
             workFactoryCustomizer,

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/ClientTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/ClientTemplate.java
@@ -7,8 +7,11 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.schedules.ScheduleClient;
 import io.temporal.client.schedules.ScheduleClientOptions;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -24,6 +27,8 @@ public class ClientTemplate {
   public ClientTemplate(
       @Nonnull String namespace,
       @Nullable DataConverter dataConverter,
+      @Nullable List<WorkflowClientInterceptor> workflowClientInterceptors,
+      @Nullable List<ScheduleClientInterceptor> scheduleClientInterceptors,
       @Nullable Tracer tracer,
       @Nullable WorkflowServiceStubs workflowServiceStubs,
       @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
@@ -31,7 +36,13 @@ public class ClientTemplate {
       @Nullable TemporalOptionsCustomizer<ScheduleClientOptions.Builder> scheduleCustomer) {
     this.optionsTemplate =
         new WorkflowClientOptionsTemplate(
-            namespace, dataConverter, tracer, clientCustomizer, scheduleCustomer);
+            namespace,
+            dataConverter,
+            workflowClientInterceptors,
+            scheduleClientInterceptors,
+            tracer,
+            clientCustomizer,
+            scheduleCustomer);
     this.workflowServiceStubs = workflowServiceStubs;
     this.testWorkflowEnvironment = testWorkflowEnvironment;
   }

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/NamespaceTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/NamespaceTemplate.java
@@ -4,12 +4,16 @@ import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.schedules.ScheduleClientOptions;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
+import io.temporal.common.interceptors.WorkerInterceptor;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.WorkflowImplementationOptions;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -17,6 +21,9 @@ public class NamespaceTemplate {
   private final @Nonnull NamespaceProperties namespaceProperties;
   private final @Nonnull WorkflowServiceStubs workflowServiceStubs;
   private final @Nullable DataConverter dataConverter;
+  private final @Nullable List<WorkflowClientInterceptor> workflowClientInterceptors;
+  private final @Nullable List<ScheduleClientInterceptor> scheduleClientInterceptors;
+  private final @Nullable List<WorkerInterceptor> workerInterceptors;
   private final @Nullable Tracer tracer;
   private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
 
@@ -36,6 +43,9 @@ public class NamespaceTemplate {
       @Nonnull NamespaceProperties namespaceProperties,
       @Nonnull WorkflowServiceStubs workflowServiceStubs,
       @Nullable DataConverter dataConverter,
+      @Nullable List<WorkflowClientInterceptor> workflowClientInterceptors,
+      @Nullable List<ScheduleClientInterceptor> scheduleClientInterceptors,
+      @Nullable List<WorkerInterceptor> workerInterceptors,
       @Nullable Tracer tracer,
       @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
       @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer,
@@ -48,6 +58,9 @@ public class NamespaceTemplate {
     this.namespaceProperties = namespaceProperties;
     this.workflowServiceStubs = workflowServiceStubs;
     this.dataConverter = dataConverter;
+    this.workflowClientInterceptors = workflowClientInterceptors;
+    this.scheduleClientInterceptors = scheduleClientInterceptors;
+    this.workerInterceptors = workerInterceptors;
     this.tracer = tracer;
     this.testWorkflowEnvironment = testWorkflowEnvironment;
 
@@ -64,6 +77,8 @@ public class NamespaceTemplate {
           new ClientTemplate(
               namespaceProperties.getNamespace(),
               dataConverter,
+              workflowClientInterceptors,
+              scheduleClientInterceptors,
               tracer,
               workflowServiceStubs,
               testWorkflowEnvironment,
@@ -79,6 +94,7 @@ public class NamespaceTemplate {
           new WorkersTemplate(
               namespaceProperties,
               getClientTemplate(),
+              workerInterceptors,
               tracer,
               testWorkflowEnvironment,
               workerFactoryCustomizer,

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/NonRootNamespaceTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/NonRootNamespaceTemplate.java
@@ -4,12 +4,16 @@ import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.schedules.ScheduleClientOptions;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
+import io.temporal.common.interceptors.WorkerInterceptor;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.NonRootNamespaceProperties;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.WorkflowImplementationOptions;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.springframework.beans.factory.BeanFactory;
@@ -24,6 +28,9 @@ public class NonRootNamespaceTemplate extends NamespaceTemplate {
       @Nonnull NonRootNamespaceProperties namespaceProperties,
       @Nonnull WorkflowServiceStubs workflowServiceStubs,
       @Nullable DataConverter dataConverter,
+      @Nullable List<WorkflowClientInterceptor> workflowClientInterceptors,
+      @Nullable List<ScheduleClientInterceptor> scheduleClientInterceptors,
+      @Nullable List<WorkerInterceptor> workerInterceptors,
       @Nullable Tracer tracer,
       @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
       @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer,
@@ -37,6 +44,9 @@ public class NonRootNamespaceTemplate extends NamespaceTemplate {
         namespaceProperties,
         workflowServiceStubs,
         dataConverter,
+        workflowClientInterceptors,
+        scheduleClientInterceptors,
+        workerInterceptors,
         tracer,
         testWorkflowEnvironment,
         workerFactoryCustomizer,

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerFactoryOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerFactoryOptionsTemplate.java
@@ -1,25 +1,32 @@
 package io.temporal.spring.boot.autoconfigure.template;
 
 import io.opentracing.Tracer;
+import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.opentracing.OpenTracingWorkerInterceptor;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.worker.WorkerFactoryOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class WorkerFactoryOptionsTemplate {
   private final @Nonnull NamespaceProperties namespaceProperties;
+  private final @Nullable List<WorkerInterceptor> workerInterceptors;
   private final @Nullable Tracer tracer;
   private final @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> customizer;
 
   public WorkerFactoryOptionsTemplate(
       @Nonnull NamespaceProperties namespaceProperties,
+      @Nullable List<WorkerInterceptor> workerInterceptors,
       @Nullable Tracer tracer,
       @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> customizer) {
     this.namespaceProperties = namespaceProperties;
+    this.workerInterceptors = workerInterceptors;
     this.tracer = tracer;
     this.customizer = customizer;
   }
@@ -38,12 +45,15 @@ public class WorkerFactoryOptionsTemplate {
           .ifPresent(options::setUsingVirtualWorkflowThreads);
     }
 
+    List<WorkerInterceptor> interceptors =
+        new ArrayList<>(workerInterceptors != null ? workerInterceptors : Collections.EMPTY_LIST);
     if (tracer != null) {
       OpenTracingWorkerInterceptor openTracingClientInterceptor =
           new OpenTracingWorkerInterceptor(
               OpenTracingOptions.newBuilder().setTracer(tracer).build());
-      options.setWorkerInterceptors(openTracingClientInterceptor);
+      interceptors.add(openTracingClientInterceptor);
     }
+    options.setWorkerInterceptors(interceptors.stream().toArray(WorkerInterceptor[]::new));
 
     if (customizer != null) {
       options = customizer.customize(options);

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerFactoryOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkerFactoryOptionsTemplate.java
@@ -8,7 +8,6 @@ import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.worker.WorkerFactoryOptions;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -45,13 +44,15 @@ public class WorkerFactoryOptionsTemplate {
           .ifPresent(options::setUsingVirtualWorkflowThreads);
     }
 
-    List<WorkerInterceptor> interceptors =
-        new ArrayList<>(workerInterceptors != null ? workerInterceptors : Collections.EMPTY_LIST);
+    List<WorkerInterceptor> interceptors = new ArrayList<>();
     if (tracer != null) {
       OpenTracingWorkerInterceptor openTracingClientInterceptor =
           new OpenTracingWorkerInterceptor(
               OpenTracingOptions.newBuilder().setTracer(tracer).build());
       interceptors.add(openTracingClientInterceptor);
+    }
+    if (workerInterceptors != null) {
+      interceptors.addAll(workerInterceptors);
     }
     options.setWorkerInterceptors(interceptors.stream().toArray(WorkerInterceptor[]::new));
 

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -9,6 +9,7 @@ import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.Experimental;
 import io.temporal.common.converter.EncodedValues;
+import io.temporal.common.interceptors.WorkerInterceptor;
 import io.temporal.common.metadata.POJOActivityImplMetadata;
 import io.temporal.common.metadata.POJOWorkflowImplMetadata;
 import io.temporal.common.metadata.POJOWorkflowMethodMetadata;
@@ -50,6 +51,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
 
   private final @Nonnull NamespaceProperties namespaceProperties;
   private final ClientTemplate clientTemplate;
+  private final @Nullable List<WorkerInterceptor> workerInterceptors;
   private final @Nullable Tracer tracer;
   // if not null, we work with an environment with defined test server
   private final @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment;
@@ -71,6 +73,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
   public WorkersTemplate(
       @Nonnull NamespaceProperties namespaceProperties,
       @Nullable ClientTemplate clientTemplate,
+      @Nullable List<WorkerInterceptor> workerInterceptors,
       @Nullable Tracer tracer,
       @Nullable TestWorkflowEnvironmentAdapter testWorkflowEnvironment,
       @Nullable TemporalOptionsCustomizer<WorkerFactoryOptions.Builder> workerFactoryCustomizer,
@@ -79,6 +82,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
           TemporalOptionsCustomizer<WorkflowImplementationOptions.Builder>
               workflowImplementationCustomizer) {
     this.namespaceProperties = namespaceProperties;
+    this.workerInterceptors = workerInterceptors;
     this.tracer = tracer;
     this.testWorkflowEnvironment = testWorkflowEnvironment;
     this.clientTemplate = clientTemplate;
@@ -120,7 +124,8 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
       return testWorkflowEnvironment.getWorkerFactory();
     } else {
       WorkerFactoryOptions workerFactoryOptions =
-          new WorkerFactoryOptionsTemplate(namespaceProperties, tracer, workerFactoryCustomizer)
+          new WorkerFactoryOptionsTemplate(
+                  namespaceProperties, workerInterceptors, tracer, workerFactoryCustomizer)
               .createWorkerFactoryOptions();
       return WorkerFactory.newInstance(workflowClient, workerFactoryOptions);
     }

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
@@ -4,9 +4,14 @@ import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.schedules.ScheduleClientOptions;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.ScheduleClientInterceptor;
+import io.temporal.common.interceptors.WorkflowClientInterceptor;
 import io.temporal.opentracing.OpenTracingClientInterceptor;
 import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -14,6 +19,8 @@ import javax.annotation.Nullable;
 public class WorkflowClientOptionsTemplate {
   private final @Nonnull String namespace;
   private final @Nullable DataConverter dataConverter;
+  private final @Nullable List<WorkflowClientInterceptor> workflowClientInterceptors;
+  private final @Nullable List<ScheduleClientInterceptor> scheduleClientInterceptors;
   private final @Nullable Tracer tracer;
   private final @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer;
   private final @Nullable TemporalOptionsCustomizer<ScheduleClientOptions.Builder>
@@ -22,11 +29,15 @@ public class WorkflowClientOptionsTemplate {
   public WorkflowClientOptionsTemplate(
       @Nonnull String namespace,
       @Nullable DataConverter dataConverter,
+      @Nullable List<WorkflowClientInterceptor> workflowClientInterceptors,
+      @Nullable List<ScheduleClientInterceptor> scheduleClientInterceptors,
       @Nullable Tracer tracer,
       @Nullable TemporalOptionsCustomizer<WorkflowClientOptions.Builder> clientCustomizer,
       @Nullable TemporalOptionsCustomizer<ScheduleClientOptions.Builder> scheduleCustomizer) {
     this.namespace = namespace;
     this.dataConverter = dataConverter;
+    this.workflowClientInterceptors = workflowClientInterceptors;
+    this.scheduleClientInterceptors = scheduleClientInterceptors;
     this.tracer = tracer;
     this.clientCustomizer = clientCustomizer;
     this.scheduleCustomizer = scheduleCustomizer;
@@ -37,12 +48,19 @@ public class WorkflowClientOptionsTemplate {
     options.setNamespace(namespace);
     Optional.ofNullable(dataConverter).ifPresent(options::setDataConverter);
 
+    List<WorkflowClientInterceptor> interceptors =
+        new ArrayList<>(
+            workflowClientInterceptors != null
+                ? workflowClientInterceptors
+                : Collections.EMPTY_LIST);
     if (tracer != null) {
       OpenTracingClientInterceptor openTracingClientInterceptor =
           new OpenTracingClientInterceptor(
               OpenTracingOptions.newBuilder().setTracer(tracer).build());
-      options.setInterceptors(openTracingClientInterceptor);
+      interceptors.add(openTracingClientInterceptor);
     }
+
+    options.setInterceptors(interceptors.stream().toArray(WorkflowClientInterceptor[]::new));
 
     if (clientCustomizer != null) {
       options = clientCustomizer.customize(options);
@@ -55,6 +73,9 @@ public class WorkflowClientOptionsTemplate {
     ScheduleClientOptions.Builder options = ScheduleClientOptions.newBuilder();
     options.setNamespace(namespace);
     Optional.ofNullable(dataConverter).ifPresent(options::setDataConverter);
+    if (scheduleClientInterceptors != null && !scheduleClientInterceptors.isEmpty()) {
+      options.setInterceptors(scheduleClientInterceptors);
+    }
 
     if (scheduleCustomizer != null) {
       options = scheduleCustomizer.customize(options);

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkflowClientOptionsTemplate.java
@@ -10,7 +10,6 @@ import io.temporal.opentracing.OpenTracingClientInterceptor;
 import io.temporal.opentracing.OpenTracingOptions;
 import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -48,16 +47,15 @@ public class WorkflowClientOptionsTemplate {
     options.setNamespace(namespace);
     Optional.ofNullable(dataConverter).ifPresent(options::setDataConverter);
 
-    List<WorkflowClientInterceptor> interceptors =
-        new ArrayList<>(
-            workflowClientInterceptors != null
-                ? workflowClientInterceptors
-                : Collections.EMPTY_LIST);
+    List<WorkflowClientInterceptor> interceptors = new ArrayList<>();
     if (tracer != null) {
       OpenTracingClientInterceptor openTracingClientInterceptor =
           new OpenTracingClientInterceptor(
               OpenTracingOptions.newBuilder().setTracer(tracer).build());
       interceptors.add(openTracingClientInterceptor);
+    }
+    if (workflowClientInterceptors != null) {
+      interceptors.addAll(workflowClientInterceptors);
     }
 
     options.setInterceptors(interceptors.stream().toArray(WorkflowClientInterceptor[]::new));

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/InterceptorsTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/InterceptorsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this material except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.common.interceptors.WorkerInterceptor;
+import io.temporal.common.interceptors.WorkerInterceptorBase;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
+import io.temporal.spring.boot.autoconfigure.template.NamespaceTemplate;
+import io.temporal.testing.TestWorkflowEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = InterceptorsTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InterceptorsTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired TestWorkflowEnvironment testWorkflowEnvironment;
+
+  @Autowired WorkflowClient workflowClient;
+
+  @Autowired WorkerInterceptor spyWorkerInterceptor;
+
+  @Autowired NamespaceTemplate namespaceTemplate;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testCustomInterceptorBeanIsPickedUpByTestWorkflowEnvironment() {
+    TestWorkflow testWorkflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue("UnitTest").build());
+    testWorkflow.execute("input");
+    verify(spyWorkerInterceptor, atLeastOnce()).interceptWorkflow(any());
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {
+
+    @Bean
+    public WorkerInterceptor spyWorkerInterceptor() {
+      WorkerInterceptor result = spy(new SpringWorkerInterceptor());
+      return result;
+    }
+
+    public static class SpringWorkerInterceptor extends WorkerInterceptorBase {
+      SpringWorkerInterceptor() {
+        super();
+      }
+    }
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/InterceptorsTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/InterceptorsTest.java
@@ -1,23 +1,3 @@
-/*
- * Copyright (C) 2022 Temporal Technologies, Inc. All Rights Reserved.
- *
- * Copyright (C) 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Modifications copyright (C) 2017 Uber Technologies, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this material except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.temporal.spring.boot.autoconfigure;
 
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
Add interceptor support to Springboot integration. With this PR any interceptor bean will be automatically picked up and registered with the worker/client. Similar to Quarkus support for [interceptors](https://docs.quarkiverse.io/quarkus-temporal/dev/index.html#_interceptors) in Temporal.

Note: Currently not supported in multi namespace.

closes: https://github.com/temporalio/sdk-java/issues/1634
