### PR TITLE
Use link from start workflow request for Nexus operations

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -23,6 +23,7 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.internal.client.external.GenericWorkflowClient;
 import io.temporal.internal.common.HeaderUtils;
+import io.temporal.internal.nexus.CurrentNexusOperationContext;
 import io.temporal.payload.context.WorkflowSerializationContext;
 import io.temporal.serviceclient.StatusUtils;
 import io.temporal.worker.WorkflowTaskDispatchHandle;
@@ -94,6 +95,9 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
               "[BUG] Eager Workflow Task was received from the Server, but failed to be dispatched on the local worker",
               e);
         }
+      }
+      if (CurrentNexusOperationContext.isNexusContext()) {
+        CurrentNexusOperationContext.get().setStartWorkflowResponseLink(response.getLink());
       }
       return new WorkflowStartOutput(execution);
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/CurrentNexusOperationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/CurrentNexusOperationContext.java
@@ -7,6 +7,10 @@ package io.temporal.internal.nexus;
 public final class CurrentNexusOperationContext {
   private static final ThreadLocal<InternalNexusOperationContext> CURRENT = new ThreadLocal<>();
 
+  public static boolean isNexusContext() {
+    return CURRENT.get() != null;
+  }
+
   public static InternalNexusOperationContext get() {
     InternalNexusOperationContext result = CURRENT.get();
     if (result == null) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/InternalNexusOperationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/InternalNexusOperationContext.java
@@ -1,6 +1,7 @@
 package io.temporal.internal.nexus;
 
 import com.uber.m3.tally.Scope;
+import io.temporal.api.common.v1.Link;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.interceptors.NexusOperationOutboundCallsInterceptor;
 import io.temporal.nexus.NexusOperationContext;
@@ -11,6 +12,7 @@ public class InternalNexusOperationContext {
   private final Scope metricScope;
   private final WorkflowClient client;
   NexusOperationOutboundCallsInterceptor outboundCalls;
+  Link startWorkflowResponseLink;
 
   public InternalNexusOperationContext(
       String namespace, String taskQueue, Scope metricScope, WorkflowClient client) {
@@ -45,6 +47,14 @@ public class InternalNexusOperationContext {
       throw new IllegalStateException("Outbound interceptor is not set");
     }
     return new NexusOperationContextImpl();
+  }
+
+  public void setStartWorkflowResponseLink(Link link) {
+    this.startWorkflowResponseLink = link;
+  }
+
+  public Link getStartWorkflowResponseLink() {
+    return startWorkflowResponseLink;
   }
 
   private class NexusOperationContextImpl implements NexusOperationContext {


### PR DESCRIPTION
Use link from start workflow request for Nexus operations to match the changes we made to the Go SDK

see also: https://github.com/temporalio/sdk-go/pull/1934

closes https://github.com/temporalio/sdk-java/issues/2523
