### PR TITLE
Add opt-in Jackson 3 support via multi-release JAR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,12 @@ jobs:
         USE_DOCKER_SERVICE: true
       run: ./gradlew --no-daemon test -x spotlessCheck -x spotlessApply -x spotlessJava
 
+    - name: Run Jackson 3 converter tests
+      env:
+        USER: unittest
+        USE_DOCKER_SERVICE: false
+      run: ./gradlew --no-daemon :temporal-sdk:jackson3Tests -x spotlessCheck -x spotlessApply -x spotlessJava
+
     - name: Run virtual thread tests
       env:
         USER: unittest

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/main/idls/*
 .settings
 .vscode/
 */bin
+/.claude

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
     // Platforms
     grpcVersion = '1.75.0' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.15.4' // [2.9.0,)
+    jackson3Version = '3.0.4'
     nexusVersion = '0.5.0-alpha'
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.13.6' : '1.9.9' // [1.0.0,)

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -38,7 +38,13 @@ dependencies {
 
 // Temporal SDK supports Java 8 or later so to support virtual threads
 // we need to compile the code with Java 21 and package it in a multi-release jar.
+// Similarly, Jackson 3 support requires Java 17+ and is compiled separately.
 sourceSets {
+    java17 {
+        java {
+            srcDirs = ['src/main/java17']
+        }
+    }
     java21 {
         java {
             srcDirs = ['src/main/java21']
@@ -47,7 +53,29 @@ sourceSets {
 }
 
 dependencies {
+    // The java17 source set needs protobuf and other main dependencies to compile. We pass
+    // the main compile classpath as files rather than extending from api/implementation
+    // configurations, because extendsFrom triggers Gradle's variant-aware resolution which
+    // rejects project dependencies when the java17 target JVM (17) differs from the resolved
+    // project's JVM compatibility (e.g. 21+ on CI edge runners).
+    java17Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
+    java17Implementation files({ sourceSets.main.compileClasspath })
+    java17CompileOnly "tools.jackson.core:jackson-databind:$jackson3Version"
+
     java21Implementation files(sourceSets.main.output.classesDirs) { builtBy compileJava }
+}
+
+tasks.named('compileJava17Java') {
+    // Gradle toolchains are too strict and require the JDK to match the specified version exactly.
+    // This is a workaround to use a JDK 17+ compiler.
+    //
+    // See also: https://github.com/gradle/gradle/issues/16256
+    if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+        javaCompiler = javaToolchains.compilerFor {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
+    options.release = 17
 }
 
 tasks.named('compileJava21Java') {
@@ -64,12 +92,36 @@ tasks.named('compileJava21Java') {
 }
 
 jar {
+    into('META-INF/versions/17') {
+        from sourceSets.java17.output
+    }
     into('META-INF/versions/21') {
         from sourceSets.java21.output
     }
     manifest.attributes(
             'Multi-Release': 'true'
     )
+}
+
+// Publish Jackson 3 as an optional dependency so users can opt-in
+afterEvaluate {
+    publishing {
+        publications {
+            mavenJava {
+                pom.withXml {
+                    def depsNode = asNode()['dependencies'][0]
+                    if (depsNode == null) {
+                        depsNode = asNode().appendNode('dependencies')
+                    }
+                    def dep = depsNode.appendNode('dependency')
+                    dep.appendNode('groupId', 'tools.jackson.core')
+                    dep.appendNode('artifactId', 'jackson-databind')
+                    dep.appendNode('version', '[' + jackson3Version + ',)')
+                    dep.appendNode('optional', 'true')
+                }
+            }
+        }
+    }
 }
 
 task registerNamespace(type: JavaExec) {
@@ -82,6 +134,22 @@ test.dependsOn 'registerNamespace'
 test {
     useJUnit {
         excludeCategories 'io.temporal.worker.IndependentResourceBasedTests'
+    }
+}
+
+// On Java 17+, prepend java17 classes to all test classpaths so that Class.forName finds
+// the real Jackson3JsonPayloadConverter instead of the Java 8 stub. This lets us test
+// the present-java17-but-absent-jackson3 behavior (NoClassDefFoundError) in the same
+// test that tests the Java 8 stub behavior (UnsupportedOperationException).
+tasks.withType(Test).configureEach {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+        dependsOn compileJava17Java
+    }
+    doFirst {
+        int launcherMajorVersion = javaLauncher.get().metadata.languageVersion.asInt()
+        if (launcherMajorVersion >= 17) {
+            classpath = files(sourceSets.java17.output.classesDirs) + classpath
+        }
     }
 }
 
@@ -121,6 +189,36 @@ testing {
                         }
                     }
                 }
+            }
+        }
+
+        jackson3Tests(JvmTestSuite) {
+            dependencies {
+                // java17 output must come before project() (added by configureEach) so that
+                // the compiler and runtime see the real Jackson3JsonPayloadConverter — which
+                // has a wider API than the Java 8 stub (newDefaultJsonMapper, JsonMapper
+                // constructor) because the stub can't reference Jackson 3 types.
+                implementation files(sourceSets.java17.output.classesDirs) { builtBy compileJava17Java }
+                implementation "tools.jackson.core:jackson-databind:$jackson3Version"
+            }
+            targets {
+                all {
+                    testTask.configure {
+                        javaLauncher = javaToolchains.launcherFor {
+                            languageVersion = JavaLanguageVersion.of(17)
+                        }
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+
+        // Unlike virtualThreadTests, jackson3Tests source directly imports Jackson 3 types
+        // and java17 classes, so the compile task also needs a Java 17 compiler (not just
+        // the test launcher).
+        tasks.named('compileJackson3TestsJava') {
+            javaCompiler = javaToolchains.compilerFor {
+                languageVersion = JavaLanguageVersion.of(17)
             }
         }
 
@@ -164,5 +262,6 @@ testing {
 }
 
 tasks.named('check') {
+    dependsOn(testing.suites.jackson3Tests)
     dependsOn(testing.suites.virtualThreadTests)
 }

--- a/temporal-sdk/src/jackson3Tests/java/io/temporal/common/converter/Jackson3JsonPayloadConverterTest.java
+++ b/temporal-sdk/src/jackson3Tests/java/io/temporal/common/converter/Jackson3JsonPayloadConverterTest.java
@@ -1,0 +1,216 @@
+package io.temporal.common.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.temporal.api.common.v1.Payload;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+public class Jackson3JsonPayloadConverterTest {
+
+  @After
+  public void resetJackson3Delegate() {
+    JacksonJsonPayloadConverter.setDefaultAsJackson3(false, false);
+  }
+
+  @Test
+  public void testSimple() {
+    Jackson3JsonPayloadConverter converter = new Jackson3JsonPayloadConverter();
+    TestPayload payload = new TestPayload(1L, Instant.now(), "myPayload");
+    Optional<Payload> data = converter.toData(payload);
+    assertTrue(data.isPresent());
+
+    // Jackson 3 native defaults sort fields alphabetically (id, name, timestamp)
+    // unlike jackson2Compat which preserves declaration order (id, timestamp, name)
+    String json = data.get().getData().toStringUtf8();
+    assertTrue(
+        "Expected alphabetical field order (Jackson 3 native), got: " + json,
+        json.indexOf("\"name\"") < json.indexOf("\"timestamp\""));
+
+    TestPayload converted = converter.fromData(data.get(), TestPayload.class, TestPayload.class);
+    assertEquals(payload, converted);
+  }
+
+  @Test
+  public void testSimpleJackson2Compat() {
+    Jackson3JsonPayloadConverter converter = new Jackson3JsonPayloadConverter(true);
+    TestPayload payload = new TestPayload(1L, Instant.now(), "myPayload");
+    Optional<Payload> data = converter.toData(payload);
+    assertTrue(data.isPresent());
+
+    // jackson2Compat preserves declaration order (id, timestamp, name)
+    // unlike Jackson 3 native which sorts alphabetically (id, name, timestamp)
+    String json = data.get().getData().toStringUtf8();
+    assertTrue(
+        "Expected declaration field order (jackson2Compat), got: " + json,
+        json.indexOf("\"timestamp\"") < json.indexOf("\"name\""));
+
+    TestPayload converted = converter.fromData(data.get(), TestPayload.class, TestPayload.class);
+    assertEquals(payload, converted);
+  }
+
+  @Test
+  public void testCustomJsonMapper() {
+    JsonMapper mapper =
+        Jackson3JsonPayloadConverter.newDefaultJsonMapper(false)
+            .rebuild()
+            .enable(tools.jackson.databind.SerializationFeature.INDENT_OUTPUT)
+            .build();
+    Jackson3JsonPayloadConverter converter = new Jackson3JsonPayloadConverter(mapper);
+    TestPayload payload = new TestPayload(1L, Instant.now(), "test");
+    Optional<Payload> data = converter.toData(payload);
+    assertTrue(data.isPresent());
+    String json = data.get().getData().toStringUtf8();
+    assertTrue("Expected pretty-printed JSON", json.contains("\n"));
+  }
+
+  @Test
+  public void testEncodingType() {
+    Jackson3JsonPayloadConverter converter = new Jackson3JsonPayloadConverter();
+    assertEquals("json/plain", converter.getEncodingType());
+  }
+
+  @Test
+  public void testWireCompatibilityBetweenJackson2AndJackson3() {
+    JacksonJsonPayloadConverter jackson2 = new JacksonJsonPayloadConverter();
+    Jackson3JsonPayloadConverter jackson3 = new Jackson3JsonPayloadConverter(true);
+
+    TestPayload payload = new TestPayload(42L, Instant.parse("2024-01-15T10:30:00Z"), "wireTest");
+
+    // Jackson 2 serialized -> Jackson 3 deserialized
+    Optional<Payload> data2 = jackson2.toData(payload);
+    assertTrue(data2.isPresent());
+    assertEquals(payload, jackson3.fromData(data2.get(), TestPayload.class, TestPayload.class));
+
+    // Jackson 3 serialized -> Jackson 2 deserialized
+    Optional<Payload> data3 = jackson3.toData(payload);
+    assertTrue(data3.isPresent());
+    assertEquals(payload, jackson2.fromData(data3.get(), TestPayload.class, TestPayload.class));
+  }
+
+  @Test
+  public void testSetDefaultAsJackson3() {
+    JacksonJsonPayloadConverter.setDefaultAsJackson3(true, false);
+
+    Optional<Payload> data =
+        GlobalDataConverter.get().toPayload(new TestPayload(1L, Instant.now(), "delegated"));
+    assertTrue(data.isPresent());
+
+    // Alphabetical field order proves Jackson 3 native is being used
+    String json = data.get().getData().toStringUtf8();
+    assertTrue(
+        "Expected alphabetical field order (Jackson 3 native), got: " + json,
+        json.indexOf("\"name\"") < json.indexOf("\"timestamp\""));
+  }
+
+  @Test
+  public void testSetDefaultAsJackson3WithCompat() {
+    JacksonJsonPayloadConverter.setDefaultAsJackson3(true, true);
+
+    Optional<Payload> data =
+        GlobalDataConverter.get().toPayload(new TestPayload(1L, Instant.now(), "delegated-compat"));
+    assertTrue(data.isPresent());
+
+    // Declaration field order proves Jackson 3 with jackson2Compat is being used
+    String json = data.get().getData().toStringUtf8();
+    assertTrue(
+        "Expected declaration field order (jackson2Compat), got: " + json,
+        json.indexOf("\"timestamp\"") < json.indexOf("\"name\""));
+  }
+
+  @Test
+  public void testExplicitObjectMapperIgnoresJackson3Delegate() {
+    // Enable Jackson 3 native globally (which sorts fields alphabetically)
+    JacksonJsonPayloadConverter.setDefaultAsJackson3(true, false);
+
+    // Converter created with explicit ObjectMapper should NOT delegate to Jackson 3
+    ObjectMapper mapper = JacksonJsonPayloadConverter.newDefaultObjectMapper();
+    JacksonJsonPayloadConverter converter = new JacksonJsonPayloadConverter(mapper);
+
+    TestPayload payload = new TestPayload(1L, Instant.now(), "explicit");
+    Optional<Payload> data = converter.toData(payload);
+    assertTrue(data.isPresent());
+
+    // Declaration field order proves Jackson 2 is still being used, not the Jackson 3 delegate
+    String json = data.get().getData().toStringUtf8();
+    assertTrue(
+        "Expected declaration field order (Jackson 2), got: " + json,
+        json.indexOf("\"timestamp\"") < json.indexOf("\"name\""));
+  }
+
+  static class TestPayload {
+    private long id;
+    private Instant timestamp;
+    private String name;
+
+    public TestPayload() {}
+
+    TestPayload(long id, Instant timestamp, String name) {
+      this.id = id;
+      this.timestamp = timestamp;
+      this.name = name;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public Instant getTimestamp() {
+      return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TestPayload that = (TestPayload) o;
+      return id == that.id
+          && Objects.equals(timestamp, that.timestamp)
+          && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, timestamp, name);
+    }
+
+    @Override
+    public String toString() {
+      return "TestPayload{"
+          + "id="
+          + id
+          + ", timestamp="
+          + timestamp
+          + ", name='"
+          + name
+          + '\''
+          + '}';
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/Experimental.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/Experimental.java
@@ -6,6 +6,7 @@ import java.lang.annotation.*;
  * Annotation that specifies that an element is experimental, has unstable API or may change without
  * notice. This annotation is inherited.
  */
+@Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/Jackson3JsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/Jackson3JsonPayloadConverter.java
@@ -1,0 +1,50 @@
+package io.temporal.common.converter;
+
+import io.temporal.api.common.v1.Payload;
+import io.temporal.common.Experimental;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * A {@link PayloadConverter} that uses Jackson 3.x for JSON serialization/deserialization. This
+ * converter uses the same {@code "json/plain"} encoding type as {@link
+ * JacksonJsonPayloadConverter}, making it wire-compatible.
+ *
+ * <p>This is a stub for Java versions prior to 17. On Java 17+ with Jackson 3.x on the classpath,
+ * the real implementation is loaded automatically via the multi-release JAR mechanism.
+ *
+ * <p>Requires Java 17+ and {@code tools.jackson.core:jackson-databind:3.x} on the classpath.
+ *
+ * @see JacksonJsonPayloadConverter#setDefaultAsJackson3(boolean, boolean)
+ */
+@Experimental
+public class Jackson3JsonPayloadConverter implements PayloadConverter {
+
+  private static final String UNSUPPORTED_MSG =
+      "Jackson 3 PayloadConverter requires Java 17+ and Jackson 3.x"
+          + " (tools.jackson.core:jackson-databind) on the classpath";
+
+  public Jackson3JsonPayloadConverter() {
+    throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+  }
+
+  public Jackson3JsonPayloadConverter(boolean jackson2Compat) {
+    throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+  }
+
+  @Override
+  public String getEncodingType() {
+    throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+  }
+
+  @Override
+  public Optional<Payload> toData(Object value) throws DataConverterException {
+    throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+  }
+
+  @Override
+  public <T> T fromData(Payload content, Class<T> valueType, Type valueGenericType)
+      throws DataConverterException {
+    throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/JacksonJsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/JacksonJsonPayloadConverter.java
@@ -11,13 +11,56 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.protobuf.ByteString;
 import io.temporal.api.common.v1.Payload;
+import io.temporal.common.Experimental;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Optional;
 
 public class JacksonJsonPayloadConverter implements PayloadConverter {
 
+  private static volatile PayloadConverter jackson3Delegate;
+
+  /**
+   * Opts in to or out of using Jackson 3.x as the default JSON payload converter. When enabled,
+   * instances created via the default constructor will delegate all serialization/deserialization
+   * to a {@link Jackson3JsonPayloadConverter}.
+   *
+   * <p>This applies globally, including to the converter in {@link
+   * DefaultDataConverter#STANDARD_PAYLOAD_CONVERTERS}. Call this method early in your application,
+   * before creating any Temporal clients.
+   *
+   * <p>Requires Java 17+ and {@code tools.jackson.core:jackson-databind:3.x} on the classpath.
+   *
+   * @param defaultAsJackson3 {@code true} to delegate to Jackson 3, {@code false} to revert to
+   *     Jackson 2
+   * @param jackson2Compat if {@code true}, the Jackson 3 converter is configured with Jackson 2.x
+   *     default behaviors for maximum wire compatibility. If {@code false}, Jackson 3.x native
+   *     defaults are used. Only relevant when {@code defaultAsJackson3} is {@code true}.
+   * @throws IllegalStateException if Jackson 3 is not available
+   * @see Jackson3JsonPayloadConverter
+   */
+  @Experimental
+  public static void setDefaultAsJackson3(boolean defaultAsJackson3, boolean jackson2Compat) {
+    if (!defaultAsJackson3) {
+      jackson3Delegate = null;
+      return;
+    }
+    try {
+      jackson3Delegate =
+          (PayloadConverter)
+              Class.forName("io.temporal.common.converter.Jackson3JsonPayloadConverter")
+                  .getDeclaredConstructor(boolean.class)
+                  .newInstance(jackson2Compat);
+    } catch (Exception | LinkageError e) {
+      throw new IllegalStateException(
+          "Failed to load Jackson 3 converter. Ensure Java 17+ and"
+              + " Jackson 3.x (tools.jackson.core:jackson-databind) are on the classpath.",
+          e);
+    }
+  }
+
   private final ObjectMapper mapper;
+  private final boolean useDefaultJackson3Delegate;
 
   /**
    * Can be used as a starting point for custom user configurations of ObjectMapper.
@@ -39,11 +82,13 @@ public class JacksonJsonPayloadConverter implements PayloadConverter {
   }
 
   public JacksonJsonPayloadConverter() {
-    this(newDefaultObjectMapper());
+    this.mapper = newDefaultObjectMapper();
+    this.useDefaultJackson3Delegate = true;
   }
 
   public JacksonJsonPayloadConverter(ObjectMapper mapper) {
     this.mapper = mapper;
+    this.useDefaultJackson3Delegate = false;
   }
 
   @Override
@@ -53,6 +98,12 @@ public class JacksonJsonPayloadConverter implements PayloadConverter {
 
   @Override
   public Optional<Payload> toData(Object value) throws DataConverterException {
+    // Delegate to Jackson 3 converter if globally opted in via setDefaultAsJackson3
+    PayloadConverter delegate = jackson3Delegate;
+    if (delegate != null && useDefaultJackson3Delegate) {
+      return delegate.toData(value);
+    }
+
     try {
       byte[] serialized = mapper.writeValueAsBytes(value);
       return Optional.of(
@@ -69,6 +120,12 @@ public class JacksonJsonPayloadConverter implements PayloadConverter {
   @Override
   public <T> T fromData(Payload content, Class<T> valueClass, Type valueType)
       throws DataConverterException {
+    // Delegate to Jackson 3 converter if globally opted in via setDefaultAsJackson3
+    PayloadConverter delegate = jackson3Delegate;
+    if (delegate != null && useDefaultJackson3Delegate) {
+      return delegate.fromData(content, valueClass, valueType);
+    }
+
     ByteString data = content.getData();
     if (data.isEmpty()) {
       return null;

--- a/temporal-sdk/src/main/java17/io/temporal/common/converter/Jackson3JsonPayloadConverter.java
+++ b/temporal-sdk/src/main/java17/io/temporal/common/converter/Jackson3JsonPayloadConverter.java
@@ -1,0 +1,134 @@
+package io.temporal.common.converter;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.google.protobuf.ByteString;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.common.Experimental;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * A {@link PayloadConverter} that uses Jackson 3.x for JSON serialization/deserialization. This
+ * converter uses the same {@code "json/plain"} encoding type as {@link
+ * JacksonJsonPayloadConverter}, making it wire-compatible.
+ *
+ * <p>Requires Java 17+ and {@code tools.jackson.core:jackson-databind:3.x} on the classpath.
+ *
+ * <p>Jackson 3.x has built-in support for {@code java.time} types and {@code java.util.Optional},
+ * so no additional module registration is needed.
+ *
+ * @see JacksonJsonPayloadConverter#setDefaultAsJackson3(boolean, boolean)
+ */
+@Experimental
+public class Jackson3JsonPayloadConverter implements PayloadConverter {
+
+  private final JsonMapper mapper;
+
+  /**
+   * Creates a new instance with the default {@link JsonMapper} configuration using Jackson 3.x
+   * native defaults. Equivalent to {@code new Jackson3JsonPayloadConverter(false)}.
+   */
+  public Jackson3JsonPayloadConverter() {
+    this(false);
+  }
+
+  /**
+   * Creates a new instance with the default {@link JsonMapper} configuration.
+   *
+   * <p>The defaults always include:
+   *
+   * <ul>
+   *   <li>Dates are written as ISO-8601 strings, not timestamps
+   *   <li>Timezone from the server payload is preserved without adjusting to the host timezone
+   *   <li>All fields are visible for serialization regardless of access modifiers
+   * </ul>
+   *
+   * @param jackson2Compat if {@code true}, uses {@link JsonMapper#builderWithJackson2Defaults()} to
+   *     preserve Jackson 2.x default behaviors for maximum wire compatibility. If {@code false},
+   *     uses Jackson 3.x native defaults.
+   */
+  public Jackson3JsonPayloadConverter(boolean jackson2Compat) {
+    this(newDefaultJsonMapper(jackson2Compat));
+  }
+
+  /**
+   * Creates a new instance with a custom {@link JsonMapper}.
+   *
+   * @param mapper a pre-configured Jackson 3.x {@link JsonMapper}
+   */
+  public Jackson3JsonPayloadConverter(JsonMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  /**
+   * Creates a default {@link JsonMapper} with configuration defaults matching {@link
+   * JacksonJsonPayloadConverter#newDefaultObjectMapper()}.
+   *
+   * <p>Can be used as a starting point for custom user configurations:
+   *
+   * <pre>{@code
+   * JsonMapper mapper = Jackson3JsonPayloadConverter.newDefaultJsonMapper(true)
+   *     .rebuild()
+   *     .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+   *     .build();
+   * new Jackson3JsonPayloadConverter(mapper);
+   * }</pre>
+   *
+   * @param jackson2Compat if {@code true}, uses {@link JsonMapper#builderWithJackson2Defaults()} to
+   *     preserve Jackson 2.x default behaviors for maximum wire compatibility. If {@code false},
+   *     uses Jackson 3.x native defaults.
+   * @return a default configuration of {@link JsonMapper}
+   */
+  public static JsonMapper newDefaultJsonMapper(boolean jackson2Compat) {
+    JsonMapper.Builder builder =
+        jackson2Compat ? JsonMapper.builderWithJackson2Defaults() : JsonMapper.builder();
+    return builder
+        // preserve the original value of timezone coming from the server in Payload
+        // without adjusting to the host timezone
+        // may be important if the replay is happening on a host in another timezone
+        .disable(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+        .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .changeDefaultVisibility(
+            vc -> vc.withVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY))
+        .build();
+  }
+
+  @Override
+  public String getEncodingType() {
+    return EncodingKeys.METADATA_ENCODING_JSON_NAME;
+  }
+
+  @Override
+  public Optional<Payload> toData(Object value) throws DataConverterException {
+    try {
+      byte[] serialized = mapper.writeValueAsBytes(value);
+      return Optional.of(
+          Payload.newBuilder()
+              .putMetadata(EncodingKeys.METADATA_ENCODING_KEY, EncodingKeys.METADATA_ENCODING_JSON)
+              .setData(ByteString.copyFrom(serialized))
+              .build());
+    } catch (JacksonException e) {
+      throw new DataConverterException(e);
+    }
+  }
+
+  @Override
+  public <T> T fromData(Payload content, Class<T> valueClass, Type valueType)
+      throws DataConverterException {
+    ByteString data = content.getData();
+    if (data.isEmpty()) {
+      return null;
+    }
+    try {
+      JavaType reference = mapper.getTypeFactory().constructType(valueType);
+      return mapper.readValue(content.getData().toByteArray(), reference);
+    } catch (JacksonException e) {
+      throw new DataConverterException(e);
+    }
+  }
+}


### PR DESCRIPTION
## What was changed

- Added `Jackson3JsonPayloadConverter` as a multi-release JAR entry (Java 8 stub in `src/main/java/`, real implementation in `src/main/java17/`) that uses Jackson 3.x `JsonMapper` for JSON serialization
- Added `JacksonJsonPayloadConverter.setDefaultAsJackson3(boolean, boolean)` static method to globally opt in to Jackson 3 delegation, including for the default converter in `DefaultDataConverter.STANDARD_PAYLOAD_CONVERTERS`
- Jackson 3 converter supports two modes: native Jackson 3 defaults (`jackson2Compat=false`) and Jackson 2 compatibility mode (`jackson2Compat=true` via `JsonMapper.builderWithJackson2Defaults()`)
- Converters with an explicit `ObjectMapper` passed to the constructor are not affected by the global Jackson 3 delegate
- Both converters produce identical `"json/plain"` encoding type and are wire-compatible in both directions
- Jackson 3 is published as an optional dependency with version range `[3.0.4,)` in the POM
- Added `jackson3Tests` test suite (8 tests, Java 17 launcher) covering direct converter usage, wire compatibility, global delegation via `GlobalDataConverter.get()`, and explicit-mapper opt-out
- Added Jackson-3-absent tests to the main test suite verifying correct error behavior on Java 8 (`UnsupportedOperationException`) and Java 17+ without Jackson 3 (`NoClassDefFoundError`)
- Added `jackson3Tests` CI step to the `unit_test_jdk8` job
- Added `@Documented` to the `@Experimental` annotation

## Checklist

1. Closes #2746