### PR TITLE
Upgrade otel & otel-shim to 1.50.0

### DIFF
--- a/temporal-spring-boot-autoconfigure/build.gradle
+++ b/temporal-spring-boot-autoconfigure/build.gradle
@@ -1,7 +1,7 @@
 description = '''Spring Boot AutoConfigure for Temporal Java SDK'''
 
 ext {
-    otelVersion = '1.25.0'
+    otelVersion = '1.50.0'
     otShimVersion = "${otelVersion}-alpha"
 }
 


### PR DESCRIPTION
## What was changed
Upgrading `io.opentelemetry:opentelemetry-bom` and `i.o:opentelemetry-opentracing-shim` to `1.50.0`.

## Why?
The opentracing version transitively referenced by `io.opentelemetry` is `1.26.0` which is quite old and causing issues. We could create a resolution rule internally for this, but it seems like a good thing to upgrade regardless.

## Checklist

2. How was this tested:

`./gradlew build check`
