### PR TITLE
Fix adding a generic parameter failing

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
@@ -143,7 +143,7 @@ public interface DataConverter {
       Class<?> pt = parameterTypes[i];
       Type gt = genericParameterTypes[i];
       if (i >= count) {
-        result[i] = Defaults.defaultValue(TypeToken.of(genericParameterTypes[i]).getRawType());
+        result[i] = Defaults.defaultValue(TypeToken.of(gt).getRawType());
       } else {
         result[i] = this.fromPayload(payloads.getPayloads(i), pt, gt);
       }

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/DataConverter.java
@@ -3,6 +3,7 @@ package io.temporal.common.converter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Defaults;
 import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.failure.v1.Failure;
@@ -132,7 +133,7 @@ public interface DataConverter {
     if (!content.isPresent()) {
       // Return defaults for all the parameters
       for (int i = 0; i < parameterTypes.length; i++) {
-        result[i] = Defaults.defaultValue((Class<?>) genericParameterTypes[i]);
+        result[i] = Defaults.defaultValue(TypeToken.of(genericParameterTypes[i]).getRawType());
       }
       return result;
     }
@@ -142,7 +143,7 @@ public interface DataConverter {
       Class<?> pt = parameterTypes[i];
       Type gt = genericParameterTypes[i];
       if (i >= count) {
-        result[i] = Defaults.defaultValue((Class<?>) gt);
+        result[i] = Defaults.defaultValue(TypeToken.of(genericParameterTypes[i]).getRawType());
       } else {
         result[i] = this.fromPayload(payloads.getPayloads(i), pt, gt);
       }

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/DataConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/DataConverterTest.java
@@ -24,10 +24,10 @@ public class DataConverterTest {
   @Test
   public void noContent() throws NoSuchMethodException {
     DataConverter dc = GlobalDataConverter.get();
-    Method m = this.getClass().getMethod("testMethod", String.class, List.class);
+    Method m = this.getClass().getMethod("testMethodGenericParameter", String.class, List.class);
     Object[] result =
         dc.fromPayloads(Optional.empty(), m.getParameterTypes(), m.getGenericParameterTypes());
-    Assert.assertNull("test", result[0]);
+    Assert.assertNull(result[0]);
     Assert.assertNull(result[1]);
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/DataConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/DataConverterTest.java
@@ -1,0 +1,64 @@
+package io.temporal.common.converter;
+
+import io.temporal.api.common.v1.Payloads;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DataConverterTest {
+  // Test methods for reflection
+  public String testMethodNormalParameter(String input, String names) {
+    return "";
+  }
+
+  public String testMethodGenericParameter(String input, List<String> names) {
+    return "";
+  }
+
+  public String testMethodGenericArrayParameter(String input, List<Integer>[] names) {
+    return "";
+  }
+
+  @Test
+  public void noContent() throws NoSuchMethodException {
+    DataConverter dc = GlobalDataConverter.get();
+    Method m = this.getClass().getMethod("testMethod", String.class, List.class);
+    Object[] result =
+        dc.fromPayloads(Optional.empty(), m.getParameterTypes(), m.getGenericParameterTypes());
+    Assert.assertNull("test", result[0]);
+    Assert.assertNull(result[1]);
+  }
+
+  @Test
+  public void addParameter() throws NoSuchMethodException {
+    DataConverter dc = GlobalDataConverter.get();
+    Optional<Payloads> p = dc.toPayloads("test");
+    Method m = this.getClass().getMethod("testMethodNormalParameter", String.class, String.class);
+    Object[] result = dc.fromPayloads(p, m.getParameterTypes(), m.getGenericParameterTypes());
+    Assert.assertEquals("test", result[0]);
+    Assert.assertNull(result[1]);
+  }
+
+  @Test
+  public void addGenericParameter() throws NoSuchMethodException {
+    DataConverter dc = GlobalDataConverter.get();
+    Optional<Payloads> p = dc.toPayloads("test");
+    Method m = this.getClass().getMethod("testMethodGenericParameter", String.class, List.class);
+    Object[] result = dc.fromPayloads(p, m.getParameterTypes(), m.getGenericParameterTypes());
+    Assert.assertEquals("test", result[0]);
+    Assert.assertNull(result[1]);
+  }
+
+  @Test
+  public void addGenericArrayParameter() throws NoSuchMethodException {
+    DataConverter dc = GlobalDataConverter.get();
+    Optional<Payloads> p = dc.toPayloads("test");
+    Method m =
+        this.getClass().getMethod("testMethodGenericArrayParameter", String.class, List[].class);
+    Object[] result = dc.fromPayloads(p, m.getParameterTypes(), m.getGenericParameterTypes());
+    Assert.assertEquals("test", result[0]);
+    Assert.assertNull(result[1]);
+  }
+}


### PR DESCRIPTION
Fix adding a generic parameter failing.

Previously adding a new parameter of type List to a workflow input causes the data converter to fail.
From:
```
        @WorkflowMethod
        String execute(String name);
```
to :
```
        @WorkflowMethod
        String execute(String name, List<String> names);
```

closes https://github.com/temporalio/sdk-java/issues/2413