### PR TITLE
Don't fail Springboot if a bean is specified twice

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -730,17 +730,17 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
     private final HashMap<String, RegisteredNexusServiceInfo> registeredNexusServiceInfos =
         new HashMap<>();
 
-    private RegisteredInfo addActivityInfo(RegisteredActivityInfo activityInfo) {
+    public RegisteredInfo addActivityInfo(RegisteredActivityInfo activityInfo) {
       registeredActivityInfo.put(activityInfo.getBeanName(), activityInfo);
       return this;
     }
 
-    private RegisteredInfo addNexusServiceInfo(RegisteredNexusServiceInfo nexusServiceInfo) {
+    public RegisteredInfo addNexusServiceInfo(RegisteredNexusServiceInfo nexusServiceInfo) {
       registeredNexusServiceInfos.put(nexusServiceInfo.getBeanName(), nexusServiceInfo);
       return this;
     }
 
-    private RegisteredInfo addWorkflowInfo(RegisteredWorkflowInfo workflowInfo) {
+    public RegisteredInfo addWorkflowInfo(RegisteredWorkflowInfo workflowInfo) {
       registeredWorkflowInfo.put(workflowInfo.getImplementationClass(), workflowInfo);
       return this;
     }

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryAndExplicitWithDuplicatesTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryAndExplicitWithDuplicatesTest.java
@@ -1,0 +1,50 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
+import io.temporal.testing.TestWorkflowEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = AutoDiscoveryAndExplicitWithDuplicatesTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-and-explicit-with-duplicate")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryAndExplicitWithDuplicatesTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired TestWorkflowEnvironment testWorkflowEnvironment;
+
+  @Autowired WorkflowClient workflowClient;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testAutoDiscoveryAndExplicitWithDuplicate() {
+    TestWorkflow testWorkflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue("UnitTest").build());
+    assertEquals("done", testWorkflow.execute("profile"));
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.bytaskqueue\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -71,6 +71,23 @@ spring:
     workers-auto-discovery:
       packages:
         - io.temporal.spring.boot.autoconfigure.byworkername
+        -
+---
+spring:
+  config:
+    activate:
+      on-profile: auto-discovery-and-explicit-with-duplicate
+  temporal:
+    workers:
+      - task-queue: UnitTest
+        name: mainWorker
+        workflow-classes:
+          - io.temporal.spring.boot.autoconfigure.byworkername.TestWorkflowImpl
+        activity-beans:
+          - TestActivityImpl
+    workers-auto-discovery:
+      packages:
+        - io.temporal.spring.boot.autoconfigure.byworkername
 
 ---
 spring:

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -71,7 +71,7 @@ spring:
     workers-auto-discovery:
       packages:
         - io.temporal.spring.boot.autoconfigure.byworkername
-        -
+
 ---
 spring:
   config:


### PR DESCRIPTION
Don't fail Springboot init. if a bean is specified twice. With explicit config and auto discovery it is possible a user specifies the same bean or class for auto-discovery, in this case we shouldn't fail init since while it is technically a duplicate registration it is an identical registration.
