### PR TITLE
Fix ApplicationFailure.Builder handling a null Category

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
@@ -341,7 +341,7 @@ public final class ApplicationFailure extends TemporalFailure {
           details == null ? new EncodedValues(null) : details,
           cause,
           nextRetryDelay,
-          category);
+          category == null ? ApplicationErrorCategory.UNSPECIFIED : category);
     }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/failure/DefaultFailureConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/DefaultFailureConverter.java
@@ -244,14 +244,16 @@ public final class DefaultFailureConverter implements FailureConverter {
       ApplicationFailureInfo.Builder info =
           ApplicationFailureInfo.newBuilder()
               .setType(ae.getType())
-              .setNonRetryable(ae.isNonRetryable())
-              .setCategory(FailureUtils.categoryToProto(ae.getCategory()));
+              .setNonRetryable(ae.isNonRetryable());
       Optional<Payloads> details = ((EncodedValues) ae.getDetails()).toPayloads();
       if (details.isPresent()) {
         info.setDetails(details.get());
       }
       if (ae.getNextRetryDelay() != null) {
         info.setNextRetryDelay(ProtobufTimeUtils.toProtoDuration(ae.getNextRetryDelay()));
+      }
+      if (ae.getCategory() != null) {
+        info.setCategory(FailureUtils.categoryToProto(ae.getCategory()));
       }
       failure.setApplicationFailureInfo(info);
     } else if (throwable instanceof TimeoutFailure) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
@@ -90,9 +90,9 @@ public class ActivityFailedMetricsTests {
     public void execute(boolean isBenign) {
       if (!isBenign) {
         throw ApplicationFailure.newBuilder()
-                .setMessage("Non-benign activity failure")
-                .setType("NonBenignType")
-                .build();
+            .setMessage("Non-benign activity failure")
+            .setType("NonBenignType")
+            .build();
       } else {
         throw ApplicationFailure.newBuilder()
             .setMessage("Benign activity failure")

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
@@ -89,7 +89,10 @@ public class ActivityFailedMetricsTests {
     @Override
     public void execute(boolean isBenign) {
       if (!isBenign) {
-        throw ApplicationFailure.newFailure("Non-benign activity failure", "NonBenignType");
+        throw ApplicationFailure.newBuilder()
+                .setMessage("Non-benign activity failure")
+                .setType("NonBenignType")
+                .build();
       } else {
         throw ApplicationFailure.newBuilder()
             .setMessage("Benign activity failure")


### PR DESCRIPTION
Fix ApplicationFailure.Builder handling a null Category

closes https://github.com/temporalio/sdk-java/issues/2601
