### PR TITLE
Clear MDC context after each task

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollTaskExecutor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollTaskExecutor.java
@@ -81,8 +81,7 @@ final class PollTaskExecutor<T> implements ShutdownableTaskExecutor<T> {
                   .uncaughtException(Thread.currentThread(), handler.wrapFailure(task, e));
             }
           } finally {
-            MDC.remove(LoggerTag.NAMESPACE);
-            MDC.remove(LoggerTag.TASK_QUEUE);
+            MDC.clear();
           }
         });
   }

--- a/temporal-sdk/src/test/java/io/temporal/worker/MdcClearedBetweenTasksTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/MdcClearedBetweenTasksTest.java
@@ -1,0 +1,71 @@
+package io.temporal.worker;
+
+import static org.junit.Assert.assertNull;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+public class MdcClearedBetweenTasksTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(new SetMdcActivityImpl(), new GetMdcActivityImpl())
+          .build();
+
+  @Test
+  public void testMdcClearedBetweenActivities() {
+    TestWorkflows.TestWorkflowReturnString workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowReturnString.class);
+    String result = workflow.execute();
+    assertNull(result);
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.TestWorkflowReturnString {
+    private final SetMdcActivity setMdcActivity =
+        Workflow.newActivityStub(
+            SetMdcActivity.class, SDKTestOptions.newActivityOptions20sScheduleToClose());
+    private final GetMdcActivity getMdcActivity =
+        Workflow.newActivityStub(
+            GetMdcActivity.class, SDKTestOptions.newActivityOptions20sScheduleToClose());
+
+    @Override
+    public String execute() {
+      setMdcActivity.execute();
+      return getMdcActivity.execute();
+    }
+  }
+
+  @ActivityInterface
+  public interface SetMdcActivity {
+    @ActivityMethod(name = "setMdc")
+    void execute();
+  }
+
+  public static class SetMdcActivityImpl implements SetMdcActivity {
+    @Override
+    public void execute() {
+      MDC.put("mdcTest", "value");
+    }
+  }
+
+  @ActivityInterface
+  public interface GetMdcActivity {
+    @ActivityMethod(name = "getMdc")
+    String execute();
+  }
+
+  public static class GetMdcActivityImpl implements GetMdcActivity {
+    @Override
+    public String execute() {
+      return MDC.get("mdcTest");
+    }
+  }
+}


### PR DESCRIPTION
Clear MDC context after each task to avoid leaking it between activities or nexus operations. We already do this for workflow threads so this is just consistent with this.

https://github.com/temporalio/sdk-java/issues/2314