### PR TITLE
Spring boot: fail creation if duplicate definitions detected

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
@@ -15,17 +15,21 @@ public class NamespaceProperties {
   private final @Nullable List<WorkerProperties> workers;
   private final @Nonnull String namespace;
   private final @Nullable WorkflowCacheProperties workflowCache;
+  private final @Nullable Boolean ignoreDuplicateDefinitions;
 
   @ConstructorBinding
   public NamespaceProperties(
       @Nullable String namespace,
       @Nullable WorkersAutoDiscoveryProperties workersAutoDiscovery,
       @Nullable List<WorkerProperties> workers,
-      @Nullable WorkflowCacheProperties workflowCache) {
+      @Nullable WorkflowCacheProperties workflowCache,
+      @Nullable Boolean ignoreDuplicateDefinitions) {
     this.workersAutoDiscovery = workersAutoDiscovery;
     this.workers = workers;
     this.namespace = MoreObjects.firstNonNull(namespace, NAMESPACE_DEFAULT);
     this.workflowCache = workflowCache;
+    this.ignoreDuplicateDefinitions =
+        MoreObjects.firstNonNull(ignoreDuplicateDefinitions, Boolean.TRUE);
   }
 
   @Nullable
@@ -49,6 +53,11 @@ public class NamespaceProperties {
   @Nullable
   public WorkflowCacheProperties getWorkflowCache() {
     return workflowCache;
+  }
+
+  @Nonnull
+  public Boolean isIgnoreDuplicateDefinitions() {
+    return Boolean.TRUE;
   }
 
   public static class WorkflowCacheProperties {

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NonRootNamespaceProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NonRootNamespaceProperties.java
@@ -43,8 +43,9 @@ public class NonRootNamespaceProperties extends NamespaceProperties {
       @Nullable List<WorkerProperties> workers,
       @Nullable WorkflowCacheProperties workflowCache,
       @Nullable ConnectionProperties connection,
-      @Nullable Boolean startWorkers) {
-    super(namespace, workersAutoDiscovery, workers, workflowCache);
+      @Nullable Boolean startWorkers,
+      @Nullable Boolean ignoreDuplicateDefinitions) {
+    super(namespace, workersAutoDiscovery, workers, workflowCache, ignoreDuplicateDefinitions);
     this.alias = alias;
     this.connection = connection;
     this.startWorkers = startWorkers;

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TemporalProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/TemporalProperties.java
@@ -24,8 +24,9 @@ public class TemporalProperties extends NamespaceProperties {
       @Nullable WorkflowCacheProperties workflowCache,
       @Nonnull ConnectionProperties connection,
       @Nullable TestServerProperties testServer,
-      @Nullable Boolean startWorkers) {
-    super(namespace, workersAutoDiscovery, workers, workflowCache);
+      @Nullable Boolean startWorkers,
+      @Nullable Boolean ignoreDuplicateDefinitions) {
+    super(namespace, workersAutoDiscovery, workers, workflowCache, ignoreDuplicateDefinitions);
     this.connection = connection;
     this.testServer = testServer;
     this.startWorkers = startWorkers;

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -432,6 +432,9 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             worker.getTaskQueue(),
             registeredEx.getRegisteredTypeName());
       }
+      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
+        throw registeredEx;
+      }
     }
   }
 
@@ -468,6 +471,9 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             worker.getTaskQueue(),
             registeredEx.getRegisteredTypeName());
       }
+      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
+        throw registeredEx;
+      }
     }
   }
 
@@ -491,6 +497,9 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             byWorkerName != null ? "'" + byWorkerName + "' " : "",
             worker.getTaskQueue(),
             registeredEx.getRegisteredTypeName());
+      }
+      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
+        throw registeredEx;
       }
     }
   }


### PR DESCRIPTION
Spring boot fail creation if duplicate definitions detected. This matches the behaviour of the regular Java SDK and most other SDKs. Users can still disable this with a new config.

closes https://github.com/temporalio/sdk-java/issues/2434
