### PR TITLE
Fix WorkflowStub.getExecution() returning null for unstarted stubs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowStubImpl.java
@@ -223,7 +223,15 @@ class WorkflowStubImpl implements WorkflowStub {
 
   @Override
   public WorkflowExecution getExecution() {
-    return options != null ? startedExecution.get() : execution.get();
+    if (options != null) {
+      // For stubs created with options (for starting workflows), prefer startedExecution if
+      // available
+      WorkflowExecution started = startedExecution.get();
+      return started != null ? started : execution.get();
+    } else {
+      // For stubs bound to existing executions, use execution directly
+      return execution.get();
+    }
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/client/WorkflowStubGetExecutionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/WorkflowStubGetExecutionTest.java
@@ -1,0 +1,64 @@
+package io.temporal.client;
+
+import static org.junit.Assert.assertNotNull;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test to verify WorkflowStub.getExecution() behavior Addresses issue where getExecution() returns
+ * null for stubs created with options but not yet started
+ */
+public class WorkflowStubGetExecutionTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowImpl.class).build();
+
+  @Test
+  public void testGetExecutionAfterStart() {
+    // Create a workflow stub with options (for starting)
+    TestWorkflows.NoArgsWorkflow workflow =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.NoArgsWorkflow.class);
+    WorkflowStub workflowStub = WorkflowStub.fromTyped(workflow);
+
+    // Start the workflow
+    workflowStub.start();
+
+    // After starting, getExecution() should not be null
+    WorkflowExecution executionAfterStart = workflowStub.getExecution();
+    assertNotNull("Execution should not be null after start", executionAfterStart);
+    assertNotNull("WorkflowId should not be null", executionAfterStart.getWorkflowId());
+    assertNotNull("RunId should not be null", executionAfterStart.getRunId());
+  }
+
+  @Test
+  public void testGetExecutionForExistingWorkflow() {
+    // Create and start a workflow first
+    TestWorkflows.NoArgsWorkflow workflow1 =
+        testWorkflowRule.newWorkflowStub(TestWorkflows.NoArgsWorkflow.class);
+    WorkflowStub workflowStub1 = WorkflowStub.fromTyped(workflow1);
+    WorkflowExecution startedExecution = workflowStub1.start();
+
+    // Create a new stub bound to the existing execution
+    WorkflowStub workflowStub2 =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(startedExecution, java.util.Optional.empty());
+
+    // This should work fine since options == null
+    WorkflowExecution execution = workflowStub2.getExecution();
+    assertNotNull("Execution should not be null for existing workflow", execution);
+    assertNotNull("WorkflowId should not be null", execution.getWorkflowId());
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflows.NoArgsWorkflow {
+    @Override
+    public void execute() {
+      // Simple workflow that does nothing
+    }
+  }
+}


### PR DESCRIPTION
When a WorkflowStub is created with WorkflowOptions but not yet started, getExecution() would return null because it only checked startedExecution which is only populated after a successful start.


## What was changed
This change adds a fallback to execution.get() when startedExecution is null,  ensuring getExecution() returns a valid WorkflowExecution when available, even before workflow start
For stubs bound to existing executions (where options == null), behavior remains unchanged.

## Why?
 This fix ensures that WorkflowStub.getExecution() never returns null inappropriately, providing better reliability   
 for users who need to access execution information from workflow stubs, especially in scenarios where stubs are      
 created but workflows haven't been started yet. 

## Checklist


1. Closes <!-- add issue number here -->
https://github.com/temporalio/sdk-java/issues/2674 
https://github.com/temporalio/sdk-java/issues/2642
2. How was this tested:
Unit test  : temporal-sdk/src/test/java/io/temporal/client/WorkflowStubGetExecutionTest.java

3. Any docs updates needed?
No
