### PR TITLE
Upgrade gRPC dependencies to 1.68.2 (#2508)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.58.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.68.2' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.14.2' // [2.9.0,)
     nexusVersion = '0.4.0-alpha'
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.

--- a/temporal-serviceclient/build.gradle
+++ b/temporal-serviceclient/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     api ("io.grpc:grpc-api") //Classes like io.grpc.Metadata are used as a part of our API
     api "io.grpc:grpc-stub" //Part of WorkflowServiceStubs API
+    api "io.grpc:grpc-protobuf" // Provides base classes used by generated gRPC code, such as io.grpc.protobuf.ProtoFileDescriptorSupplier
     api "io.grpc:grpc-netty-shaded" //Part of WorkflowServiceStubs API, specifically SslContext
     api "io.grpc:grpc-services" //Standard gRPC HealthCheck Response class
     api "io.grpc:grpc-inprocess" //For the in-process time skipping test server
@@ -67,7 +68,9 @@ sourceSets {
     proto {
         srcDir 'src/main/protocloud'
         // TODO(https://github.com/temporalio/api/issues/400): Remove this exclusion once the 3rd party protos are removed.
-        exclude '**/google/**/*'
+        // exclude '**/google/**/*'
+        // Commented out because newer versions of proto-google-common-protos no longer include compiled classes,
+        // only .proto files, so we need to generate the classes ourselves.
     }
   }
 }

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -453,9 +453,10 @@ public class SDKTestWorkflowRule implements TestRule {
       try {
         sink.write(json);
       } catch (IOException e) {
-        Throwables.propagateIfPossible(e, RuntimeException.class);
+        Throwables.throwIfInstanceOf(e, RuntimeException.class);
+        throw new RuntimeException(e);
       }
-      log.info("Regenerated history file: " + resourceFile);
+      log.info("Regenerated history file: {}", resourceFile);
     }
   }
 


### PR DESCRIPTION

## What was changed
Upgrade gRPC dependencies to 1.68.2 (#2508)

## Why?
The framework we are using is a newer version of grpc, which is not compatible with the current grpc version of the SDK, so we need to upgrade it. This should be a seamless upgrade for users
