### PR TITLE
VLN-512: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   code-coverage:
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,9 @@
 name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Gradle wrapper validation"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,6 +24,10 @@ on:
         description: "Publish Java Artifacts"
         required: true
         default: "true"
+
+permissions:
+  contents: read
+
 env:
   INPUT_REF: ${{ github.event.inputs.ref }}
   INPUT_TAG: ${{ github.event.inputs.tag }}
@@ -32,6 +36,8 @@ jobs:
   create_draft_release:
     name: Create Github draft release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Audit gh version
         run: gh --version
@@ -133,6 +139,9 @@ jobs:
     name: Attach native executables to release
     needs: [build_native_images, create_draft_release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - name: Audit gh version
         run: gh --version

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -22,6 +22,9 @@ on:
     tags-ignore:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     if: github.repository == 'temporalio/sdk-java' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

- `.github/workflows/coverage.yml`: Added read-only workflow permissions (`.github/workflows/coverage.yml:7`) so checkout still works while the default token stays least-privilege; no workflow tests required.
- `.github/workflows/gradle-wrapper-validation.yml`: Added read-only workflow permissions (`.github/workflows/gradle-wrapper-validation.yml:4`) to allow checkout while locking the token to minimal scope.
- `.github/workflows/prepare-release.yml`: Introduced a read-only baseline and scoped job overrides (`.github/workflows/prepare-release.yml:28`, `...:39`, `...:142`) so the draft-release and asset-attachment steps keep the required write abilities without granting excess access elsewhere.
- `.github/workflows/publish-snapshot.yml`: Added a workflow-level read-only token configuration (`.github/workflows/publish-snapshot.yml:25`) to support checkout with least privilege.