### PR TITLE
Do not auto-retry gRPC-message-size-too-large errors

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
@@ -236,9 +236,7 @@ public final class ApplicationFailure extends TemporalFailure {
     private Duration nextRetryDelay;
     private ApplicationErrorCategory category;
 
-    private Builder() {
-      category = ApplicationErrorCategory.UNSPECIFIED;
-    }
+    private Builder() {}
 
     private Builder(ApplicationFailure options) {
       if (options == null) {

--- a/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
+++ b/temporal-sdk/src/main/java/io/temporal/failure/ApplicationFailure.java
@@ -236,7 +236,9 @@ public final class ApplicationFailure extends TemporalFailure {
     private Duration nextRetryDelay;
     private ApplicationErrorCategory category;
 
-    private Builder() {}
+    private Builder() {
+      category = ApplicationErrorCategory.UNSPECIFIED;
+    }
 
     private Builder(ApplicationFailure options) {
       if (options == null) {

--- a/temporal-sdk/src/test/java/io/temporal/testUtils/LoggerUtils.java
+++ b/temporal-sdk/src/test/java/io/temporal/testUtils/LoggerUtils.java
@@ -1,0 +1,41 @@
+package io.temporal.testUtils;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.LoggerFactory;
+
+public class LoggerUtils {
+  public static SilenceLoggers silenceLoggers(Class<?>... classes) {
+    return new SilenceLoggers(classes);
+  }
+
+  public static class SilenceLoggers implements AutoCloseable {
+    private final List<Logger> loggers;
+    List<Level> oldLogLevels;
+
+    public SilenceLoggers(Class<?>... classes) {
+      loggers =
+          Arrays.stream(classes)
+              .map(LoggerFactory::getLogger)
+              .filter(Logger.class::isInstance)
+              .map(Logger.class::cast)
+              .collect(Collectors.toList());
+      oldLogLevels = new ArrayList<>();
+      for (Logger logger : loggers) {
+        oldLogLevels.add(logger.getLevel());
+        logger.setLevel(Level.OFF);
+      }
+    }
+
+    @Override
+    public void close() {
+      for (int i = 0; i < loggers.size(); i++) {
+        loggers.get(i).setLevel(oldLogLevels.get(i));
+      }
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GrpcMessageTooLargeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GrpcMessageTooLargeTest.java
@@ -1,0 +1,105 @@
+package io.temporal.workflow;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.enums.v1.WorkflowTaskFailedCause;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowServiceException;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.TimeoutFailure;
+import io.temporal.internal.retryer.GrpcMessageTooLargeException;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestActivities;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GrpcMessageTooLargeTest {
+  private static final String VERY_LARGE_DATA;
+
+  static {
+    String argPiece = "Very Large Data ";
+    int argRepeats = 500_000; // circa 8MB, double the 4MB limit
+    StringBuilder argBuilder = new StringBuilder(argPiece.length() * argRepeats);
+    for (int i = 0; i < argRepeats; i++) {
+      argBuilder.append(argPiece);
+    }
+    VERY_LARGE_DATA = argBuilder.toString();
+  }
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(new TestActivityImpl())
+          .build();
+
+  @Test
+  public void workflowStartTooLarge() {
+    TestWorkflows.TestWorkflowStringArg workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.TestWorkflowStringArg.class);
+    WorkflowServiceException e =
+        assertThrows(
+            WorkflowServiceException.class,
+            () -> WorkflowClient.start(workflow::execute, VERY_LARGE_DATA));
+    assertTrue(e.getCause() instanceof GrpcMessageTooLargeException);
+  }
+
+  @Test
+  public void activityStartTooLarge() {
+    WorkflowOptions options =
+        WorkflowOptions.newBuilder()
+            .setWorkflowRunTimeout(Duration.ofSeconds(1))
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .build();
+    TestWorkflows.TestWorkflowStringArg workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(TestWorkflows.TestWorkflowStringArg.class, options);
+
+    WorkflowFailedException e =
+        assertThrows(WorkflowFailedException.class, () -> workflow.execute(""));
+    assertTrue(e.getCause() instanceof TimeoutFailure);
+
+    List<HistoryEvent> events =
+        testWorkflowRule.getHistoryEvents(
+            e.getExecution().getWorkflowId(), EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
+    assertFalse(events.isEmpty());
+    for (HistoryEvent event : events) {
+      assertEquals(
+          WorkflowTaskFailedCause.WORKFLOW_TASK_FAILED_CAUSE_GRPC_MESSAGE_TOO_LARGE,
+          event.getWorkflowTaskFailedEventAttributes().getCause());
+    }
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.TestWorkflowStringArg {
+    @Override
+    public void execute(String arg) {
+      Workflow.newActivityStub(
+              TestActivities.TestActivity1.class,
+              ActivityOptions.newBuilder()
+                  .setStartToCloseTimeout(Duration.ofSeconds(1))
+                  .validateAndBuildWithDefaults())
+          .execute(VERY_LARGE_DATA);
+    }
+  }
+
+  public static class TestActivityImpl implements TestActivities.TestActivity1 {
+    @Override
+    public String execute(String arg) {
+      throw ApplicationFailure.newBuilder()
+          .setMessage("This activity should not start executing")
+          .setType("TestFailure")
+          .setNonRetryable(true)
+          .build();
+    }
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcMessageTooLargeException.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcMessageTooLargeException.java
@@ -1,0 +1,7 @@
+package io.temporal.internal.retryer;
+
+public class GrpcMessageTooLargeException extends RuntimeException {
+  public GrpcMessageTooLargeException(io.grpc.StatusRuntimeException cause) {
+    super(cause.getMessage(), cause);
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcMessageTooLargeException.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcMessageTooLargeException.java
@@ -1,7 +1,34 @@
 package io.temporal.internal.retryer;
 
-public class GrpcMessageTooLargeException extends RuntimeException {
-  public GrpcMessageTooLargeException(io.grpc.StatusRuntimeException cause) {
-    super(cause.getMessage(), cause);
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import javax.annotation.Nullable;
+
+/**
+ * Internal exception used to mark when StatusRuntimeException is caused by message being too large.
+ * Exceptions are only wrapped if {@link GrpcRetryer} was used, which is an implementation detail
+ * and not always the case - user code should catch {@link StatusRuntimeException}.
+ */
+public class GrpcMessageTooLargeException extends StatusRuntimeException {
+  private GrpcMessageTooLargeException(Status status, @Nullable Metadata trailers) {
+    super(status, trailers);
+  }
+
+  public static @Nullable GrpcMessageTooLargeException tryWrap(StatusRuntimeException exception) {
+    Status status = exception.getStatus();
+    if (status.getCode() == Status.Code.RESOURCE_EXHAUSTED
+        && status.getDescription() != null
+        && (status.getDescription().startsWith("grpc: received message larger than max")
+            || status
+                .getDescription()
+                .startsWith("grpc: message after decompression larger than max")
+            || status
+                .getDescription()
+                .startsWith("grpc: received message after decompression larger than max"))) {
+      return new GrpcMessageTooLargeException(status.withCause(exception), exception.getTrailers());
+    } else {
+      return null;
+    }
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
@@ -29,9 +29,9 @@ class GrpcRetryerUtils {
       @Nonnull StatusRuntimeException currentException,
       @Nonnull RpcRetryOptions options,
       GetSystemInfoResponse.Capabilities serverCapabilities) {
-    Status status = currentException.getStatus();
+    Status.Code code = currentException.getStatus().getCode();
 
-    switch (status.getCode()) {
+    switch (code) {
       // CANCELLED and DEADLINE_EXCEEDED usually considered non-retryable in GRPC world, for
       // example:
       // https://github.com/grpc-ecosystem/go-grpc-middleware/blob/master/retry/retry.go#L287
@@ -65,7 +65,7 @@ class GrpcRetryerUtils {
         break;
       default:
         for (RpcRetryOptions.DoNotRetryItem pair : options.getDoNotRetry()) {
-          if (pair.getCode() == status.getCode()
+          if (pair.getCode() == code
               && (pair.getDetailsClass() == null
                   || StatusUtils.hasFailure(currentException, pair.getDetailsClass()))) {
             return currentException;

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/retryer/GrpcRetryerUtils.java
@@ -58,15 +58,9 @@ class GrpcRetryerUtils {
         break;
       case RESOURCE_EXHAUSTED:
         // Retry RESOURCE_EXHAUSTED unless the max message size was exceeded
-        if (status.getDescription() != null
-            && (status.getDescription().startsWith("grpc: received message larger than max")
-                || status
-                    .getDescription()
-                    .startsWith("grpc: message after decompression larger than max")
-                || status
-                    .getDescription()
-                    .startsWith("grpc: received message after decompression larger than max"))) {
-          return new GrpcMessageTooLargeException(currentException);
+        GrpcMessageTooLargeException e = GrpcMessageTooLargeException.tryWrap(currentException);
+        if (e != null) {
+          return e;
         }
         break;
       default:

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/testservice/GRPCServerHelper.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/testservice/GRPCServerHelper.java
@@ -1,24 +1,31 @@
 package io.temporal.internal.testservice;
 
-import io.grpc.BindableService;
-import io.grpc.ServerBuilder;
-import io.grpc.ServerServiceDefinition;
+import io.grpc.*;
 import io.grpc.health.v1.HealthCheckResponse;
 import io.grpc.protobuf.services.HealthStatusManager;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 // TODO move to temporal-testing or temporal-test-server modules after WorkflowServiceStubs cleanup
 public class GRPCServerHelper {
   public static void registerServicesAndHealthChecks(
       Collection<BindableService> services, ServerBuilder<?> toServerBuilder) {
+    registerServicesAndHealthChecks(services, toServerBuilder, Collections.emptyList());
+  }
+
+  public static void registerServicesAndHealthChecks(
+      Collection<BindableService> services,
+      ServerBuilder<?> toServerBuilder,
+      List<ServerInterceptor> interceptors) {
     HealthStatusManager healthStatusManager = new HealthStatusManager();
     for (BindableService service : services) {
-      ServerServiceDefinition serverServiceDefinition = service.bindService();
-      toServerBuilder.addService(serverServiceDefinition);
+      toServerBuilder.addService(ServerInterceptors.intercept(service.bindService(), interceptors));
       healthStatusManager.setStatus(
           service.bindService().getServiceDescriptor().getName(),
           HealthCheckResponse.ServingStatus.SERVING);
     }
-    toServerBuilder.addService(healthStatusManager.getHealthService());
+    toServerBuilder.addService(
+        ServerInterceptors.intercept(healthStatusManager.getHealthService(), interceptors));
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/internal/testservice/InProcessGRPCServer.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/internal/testservice/InProcessGRPCServer.java
@@ -1,13 +1,13 @@
 package io.temporal.internal.testservice;
 
-import io.grpc.BindableService;
-import io.grpc.ManagedChannel;
-import io.grpc.Server;
+import com.google.protobuf.MessageLite;
+import io.grpc.*;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -45,7 +45,8 @@ public class InProcessGRPCServer {
     String serverName = InProcessServerBuilder.generateName();
     try {
       InProcessServerBuilder inProcessServerBuilder = InProcessServerBuilder.forName(serverName);
-      GRPCServerHelper.registerServicesAndHealthChecks(services, inProcessServerBuilder);
+      GRPCServerHelper.registerServicesAndHealthChecks(
+          services, inProcessServerBuilder, Collections.singletonList(new MessageSizeChecker()));
       server = inProcessServerBuilder.build().start();
     } catch (IOException unexpected) {
       throw new RuntimeException(unexpected);
@@ -100,5 +101,68 @@ public class InProcessGRPCServer {
   @Nullable
   public ManagedChannel getChannel() {
     return channel;
+  }
+
+  /**
+   * This interceptor is needed for testing RESOURCE_EXHAUSTED error handling because in-process
+   * gRPC server doesn't check and cannot be configured to check message size.
+   */
+  public static class MessageSizeChecker implements ServerInterceptor {
+    private final int maxMessageSize;
+
+    public MessageSizeChecker() {
+      this(4 * 1024 * 1024); // matching gRPC's default 4MB
+    }
+
+    public MessageSizeChecker(int maxMessageSize) {
+      this.maxMessageSize = maxMessageSize;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      call.request(1);
+      return new Listener<>(call, headers, next);
+    }
+
+    private class Listener<ReqT, RespT> extends ForwardingServerCallListener<ReqT> {
+      private final ServerCall<ReqT, RespT> call;
+      private final Metadata headers;
+      private final ServerCallHandler<ReqT, RespT> next;
+      private ServerCall.Listener<ReqT> delegate;
+      private boolean delegateSet;
+
+      public Listener(
+          ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        this.call = call;
+        this.headers = headers;
+        this.next = next;
+        delegate = new ServerCall.Listener<ReqT>() {};
+        delegateSet = false;
+      }
+
+      @Override
+      protected ServerCall.Listener<ReqT> delegate() {
+        return delegate;
+      }
+
+      @Override
+      public void onMessage(ReqT message) {
+        int size = ((MessageLite) message).getSerializedSize();
+        if (size > maxMessageSize) {
+          call.close(
+              Status.RESOURCE_EXHAUSTED.withDescription(
+                  String.format(
+                      "grpc: received message larger than max (%d vs. %d)", size, maxMessageSize)),
+              new Metadata());
+        } else {
+          if (!delegateSet) {
+            delegateSet = true;
+            delegate = next.startCall(call, headers);
+          }
+          super.onMessage(message);
+        }
+      }
+    }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -428,10 +428,8 @@ public class GrpcAsyncRetryerTest {
                           GetSystemInfoResponse.Capabilities.getDefaultInstance())
                       .retry()
                       .get());
-      assertTrue(e.getCause() instanceof StatusRuntimeException);
-      Status status = ((StatusRuntimeException) e.getCause()).getStatus();
-      assertEquals(Status.Code.RESOURCE_EXHAUSTED, status.getCode());
-      assertEquals(description, status.getDescription());
+      assertTrue(e.getCause() instanceof GrpcMessageTooLargeException);
+      assertEquals(Status.Code.RESOURCE_EXHAUSTED + ": " + description, e.getMessage());
     }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -429,7 +429,7 @@ public class GrpcAsyncRetryerTest {
                       .retry()
                       .get());
       assertTrue(e.getCause() instanceof GrpcMessageTooLargeException);
-      assertEquals(Status.Code.RESOURCE_EXHAUSTED + ": " + description, e.getMessage());
+      assertEquals(Status.Code.RESOURCE_EXHAUSTED + ": " + description, e.getCause().getMessage());
     }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcAsyncRetryerTest.java
@@ -405,7 +405,6 @@ public class GrpcAsyncRetryerTest {
           "grpc: message after decompression larger than max (2000 vs. 1000)",
           "grpc: received message after decompression larger than max (2000 vs. 1000)",
         }) {
-      long start = System.currentTimeMillis();
       final AtomicInteger attempts = new AtomicInteger();
       ExecutionException e =
           assertThrows(
@@ -430,6 +429,7 @@ public class GrpcAsyncRetryerTest {
                       .get());
       assertTrue(e.getCause() instanceof GrpcMessageTooLargeException);
       assertEquals(Status.Code.RESOURCE_EXHAUSTED + ": " + description, e.getCause().getMessage());
+      assertTrue(e.getCause().getCause() instanceof StatusRuntimeException);
     }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -342,9 +342,9 @@ public class GrpcSyncRetryerTest {
         }) {
       long start = System.currentTimeMillis();
       final AtomicInteger attempts = new AtomicInteger();
-      StatusRuntimeException e =
+      GrpcMessageTooLargeException e =
           assertThrows(
-              StatusRuntimeException.class,
+              GrpcMessageTooLargeException.class,
               () ->
                   DEFAULT_SYNC_RETRYER.retry(
                       () -> {
@@ -358,8 +358,7 @@ public class GrpcSyncRetryerTest {
                       },
                       new GrpcRetryer.GrpcRetryerOptions(options, null),
                       GetSystemInfoResponse.Capabilities.getDefaultInstance()));
-      assertEquals(Status.Code.RESOURCE_EXHAUSTED, e.getStatus().getCode());
-      assertEquals(description, e.getStatus().getDescription());
+      assertEquals(Status.Code.RESOURCE_EXHAUSTED + ": " + description, e.getMessage());
     }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -324,4 +324,42 @@ public class GrpcSyncRetryerTest {
     assertEquals(CONGESTION_INITIAL_INTERVAL, options.getCongestionInitialInterval());
     assertEquals(MAXIMUM_JITTER_COEFFICIENT, options.getMaximumJitterCoefficient(), 0.01);
   }
+
+  @Test
+  public void testMessageLargerThanMaxFailure() {
+    RpcRetryOptions options =
+        RpcRetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofMillis(1000))
+            .setMaximumInterval(Duration.ofMillis(1000))
+            .setMaximumJitterCoefficient(0)
+            .validateBuildWithDefaults();
+
+    for (String description :
+        new String[] {
+          "grpc: received message larger than max (2000 vs. 1000)",
+          "grpc: message after decompression larger than max (2000 vs. 1000)",
+          "grpc: received message after decompression larger than max (2000 vs. 1000)",
+        }) {
+      long start = System.currentTimeMillis();
+      final AtomicInteger attempts = new AtomicInteger();
+      StatusRuntimeException e =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  DEFAULT_SYNC_RETRYER.retry(
+                      () -> {
+                        if (attempts.incrementAndGet() > 1) {
+                          fail(
+                              "We should not retry on RESOURCE_EXHAUSTED with description: "
+                                  + description);
+                        }
+                        throw new StatusRuntimeException(
+                            Status.RESOURCE_EXHAUSTED.withDescription(description));
+                      },
+                      new GrpcRetryer.GrpcRetryerOptions(options, null),
+                      GetSystemInfoResponse.Capabilities.getDefaultInstance()));
+      assertEquals(Status.Code.RESOURCE_EXHAUSTED, e.getStatus().getCode());
+      assertEquals(description, e.getStatus().getDescription());
+    }
+  }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/internal/retryer/GrpcSyncRetryerTest.java
@@ -340,7 +340,6 @@ public class GrpcSyncRetryerTest {
           "grpc: message after decompression larger than max (2000 vs. 1000)",
           "grpc: received message after decompression larger than max (2000 vs. 1000)",
         }) {
-      long start = System.currentTimeMillis();
       final AtomicInteger attempts = new AtomicInteger();
       GrpcMessageTooLargeException e =
           assertThrows(
@@ -359,6 +358,7 @@ public class GrpcSyncRetryerTest {
                       new GrpcRetryer.GrpcRetryerOptions(options, null),
                       GetSystemInfoResponse.Capabilities.getDefaultInstance()));
       assertEquals(Status.Code.RESOURCE_EXHAUSTED + ": " + description, e.getMessage());
+      assertTrue(e.getCause() instanceof StatusRuntimeException);
     }
   }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- `GrpcRetryer` does not retry on gRPC error if the cause is message size limit, instead wraps the error in the new custom `GrpcMessageTooLargeException` and throws.
- `WorkflowWorker` catches `GrpcMessageTooLargeException` on reporting workflow task completion/failure, and reports task failure with this error. This does NOT prevent server-side retry of the workflow task, but it does record the error in event history for easier debugging.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request: https://github.com/temporalio/features/issues/624

## Checklist
<!--- add/delete as needed --->

1. Closes #1585

2. How was this tested: added tests to `GrpcSyncRetryerTest`, `GrpcAsyncRetryerTest` and `GrpcMessageTooLargeTest`.