### PR TITLE
Wire reason parameter in workflow cancellation request

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStub.java
@@ -370,6 +370,21 @@ public interface WorkflowStub {
   void cancel();
 
   /**
+   * Request cancellation of a workflow execution with a reason.
+   *
+   * <p>Cancellation cancels {@link io.temporal.workflow.CancellationScope} that wraps the main
+   * workflow method. Note that workflow can take long time to get canceled or even completely
+   * ignore the cancellation request.
+   *
+   * @param reason optional reason for the cancellation request
+   * @throws WorkflowNotFoundException if the workflow execution doesn't exist or is already
+   *     completed
+   * @throws WorkflowServiceException for all other failures including networking and service
+   *     availability issues
+   */
+  void cancel(@Nullable String reason);
+
+  /**
    * Terminates a workflow execution.
    *
    * <p>Termination is a hard stop of a workflow execution which doesn't give workflow code any

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -429,10 +429,16 @@ class WorkflowStubImpl implements WorkflowStub {
 
   @Override
   public void cancel() {
+    cancel(null);
+  }
+
+  @Override
+  public void cancel(@Nullable String reason) {
     checkStarted();
     WorkflowExecution targetExecution = currentExecutionWithoutRunId();
     try {
-      workflowClientInvoker.cancel(new WorkflowClientCallsInterceptor.CancelInput(targetExecution));
+      workflowClientInvoker.cancel(
+          new WorkflowClientCallsInterceptor.CancelInput(targetExecution, reason));
     } catch (Exception e) {
       Throwable failure = throwAsWorkflowFailureException(e, targetExecution);
       throw new WorkflowServiceException(targetExecution, workflowType.orElse(null), failure);

--- a/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptor.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/interceptors/WorkflowClientCallsInterceptor.java
@@ -398,13 +398,29 @@ public interface WorkflowClientCallsInterceptor {
 
   final class CancelInput {
     private final WorkflowExecution workflowExecution;
+    private final @Nullable String reason;
 
+    /**
+     * @deprecated Use {@link #CancelInput(WorkflowExecution, String)} to provide a cancellation
+     *     reason instead.
+     */
+    @Deprecated
     public CancelInput(WorkflowExecution workflowExecution) {
+      this(workflowExecution, null);
+    }
+
+    public CancelInput(WorkflowExecution workflowExecution, @Nullable String reason) {
       this.workflowExecution = workflowExecution;
+      this.reason = reason;
     }
 
     public WorkflowExecution getWorkflowExecution() {
       return workflowExecution;
+    }
+
+    @Nullable
+    public String getReason() {
+      return reason;
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -630,6 +630,9 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
             .setWorkflowExecution(input.getWorkflowExecution())
             .setNamespace(clientOptions.getNamespace())
             .setIdentity(clientOptions.getIdentity());
+    if (input.getReason() != null) {
+      request.setReason(input.getReason());
+    }
     genericClient.requestCancel(request.build());
     return new CancelOutput();
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitCancellationTest.java
@@ -10,6 +10,7 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.internal.common.WorkflowExecutionUtils;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -29,7 +30,7 @@ public class WorkflowAwaitCancellationTest {
     execution = WorkflowClient.start(workflow::execute, "input1");
     try {
       WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
-      untyped.cancel();
+      untyped.cancel("test reason");
       untyped.getResult(String.class);
       fail("unreacheable");
     } catch (WorkflowFailedException e) {
@@ -42,6 +43,13 @@ public class WorkflowAwaitCancellationTest {
           "WorkflowExecutionCancelled event is expected",
           EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
           lastEvent.getEventType());
+      assertEquals(
+          "WorkflowExecutionCancelled event should have the correct cause",
+          "test reason",
+          WorkflowExecutionUtils.getEventOfType(
+                  history, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED)
+              .getWorkflowExecutionCancelRequestedEventAttributes()
+              .getCause());
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitWithDurationCancellationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/cancellationTests/WorkflowAwaitWithDurationCancellationTest.java
@@ -35,7 +35,7 @@ public class WorkflowAwaitWithDurationCancellationTest {
     try {
       WorkflowStub untyped = WorkflowStub.fromTyped(workflow);
       workflowStarted.waitForSignal();
-      untyped.cancel();
+      untyped.cancel("reason");
       untyped.getResult(String.class);
       fail("unreacheable");
     } catch (WorkflowFailedException e) {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1488,7 +1488,8 @@ class StateMachines {
       long notUsed) {
     WorkflowExecutionCancelRequestedEventAttributes.Builder a =
         WorkflowExecutionCancelRequestedEventAttributes.newBuilder()
-            .setIdentity(cancelRequest.getIdentity());
+            .setIdentity(cancelRequest.getIdentity())
+            .setCause(cancelRequest.getReason());
     HistoryEvent cancelRequested =
         HistoryEvent.newBuilder()
             .setEventType(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED)

--- a/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TimeLockingInterceptor.java
@@ -165,6 +165,11 @@ class TimeLockingInterceptor extends WorkflowClientInterceptorBase {
     }
 
     @Override
+    public void cancel(@Nullable String reason) {
+      next.cancel(reason);
+    }
+
+    @Override
     public void terminate(@Nullable String reason, Object... details) {
       next.terminate(reason, details);
     }


### PR DESCRIPTION
Wire reason parameter in workflow cancellation request. Not this does not cover wiring the cancellation reason on the workflow side. There is a different issue to track that work.

closes https://github.com/temporalio/sdk-java/issues/1350
