### PR TITLE
Update Proto API to v1.50.0

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/DefaultFailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/DefaultFailureConverter.java
@@ -70,6 +70,7 @@ public final class DefaultFailureConverter implements FailureConverter {
     return result;
   }
 
+  @SuppressWarnings("deprecation") // Continue to check operation id for history compatibility
   private RuntimeException failureToExceptionImpl(Failure failure, DataConverter dataConverter) {
     Exception cause =
         failure.hasCause() ? failureToException(failure.getCause(), dataConverter) : null;
@@ -217,6 +218,7 @@ public final class DefaultFailureConverter implements FailureConverter {
   }
 
   @Nonnull
+  @SuppressWarnings("deprecation") // Continue to check operation id for history compatibility
   private Failure exceptionToFailure(Throwable throwable) {
     if (throwable instanceof CheckedExceptionWrapper) {
       return exceptionToFailure(throwable.getCause());

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
@@ -179,6 +179,7 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
     }
   }
 
+  @SuppressWarnings("deprecation") // Continue to check operation id for history compatibility
   private CancelOperationResponse handleCancelledOperation(
       OperationContext.Builder ctx, CancelOperationRequest task) {
     ctx.setService(task.getService()).setOperation(task.getOperation());
@@ -237,6 +238,7 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
     }
   }
 
+  @SuppressWarnings("deprecation") // Continue to check operation id for history compatibility
   private StartOperationResponse handleStartOperation(
       OperationContext.Builder ctx, StartOperationRequest task) {
     ctx.setService(task.getService()).setOperation(task.getOperation());

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/NexusOperationStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/NexusOperationStateMachine.java
@@ -160,11 +160,11 @@ final class NexusOperationStateMachine
     completionCallback.apply(Optional.empty(), failure);
   }
 
+  @SuppressWarnings("deprecation") // Continue to check operation id for history compatibility
   private void notifyStarted() {
     async = true;
     String operationToken =
         currentEvent.getNexusOperationStartedEventAttributes().getOperationToken();
-    // TODO(#2423) Remove support for operationId
     String operationId = currentEvent.getNexusOperationStartedEventAttributes().getOperationId();
     startedCallback.apply(
         Optional.of(operationToken.isEmpty() ? operationId : operationToken), null);

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/NexusTaskHandlerImplTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/NexusTaskHandlerImplTest.java
@@ -156,7 +156,7 @@ public class NexusTaskHandlerImplTest {
     Assert.assertNull(result.getHandlerError());
     Assert.assertNotNull(result.getResponse());
     Assert.assertEquals(
-        "test id", result.getResponse().getStartOperation().getAsyncSuccess().getOperationId());
+        "test id", result.getResponse().getStartOperation().getAsyncSuccess().getOperationToken());
   }
 
   @ServiceImpl(service = TestNexusServices.TestNexusService1.class)

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/CancelNexusOperationStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/CancelNexusOperationStateMachineTest.java
@@ -105,7 +105,7 @@ public class CancelNexusOperationStateMachineTest {
             NexusOperationStartedEventAttributes.newBuilder()
                 .setScheduledEventId(scheduledEventId)
                 .setRequestId("requestId")
-                .setOperationId(OPERATION_ID)
+                .setOperationToken(OPERATION_ID)
                 .build())
         .addWorkflowTask();
     long cancelRequestedEventId =
