### PR TITLE
Make CancellationScopeImpl more deterministic

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlag.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlag.java
@@ -14,6 +14,10 @@ public enum SdkFlag {
    * Changes behavior of GetVersion to never yield.
    */
   SKIP_YIELD_ON_VERSION(2),
+  /*
+   * Changes behavior of CancellationScope to cancel children in a deterministic order.
+   */
+  DETERMINISTIC_CANCELLATION_SCOPE_ORDER(3),
   UNKNOWN(Integer.MAX_VALUE);
 
   private final int value;

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/CancellationScopeImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/CancellationScopeImpl.java
@@ -33,8 +33,9 @@ class CancellationScopeImpl implements CancellationScope {
 
   private final Runnable runnable;
   private CancellationScopeImpl parent;
-  // We use a LinkedHashSet because we will iterate through the children, so we need to keep a deterministic order.
-  private final Set<CancellationScopeImpl> children = new LinkedHashSet<>();
+  // We use a LinkedHashSet because we will iterate through the children, so we need to keep a
+  // deterministic order.
+  private final Set<CancellationScopeImpl> children;
 
   /**
    * When disconnected scope has no parent and thus doesn't receive cancellation requests from it.
@@ -43,20 +44,37 @@ class CancellationScopeImpl implements CancellationScope {
 
   private String reason;
 
-  CancellationScopeImpl(boolean ignoreParentCancellation, Runnable runnable) {
-    this(ignoreParentCancellation, runnable, current());
+  CancellationScopeImpl(
+      boolean ignoreParentCancellation, boolean deterministicOrder, Runnable runnable) {
+    this(ignoreParentCancellation, deterministicOrder, runnable, current());
   }
 
-  CancellationScopeImpl(boolean detached, Runnable runnable, CancellationScopeImpl parent) {
+  CancellationScopeImpl(
+      boolean detached,
+      boolean deterministicOrder,
+      Runnable runnable,
+      CancellationScopeImpl parent) {
     this.detached = detached;
     this.runnable = runnable;
+    if (deterministicOrder) {
+      this.children = new LinkedHashSet<>();
+    } else {
+      this.children = new HashSet<>();
+    }
     setParent(parent);
   }
 
   public CancellationScopeImpl(
-      boolean ignoreParentCancellation, Functions.Proc1<CancellationScope> proc) {
+      boolean ignoreParentCancellation,
+      boolean deterministicOrder,
+      Functions.Proc1<CancellationScope> proc) {
     this.detached = ignoreParentCancellation;
     this.runnable = () -> proc.apply(this);
+    if (deterministicOrder) {
+      this.children = new LinkedHashSet<>();
+    } else {
+      this.children = new HashSet<>();
+    }
     setParent(current());
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/CancellationScopeImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/CancellationScopeImpl.java
@@ -1,10 +1,7 @@
 package io.temporal.internal.sync;
 
 import io.temporal.workflow.*;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 class CancellationScopeImpl implements CancellationScope {
 
@@ -36,7 +33,8 @@ class CancellationScopeImpl implements CancellationScope {
 
   private final Runnable runnable;
   private CancellationScopeImpl parent;
-  private final Set<CancellationScopeImpl> children = new HashSet<>();
+  // We use a LinkedHashSet because we will iterate through the children, so we need to keep a deterministic order.
+  private final Set<CancellationScopeImpl> children = new LinkedHashSet<>();
 
   /**
    * When disconnected scope has no parent and thus doesn't receive cancellation requests from it.

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.internal.WorkflowThreadMarker;
+import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.context.ContextThreadLocal;
 import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.serviceclient.CheckedExceptionWrapper;
@@ -157,7 +158,12 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     // a bad practice
     this.workflowContext.setRunner(this);
     this.cache = cache;
-    this.runnerCancellationScope = new CancellationScopeImpl(true, null, null);
+    boolean deterministicCancellationScopeOrder =
+        workflowContext
+            .getReplayContext()
+            .checkSdkFlag(SdkFlag.DETERMINISTIC_CANCELLATION_SCOPE_ORDER);
+    this.runnerCancellationScope =
+        new CancellationScopeImpl(true, deterministicCancellationScopeOrder, null, null);
     this.rootRunnable = root;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -24,6 +24,7 @@ import io.temporal.common.metadata.POJOWorkflowMethodMetadata;
 import io.temporal.internal.WorkflowThreadMarker;
 import io.temporal.internal.common.ActivityOptionUtils;
 import io.temporal.internal.common.NonIdempotentHandle;
+import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.common.SearchAttributesUtil;
 import io.temporal.internal.logging.ReplayAwareLogger;
 import io.temporal.internal.statemachines.UnsupportedContinueAsNewRequest;
@@ -546,12 +547,20 @@ public final class WorkflowInternal {
   }
 
   public static CancellationScope newCancellationScope(boolean detached, Runnable runnable) {
-    return new CancellationScopeImpl(detached, runnable);
+    boolean deterministicCancellationScopeOrder =
+        getRootWorkflowContext()
+            .getReplayContext()
+            .checkSdkFlag(SdkFlag.DETERMINISTIC_CANCELLATION_SCOPE_ORDER);
+    return new CancellationScopeImpl(detached, deterministicCancellationScopeOrder, runnable);
   }
 
   public static CancellationScope newCancellationScope(
       boolean detached, Functions.Proc1<CancellationScope> proc) {
-    return new CancellationScopeImpl(detached, proc);
+    boolean deterministicCancellationScopeOrder =
+        getRootWorkflowContext()
+            .getReplayContext()
+            .checkSdkFlag(SdkFlag.DETERMINISTIC_CANCELLATION_SCOPE_ORDER);
+    return new CancellationScopeImpl(detached, deterministicCancellationScopeOrder, proc);
   }
 
   public static CancellationScopeImpl currentCancellationScope() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadImpl.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.common.NonIdempotentHandle;
+import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.context.ContextThreadLocal;
 import io.temporal.internal.logging.LoggerTag;
 import io.temporal.internal.replay.ReplayWorkflowContext;
@@ -55,7 +56,11 @@ class WorkflowThreadImpl implements WorkflowThread {
       this.threadContext = threadContext;
       this.replayWorkflowContext = replayWorkflowContext;
       this.name = name;
-      this.cancellationScope = new CancellationScopeImpl(detached, runnable, parent);
+      boolean deterministicCancellationScopeOrder =
+          replayWorkflowContext.checkSdkFlag(SdkFlag.DETERMINISTIC_CANCELLATION_SCOPE_ORDER);
+      this.cancellationScope =
+          new CancellationScopeImpl(
+              detached, deterministicCancellationScopeOrder, runnable, parent);
       Preconditions.checkState(
           context.getStatus() == Status.CREATED, "threadContext not in CREATED state");
       this.contextPropagators = contextPropagators;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowCancellationScopeDeterminism.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowCancellationScopeDeterminism.java
@@ -1,0 +1,100 @@
+package io.temporal.workflow.cancellationTests;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.testing.WorkflowReplayer;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkflowCancellationScopeDeterminism {
+  private static final Logger log =
+      LoggerFactory.getLogger(WorkflowCancellationScopeDeterminism.class);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(new TestActivityImpl())
+          .setUseExternalService(true)
+          .build();
+
+  @Test(timeout = 1000000)
+  public void replayCanceledWorkflow() throws Exception {
+    for (int i = 0; i < 1000; i++) {
+      log.info("Running test iteration {}", i);
+      TestWorkflow testWorkflow = testWorkflowRule.newWorkflowStub(TestWorkflow.class);
+
+      WorkflowClient.start(testWorkflow::start);
+
+      WorkflowStub stub = WorkflowStub.fromTyped(testWorkflow);
+      stub.cancel();
+      try {
+        stub.getResult(Void.class);
+      } catch (Exception e) {
+        // ignore; just blocking to make sure workflow is actually finished
+      }
+
+      WorkflowExecutionHistory history =
+          testWorkflowRule
+              .getWorkflowClient()
+              .fetchHistory(stub.getExecution().getWorkflowId(), stub.getExecution().getRunId());
+      WorkflowReplayer.replayWorkflowExecution(history, testWorkflowRule.getWorker());
+    }
+  }
+
+  @Test
+  public void replayTest() throws Exception {
+    WorkflowReplayer.replayWorkflowExecutionFromResource(
+        "cancellationScopeDeterminism.json", TestWorkflowImpl.class);
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    void start();
+  }
+
+  @ActivityInterface
+  public interface TestActivity {
+    void doActivity();
+  }
+
+  public static class TestActivityImpl implements TestActivity {
+    @Override
+    public void doActivity() {
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflow {
+
+    TestActivity activity =
+        Workflow.newActivityStub(
+            TestActivity.class,
+            ActivityOptions.newBuilder().setScheduleToCloseTimeout(Duration.ofSeconds(60)).build());
+
+    @Override
+    public void start() {
+      CancellationScope scope = Workflow.newCancellationScope(() -> activity.doActivity());
+
+      Async.procedure(
+          () -> {
+            Workflow.sleep(Duration.ofMinutes(5));
+          });
+
+      scope.run();
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowCancellationScopeDeterminism.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowCancellationScopeDeterminism.java
@@ -5,19 +5,19 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.internal.common.SdkFlag;
+import io.temporal.internal.statemachines.WorkflowStateMachines;
 import io.temporal.testing.WorkflowReplayer;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class WorkflowCancellationScopeDeterminism {
-  private static final Logger log =
-      LoggerFactory.getLogger(WorkflowCancellationScopeDeterminism.class);
-
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
@@ -26,10 +26,15 @@ public class WorkflowCancellationScopeDeterminism {
           .setUseExternalService(true)
           .build();
 
-  @Test(timeout = 1000000)
+  @Before
+  public void setUp() {
+    WorkflowStateMachines.initialFlags =
+        Collections.unmodifiableList(Arrays.asList(SdkFlag.DETERMINISTIC_CANCELLATION_SCOPE_ORDER));
+  }
+
+  @Test(timeout = 60000)
   public void replayCanceledWorkflow() throws Exception {
-    for (int i = 0; i < 1000; i++) {
-      log.info("Running test iteration {}", i);
+    for (int i = 0; i < 100; i++) {
       TestWorkflow testWorkflow = testWorkflowRule.newWorkflowStub(TestWorkflow.class);
 
       WorkflowClient.start(testWorkflow::start);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowCancellationScopeDeterminism.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowCancellationScopeDeterminism.java
@@ -23,7 +23,6 @@ public class WorkflowCancellationScopeDeterminism {
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(TestWorkflowImpl.class)
           .setActivityImplementations(new TestActivityImpl())
-          .setUseExternalService(true)
           .build();
 
   @Before

--- a/temporal-sdk/src/test/resources/cancellationScopeDeterminism.json
+++ b/temporal-sdk/src/test/resources/cancellationScopeDeterminism.json
@@ -1,0 +1,197 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2025-05-07T16:31:45.402827Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "4053782",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "TestWorkflow"
+        },
+        "taskQueue": {
+          "name": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "0196ab96-befa-7c96-8adf-f3801ed7a09e",
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "firstExecutionRunId": "0196ab96-befa-7c96-8adf-f3801ed7a09e",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "03e7349c-652f-4a32-a3b2-9015bc5cc7fe"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2025-05-07T16:31:45.402919Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "4053783",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2025-05-07T16:31:45.412234Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "4053788",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "requestId": "d5db764e-cb78-43f7-b0fb-3e2c2d085c83",
+        "historySizeBytes": "407"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2025-05-07T16:31:45.541892Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "4053792",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "workerVersion": {},
+        "sdkMetadata": {
+          "langUsedFlags": [
+            1
+          ],
+          "sdkName": "temporal-java",
+          "sdkVersion": "1.23.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2025-05-07T16:31:45.541956Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "4053793",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "627e725e-c872-319c-a1d4-d03bb18bc572",
+        "activityType": {
+          "name": "DoActivity"
+        },
+        "taskQueue": {
+          "name": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "scheduleToCloseTimeout": "60s",
+        "scheduleToStartTimeout": "60s",
+        "startToCloseTimeout": "60s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s"
+        }
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2025-05-07T16:31:45.541989Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "taskId": "4053794",
+      "timerStartedEventAttributes": {
+        "timerId": "47c34e95-d85f-3834-80ed-8b58cebe2289",
+        "startToFireTimeout": "300s",
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2025-05-07T16:31:45.416574Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED",
+      "taskId": "4053795",
+      "workflowExecutionCancelRequestedEventAttributes": {
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2025-05-07T16:31:45.542001Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "4053796",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "93896@Quinn-Klassens-MacBook-Pro.local:8bb44ec5-1202-4757-a16d-ef65d158c965",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2025-05-07T16:31:45.547789Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "4053804",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "requestId": "c2a474e4-b040-4a90-bb0d-b8bb81f1f827",
+        "historySizeBytes": "1148"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2025-05-07T16:31:45.572751Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "4053810",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "workerVersion": {},
+        "sdkMetadata": {
+          "sdkName": "temporal-java",
+          "sdkVersion": "1.23.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2025-05-07T16:31:45.572813Z",
+      "eventType": "EVENT_TYPE_TIMER_CANCELED",
+      "taskId": "4053811",
+      "timerCanceledEventAttributes": {
+        "timerId": "47c34e95-d85f-3834-80ed-8b58cebe2289",
+        "startedEventId": "6",
+        "workflowTaskCompletedEventId": "10",
+        "identity": "93896@Quinn-Klassens-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2025-05-07T16:31:45.572824Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED",
+      "taskId": "4053812",
+      "activityTaskCancelRequestedEventAttributes": {
+        "scheduledEventId": "5",
+        "workflowTaskCompletedEventId": "10"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2025-05-07T16:31:45.572835Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED",
+      "taskId": "4053813",
+      "workflowExecutionCanceledEventAttributes": {
+        "workflowTaskCompletedEventId": "10"
+      }
+    }
+  ]
+}

--- a/temporal-sdk/src/test/resources/cancellationScopeDeterminism.json
+++ b/temporal-sdk/src/test/resources/cancellationScopeDeterminism.json
@@ -2,37 +2,37 @@
   "events": [
     {
       "eventId": "1",
-      "eventTime": "2025-05-07T16:31:45.402827Z",
+      "eventTime": "2025-05-07T17:40:05.525035Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
-      "taskId": "4053782",
+      "taskId": "4090963",
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
           "name": "TestWorkflow"
         },
         "taskQueue": {
-          "name": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8",
+          "name": "WorkflowTest-replayCanceledWorkflow-06329052-559e-4e2b-a33b-f324bc2c7822",
           "kind": "TASK_QUEUE_KIND_NORMAL"
         },
         "workflowExecutionTimeout": "0s",
         "workflowRunTimeout": "0s",
         "workflowTaskTimeout": "10s",
-        "originalExecutionRunId": "0196ab96-befa-7c96-8adf-f3801ed7a09e",
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
-        "firstExecutionRunId": "0196ab96-befa-7c96-8adf-f3801ed7a09e",
+        "originalExecutionRunId": "0196abd5-4f15-7084-ae26-a03ef0d62ba7",
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local",
+        "firstExecutionRunId": "0196abd5-4f15-7084-ae26-a03ef0d62ba7",
         "attempt": 1,
         "firstWorkflowTaskBackoff": "0s",
         "header": {},
-        "workflowId": "03e7349c-652f-4a32-a3b2-9015bc5cc7fe"
+        "workflowId": "f73757fe-34ca-480e-8730-f30aee26558f"
       }
     },
     {
       "eventId": "2",
-      "eventTime": "2025-05-07T16:31:45.402919Z",
+      "eventTime": "2025-05-07T17:40:05.525136Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
-      "taskId": "4053783",
+      "taskId": "4090964",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8",
+          "name": "WorkflowTest-replayCanceledWorkflow-06329052-559e-4e2b-a33b-f324bc2c7822",
           "kind": "TASK_QUEUE_KIND_NORMAL"
         },
         "startToCloseTimeout": "10s",
@@ -41,29 +41,29 @@
     },
     {
       "eventId": "3",
-      "eventTime": "2025-05-07T16:31:45.412234Z",
+      "eventTime": "2025-05-07T17:40:05.529398Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
-      "taskId": "4053788",
+      "taskId": "4090969",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
-        "requestId": "d5db764e-cb78-43f7-b0fb-3e2c2d085c83",
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local",
+        "requestId": "8781a5f1-a3e3-40a3-94b1-7ffa01561897",
         "historySizeBytes": "407"
       }
     },
     {
       "eventId": "4",
-      "eventTime": "2025-05-07T16:31:45.541892Z",
+      "eventTime": "2025-05-07T17:40:05.650225Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
-      "taskId": "4053792",
+      "taskId": "4090973",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
         "startedEventId": "3",
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local",
         "workerVersion": {},
         "sdkMetadata": {
           "langUsedFlags": [
-            1
+            3
           ],
           "sdkName": "temporal-java",
           "sdkVersion": "1.23.0"
@@ -73,16 +73,16 @@
     },
     {
       "eventId": "5",
-      "eventTime": "2025-05-07T16:31:45.541956Z",
+      "eventTime": "2025-05-07T17:40:05.650291Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
-      "taskId": "4053793",
+      "taskId": "4090974",
       "activityTaskScheduledEventAttributes": {
-        "activityId": "627e725e-c872-319c-a1d4-d03bb18bc572",
+        "activityId": "01eb36ed-7c25-32e2-9026-6e27f249ca29",
         "activityType": {
           "name": "DoActivity"
         },
         "taskQueue": {
-          "name": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8",
+          "name": "WorkflowTest-replayCanceledWorkflow-06329052-559e-4e2b-a33b-f324bc2c7822",
           "kind": "TASK_QUEUE_KIND_NORMAL"
         },
         "header": {},
@@ -100,34 +100,34 @@
     },
     {
       "eventId": "6",
-      "eventTime": "2025-05-07T16:31:45.541989Z",
+      "eventTime": "2025-05-07T17:40:05.650330Z",
       "eventType": "EVENT_TYPE_TIMER_STARTED",
-      "taskId": "4053794",
+      "taskId": "4090975",
       "timerStartedEventAttributes": {
-        "timerId": "47c34e95-d85f-3834-80ed-8b58cebe2289",
+        "timerId": "a0b42b7b-d179-3d73-acf4-960f6aa0436a",
         "startToFireTimeout": "300s",
         "workflowTaskCompletedEventId": "4"
       }
     },
     {
       "eventId": "7",
-      "eventTime": "2025-05-07T16:31:45.416574Z",
+      "eventTime": "2025-05-07T17:40:05.532054Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED",
-      "taskId": "4053795",
+      "taskId": "4090976",
       "workflowExecutionCancelRequestedEventAttributes": {
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local"
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local"
       }
     },
     {
       "eventId": "8",
-      "eventTime": "2025-05-07T16:31:45.542001Z",
+      "eventTime": "2025-05-07T17:40:05.650341Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
-      "taskId": "4053796",
+      "taskId": "4090977",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "93896@Quinn-Klassens-MacBook-Pro.local:8bb44ec5-1202-4757-a16d-ef65d158c965",
+          "name": "83364@Quinn-Klassens-MacBook-Pro.local:a68365be-2604-4267-9bf1-2a0e0681fc7c",
           "kind": "TASK_QUEUE_KIND_STICKY",
-          "normalName": "WorkflowTest-replayCanceledWorkflow-402be3d9-0bf9-41f3-a3df-301df10d22d8"
+          "normalName": "WorkflowTest-replayCanceledWorkflow-06329052-559e-4e2b-a33b-f324bc2c7822"
         },
         "startToCloseTimeout": "10s",
         "attempt": 1
@@ -135,25 +135,25 @@
     },
     {
       "eventId": "9",
-      "eventTime": "2025-05-07T16:31:45.547789Z",
+      "eventTime": "2025-05-07T17:40:05.656085Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
-      "taskId": "4053804",
+      "taskId": "4090985",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
-        "requestId": "c2a474e4-b040-4a90-bb0d-b8bb81f1f827",
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local",
+        "requestId": "491557d2-cd45-4d7c-9b92-bbba5204af4b",
         "historySizeBytes": "1148"
       }
     },
     {
       "eventId": "10",
-      "eventTime": "2025-05-07T16:31:45.572751Z",
+      "eventTime": "2025-05-07T17:40:05.680811Z",
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
-      "taskId": "4053810",
+      "taskId": "4090991",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
         "startedEventId": "9",
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local",
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local",
         "workerVersion": {},
         "sdkMetadata": {
           "sdkName": "temporal-java",
@@ -164,31 +164,31 @@
     },
     {
       "eventId": "11",
-      "eventTime": "2025-05-07T16:31:45.572813Z",
-      "eventType": "EVENT_TYPE_TIMER_CANCELED",
-      "taskId": "4053811",
-      "timerCanceledEventAttributes": {
-        "timerId": "47c34e95-d85f-3834-80ed-8b58cebe2289",
-        "startedEventId": "6",
-        "workflowTaskCompletedEventId": "10",
-        "identity": "93896@Quinn-Klassens-MacBook-Pro.local"
-      }
-    },
-    {
-      "eventId": "12",
-      "eventTime": "2025-05-07T16:31:45.572824Z",
+      "eventTime": "2025-05-07T17:40:05.680892Z",
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED",
-      "taskId": "4053812",
+      "taskId": "4090992",
       "activityTaskCancelRequestedEventAttributes": {
         "scheduledEventId": "5",
         "workflowTaskCompletedEventId": "10"
       }
     },
     {
+      "eventId": "12",
+      "eventTime": "2025-05-07T17:40:05.680906Z",
+      "eventType": "EVENT_TYPE_TIMER_CANCELED",
+      "taskId": "4090993",
+      "timerCanceledEventAttributes": {
+        "timerId": "a0b42b7b-d179-3d73-acf4-960f6aa0436a",
+        "startedEventId": "6",
+        "workflowTaskCompletedEventId": "10",
+        "identity": "83364@Quinn-Klassens-MacBook-Pro.local"
+      }
+    },
+    {
       "eventId": "13",
-      "eventTime": "2025-05-07T16:31:45.572835Z",
+      "eventTime": "2025-05-07T17:40:05.680914Z",
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED",
-      "taskId": "4053813",
+      "taskId": "4090994",
       "workflowExecutionCanceledEventAttributes": {
         "workflowTaskCompletedEventId": "10"
       }


### PR DESCRIPTION
Make `CancellationScopeImpl` more deterministic, our use of `HashSet` is not deterministic since we iterate over the map and the order matters her. 

closes https://github.com/temporalio/sdk-java/issues/2473