### PR TITLE
Bump github actions versions

### DIFF
--- a/.github/workflows/build-native-image.yml
+++ b/.github/workflows/build-native-image.yml
@@ -102,7 +102,7 @@ jobs:
       # path ends in a wildcard because on windows the file ends in '.exe'
       - name: Upload executable to workflow
         if: ${{ inputs.upload_artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.musl && format('{0}_{1}_musl', matrix.os_family, matrix.arch) || format('{0}_{1}', matrix.os_family, matrix.arch)}}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: ./gradlew --no-daemon temporal-sdk:testResourceIndependent -x spotlessCheck -x spotlessApply -x spotlessJava -P edgeDepsTest
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/build/test-results/test/TEST-*.xml'
@@ -127,7 +127,7 @@ jobs:
       run: ./gradlew --no-daemon :temporal-sdk:virtualThreadTests -x spotlessCheck -x spotlessApply -x spotlessJava
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/build/test-results/test/TEST-*.xml'
@@ -166,7 +166,7 @@ jobs:
       run: ./gradlew --no-daemon :temporal-sdk:test --tests '*CloudOperationsClientTest'
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure() # always run even if the previous step fails
       with:
         report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -68,7 +68,7 @@ jobs:
           path: omes
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: omes/go.mod
           cache-dependency-path: omes/go.sum
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: throughput-stress-logs
           path: ${{ env.WORKER_LOG_DIR }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -148,7 +148,7 @@ jobs:
 
       # when no artifact is specified, all artifacts are downloaded and expanded into CWD
       - name: Fetch executables
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
 
       # example: linux_amd64/ -> temporal-test-server_1.2.3_linux_amd64
       # the name of the directory created becomes the basename of the archive (*.tar.gz or *.zip) and
@@ -165,7 +165,7 @@ jobs:
         run: for dir in *windows*; do zip -r "${dir}.zip" "$dir"; done
 
       - name: Upload release archives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-archives
           path: |


### PR DESCRIPTION
Bump github actions versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions to newer major versions (upload/download-artifact, junit report, setup-go) across CI, nightly, build, and release workflows.
> 
> - **Workflows**:
>   - **CI (`.github/workflows/ci.yml`)**:
>     - Update `mikepenz/action-junit-report` from `v5` to `v6` for all test report steps.
>   - **Nightly Throughput Stress (`.github/workflows/nightly-throughput-stress.yml`)**:
>     - Update `actions/setup-go` from `v5` to `v6`.
>     - Update `actions/upload-artifact` from `v4` to `v5` for failure log uploads.
>   - **Build Native Image (`.github/workflows/build-native-image.yml`)**:
>     - Update `actions/upload-artifact` from `v4` to `v5` for executable uploads.
>   - **Prepare Release (`.github/workflows/prepare-release.yml`)**:
>     - Update `actions/download-artifact` from `v5` to `v6`.
>     - Update `actions/upload-artifact` from `v4` to `v5` for release archives.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8598acf1fb9a15143f60afa153d31880025d015. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->