### PR TITLE
Cancel pending heartbeat when activity completes

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityExecutionContextImpl.java
@@ -157,6 +157,11 @@ class ActivityExecutionContextImpl implements InternalActivityExecutionContext {
   }
 
   @Override
+  public void cancelOutstandingHeartbeat() {
+    heartbeatContext.cancelOutstandingHeartbeat();
+  }
+
+  @Override
   public WorkflowClient getWorkflowClient() {
     return client;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskExecutors.java
@@ -128,6 +128,12 @@ final class ActivityTaskExecutors {
             metricsScope,
             local,
             dataConverterWithActivityContext);
+      } finally {
+        if (!context.isDoNotCompleteOnReturn()) {
+          // if the activity is not completed, we need to cancel the heartbeat
+          // to avoid sending it after the activity is completed
+          context.cancelOutstandingHeartbeat();
+        }
       }
     }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContext.java
@@ -17,4 +17,7 @@ interface HeartbeatContext {
   <V> Optional<V> getHeartbeatDetails(Class<V> detailsClass, Type detailsGenericType);
 
   Object getLastHeartbeatDetails();
+
+  /** Cancel any pending heartbeat and discard cached heartbeat details. */
+  void cancelOutstandingHeartbeat();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/HeartbeatContextImpl.java
@@ -143,6 +143,20 @@ class HeartbeatContextImpl implements HeartbeatContext {
     }
   }
 
+  @Override
+  public void cancelOutstandingHeartbeat() {
+    lock.lock();
+    try {
+      if (scheduledHeartbeat != null) {
+        scheduledHeartbeat.cancel(false);
+        scheduledHeartbeat = null;
+      }
+      hasOutstandingHeartbeat = false;
+    } finally {
+      lock.unlock();
+    }
+  }
+
   private void doHeartBeatLocked(Object details) {
     long nextHeartbeatDelay;
     try {

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/InternalActivityExecutionContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/InternalActivityExecutionContext.java
@@ -9,4 +9,7 @@ import io.temporal.activity.ActivityExecutionContext;
 public interface InternalActivityExecutionContext extends ActivityExecutionContext {
   /** Get the latest value of {@link ActivityExecutionContext#heartbeat(Object)}. */
   Object getLastHeartbeatValue();
+
+  /** Cancel any pending heartbeat and discard cached heartbeat details. */
+  void cancelOutstandingHeartbeat();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/LocalActivityExecutionContextImpl.java
@@ -80,6 +80,11 @@ class LocalActivityExecutionContextImpl implements InternalActivityExecutionCont
   }
 
   @Override
+  public void cancelOutstandingHeartbeat() {
+    // Ignored
+  }
+
+  @Override
   public WorkflowClient getWorkflowClient() {
     return client;
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/ActivityTimeoutTest.java
@@ -49,11 +49,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(JUnitParamsRunner.class)
 public class ActivityTimeoutTest {
-  // TODO This test takes longer than it should to complete because
-  //  of the cached heartbeat that prevents a quick shutdown
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setTestTimeoutSeconds(15).setDoNotStart(true).build();
+      SDKTestWorkflowRule.newBuilder().setDoNotStart(true).build();
 
   /**
    * An activity reaches startToClose timeout once, max retries are set to 1. o


### PR DESCRIPTION
Cancel pending heartbeat when activity completes. This prevents the heartbeat from holding up worker shutdown and prevents heartbeating an already completed activity

closes: https://github.com/temporalio/sdk-java/issues/1256
