### PR TITLE
Release Java SDK v1.32.1

### DIFF
--- a/releases/v1.32.1
+++ b/releases/v1.32.1
@@ -1,0 +1,15 @@
+# Bugfixes
+
+## Spring Boot
+
+Fixed a bug preventing using the in-memory test server for non-root namespaces.
+
+## Environment Config
+
+Fixed a bug causing an exception to be thrown if the default config file was not present.
+
+# What's Changed
+
+2025-11-26 - 0bfa9103 - fix(spring-boot): use in-memory test server for non-root namespaces (#2736)
+2025-11-28 - 6bb0fdf6 - Fix Javadoc for RateLimitsConfigurationProperties (#2729)
+2025-11-29 - b06f15d6 - Allow for FileNotFound. Do not error, instead return a default instance (#2739)


### PR DESCRIPTION
Release Java SDK v1.32.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add release notes for v1.32.1 with Spring Boot in-memory test server fix and Environment Config default-file handling.
> 
> - **Release notes** (`releases/v1.32.1`):
>   - **Bugfixes**:
>     - Spring Boot: enable in-memory test server for non-root namespaces.
>     - Environment Config: handle missing default config file without throwing.
>   - **What's Changed**:
>     - fix(spring-boot): use in-memory test server for non-root namespaces (#2736)
>     - Docs: Fix Javadoc for `RateLimitsConfigurationProperties` (#2729)
>     - Config: return default instance on `FileNotFound` (#2739)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91001b52f2161916007f5e930d1288e8c4662865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->