### PR TITLE
Fix sonatype publish

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -118,7 +118,7 @@ jobs:
           RH_PASSWORD: ${{ secrets.RH_PASSWORD }}
 
       - name: Publish
-        run: ./gradlew publishToSonatype
+        run: ./gradlew publishToSonatype closeSonatypeStagingRepository
 
   build_native_images:
     name: Build native test server


### PR DESCRIPTION
For sonatype central we now need to close the repo as part of CI since it won't be visible in the UI to publish until closed

https://github.com/gradle-nexus/publish-plugin/issues/379
