### PR TITLE
Fix UnsupportedOperationException when merging ActivityOptions with i…

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
@@ -6,6 +6,7 @@ import io.temporal.common.*;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.failure.CanceledFailure;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Options used to configure how an activity is invoked. */
@@ -282,7 +283,9 @@ public final class ActivityOptions {
       if (this.contextPropagators == null) {
         this.contextPropagators = override.contextPropagators;
       } else if (override.contextPropagators != null) {
-        this.contextPropagators.addAll(override.contextPropagators);
+        List<ContextPropagator> merged = new ArrayList<>(this.contextPropagators);
+        merged.addAll(override.contextPropagators);
+        this.contextPropagators = merged;
       }
       if (override.versioningIntent != VersioningIntent.VERSIONING_INTENT_UNSPECIFIED) {
         this.versioningIntent = override.versioningIntent;


### PR DESCRIPTION
 ## What was changed

  Modified `ActivityOptions.Builder.mergeActivityOptions()` to create a new `ArrayList` when combining context propagators instead of calling `addAll()` directly on the existing list. Added a test to verify the fix.

  **Files changed:**
  - `temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java`
  - `temporal-sdk/src/test/java/io/temporal/activity/ActivityOptionsTest.java`

  ## Why?

  When users set context propagators using immutable lists (e.g., `List.of()` or `Collections.emptyList()`), merging `ActivityOptions` would throw `UnsupportedOperationException` because the code attempted to call `addAll()` on an immutable list.

  This fix follows the approach suggested by @cretz in the issue: create a new list that combines both instead of modifying one of them.

  ## Checklist

  1. Closes #2482

  2. How was this tested:
     - Added unit test `testActivityOptionsMergeWithImmutableContextPropagators` that creates two `ActivityOptions` with immutable context propagator lists (`Collections.emptyList()`) and verifies they can be merged without throwing `UnsupportedOperationException`
     - All existing `ActivityOptionsTest` tests pass
     - Full build passes (`./gradlew clean build`)

  3. Any docs updates needed?
     - No documentation updates needed - this is a bug fix with no API changes