### PR TITLE
Publish to Sonatype central

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -4,6 +4,8 @@ nexusPublishing {
         sonatype {
             username = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : ''
             password = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : ''
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
Publish to Sonatype central since [ossrh](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/) is end of life

following this guide: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/