### PR TITLE
Fix some dependency issues with NonRootBeanPostProcessor

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NamespacesPresentCondition.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NamespacesPresentCondition.java
@@ -1,0 +1,34 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import io.temporal.spring.boot.autoconfigure.properties.NonRootNamespaceProperties;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition that checks if the "spring.temporal.namespaces" property is present in the application
+ * context.
+ */
+class NamespacesPresentCondition extends SpringBootCondition {
+  private static final Bindable<List<NonRootNamespaceProperties>> NAMESPACES_LIST =
+      Bindable.listOf(NonRootNamespaceProperties.class);
+  private static final String NAMESPACES_KEY = "spring.temporal.namespaces";
+
+  @Override
+  public ConditionOutcome getMatchOutcome(
+      ConditionContext context, AnnotatedTypeMetadata metadata) {
+    BindResult<?> namespacesProperty =
+        Binder.get(context.getEnvironment()).bind(NAMESPACES_KEY, NAMESPACES_LIST);
+    ConditionMessage.Builder messageBuilder = ConditionMessage.forCondition("Present namespaces");
+    if (namespacesProperty.isBound()) {
+      return ConditionOutcome.match(messageBuilder.found("property").items(NAMESPACES_KEY));
+    }
+    return ConditionOutcome.noMatch(messageBuilder.didNotFind("property").items(NAMESPACES_KEY));
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NonRootBeanPostProcessor.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NonRootBeanPostProcessor.java
@@ -61,10 +61,12 @@ public class NonRootBeanPostProcessor implements BeanPostProcessor, BeanFactoryA
     if (bean instanceof NamespaceTemplate && beanName.equals("temporalRootNamespaceTemplate")) {
       if (namespaceProperties != null) {
         // If there are non-root namespaces, we need to inject beans for each of them. Look
-        // up the bean manually instead of using @Autowired to avoid circular dependencies or causing the dependency to
+        // up the bean manually instead of using @Autowired to avoid circular dependencies or
+        // causing the dependency to
         // get initialized to early and skip post-processing.
         //
-        // Note: We don't use @Lazy here because these dependencies are optional and @Lazy doesn't interact well with
+        // Note: We don't use @Lazy here because these dependencies are optional and @Lazy doesn't
+        // interact well with
         // optional dependencies.
         metricsScope = findBean("temporalMetricsScope", Scope.class);
         tracer = findBean(Tracer.class);

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NonRootNamespaceAutoConfiguration.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/NonRootNamespaceAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.ApplicationContextEvent;
@@ -30,8 +31,9 @@ import org.springframework.context.event.ContextRefreshedEvent;
 @EnableConfigurationProperties(TemporalProperties.class)
 @AutoConfigureAfter({RootNamespaceAutoConfiguration.class, ServiceStubsAutoConfiguration.class})
 @ConditionalOnBean(ServiceStubsAutoConfiguration.class)
+@Conditional(NamespacesPresentCondition.class)
 @ConditionalOnExpression(
-    "(${spring.temporal.test-server.enabled:false} || '${spring.temporal.connection.target:}'.length() > 0) && ('${spring.temporal.namespaces:}'.length() > 0)")
+    "${spring.temporal.test-server.enabled:false} || '${spring.temporal.connection.target:}'.length() > 0")
 public class NonRootNamespaceAutoConfiguration {
 
   protected static final Logger log =

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/MultiNamespaceTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/MultiNamespaceTest.java
@@ -36,6 +36,7 @@ public class MultiNamespaceTest {
   @Test
   @Timeout(value = 10)
   public void shouldContainsNonRootRelatedBean() {
+    Assertions.assertTrue(applicationContext.containsBean("nonRootBeanPostProcessor"));
     Assertions.assertTrue(applicationContext.containsBean("ns1NamespaceTemplate"));
     Assertions.assertTrue(applicationContext.containsBean("namespace2NamespaceTemplate"));
     Assertions.assertTrue(applicationContext.containsBean("ns1ClientTemplate"));

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/StartWorkersTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/StartWorkersTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.temporal.spring.boot.autoconfigure.properties.TemporalProperties;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles(profiles = "disable-start-workers")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class StartWorkersTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
 
   @Autowired TemporalProperties temporalProperties;
 
@@ -33,6 +36,7 @@ public class StartWorkersTest {
   @Timeout(value = 10)
   public void testWorkersStarted() {
     Worker worker = testWorkflowEnvironment.getWorkerFactory().getWorker("UnitTest");
+    Assertions.assertFalse(applicationContext.containsBean("nonRootBeanPostProcessor"));
     assertNotNull(worker);
     assertTrue(worker.isSuspended());
   }


### PR DESCRIPTION
Fix some dependency issues with NonRootBeanPostProcessor. Also don't attempt to create `NonRootBeanPostProcessor` if we are not in a multinamespace config.