### PR TITLE
Fix build native image action to use the correct input

### DIFF
--- a/.github/workflows/build-native-image.yml
+++ b/.github/workflows/build-native-image.yml
@@ -30,7 +30,7 @@ on:
           required: false
           default: false
 env:
-  INPUT_REF: ${{ github.event.inputs.ref }}
+  INPUT_REF: ${{ inputs.ref }}
 
 jobs:
   build_native_images:
@@ -101,7 +101,7 @@ jobs:
             sh -c "./gradlew -PnativeBuild -PnativeBuildMusl  :temporal-test-server:nativeCompile"
       # path ends in a wildcard because on windows the file ends in '.exe'
       - name: Upload executable to workflow
-        if: ${{ github.event.inputs.upload_artifact == 'true'}}
+        if: ${{ inputs.upload_artifact == 'true'}}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.musl && format('{0}_{1}_musl', matrix.os_family, matrix.arch) || format('{0}_{1}', matrix.os_family, matrix.arch)}}


### PR DESCRIPTION
Fix build native image action to use the correct input
