### PR TITLE
Update Jackson to 2.15.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
 ext {
     // Platforms
     grpcVersion = '1.58.1' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
-    jacksonVersion = '2.14.2' // [2.9.0,)
+    jacksonVersion = '2.15.4' // [2.9.0,)
     nexusVersion = '0.4.0-alpha'
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.13.6' : '1.9.9' // [1.0.0,)


### PR DESCRIPTION
Update Jackson to 2.15.4 due to [CVE](https://www.cve.org/CVERecord?id=CVE-2025-52999).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `jacksonVersion` in `build.gradle` from `2.14.2` to `2.15.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b3b9274b9294467688bbda0972298da5d897b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->