### PR TITLE
Add javadocs for in-workflow, workflow stubs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowStubImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/ExternalWorkflowStubImpl.java
@@ -43,7 +43,7 @@ class ExternalWorkflowStubImpl implements ExternalWorkflowStub {
     try {
       signaled.get();
     } catch (SignalExternalWorkflowException e) {
-      // Reset stack to the current one. Otherwise it is very confusing to see a stack of
+      // Reset stack to the current one. Otherwise, it is very confusing to see a stack of
       // an event handling method.
       e.setStackTrace(Thread.currentThread().getStackTrace());
       throw e;

--- a/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowStub.java
@@ -35,6 +35,9 @@ public interface ChildWorkflowStub {
     return (ChildWorkflowStub) supplier.__getUntypedStub();
   }
 
+  /**
+   * @return workflow type name.
+   */
   String getWorkflowType();
 
   /**
@@ -44,15 +47,62 @@ public interface ChildWorkflowStub {
    */
   Promise<WorkflowExecution> getExecution();
 
+  /**
+   * @return child workflow options used to create this stub.
+   */
   ChildWorkflowOptions getOptions();
 
+  /**
+   * Synchronously starts a child workflow execution and waits for its result.
+   *
+   * @param resultClass the expected return class of the workflow.
+   * @param args workflow arguments.
+   * @param <R> return type.
+   * @return workflow result.
+   */
   <R> R execute(Class<R> resultClass, Object... args);
 
+  /**
+   * Synchronously starts a child workflow execution and waits for its result.
+   *
+   * @param resultClass the expected return class of the workflow.
+   * @param resultType the expected return class of the workflow. Differs from resultClass for
+   *     generic types.
+   * @param args workflow arguments.
+   * @param <R> return type.
+   * @return workflow result.
+   */
   <R> R execute(Class<R> resultClass, Type resultType, Object... args);
 
+  /**
+   * Executes a child workflow asynchronously.
+   *
+   * @param resultClass the expected return type of the workflow.
+   * @param args arguments of the activity.
+   * @param <R> return type.
+   * @return Promise to the activity result.
+   */
   <R> Promise<R> executeAsync(Class<R> resultClass, Object... args);
 
+  /**
+   * Executes a child workflow asynchronously.
+   *
+   * @param resultClass the expected return type of the workflow.
+   * @param resultType the expected return class of the workflow. Differs from resultClass for
+   *     generic types.
+   * @param args arguments of the activity.
+   * @param <R> return type.
+   * @return Promise to the activity result.
+   */
   <R> Promise<R> executeAsync(Class<R> resultClass, Type resultType, Object... args);
 
+  /**
+   * Synchronously signals a workflow by invoking its signal handler. Usually a signal handler is a
+   * method annotated with {@link io.temporal.workflow.SignalMethod}.
+   *
+   * @param signalName name of the signal handler. Usually it is a method name.
+   * @param args signal method arguments.
+   * @throws SignalExternalWorkflowException if there is failure to signal the workflow.
+   */
   void signal(String signalName, Object... args);
 }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/ExternalWorkflowStub.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/ExternalWorkflowStub.java
@@ -34,8 +34,19 @@ public interface ExternalWorkflowStub {
     return (ExternalWorkflowStub) supplier.__getUntypedStub();
   }
 
+  /**
+   * @return workflow execution used to create this stub.
+   */
   WorkflowExecution getExecution();
 
+  /**
+   * Synchronously signals a workflow by invoking its signal handler. Usually a signal handler is a
+   * method annotated with {@link io.temporal.workflow.SignalMethod}.
+   *
+   * @param signalName name of the signal handler. Usually it is a method name.
+   * @param args signal method arguments
+   * @throws SignalExternalWorkflowException if there is failure to signal the workflow.
+   */
   void signal(String signalName, Object... args);
 
   void cancel();

--- a/temporal-sdk/src/main/java/io/temporal/workflow/SignalExternalWorkflowException.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/SignalExternalWorkflowException.java
@@ -4,7 +4,6 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowException;
 
 /** Exception used to communicate failure of a request to signal an external workflow. */
-@SuppressWarnings("serial")
 public final class SignalExternalWorkflowException extends WorkflowException {
 
   public SignalExternalWorkflowException(WorkflowExecution execution, String workflowType) {


### PR DESCRIPTION
Add javadocs for in-workflow, workflow stubs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Javadocs across child/external workflow stubs and tidy related comments/annotations.
> 
> - **Docs**:
>   - Add Javadocs for `ChildWorkflowStub` methods (`getWorkflowType`, `getOptions`, `execute*`, `executeAsync*`, `signal`).
>   - Add Javadocs for `ExternalWorkflowStub` methods (`getExecution`, `signal`).
> - **Minor cleanup**:
>   - Remove `@SuppressWarnings("serial")` from `SignalExternalWorkflowException`.
>   - Punctuation fix in a comment in `ExternalWorkflowStubImpl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e809356b9febae4c17c93242e5554c0e22b4f198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->