### PR TITLE
Add num_pollers metric

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -120,6 +120,8 @@ public final class MetricsType {
   public static final String WORKER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "worker_start";
   public static final String POLLER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "poller_start";
   // gauge
+  public static final String NUM_POLLERS = TEMPORAL_METRICS_PREFIX + "num_pollers";
+
   public static final String WORKER_TASK_SLOTS_AVAILABLE =
       TEMPORAL_METRICS_PREFIX + "worker_task_slots_available";
 

--- a/temporal-sdk/src/main/java/io/temporal/worker/PollerTypeMetricsTag.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/PollerTypeMetricsTag.java
@@ -1,0 +1,28 @@
+package io.temporal.worker;
+
+import io.temporal.serviceclient.MetricsTag;
+
+public class PollerTypeMetricsTag {
+  public enum PollerType implements MetricsTag.TagValue {
+    WORKFLOW_TASK("workflow_task"),
+    WORKFLOW_STICKY_TASK("workflow_sticky_task"),
+    ACTIVITY_TASK("activity_task"),
+    NEXUS_TASK("nexus_task"),
+    ;
+
+    PollerType(String value) {
+      this.value = value;
+    }
+
+    private final String value;
+
+    @Override
+    public String getTag() {
+      return MetricsTag.POLLER_TYPE;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -31,6 +31,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.PollerTypeMetricsTag;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactoryOptions;
 import io.temporal.worker.WorkerMetricsTag;
@@ -87,6 +88,26 @@ public class MetricsTest {
       new ImmutableMap.Builder<String, String>()
           .putAll(TAGS_TASK_QUEUE)
           .put(MetricsTag.WORKER_TYPE, WorkerMetricsTag.WorkerType.WORKFLOW_WORKER.getValue())
+          .build();
+
+  private static final Map<String, String> TAGS_WORKFLOW_NORMAL_POLLER =
+      new ImmutableMap.Builder<String, String>()
+          .putAll(TAGS_WORKFLOW_WORKER)
+          .put(MetricsTag.POLLER_TYPE, PollerTypeMetricsTag.PollerType.WORKFLOW_TASK.getValue())
+          .build();
+
+  private static final Map<String, String> TAGS_WORKFLOW_STICKY_POLLER =
+      new ImmutableMap.Builder<String, String>()
+          .putAll(TAGS_WORKFLOW_WORKER)
+          .put(
+              MetricsTag.POLLER_TYPE,
+              PollerTypeMetricsTag.PollerType.WORKFLOW_STICKY_TASK.getValue())
+          .build();
+
+  private static final Map<String, String> TAGS_ACTIVITY_POLLER =
+      new ImmutableMap.Builder<String, String>()
+          .putAll(TAGS_ACTIVITY_WORKER)
+          .put(MetricsTag.POLLER_TYPE, PollerTypeMetricsTag.PollerType.ACTIVITY_TASK.getValue())
           .build();
 
   @Rule
@@ -150,7 +171,10 @@ public class MetricsTest {
     reporter.assertCounter("temporal_worker_start", TAGS_LOCAL_ACTIVITY_WORKER, 1);
 
     reporter.assertCounter("temporal_poller_start", TAGS_WORKFLOW_WORKER, 5);
+    reporter.assertGauge("temporal_num_pollers", TAGS_WORKFLOW_NORMAL_POLLER, 2);
+    reporter.assertGauge("temporal_num_pollers", TAGS_WORKFLOW_STICKY_POLLER, 3);
     reporter.assertCounter("temporal_poller_start", TAGS_ACTIVITY_WORKER, 5);
+    reporter.assertGauge("temporal_num_pollers", TAGS_ACTIVITY_POLLER, 5);
   }
 
   @Test

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -24,6 +24,7 @@ public class MetricsTag {
   public static final String EXCEPTION = "exception";
   public static final String OPERATION_NAME = "operation";
   public static final String TASK_FAILURE_TYPE = "failure_reason";
+  public static final String POLLER_TYPE = "poller_type";
 
   /** Used to pass metrics scope to the interceptor */
   public static final CallOptions.Key<Scope> METRICS_TAGS_CALL_OPTIONS_KEY =


### PR DESCRIPTION
Add `num_pollers` metric. This metric is available in Core and Go, but was never added to Java. We will need this as part of poller autoscaling so users can tell how many active pollers there are.

closes https://github.com/temporalio/sdk-java/issues/1519
