### PR TITLE
Bump gradle action to v5

### DIFF
--- a/.github/workflows/build-native-image.yml
+++ b/.github/workflows/build-native-image.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Set up Gradle
         if: matrix.os_family != 'Linux'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build native test server (non-Docker)
         if: matrix.os_family != 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         distribution: "temurin"
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
     
     - name: Run unit tests
       env:
@@ -68,7 +68,7 @@ jobs:
         distribution: "temurin"
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
 
     - name: Start containerized server and dependencies
       env:
@@ -151,7 +151,7 @@ jobs:
         distribution: "temurin"
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
     
     - name: Run cloud test
       # Only supported in non-fork runs, since secrets are not available in forks. We intentionally
@@ -190,7 +190,7 @@ jobs:
         distribution: "temurin"
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
     
     - name: Run copyright and code format checks
       run: ./gradlew --no-daemon spotlessCheck

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run Tests
         run: ./gradlew test -x spotlessCheck -x spotlessApply -Pjacoco

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -92,7 +92,7 @@ jobs:
           distribution: "temurin"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Set up signing key
         run: mkdir -p "$HOME/.gnupg" && echo -n "$KEY" | base64 -d > "$HOME/.gnupg/secring.gpg"

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: 'temurin'
           
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       # Prefer env variables here rather than inline ${{ secrets.FOO }} to
       # decrease the likelihood that secrets end up printed to stdout.


### PR DESCRIPTION
Bump gradle action to v5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates gradle/actions/setup-gradle from v4 to v5 across CI, coverage, release, snapshot, and native-image workflows.
> 
> - **CI/CD Workflows**:
>   - Update `gradle/actions/setup-gradle` from `v4` to `v5` in:
>     - `.github/workflows/ci.yml` (all jobs)
>     - `.github/workflows/coverage.yml`
>     - `.github/workflows/prepare-release.yml`
>     - `.github/workflows/publish-snapshot.yml`
>     - `.github/workflows/build-native-image.yml` (non-Linux steps)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8060e1a1444fe5e9109a2574405ce1629080cd09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->