### PR TITLE
Remove experimental designation from poller behavior options

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -502,21 +502,18 @@ public final class WorkerOptions {
      * <p>If the sticky queue is enabled, the poller behavior will be used for the sticky queue as
      * well.
      */
-    @Experimental
     public Builder setWorkflowTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.workflowTaskPollersBehavior = pollerBehavior;
       return this;
     }
 
     /** Set the poller behavior for activity task pollers. */
-    @Experimental
     public Builder setActivityTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.activityTaskPollersBehavior = pollerBehavior;
       return this;
     }
 
     /** Set the poller behavior for nexus task pollers. */
-    @Experimental
     public Builder setNexusTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.nexusTaskPollersBehavior = pollerBehavior;
       return this;
@@ -894,17 +891,14 @@ public final class WorkerOptions {
     return deploymentOptions;
   }
 
-  @Experimental
   public PollerBehavior getWorkflowTaskPollersBehavior() {
     return workflowTaskPollersBehavior;
   }
 
-  @Experimental
   public PollerBehavior getActivityTaskPollersBehavior() {
     return activityTaskPollersBehavior;
   }
 
-  @Experimental
   public PollerBehavior getNexusTaskPollersBehavior() {
     return nexusTaskPollersBehavior;
   }

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/PollerBehavior.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/PollerBehavior.java
@@ -1,7 +1,5 @@
 package io.temporal.worker.tuning;
 
-import io.temporal.common.Experimental;
-
 /**
  * Defines the behavior of a poller.
  *
@@ -10,5 +8,4 @@ import io.temporal.common.Experimental;
  * PollerBehaviorSimpleMaximum}. For all intents and purpose this interface should be considered
  * sealed.
  */
-@Experimental
 public interface PollerBehavior {}

--- a/temporal-sdk/src/main/java/io/temporal/worker/tuning/PollerBehaviorAutoscaling.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/tuning/PollerBehaviorAutoscaling.java
@@ -1,6 +1,5 @@
 package io.temporal.worker.tuning;
 
-import io.temporal.common.Experimental;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -11,7 +10,6 @@ import javax.annotation.Nullable;
  * <p>If the server does not support autoscaling, then the number of pollers will stay at the
  * initial number of pollers.
  */
-@Experimental
 public final class PollerBehaviorAutoscaling implements PollerBehavior {
   private final int minConcurrentTaskPollers;
   private final int maxConcurrentTaskPollers;


### PR DESCRIPTION
## Summary
- remove experimental annotations from poller behavior builder and getter APIs
- drop experimental markers from poller behavior implementations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f12480fd408331b4f82a736918cc49