### PR TITLE
Implement Nexus operation cancellation types

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -2,7 +2,6 @@ package io.temporal.internal.replay;
 
 import com.uber.m3.tally.Scope;
 import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.ScheduleNexusOperationCommandAttributes;
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
 import io.temporal.api.common.v1.*;
 import io.temporal.api.failure.v1.Failure;
@@ -10,10 +9,7 @@ import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.common.RetryOptions;
 import io.temporal.internal.common.SdkFlag;
-import io.temporal.internal.statemachines.ExecuteActivityParameters;
-import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
-import io.temporal.internal.statemachines.LocalActivityCallback;
-import io.temporal.internal.statemachines.StartChildWorkflowExecutionParameters;
+import io.temporal.internal.statemachines.*;
 import io.temporal.workflow.Functions;
 import io.temporal.workflow.Functions.Func;
 import io.temporal.workflow.Functions.Func1;
@@ -162,8 +158,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
   /**
    * Start a Nexus operation.
    *
-   * @param attributes nexus operation attributes
-   * @param metadata user metadata to be associated with the operation.
+   * @param parameters encapsulates all the information required to schedule a Nexus operation
    * @param startedCallback callback that is called when the operation is start if async, or
    *     completes if it is sync.
    * @param completionCallback callback that is called upon child workflow completion or failure
@@ -171,8 +166,7 @@ public interface ReplayWorkflowContext extends ReplayAware {
    *     to cancel activity task.
    */
   Functions.Proc1<Exception> startNexusOperation(
-      ScheduleNexusOperationCommandAttributes attributes,
-      @Nullable UserMetadata metadata,
+      StartNexusOperationParameters parameters,
       Functions.Proc2<Optional<String>, Failure> startedCallback,
       Functions.Proc2<Optional<Payload>, Failure> completionCallback);
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -207,13 +207,11 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
 
   @Override
   public Functions.Proc1<Exception> startNexusOperation(
-      ScheduleNexusOperationCommandAttributes attributes,
-      @Nullable UserMetadata metadata,
+      StartNexusOperationParameters parameters,
       Functions.Proc2<Optional<String>, Failure> startedCallback,
       Functions.Proc2<Optional<Payload>, Failure> completionCallback) {
     Functions.Proc cancellationHandler =
-        workflowStateMachines.startNexusOperation(
-            attributes, metadata, startedCallback, completionCallback);
+        workflowStateMachines.startNexusOperation(parameters, startedCallback, completionCallback);
     return (exception) -> cancellationHandler.apply();
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/CancelNexusOperationStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/CancelNexusOperationStateMachine.java
@@ -4,6 +4,8 @@ import io.temporal.api.command.v1.Command;
 import io.temporal.api.command.v1.RequestCancelNexusOperationCommandAttributes;
 import io.temporal.api.enums.v1.CommandType;
 import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.failure.v1.CanceledFailureInfo;
+import io.temporal.api.failure.v1.Failure;
 import io.temporal.workflow.Functions;
 
 /** CancelNexusOperationStateMachine manges a request to cancel a nexus operation. */
@@ -15,23 +17,29 @@ final class CancelNexusOperationStateMachine
 
   private final RequestCancelNexusOperationCommandAttributes requestCancelNexusAttributes;
 
+  private final Functions.Proc2<Void, Failure> completionCallback;
+
   /**
    * @param attributes attributes to use to cancel a nexus operation
    * @param commandSink sink to send commands
    */
   public static void newInstance(
       RequestCancelNexusOperationCommandAttributes attributes,
+      Functions.Proc2<Void, Failure> completionCallback,
       Functions.Proc1<CancellableCommand> commandSink,
       Functions.Proc1<StateMachine> stateMachineSink) {
-    new CancelNexusOperationStateMachine(attributes, commandSink, stateMachineSink);
+    new CancelNexusOperationStateMachine(
+        attributes, completionCallback, commandSink, stateMachineSink);
   }
 
   private CancelNexusOperationStateMachine(
       RequestCancelNexusOperationCommandAttributes attributes,
+      Functions.Proc2<Void, Failure> completionCallback,
       Functions.Proc1<CancellableCommand> commandSink,
       Functions.Proc1<StateMachine> stateMachineSink) {
     super(STATE_MACHINE_DEFINITION, commandSink, stateMachineSink);
     this.requestCancelNexusAttributes = attributes;
+    this.completionCallback = completionCallback;
     explicitEvent(ExplicitEvent.SCHEDULE);
   }
 
@@ -42,14 +50,19 @@ final class CancelNexusOperationStateMachine
   enum State {
     CREATED,
     REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_CREATED,
+    REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_RECORDED,
     CANCEL_REQUESTED,
+    REQUEST_CANCEL_FAILED,
   }
 
   public static final StateMachineDefinition<State, ExplicitEvent, CancelNexusOperationStateMachine>
       STATE_MACHINE_DEFINITION =
           StateMachineDefinition
               .<State, ExplicitEvent, CancelNexusOperationStateMachine>newInstance(
-                  "CancelNexusOperation", State.CREATED, State.CANCEL_REQUESTED)
+                  "CancelNexusOperation",
+                  State.CREATED,
+                  State.CANCEL_REQUESTED,
+                  State.REQUEST_CANCEL_FAILED)
               .add(
                   State.CREATED,
                   ExplicitEvent.SCHEDULE,
@@ -62,8 +75,18 @@ final class CancelNexusOperationStateMachine
               .add(
                   State.REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_CREATED,
                   EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+                  State.REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_RECORDED,
+                  EntityStateMachineInitialCommand::setInitialCommandEventId)
+              .add(
+                  State.REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_RECORDED,
+                  EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED,
                   State.CANCEL_REQUESTED,
-                  CancelNexusOperationStateMachine::notifyCompleted);
+                  CancelNexusOperationStateMachine::notifyCompleted)
+              .add(
+                  State.REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_RECORDED,
+                  EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED,
+                  State.REQUEST_CANCEL_FAILED,
+                  CancelNexusOperationStateMachine::notifyFailed);
 
   private void createCancelNexusCommand() {
     addCommand(
@@ -74,6 +97,17 @@ final class CancelNexusOperationStateMachine
   }
 
   private void notifyCompleted() {
-    setInitialCommandEventId();
+    Failure canceledFailure =
+        Failure.newBuilder()
+            .setMessage("operation canceled")
+            .setCanceledFailureInfo(CanceledFailureInfo.getDefaultInstance())
+            .build();
+    completionCallback.apply(null, canceledFailure);
+  }
+
+  private void notifyFailed() {
+    Failure failure =
+        currentEvent.getNexusOperationCancelRequestFailedEventAttributes().getFailure();
+    completionCallback.apply(null, failure);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StartNexusOperationParameters.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/StartNexusOperationParameters.java
@@ -1,0 +1,34 @@
+package io.temporal.internal.statemachines;
+
+import io.temporal.api.command.v1.ScheduleNexusOperationCommandAttributes;
+import io.temporal.api.sdk.v1.UserMetadata;
+import io.temporal.workflow.NexusOperationCancellationType;
+import javax.annotation.Nullable;
+
+public class StartNexusOperationParameters {
+
+  private final ScheduleNexusOperationCommandAttributes.Builder attributes;
+  private final NexusOperationCancellationType cancellationType;
+  private final UserMetadata metadata;
+
+  public StartNexusOperationParameters(
+      ScheduleNexusOperationCommandAttributes.Builder attributes,
+      NexusOperationCancellationType cancellationType,
+      @Nullable UserMetadata metadata) {
+    this.attributes = attributes;
+    this.cancellationType = cancellationType;
+    this.metadata = metadata;
+  }
+
+  public ScheduleNexusOperationCommandAttributes.Builder getAttributes() {
+    return attributes;
+  }
+
+  public NexusOperationCancellationType getCancellationType() {
+    return cancellationType;
+  }
+
+  public @Nullable UserMetadata getMetadata() {
+    return metadata;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -808,10 +808,13 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
         makeUserMetaData(
             input.getOptions().getSummary(), null, dataConverterWithCurrentWorkflowContext);
 
+    StartNexusOperationParameters parameters =
+        new StartNexusOperationParameters(
+            attributes, input.getOptions().getCancellationType(), userMetadata);
+
     Functions.Proc1<Exception> cancellationCallback =
         replayContext.startNexusOperation(
-            attributes.build(),
-            userMetadata,
+            parameters,
             (operationExec, failure) -> {
               if (failure != null) {
                 runner.executeInWorkflowThread(

--- a/temporal-sdk/src/main/java/io/temporal/workflow/NexusOperationCancellationType.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/NexusOperationCancellationType.java
@@ -1,0 +1,29 @@
+package io.temporal.workflow;
+
+import io.temporal.failure.CanceledFailure;
+
+/**
+ * Defines behavior of the parent workflow when {@link CancellationScope} that wraps Nexus operation
+ * is canceled. The result of the cancellation independently of the type is a {@link
+ * CanceledFailure} thrown from the Nexus operation method.
+ */
+public enum NexusOperationCancellationType {
+  /** Wait for operation completion. Operation may or may not complete as cancelled. Default. */
+  WAIT_COMPLETED,
+
+  /**
+   * Request cancellation of the operation and wait for confirmation that the request was received.
+   * Doesn't wait for actual cancellation.
+   */
+  WAIT_REQUESTED,
+
+  /**
+   * Initiate a cancellation request and immediately report cancellation to the caller. Note that it
+   * doesn't guarantee that cancellation is delivered to the operation handler if the caller exits
+   * before the delivery is done.
+   */
+  TRY_CANCEL,
+
+  /** Do not request cancellation of the operation. */
+  ABANDON,
+}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/NexusOperationOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/NexusOperationOptions.java
@@ -31,6 +31,7 @@ public final class NexusOperationOptions {
 
   public static final class Builder {
     private Duration scheduleToCloseTimeout;
+    private NexusOperationCancellationType cancellationType;
     private String summary;
 
     /**
@@ -42,6 +43,18 @@ public final class NexusOperationOptions {
     public NexusOperationOptions.Builder setScheduleToCloseTimeout(
         Duration scheduleToCloseTimeout) {
       this.scheduleToCloseTimeout = scheduleToCloseTimeout;
+      return this;
+    }
+
+    /**
+     * Sets the cancellation type for the Nexus operation.
+     *
+     * @param cancellationType the cancellation type for the Nexus operation
+     * @return this
+     */
+    public NexusOperationOptions.Builder setCancellationType(
+        NexusOperationCancellationType cancellationType) {
+      this.cancellationType = cancellationType;
       return this;
     }
 
@@ -64,11 +77,12 @@ public final class NexusOperationOptions {
         return;
       }
       this.scheduleToCloseTimeout = options.getScheduleToCloseTimeout();
+      this.cancellationType = options.getCancellationType();
       this.summary = options.getSummary();
     }
 
     public NexusOperationOptions build() {
-      return new NexusOperationOptions(scheduleToCloseTimeout, summary);
+      return new NexusOperationOptions(scheduleToCloseTimeout, cancellationType, summary);
     }
 
     public NexusOperationOptions.Builder mergeNexusOperationOptions(
@@ -80,13 +94,19 @@ public final class NexusOperationOptions {
           (override.scheduleToCloseTimeout == null)
               ? this.scheduleToCloseTimeout
               : override.scheduleToCloseTimeout;
+      this.cancellationType =
+          (override.cancellationType == null) ? this.cancellationType : override.cancellationType;
       this.summary = (override.summary == null) ? this.summary : override.summary;
       return this;
     }
   }
 
-  private NexusOperationOptions(Duration scheduleToCloseTimeout, String summary) {
+  private NexusOperationOptions(
+      Duration scheduleToCloseTimeout,
+      NexusOperationCancellationType cancellationType,
+      String summary) {
     this.scheduleToCloseTimeout = scheduleToCloseTimeout;
+    this.cancellationType = cancellationType;
     this.summary = summary;
   }
 
@@ -95,10 +115,15 @@ public final class NexusOperationOptions {
   }
 
   private final Duration scheduleToCloseTimeout;
+  private final NexusOperationCancellationType cancellationType;
   private final String summary;
 
   public Duration getScheduleToCloseTimeout() {
     return scheduleToCloseTimeout;
+  }
+
+  public NexusOperationCancellationType getCancellationType() {
+    return cancellationType;
   }
 
   @Experimental
@@ -112,12 +137,13 @@ public final class NexusOperationOptions {
     if (o == null || getClass() != o.getClass()) return false;
     NexusOperationOptions that = (NexusOperationOptions) o;
     return Objects.equals(scheduleToCloseTimeout, that.scheduleToCloseTimeout)
+        && Objects.equals(cancellationType, that.cancellationType)
         && Objects.equals(summary, that.summary);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(scheduleToCloseTimeout, summary);
+    return Objects.hash(scheduleToCloseTimeout, cancellationType, summary);
   }
 
   @Override
@@ -125,6 +151,8 @@ public final class NexusOperationOptions {
     return "NexusOperationOptions{"
         + "scheduleToCloseTimeout="
         + scheduleToCloseTimeout
+        + ", cancellationType="
+        + cancellationType
         + ", summary='"
         + summary
         + '\''

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/CancelNexusOperationStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/CancelNexusOperationStateMachineTest.java
@@ -6,12 +6,12 @@ import static org.junit.Assert.*;
 
 import io.temporal.api.command.v1.Command;
 import io.temporal.api.command.v1.RequestCancelNexusOperationCommandAttributes;
-import io.temporal.api.command.v1.ScheduleNexusOperationCommandAttributes;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.api.enums.v1.CommandType;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.history.v1.*;
+import io.temporal.workflow.NexusOperationCancellationType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -54,7 +54,7 @@ public class CancelNexusOperationStateMachineTest {
   }
 
   @Test
-  public void testCancelNexusOperationStateMachine() {
+  public void testCancelNexusOperationStateMachineSuccess() {
     class TestListener extends TestEntityManagerListenerBase {
       @Override
       protected void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
@@ -62,16 +62,17 @@ public class CancelNexusOperationStateMachineTest {
             RequestCancelNexusOperationCommandAttributes.newBuilder()
                 .setScheduledEventId(5)
                 .build();
-        ScheduleNexusOperationCommandAttributes scheduleAttributes =
-            newScheduleNexusOperationCommandAttributesBuilder().build();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         NexusOperationStateMachineTest.DelayedCallback2<Optional<Payload>, Failure>
             delayedCallback = new NexusOperationStateMachineTest.DelayedCallback2();
         builder
             .<Optional<String>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(
-                        scheduleAttributes, null, c, delayedCallback::run))
-            .add((v) -> stateMachines.requestCancelNexusOperation(cancelAttributes))
+                (v, c) -> stateMachines.startNexusOperation(startParams, c, delayedCallback::run))
+            .add((v) -> stateMachines.requestCancelNexusOperation(cancelAttributes, (r, f) -> {}))
             .<Optional<Payload>, Failure>add2((pair, c) -> delayedCallback.set(c))
             .add((pair) -> stateMachines.failWorkflow(pair.getT2()));
       }
@@ -86,9 +87,10 @@ public class CancelNexusOperationStateMachineTest {
         7: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
         8: EVENT_TYPE_WORKFLOW_TASK_STARTED
         9: EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
-        10: EVENT_TYPE_NEXUS_OPERATION_CANCELED
-        11: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
-        12: EVENT_TYPE_WORKFLOW_TASK_STARTED
+        10: EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED
+        11: EVENT_TYPE_NEXUS_OPERATION_CANCELED
+        12: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+        13: EVENT_TYPE_WORKFLOW_TASK_STARTED
     */
     TestHistoryBuilder h =
         new TestHistoryBuilder()
@@ -105,11 +107,109 @@ public class CancelNexusOperationStateMachineTest {
                 .setRequestId("requestId")
                 .setOperationId(OPERATION_ID)
                 .build())
-        .addWorkflowTask()
-        .add(
+        .addWorkflowTask();
+    long cancelRequestedEventId =
+        h.addGetEventId(
             EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
             NexusOperationCancelRequestedEventAttributes.newBuilder()
                 .setScheduledEventId(scheduledEventId)
+                .build());
+    h.add(
+            EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED,
+            NexusOperationCancelRequestCompletedEventAttributes.newBuilder()
+                .setRequestedEventId(cancelRequestedEventId)
+                .build())
+        .add(
+            EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
+            NexusOperationCanceledEventAttributes.newBuilder()
+                .setScheduledEventId(scheduledEventId)
+                .setFailure(Failure.newBuilder().setMessage("canceled").build())
+                .build())
+        .addWorkflowTaskScheduledAndStarted();
+    {
+      TestEntityManagerListenerBase listener = new TestListener();
+      stateMachines = newStateMachines(listener);
+      List<Command> commands = h.handleWorkflowTaskTakeCommands(stateMachines, 1);
+      assertCommand(CommandType.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION, commands);
+    }
+    {
+      List<Command> commands = h.handleWorkflowTaskTakeCommands(stateMachines, 2);
+      assertEquals(1, commands.size());
+      assertCommand(CommandType.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION, commands);
+    }
+    {
+      List<Command> commands = h.handleWorkflowTaskTakeCommands(stateMachines, 3);
+      assertEquals(1, commands.size());
+      assertCommand(CommandType.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION, commands);
+    }
+  }
+
+  @Test
+  public void testCancelNexusOperationStateMachineFailure() {
+    class TestListener extends TestEntityManagerListenerBase {
+      @Override
+      protected void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
+        RequestCancelNexusOperationCommandAttributes cancelAttributes =
+            RequestCancelNexusOperationCommandAttributes.newBuilder()
+                .setScheduledEventId(5)
+                .build();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
+        NexusOperationStateMachineTest.DelayedCallback2<Optional<Payload>, Failure>
+            delayedCallback = new NexusOperationStateMachineTest.DelayedCallback2();
+        builder
+            .<Optional<String>, Failure>add2(
+                (v, c) -> stateMachines.startNexusOperation(startParams, c, delayedCallback::run))
+            .add((v) -> stateMachines.requestCancelNexusOperation(cancelAttributes, (r, f) -> {}))
+            .<Optional<Payload>, Failure>add2((pair, c) -> delayedCallback.set(c))
+            .add((pair) -> stateMachines.failWorkflow(pair.getT2()));
+      }
+    }
+    /*
+        1: EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+        2: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+        3: EVENT_TYPE_WORKFLOW_TASK_STARTED
+        4: EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+        5: EVENT_TYPE_NEXUS_OPERATION_SCHEDULED
+        6: EVENT_TYPE_NEXUS_OPERATION_STARTED
+        7: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+        8: EVENT_TYPE_WORKFLOW_TASK_STARTED
+        9: EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
+        10: EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED
+        11: EVENT_TYPE_NEXUS_OPERATION_CANCELED
+        12: EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
+        13: EVENT_TYPE_WORKFLOW_TASK_STARTED
+    */
+    TestHistoryBuilder h =
+        new TestHistoryBuilder()
+            .add(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED)
+            .addWorkflowTask();
+    long scheduledEventId =
+        h.addGetEventId(
+            EventType.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
+            newNexusOperationScheduledEventAttributesBuilder().build());
+    h.add(
+            EventType.EVENT_TYPE_NEXUS_OPERATION_STARTED,
+            NexusOperationStartedEventAttributes.newBuilder()
+                .setScheduledEventId(scheduledEventId)
+                .setRequestId("requestId")
+                .setOperationId(OPERATION_ID)
+                .build())
+        .addWorkflowTask();
+    long cancelRequestedEventId =
+        h.addGetEventId(
+            EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+            NexusOperationCancelRequestedEventAttributes.newBuilder()
+                .setScheduledEventId(scheduledEventId)
+                .build());
+    h.add(
+            EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED,
+            NexusOperationCancelRequestFailedEventAttributes.newBuilder()
+                .setRequestedEventId(cancelRequestedEventId)
+                .setFailure(Failure.newBuilder().setMessage("cancel handler failure").build())
                 .build())
         .add(
             EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED,

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/NexusOperationStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/NexusOperationStateMachineTest.java
@@ -15,6 +15,7 @@ import io.temporal.api.history.v1.*;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.workflow.Functions;
+import io.temporal.workflow.NexusOperationCancellationType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -68,12 +69,14 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         builder
             .<Optional<Payload>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(attributes.build(), null, (o, f) -> {}, c))
+                (v, c) -> stateMachines.startNexusOperation(startParams, (o, f) -> {}, c))
             .add(
                 (pair) ->
                     stateMachines.completeWorkflow(
@@ -144,12 +147,14 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         builder
             .<Optional<Payload>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(attributes.build(), null, (o, f) -> {}, c))
+                (v, c) -> stateMachines.startNexusOperation(startParams, (o, f) -> {}, c))
             .add((pair) -> stateMachines.failWorkflow(pair.getT2()));
       }
     }
@@ -216,12 +221,14 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         builder
             .<Optional<Payload>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(attributes.build(), null, (o, f) -> {}, c))
+                (v, c) -> stateMachines.startNexusOperation(startParams, (o, f) -> {}, c))
             .add((pair) -> stateMachines.failWorkflow(pair.getT2()));
       }
     }
@@ -288,12 +295,14 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         builder
             .<Optional<Payload>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(attributes.build(), null, (o, f) -> {}, c))
+                (v, c) -> stateMachines.startNexusOperation(startParams, (o, f) -> {}, c))
             .add((pair) -> stateMachines.failWorkflow(pair.getT2()));
       }
     }
@@ -361,14 +370,16 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         builder
             .<Optional<Payload>, Failure>add2(
                 (v, c) ->
                     cancellationHandler =
-                        stateMachines.startNexusOperation(
-                            attributes.build(), null, (o, f) -> {}, c))
+                        stateMachines.startNexusOperation(startParams, (o, f) -> {}, c))
             .add((pair) -> stateMachines.failWorkflow(pair.getT2()));
         // Immediate cancellation
         builder.add((v) -> cancellationHandler.apply());
@@ -399,14 +410,15 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         DelayedCallback2<Optional<Payload>, Failure> delayedCallback = new DelayedCallback2();
         builder
             .<Optional<String>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(
-                        attributes.build(), null, c, delayedCallback::run))
+                (v, c) -> stateMachines.startNexusOperation(startParams, c, delayedCallback::run))
             .<Optional<Payload>, Failure>add2(
                 (pair, c) -> {
                   Assert.assertEquals(OPERATION_ID, pair.getT1().get());
@@ -494,14 +506,15 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         DelayedCallback2<Optional<Payload>, Failure> delayedCallback = new DelayedCallback2();
         builder
             .<Optional<String>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(
-                        attributes.build(), null, c, delayedCallback::run))
+                (v, c) -> stateMachines.startNexusOperation(startParams, c, delayedCallback::run))
             .<Optional<Payload>, Failure>add2(
                 (pair, c) -> {
                   Assert.assertEquals(OPERATION_ID, pair.getT1().get());
@@ -585,14 +598,15 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         DelayedCallback2<Optional<Payload>, Failure> delayedCallback = new DelayedCallback2();
         builder
             .<Optional<String>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(
-                        attributes.build(), null, c, delayedCallback::run))
+                (v, c) -> stateMachines.startNexusOperation(startParams, c, delayedCallback::run))
             .<Optional<Payload>, Failure>add2(
                 (pair, c) -> {
                   Assert.assertEquals(OPERATION_ID, pair.getT1().get());
@@ -676,14 +690,15 @@ public class NexusOperationStateMachineTest {
 
       @Override
       public void buildWorkflow(AsyncWorkflowBuilder<Void> builder) {
-        ScheduleNexusOperationCommandAttributes.Builder attributes =
-            newScheduleNexusOperationCommandAttributesBuilder();
+        StartNexusOperationParameters startParams =
+            new StartNexusOperationParameters(
+                newScheduleNexusOperationCommandAttributesBuilder(),
+                NexusOperationCancellationType.WAIT_COMPLETED,
+                null);
         DelayedCallback2<Optional<Payload>, Failure> delayedCallback = new DelayedCallback2();
         builder
             .<Optional<String>, Failure>add2(
-                (v, c) ->
-                    stateMachines.startNexusOperation(
-                        attributes.build(), null, c, delayedCallback::run))
+                (v, c) -> stateMachines.startNexusOperation(startParams, c, delayedCallback::run))
             .<Optional<Payload>, Failure>add2(
                 (pair, c) -> {
                   Assert.assertEquals(OPERATION_ID, pair.getT1().get());

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/TestHistoryBuilder.java
@@ -572,6 +572,14 @@ class TestHistoryBuilder {
           result.setNexusOperationCancelRequestedEventAttributes(
               (NexusOperationCancelRequestedEventAttributes) attributes);
           break;
+        case EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED:
+          result.setNexusOperationCancelRequestCompletedEventAttributes(
+              (NexusOperationCancelRequestCompletedEventAttributes) attributes);
+          break;
+        case EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED:
+          result.setNexusOperationCancelRequestFailedEventAttributes(
+              (NexusOperationCancelRequestFailedEventAttributes) attributes);
+          break;
         case EVENT_TYPE_UNSPECIFIED:
         case EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
         case EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:

--- a/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -3,7 +3,6 @@ package io.temporal.internal.sync;
 import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.Scope;
 import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes;
-import io.temporal.api.command.v1.ScheduleNexusOperationCommandAttributes;
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
 import io.temporal.api.common.v1.*;
 import io.temporal.api.failure.v1.Failure;
@@ -13,10 +12,7 @@ import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.replay.ReplayWorkflowContext;
-import io.temporal.internal.statemachines.ExecuteActivityParameters;
-import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
-import io.temporal.internal.statemachines.LocalActivityCallback;
-import io.temporal.internal.statemachines.StartChildWorkflowExecutionParameters;
+import io.temporal.internal.statemachines.*;
 import io.temporal.workflow.Functions;
 import java.time.Duration;
 import java.util.*;
@@ -197,8 +193,7 @@ public class DummySyncWorkflowContext {
 
     @Override
     public Functions.Proc1<Exception> startNexusOperation(
-        ScheduleNexusOperationCommandAttributes attributes,
-        @Nullable UserMetadata metadata,
+        StartNexusOperationParameters parameters,
         Functions.Proc2<Optional<String>, Failure> startedCallback,
         Functions.Proc2<Optional<Payload>, Failure> completionCallback) {
       throw new UnsupportedOperationException("not implemented");


### PR DESCRIPTION
## What was changed
Implemented cancellation types for Nexus operations which specify what action to take when the caller context is cancelled.
* `ABANDON` -> Do not request cancellation of the operation.
* `TRY_CANCEL` -> Initiate a cancellation request and immediately report cancellation to the caller.
* `WAIT_REQUESTED` -> Request cancellation of the operation and wait for confirmation that the request was received.
* `WAIT_COMPLETED` -> Wait for operation completion. Default.
These options are set on NexusOperationOptions which are passed in when starting an operation.

## Why?
To give users more control over what happens to their handler workflows when their caller workflows are cancelled.
