### PR TITLE
Fix Javadoc of io.temporal.workflow.Workflow#getVersion

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -964,7 +964,7 @@ public final class Workflow {
    * for example change activity3 to activity4, you just need to update the maxVersion from 2 to 3.
    *
    * <p>Note that, you only need to preserve the first call to GetVersion() for each changeId. All
-   * subsequent call to GetVersion() with same changeId are safe to remove. However, if you really
+   * subsequent calls to GetVersion() with same changeId are safe to remove. However, if you really
    * want to get rid of the first GetVersion() call as well, you can do so, but you need to make
    * sure: 1) all older version executions are completed; 2) you can no longer use “fooChange” as
    * changeId. If you ever need to make changes to that same part, you would need to use a different


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updated Javadoc for `io.temporal.workflow.Workflow#getVersion`.

## Why?
<!-- Tell your future self why have you made these changes -->
Using plural makes more sense in a sentence `All subsequent call to GetVersion()...` 

## Checklist
<!--- add/delete as needed --->

1. Closes n/a

2. How was this tested:
Javadoc chnages, n/a

3. Any docs updates needed?
No