@@ -196,7 +196,7 @@ public class CancelNexusOperationStateMachineTest {
             NexusOperationStartedEventAttributes.newBuilder()
                 .setScheduledEventId(scheduledEventId)
                 .setRequestId("requestId")
-                .setOperationId(OPERATION_ID)
+                .setOperationToken(OPERATION_ID)
                 .build())
         .addWorkflowTask();
     long cancelRequestedEventId =

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/NexusOperationStateMachineTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/NexusOperationStateMachineTest.java
@@ -461,7 +461,7 @@ public class NexusOperationStateMachineTest {
           NexusOperationStartedEventAttributes.newBuilder()
               .setScheduledEventId(scheduledEventId)
               .setRequestId("requestId")
-              .setOperationId(OPERATION_ID)
+              .setOperationToken(OPERATION_ID)
               .build());
       h.addWorkflowTask();
       h.add(
@@ -553,7 +553,7 @@ public class NexusOperationStateMachineTest {
           NexusOperationStartedEventAttributes.newBuilder()
               .setScheduledEventId(scheduledEventId)
               .setRequestId("requestId")
-              .setOperationId(OPERATION_ID)
+              .setOperationToken(OPERATION_ID)
               .build());
       h.addWorkflowTask();
       h.add(
@@ -645,7 +645,7 @@ public class NexusOperationStateMachineTest {
           NexusOperationStartedEventAttributes.newBuilder()
               .setScheduledEventId(scheduledEventId)
               .setRequestId("requestId")
-              .setOperationId(OPERATION_ID)
+              .setOperationToken(OPERATION_ID)
               .build());
       h.addWorkflowTask();
       h.add(
@@ -737,7 +737,7 @@ public class NexusOperationStateMachineTest {
           NexusOperationStartedEventAttributes.newBuilder()
               .setScheduledEventId(scheduledEventId)
               .setRequestId("requestId")
-              .setOperationId(OPERATION_ID)
+              .setOperationToken(OPERATION_ID)
               .build());
       h.addWorkflowTask();
       h.add(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -268,6 +268,7 @@ public class UpdateTest {
     assertEquals("Execute-Hello Update", workflow.update(0, "Hello Update"));
 
     // Reset the workflow
+    @SuppressWarnings("deprecation")
     ResetWorkflowExecutionResponse resetResponse =
         workflowClient
             .getWorkflowServiceStubs()

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -2358,7 +2358,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
   public void completeAsyncNexusOperation(
       NexusOperationRef ref,
       Payload result,
-      String operationID,
+      String operationToken,
       io.temporal.api.nexus.v1.Link startLink) {
     update(
         ctx -> {
@@ -2368,7 +2368,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             // Received completion before start, so fabricate started event.
             StartOperationResponse.Async start =
                 StartOperationResponse.Async.newBuilder()
-                    .setOperationId(operationID)
+                    .setOperationToken(operationToken)
                     .addLinks(startLink)
                     .build();
             operation.action(Action.START, ctx, start, 0);
@@ -2487,7 +2487,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
 
           LockHandle lockHandle =
               timerService.lockTimeSkipping(
-                  "nexusOperationRetryTimer " + operation.getData().operationId);
+                  "nexusOperationRetryTimer " + operation.getData().operationToken);
           boolean unlockTimer = false;
           data.isBackingOff = false;
 
@@ -2506,7 +2506,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
           } finally {
             if (unlockTimer) {
               // Allow time skipping when waiting for an operation retry
-              lockHandle.unlock("nexusOperationRetryTimer " + operation.getData().operationId);
+              lockHandle.unlock("nexusOperationRetryTimer " + operation.getData().operationToken);
             }
           }
         },
@@ -3361,7 +3361,7 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
             .setEndpoint(data.scheduledEvent.getEndpoint())
             .setService(data.scheduledEvent.getService())
             .setOperation(data.scheduledEvent.getOperation())
-            .setOperationId(data.operationId)
+            .setOperationToken(data.operationToken)
             .setScheduledEventId(data.scheduledEventId)
             .setScheduleToCloseTimeout(data.scheduledEvent.getScheduleToCloseTimeout())
             .setState(convertNexusOperationState(sm.getState(), data))

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1424,7 +1424,6 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
               .setSignalName(r.getSignalName())
               .setWorkflowExecution(executionId.getExecution())
               .setRequestId(r.getRequestId())
-              .setControl(r.getControl())
               .setNamespace(r.getNamespace())
               .setIdentity(r.getIdentity())
               .addAllLinks(r.getLinksList())
@@ -1526,6 +1525,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
    *
    * @return RunId
    */
+  @SuppressWarnings("deprecation")
   public String continueAsNew(
       StartWorkflowExecutionRequest previousRunStartRequest,
       ContinueAsNewWorkflowExecutionCommandAttributes ca,

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/NexusWorkflowTest.java
@@ -1009,7 +1009,7 @@ public class NexusWorkflowTest {
             .setStartOperation(
                 StartOperationResponse.newBuilder()
                     .setAsyncSuccess(
-                        StartOperationResponse.Async.newBuilder().setOperationId(operationId)))
+                        StartOperationResponse.Async.newBuilder().setOperationToken(operationId)))
             .build());
   }
 
@@ -1055,7 +1055,7 @@ public class NexusWorkflowTest {
 
   private void assertOperationFailureInfo(String operationID, NexusOperationFailureInfo info) {
     Assert.assertNotNull(info);
-    Assert.assertEquals(operationID, info.getOperationId());
+    Assert.assertEquals(operationID, info.getOperationToken());
     Assert.assertEquals(testEndpoint.getSpec().getName(), info.getEndpoint());
     Assert.assertEquals(testService, info.getService());
     Assert.assertEquals(testOperation, info.getOperation());


### PR DESCRIPTION
Update Proto API to v1.50.0. Removing some deprecated fields in the test server.

Note: Left support for Nexus operation ID in just the workflow code so we can continue to support old histories.