### PR TITLE
__temporal_workflow_metadata query responses should use "RawValue"

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/common/converter/CodecDataConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/CodecDataConverterTest.java
@@ -123,7 +123,7 @@ public class CodecDataConverterTest {
     return payload.getData().startsWith(PrefixPayloadCodec.PREFIX);
   }
 
-  private static final class PrefixPayloadCodec implements PayloadCodec {
+  public static final class PrefixPayloadCodec implements PayloadCodec {
     public static final ByteString PREFIX = ByteString.copyFromUtf8("ENCODED: ");
 
     @Override

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowMetadataTest.java
@@ -4,17 +4,36 @@ import io.temporal.api.sdk.v1.WorkflowDefinition;
 import io.temporal.api.sdk.v1.WorkflowInteractionDefinition;
 import io.temporal.api.sdk.v1.WorkflowMetadata;
 import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowStub;
+import io.temporal.common.converter.CodecDataConverter;
+import io.temporal.common.converter.CodecDataConverterTest;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
+import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class WorkflowMetadataTest {
 
+  CodecDataConverterTest.PrefixPayloadCodec prefixPayloadCodec =
+      new CodecDataConverterTest.PrefixPayloadCodec();
+
+  DataConverter dataConverter =
+      new CodecDataConverter(
+          DefaultDataConverter.newDefaultInstance(),
+          Collections.singletonList(prefixPayloadCodec),
+          true);
+
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowWithMetadataImpl.class).build();
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder().setDataConverter(dataConverter).build())
+          .setWorkflowTypes(TestWorkflowWithMetadataImpl.class)
+          .build();
 
   @Test
   public void testGetMetadata() {


### PR DESCRIPTION
closes https://github.com/temporalio/sdk-java/issues/2426