### PR TITLE
Fix Javadoc for RateLimitsConfigurationProperties

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkerProperties.java
@@ -270,10 +270,10 @@ public class WorkerProperties {
     private final @Nullable Double maxTaskQueueActivitiesPerSecond;
 
     /**
+     * @param maxWorkerActivitiesPerSecond defines {@link
+     *     io.temporal.worker.WorkerOptions.Builder#setMaxWorkerActivitiesPerSecond(double)}
      * @param maxTaskQueueActivitiesPerSecond defines {@link
      *     io.temporal.worker.WorkerOptions.Builder#setMaxTaskQueueActivitiesPerSecond(double)}}
-     * @param maxWorkerActivitiesPerSecond defines {@link
-     *     io.temporal.worker.WorkerOptions.Builder#setMaxConcurrentActivityExecutionSize(int)}
      */
     @ConstructorBinding
     public RateLimitsConfigurationProperties(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
RateLimitsConfigurationProperties Javadoc for `maxWorkerActivitiesPerSecond` was wrongly describing to call `setMaxConcurrentActivityExecutionSize`. Also switch order according to constructor.

## Why?
Confusing docs even though code behaves differently (correctly)

## Checklist
<!--- add/delete as needed --->

1. Closes minor issue :)

2. How was this tested:
Docs only

3. Any docs updates needed?
Javadoc updated
