### PR TITLE
Add maven metadata and signature on workflowcheck aritfacts

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -27,27 +27,24 @@ subprojects {
                 }
             }
         }
-        // to test local publishing use ./gradlew publish and comment nexusPublishing
-//        repositories {
-//            maven {
-//                def releasesRepoUrl = "$System.env.HOME/repos/releases"
-//                def snapshotsRepoUrl = "$System.env.HOME/repos/snapshots"
-//                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-//            }
-//        }
+
+        // To test local publishing use ./gradlew publish and comment nexusPublishing
+        //
+        // repositories {
+        //     maven {
+        //         def releasesRepoUrl = "$System.env.HOME/repos/releases"
+        //         def snapshotsRepoUrl = "$System.env.HOME/repos/snapshots"
+        //         url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+        //     }
+        // }
     }
 
-    if (project.hasProperty('signing.keyId')) {
-        signing {
-            sign publishing.publications.mavenJava
-        }
-    }
-
-    //customize the pom in afterEvaluate to allow subproject build.gradle files to
-    //contribute the description field
+    // Customize the pom for all publications and sign all, in afterEvaluate so
+    // subproject build.gradle files can contribute (e.g. description) and custom
+    // publications (e.g. shadow) exist.
     afterEvaluate { subproject ->
-        subproject.publishing.publications.mavenJava {
-            pom {
+        subproject.publishing.publications.withType(MavenPublication).each { publication ->
+            publication.pom {
                 name = subproject.description
                 description = subproject.description
                 url = 'https://github.com/temporalio/sdk-java'
@@ -76,6 +73,13 @@ subprojects {
                         name = 'Samar Abbas'
                         email = 'samar@temporal.io'
                     }
+                }
+            }
+        }
+        if (subproject.hasProperty('signing.keyId')) {
+            subproject.signing {
+                subproject.publishing.publications.withType(MavenPublication).each { publication ->
+                    sign publication
                 }
             }
         }

--- a/temporal-workflowcheck/build.gradle
+++ b/temporal-workflowcheck/build.gradle
@@ -33,14 +33,16 @@ startScripts.dependsOn shadowJar
 // Configure publishing to publish both regular library jar and shadow executable jar
 publishing {
     publications {
-        // Regular library jar for programmatic usage and compile-time annotations
-        maven(MavenPublication) {
-            from components.java
-        }
+        // Regular library jar for programmatic usage and compile-time annotations.
+        // That publication is configured by the default setup in publishing.gradle.
+        // mavenJava(MavenPublication) { ... }
+
         // Fat executable jar with shaded dependencies
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
             artifactId = "${project.name}-all"
+            artifact sourcesJar
+            artifact javadocJar
         }
     }
 }


### PR DESCRIPTION
## What was changed

- Modified the root Gradle `subprojects.publishing.publications` config so it applies to every `MavenPublication` object, not only the `mavenJava` target. This allows subprojects to register extra publication targets that also inherit the POM and artifact signature configuration.
- For the `workflowcheck` shadow (-all) publication, added the required sources and javadoc artifacts.

## Why

- This resolves Sonatype validation failures seen when publishing the newly added `workflowcheck` module.