### PR TITLE
Fix UNKNOWN gRPC error on describe

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -393,14 +393,22 @@ class StateMachines {
   static final class ChildWorkflowData {
 
     final TestWorkflowService service;
+    final String workflowId;
+    final String workflowType;
     final UserMetadata metadata;
     StartChildWorkflowExecutionInitiatedEventAttributes initiatedEvent;
     long initiatedEventId;
     long startedEventId;
     WorkflowExecution execution;
 
-    public ChildWorkflowData(TestWorkflowService service, UserMetadata metadata) {
+    public ChildWorkflowData(
+        TestWorkflowService service,
+        String workflowId,
+        String workflowType,
+        UserMetadata metadata) {
       this.service = service;
+      this.workflowId = workflowId;
+      this.workflowType = workflowType;
       this.metadata = metadata;
     }
 
@@ -568,8 +576,8 @@ class StateMachines {
   }
 
   public static StateMachine<ChildWorkflowData> newChildWorkflowStateMachine(
-      TestWorkflowService service, UserMetadata metadata) {
-    return new StateMachine<>(new ChildWorkflowData(service, metadata))
+      TestWorkflowService service, String workflowId, String workflowType, UserMetadata metadata) {
+    return new StateMachine<>(new ChildWorkflowData(service, workflowId, workflowType, metadata))
         .add(NONE, INITIATE, INITIATED, StateMachines::initiateChildWorkflow)
         .add(INITIATED, START, STARTED, StateMachines::childWorkflowStarted)
         .add(INITIATED, FAIL, FAILED, StateMachines::startChildWorkflowFailed)


### PR DESCRIPTION
Fix UNKNOWN gRPC error on describe. Previously there was a bug with describe on a workflow with a child workflow that had not yet been started would fail because the child workflow did not have some of the details and the describe call didn't account for this case. I was not able to make a test for this condition because the race is so tight, but from the reported stack trace I am confident in the fix.

```
00:12:24.820	SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@77c3bde9
00:12:24.820	java.lang.NullPointerException: Cannot invoke "io.temporal.api.common.v1.WorkflowExecution.getWorkflowId()" because "data.execution" is null
00:12:24.820		at io.temporal.internal.testservice.TestWorkflowMutableStateImpl.constructPendingChildExecutionInfo(TestWorkflowMutableStateImpl.java:3115)
00:12:24.820		at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
00:12:24.820		at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
00:12:24.820		at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1779)
00:12:24.820		at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
00:12:24.820		at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
00:12:24.820		at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
00:12:24.820		at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
00:12:24.820		at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
00:12:24.820		at io.temporal.internal.testservice.TestWorkflowMutableStateImpl.describeWorkflowExecutionInsideLock(TestWorkflowMutableStateImpl.java:3099)
00:12:24.820		at io.temporal.internal.testservice.TestWorkflowMutableStateImpl.describeWorkflowExecution(TestWorkflowMutableStateImpl.java:3030)
00:12:24.820		at io.temporal.internal.testservice.TestWorkflowService.describeWorkflowExecution(TestWorkflowService.java:1584)
00:12:24.820		at io.temporal.api.workflowservice.v1.WorkflowServiceGrpc$MethodHandlers.invoke(WorkflowServiceGrpc.java:7312)
00:12:24.820		at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
00:12:24.820		at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:354)
00:12:24.820		at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:866)
00:12:24.820		at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
00:12:24.820		at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
00:12:24.820		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
00:12:24.820		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
00:12:24.820		at java.base/java.lang.Thread.run(Thread.java:840)
```

closes https://github.com/temporalio/sdk-java/issues/2652