### PR TITLE
Fix Workflow.getWorkflowExecution for ExternalWorkflowStub

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInternal.java
@@ -418,11 +418,18 @@ public final class WorkflowInternal {
 
   public static Promise<WorkflowExecution> getWorkflowExecution(Object workflowStub) {
     if (workflowStub instanceof StubMarker) {
-      Object stub = ((StubMarker) workflowStub).__getUntypedStub();
-      return ((ChildWorkflowStub) stub).getExecution();
+      Object untyped = ((StubMarker) workflowStub).__getUntypedStub();
+      if (untyped instanceof ChildWorkflowStub) {
+        return ((ChildWorkflowStub) untyped).getExecution();
+      }
+
+      if (untyped instanceof ExternalWorkflowStub) {
+        return newPromise(((ExternalWorkflowStub) untyped).getExecution());
+      }
     }
     throw new IllegalArgumentException(
-        "Not a workflow stub created through Workflow.newChildWorkflowStub: " + workflowStub);
+        "Not a workflow stub created through Workflow.newChildWorkflowStub or Workflow.newExternalWorkflowStub: "
+            + workflowStub);
   }
 
   public static ChildWorkflowStub newUntypedChildWorkflowStub(

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -200,10 +200,11 @@ public final class Workflow {
   /**
    * Extracts workflow execution from a stub created through {@link #newChildWorkflowStub(Class,
    * ChildWorkflowOptions)} or {@link #newExternalWorkflowStub(Class, String)}. Wrapped in a Promise
-   * as child workflow start is asynchronous.
+   * as child workflow start is asynchronous. For an external workflow the returned promise is
+   * already completed.
    */
-  public static Promise<WorkflowExecution> getWorkflowExecution(Object childWorkflowStub) {
-    return WorkflowInternal.getWorkflowExecution(childWorkflowStub);
+  public static Promise<WorkflowExecution> getWorkflowExecution(Object workflowStub) {
+    return WorkflowInternal.getWorkflowExecution(workflowStub);
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ExternalWorkflowGetExecutionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ExternalWorkflowGetExecutionTest.java
@@ -1,0 +1,57 @@
+package io.temporal.workflow;
+
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowStub;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExternalWorkflowGetExecutionTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ParentWorkflowImpl.class, ChildWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testGetExecutionFromExternalWorkflowStub() {
+    ParentWorkflow client =
+        testWorkflowRule.newWorkflowStub200sTimeoutOptions(ParentWorkflow.class);
+    WorkflowExecution execution = WorkflowClient.start(client::execute);
+    String result = WorkflowStub.fromTyped(client).getResult(String.class);
+    assertEquals(execution.getWorkflowId(), result);
+  }
+
+  @WorkflowInterface
+  public interface ParentWorkflow {
+    @WorkflowMethod
+    String execute();
+  }
+
+  @WorkflowInterface
+  public interface ChildWorkflow {
+    @WorkflowMethod
+    String execute();
+  }
+
+  public static class ParentWorkflowImpl implements ParentWorkflow {
+    @Override
+    public String execute() {
+      ChildWorkflow child = Workflow.newChildWorkflowStub(ChildWorkflow.class);
+      return child.execute();
+    }
+  }
+
+  public static class ChildWorkflowImpl implements ChildWorkflow {
+    @Override
+    public String execute() {
+      String parentId = Workflow.getInfo().getParentWorkflowId().get();
+      ParentWorkflow parent = Workflow.newExternalWorkflowStub(ParentWorkflow.class, parentId);
+      return Workflow.getWorkflowExecution(parent).get().getWorkflowId();
+    }
+  }
+}


### PR DESCRIPTION
Fix Workflow.getWorkflowExecution for ExternalWorkflowStub. The docs said this should work but it never has, now it will. Technically a backwards incompatible change, previously it just caused a task failure so this should be fine.

closes https://github.com/temporalio/sdk-java/issues/1237