### PR TITLE
Make sure workflow_task_queue_poll_succeed is emitted

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/AsyncWorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/AsyncWorkflowPollTask.java
@@ -151,6 +151,9 @@ public class AsyncWorkflowPollTask
                     .inc(1);
                 return null;
               }
+              pollerMetricScope
+                  .counter(MetricsType.WORKFLOW_TASK_QUEUE_POLL_SUCCEED_COUNTER)
+                  .inc(1);
               Timestamp startedTime = ProtobufTimeUtils.getCurrentProtoTime();
               pollerMetricScope
                   .timer(MetricsType.WORKFLOW_TASK_SCHEDULE_TO_START_LATENCY)

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -179,6 +179,9 @@ public class MetricsTest {
     reporter.assertCounter("temporal_worker_start", TAGS_WORKFLOW_WORKER, 1);
     reporter.assertCounter("temporal_worker_start", TAGS_ACTIVITY_WORKER, 1);
     reporter.assertCounter("temporal_worker_start", TAGS_LOCAL_ACTIVITY_WORKER, 1);
+    reporter.assertCounter(
+        "temporal_workflow_task_queue_poll_succeed", TAGS_STICKY_WORKFLOW_WORKER);
+    reporter.assertCounter("temporal_workflow_task_queue_poll_succeed", TAGS_WORKFLOW_WORKER);
     // We ran some workflow and activity tasks, so we should have some timers here.
     reporter.assertTimer("temporal_activity_schedule_to_start_latency", TAGS_ACTIVITY_WORKER);
     reporter.assertTimer("temporal_workflow_task_schedule_to_start_latency", TAGS_WORKFLOW_WORKER);
@@ -221,6 +224,9 @@ public class MetricsTest {
     reporter.assertCounter("temporal_worker_start", TAGS_WORKFLOW_WORKER, 1);
     reporter.assertCounter("temporal_worker_start", TAGS_ACTIVITY_WORKER, 1);
     reporter.assertCounter("temporal_worker_start", TAGS_LOCAL_ACTIVITY_WORKER, 1);
+    reporter.assertCounter(
+        "temporal_workflow_task_queue_poll_succeed", TAGS_STICKY_WORKFLOW_WORKER);
+    reporter.assertCounter("temporal_workflow_task_queue_poll_succeed", TAGS_WORKFLOW_WORKER);
     // We ran some workflow and activity tasks, so we should have some timers here.
     reporter.assertTimer("temporal_activity_schedule_to_start_latency", TAGS_ACTIVITY_WORKER);
     reporter.assertTimer("temporal_workflow_task_schedule_to_start_latency", TAGS_WORKFLOW_WORKER);


### PR DESCRIPTION
Make sure workflow_task_queue_poll_succeed is emitted for poller autoscaling

closes https://github.com/temporalio/sdk-java/issues/2644