### PR TITLE
Make search attribute type more lenient when parsing

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SearchAttributePayloadConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SearchAttributePayloadConverter.java
@@ -331,13 +331,19 @@ final class SearchAttributePayloadConverter {
 
   @Nullable
   private static IndexedValueType encodedValueToIndexValueType(String encodedValue) {
+    // The type metadata is usually in PascalCase (e.g. "KeywordList") but in rare cases may be in
+    // SCREAMING_SNAKE_CASE (e.g. "INDEXED_VALUE_TYPE_KEYWORD_LIST").
     try {
       return IndexedValueType.valueOf(
           ProtoEnumNameUtils.simplifiedToUniqueName(
               encodedValue, ProtoEnumNameUtils.INDEXED_VALUE_TYPE_PREFIX));
     } catch (IllegalArgumentException e) {
-      log.warn("[BUG] No IndexedValueType mapping for {} value exist", encodedValue);
-      return null;
+      try {
+        return IndexedValueType.valueOf(encodedValue);
+      } catch (IllegalArgumentException e2) {
+        log.warn("[BUG] No IndexedValueType mapping for {} value exist", encodedValue);
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
## What was changed

There was a case in Core where we used SCREAMING_SNAKE_CASE for metadata type instead of PascalCase, see https://github.com/temporalio/features/issues/741. This adjusts Java to be a bit more lenient (but no great way to test the Core issue that's already fixed).