### PR TITLE
Fix test server to return INVALID_ARGUMENT for UNHANDLED_COMMAND

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/client/functional/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/MetricsTest.java
@@ -63,6 +63,7 @@ public class MetricsTest {
 
   @Before
   public void setUp() {
+    registry.clear();
     tagsNamespaceQueue =
         replaceTags(TAGS_NAMESPACE, MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue());
   }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -488,14 +488,16 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
 
           if (unhandledCommand(request) || unhandledMessages(request)) {
             // Fail the workflow task if there are new events or messages and a command tries to
-            // complete the
-            // workflow
+            // complete the workflow. Record the failure in history, then throw an error to the
+            // caller (matching real server behavior).
             failWorkflowTaskWithAReason(
                 WorkflowTaskFailedCause.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND,
                 null,
                 ctx,
                 request,
                 false);
+            ctx.setExceptionIfEmpty(
+                Status.INVALID_ARGUMENT.withDescription("UnhandledCommand").asRuntimeException());
             return;
           }
 


### PR DESCRIPTION
## Summary
- Fix test server to throw `INVALID_ARGUMENT: UnhandledCommand` error for UNHANDLED_COMMAND, matching real Temporal server behavior
- Add `registry.clear()` in MetricsTest setUp for clean state between tests

## Problem
The `MetricsTest.testUnhandledCommand` test was flaky because completion metrics were being double-counted. The real Temporal server returns `INVALID_ARGUMENT` error when a workflow task has unhandled commands, which prevents the SDK from applying metrics. The test server was silently recording the failure in history but returning success to the caller, causing the SDK to apply metrics before learning (during replay) that the task was rejected.

## Solution
Make the test server throw `INVALID_ARGUMENT: UnhandledCommand` to match real server behavior. This was validated by running the test against a real Temporal server first.

## Test plan
- [x] `MetricsTest.testUnhandledCommand` passes against real Temporal server
- [x] `MetricsTest.testUnhandledCommand` passes against test server with fix
- [x] All MetricsTest tests pass (7/7)