### PR TITLE
Fix ignoreDuplicateDefinitions to log only if we are ignoring

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/NamespaceProperties.java
@@ -15,7 +15,7 @@ public class NamespaceProperties {
   private final @Nullable List<WorkerProperties> workers;
   private final @Nonnull String namespace;
   private final @Nullable WorkflowCacheProperties workflowCache;
-  private final @Nullable Boolean ignoreDuplicateDefinitions;
+  private final @Nonnull Boolean ignoreDuplicateDefinitions;
 
   @ConstructorBinding
   public NamespaceProperties(
@@ -29,7 +29,7 @@ public class NamespaceProperties {
     this.namespace = MoreObjects.firstNonNull(namespace, NAMESPACE_DEFAULT);
     this.workflowCache = workflowCache;
     this.ignoreDuplicateDefinitions =
-        MoreObjects.firstNonNull(ignoreDuplicateDefinitions, Boolean.TRUE);
+        MoreObjects.firstNonNull(ignoreDuplicateDefinitions, Boolean.FALSE);
   }
 
   @Nullable
@@ -57,7 +57,7 @@ public class NamespaceProperties {
 
   @Nonnull
   public Boolean isIgnoreDuplicateDefinitions() {
-    return Boolean.TRUE;
+    return ignoreDuplicateDefinitions;
   }
 
   public static class WorkflowCacheProperties {

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -422,6 +422,9 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             worker.getTaskQueue());
       }
     } catch (TypeAlreadyRegisteredException registeredEx) {
+      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
+        throw registeredEx;
+      }
       if (log.isInfoEnabled()) {
         log.info(
             "Skipping auto-discovered activity bean '{}' of class {} on a worker {} with a task queue '{}'"
@@ -431,9 +434,6 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             byWorkerName != null ? "'" + byWorkerName + "' " : "",
             worker.getTaskQueue(),
             registeredEx.getRegisteredTypeName());
-      }
-      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
-        throw registeredEx;
       }
     }
   }
@@ -461,6 +461,9 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             worker.getTaskQueue());
       }
     } catch (TypeAlreadyRegisteredException registeredEx) {
+      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
+        throw registeredEx;
+      }
       if (log.isInfoEnabled()) {
         log.info(
             "Skipping auto-discovered nexus service bean '{}' of class {} on a worker {} with a task queue '{}'"
@@ -470,9 +473,6 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             byWorkerName != null ? "'" + byWorkerName + "' " : "",
             worker.getTaskQueue(),
             registeredEx.getRegisteredTypeName());
-      }
-      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
-        throw registeredEx;
       }
     }
   }
@@ -489,6 +489,9 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             worker.getTaskQueue());
       }
     } catch (TypeAlreadyRegisteredException registeredEx) {
+      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
+        throw registeredEx;
+      }
       if (log.isInfoEnabled()) {
         log.info(
             "Skip registering of auto-discovered workflow class {} on a worker {}with a task queue '{}' "
@@ -497,9 +500,6 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
             byWorkerName != null ? "'" + byWorkerName + "' " : "",
             worker.getTaskQueue(),
             registeredEx.getRegisteredTypeName());
-      }
-      if (!namespaceProperties.isIgnoreDuplicateDefinitions()) {
-        throw registeredEx;
       }
     }
   }


### PR DESCRIPTION
Fix `ignoreDuplicateDefinitions` to log only if we are ignoring