### PR TITLE
Add explicit opt-in flags for activity/nexus bean auto-discovery in Spring Boot

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/WorkersPresentCondition.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/WorkersPresentCondition.java
@@ -1,6 +1,7 @@
 package io.temporal.spring.boot.autoconfigure;
 
 import io.temporal.spring.boot.autoconfigure.properties.WorkerProperties;
+import io.temporal.spring.boot.autoconfigure.properties.WorkersAutoDiscoveryProperties;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
@@ -15,11 +16,10 @@ class WorkersPresentCondition extends SpringBootCondition {
   private static final Bindable<List<WorkerProperties>> WORKER_PROPERTIES_LIST =
       Bindable.listOf(WorkerProperties.class);
 
-  private static final Bindable<List<String>> AUTO_DISCOVERY_PACKAGES_LIST =
-      Bindable.listOf(String.class);
+  private static final Bindable<WorkersAutoDiscoveryProperties> AUTO_DISCOVERY_BINDABLE =
+      Bindable.of(WorkersAutoDiscoveryProperties.class);
   private static final String WORKERS_KEY = "spring.temporal.workers";
-  private static final String AUTO_DISCOVERY_KEY =
-      "spring.temporal.workers-auto-discovery.packages";
+  private static final String AUTO_DISCOVERY_KEY = "spring.temporal.workers-auto-discovery";
 
   public WorkersPresentCondition() {}
 
@@ -34,8 +34,8 @@ class WorkersPresentCondition extends SpringBootCondition {
     }
 
     BindResult<?> autoDiscoveryProperty =
-        Binder.get(context.getEnvironment()).bind(AUTO_DISCOVERY_KEY, AUTO_DISCOVERY_PACKAGES_LIST);
-    messageBuilder = ConditionMessage.forCondition("Auto Discovery Packages Set");
+        Binder.get(context.getEnvironment()).bind(AUTO_DISCOVERY_KEY, AUTO_DISCOVERY_BINDABLE);
+    messageBuilder = ConditionMessage.forCondition("Workers Auto Discovery Set");
     if (autoDiscoveryProperty.isBound()) {
       return ConditionOutcome.match(messageBuilder.found("property").items(AUTO_DISCOVERY_KEY));
     }

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkersAutoDiscoveryProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkersAutoDiscoveryProperties.java
@@ -1,17 +1,121 @@
 package io.temporal.spring.boot.autoconfigure.properties;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 public class WorkersAutoDiscoveryProperties {
-  private final @Nullable List<String> packages;
+  /**
+   * When {@code true}, enables auto-registration of all {@code @ActivityImpl}-,
+   * {@code @NexusServiceImpl}-, and {@code @WorkflowImpl}-annotated classes that are Spring-managed
+   * beans. This is the recommended option for simple use cases where all implementations are
+   * Spring-managed beans. It implies {@link #registerActivityBeans} and {@link
+   * #registerNexusServiceBeans} default to {@code true}, and also enables auto-registration of
+   * {@code @WorkflowImpl}-annotated classes that are Spring-managed beans, without needing {@link
+   * #workflowPackages}.
+   *
+   * <p>Classpath-scanning via {@link #workflowPackages} (for non-bean workflow classes) still
+   * requires explicit package configuration regardless of this flag.
+   */
+  private final @Nullable Boolean enable;
+
+  private final @Nullable List<String> workflowPackages;
+  private final @Nullable Boolean registerActivityBeans;
+  private final @Nullable Boolean registerNexusServiceBeans;
+
+  /**
+   * @deprecated Use {@link #workflowPackages} instead. If set and non-empty, this property causes
+   *     {@link #registerActivityBeans} and {@link #registerNexusServiceBeans} to default to {@code
+   *     true}, and its entries to be considered as if they were provided through {@link
+   *     #workflowPackages}. Setting both {@link #packages} and any of the other new properties is
+   *     unsupported and will result in an exception.
+   */
+  @Deprecated private final @Nullable List<String> packages;
 
   @ConstructorBinding
-  public WorkersAutoDiscoveryProperties(@Nullable List<String> packages) {
+  public WorkersAutoDiscoveryProperties(
+      @Nullable Boolean enable,
+      @Nullable List<String> workflowPackages,
+      @Nullable Boolean registerActivityBeans,
+      @Nullable Boolean registerNexusServiceBeans,
+      @Nullable List<String> packages) {
+    if (packages != null
+        && !packages.isEmpty()
+        && (enable != null
+            || workflowPackages != null
+            || registerActivityBeans != null
+            || registerNexusServiceBeans != null)) {
+      throw new IllegalStateException(
+          "spring.temporal.workers-auto-discovery.packages is deprecated and cannot be combined "
+              + "with enable, workflow-packages, register-activity-beans, or register-nexus-service-beans. "
+              + "Migrate to the new properties and remove packages.");
+    }
+    this.enable = enable;
+    this.workflowPackages = workflowPackages;
+    this.registerActivityBeans = registerActivityBeans;
+    this.registerNexusServiceBeans = registerNexusServiceBeans;
     this.packages = packages;
   }
 
+  /**
+   * Returns whether {@code @WorkflowImpl}-annotated classes that are also Spring-managed beans
+   * should be automatically registered with matching workers (without classpath scanning). Defaults
+   * to {@code true} when {@link #enable} is {@code true}, {@code false} otherwise. Workflow
+   * implementation classes that are not Spring-managed beans still require {@link
+   * #workflowPackages} for classpath scanning.
+   */
+  public boolean isRegisterWorkflowManagedBeans() {
+    return Boolean.TRUE.equals(enable);
+  }
+
+  /**
+   * Returns whether {@code @ActivityImpl}-annotated beans should be automatically registered with
+   * matching workers. Defaults to {@code true} when {@link #enable} is {@code true} or when the
+   * deprecated {@link #packages} property is set and non-empty; {@code false} otherwise.
+   */
+  public boolean isRegisterActivityBeans() {
+    if (registerActivityBeans != null) return registerActivityBeans;
+    return Boolean.TRUE.equals(enable) || (packages != null && !packages.isEmpty());
+  }
+
+  /**
+   * Returns whether {@code @NexusServiceImpl}-annotated beans should be automatically registered
+   * with matching workers. Defaults to {@code true} when {@link #enable} is {@code true} or when
+   * the deprecated {@link #packages} property is set and non-empty; {@code false} otherwise.
+   */
+  public boolean isRegisterNexusServiceBeans() {
+    if (registerNexusServiceBeans != null) return registerNexusServiceBeans;
+    return Boolean.TRUE.equals(enable) || (packages != null && !packages.isEmpty());
+  }
+
+  /**
+   * Returns the list of packages to scan for {@code @WorkflowImpl} classes. When the deprecated
+   * {@link #packages} property is set, its entries are used; otherwise returns the entries of
+   * {@link #workflowPackages}. The two properties cannot be set simultaneously.
+   */
+  public List<String> getEffectiveWorkflowPackages() {
+    List<String> result = new ArrayList<>();
+    if (packages != null) result.addAll(packages);
+    if (workflowPackages != null) result.addAll(workflowPackages);
+    return result;
+  }
+
+  @Nullable
+  public List<String> getWorkflowPackages() {
+    return workflowPackages;
+  }
+
+  /**
+   * @deprecated `packages` has unclear semantics with regard to registration of activity and nexus
+   *     service beans; use {@link #getWorkflowPackages()} instead.
+   */
+  @Deprecated
+  @DeprecatedConfigurationProperty(
+      replacement = "spring.temporal.workers-auto-discovery.workflow-packages",
+      reason =
+          "'packages' has unclear semantics with regard to registration of activity and nexus service beans; use 'workflow-packages' instead")
   @Nullable
   public List<String> getPackages() {
     return packages;

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkersAutoDiscoveryProperties.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/properties/WorkersAutoDiscoveryProperties.java
@@ -19,7 +19,7 @@ public class WorkersAutoDiscoveryProperties {
    * <p>Classpath-scanning via {@link #workflowPackages} (for non-bean workflow classes) still
    * requires explicit package configuration regardless of this flag.
    */
-  private final @Nullable Boolean enable;
+  private final @Nullable Boolean enabled;
 
   private final @Nullable List<String> workflowPackages;
   private final @Nullable Boolean registerActivityBeans;
@@ -36,23 +36,23 @@ public class WorkersAutoDiscoveryProperties {
 
   @ConstructorBinding
   public WorkersAutoDiscoveryProperties(
-      @Nullable Boolean enable,
+      @Nullable Boolean enabled,
       @Nullable List<String> workflowPackages,
       @Nullable Boolean registerActivityBeans,
       @Nullable Boolean registerNexusServiceBeans,
       @Nullable List<String> packages) {
     if (packages != null
         && !packages.isEmpty()
-        && (enable != null
+        && (enabled != null
             || workflowPackages != null
             || registerActivityBeans != null
             || registerNexusServiceBeans != null)) {
       throw new IllegalStateException(
           "spring.temporal.workers-auto-discovery.packages is deprecated and cannot be combined "
-              + "with enable, workflow-packages, register-activity-beans, or register-nexus-service-beans. "
+              + "with enabled, workflow-packages, register-activity-beans, or register-nexus-service-beans. "
               + "Migrate to the new properties and remove packages.");
     }
-    this.enable = enable;
+    this.enabled = enabled;
     this.workflowPackages = workflowPackages;
     this.registerActivityBeans = registerActivityBeans;
     this.registerNexusServiceBeans = registerNexusServiceBeans;
@@ -62,32 +62,32 @@ public class WorkersAutoDiscoveryProperties {
   /**
    * Returns whether {@code @WorkflowImpl}-annotated classes that are also Spring-managed beans
    * should be automatically registered with matching workers (without classpath scanning). Defaults
-   * to {@code true} when {@link #enable} is {@code true}, {@code false} otherwise. Workflow
+   * to {@code true} when {@link #enabled} is {@code true}, {@code false} otherwise. Workflow
    * implementation classes that are not Spring-managed beans still require {@link
    * #workflowPackages} for classpath scanning.
    */
   public boolean isRegisterWorkflowManagedBeans() {
-    return Boolean.TRUE.equals(enable);
+    return Boolean.TRUE.equals(enabled);
   }
 
   /**
    * Returns whether {@code @ActivityImpl}-annotated beans should be automatically registered with
-   * matching workers. Defaults to {@code true} when {@link #enable} is {@code true} or when the
+   * matching workers. Defaults to {@code true} when {@link #enabled} is {@code true} or when the
    * deprecated {@link #packages} property is set and non-empty; {@code false} otherwise.
    */
   public boolean isRegisterActivityBeans() {
     if (registerActivityBeans != null) return registerActivityBeans;
-    return Boolean.TRUE.equals(enable) || (packages != null && !packages.isEmpty());
+    return Boolean.TRUE.equals(enabled) || (packages != null && !packages.isEmpty());
   }
 
   /**
    * Returns whether {@code @NexusServiceImpl}-annotated beans should be automatically registered
-   * with matching workers. Defaults to {@code true} when {@link #enable} is {@code true} or when
+   * with matching workers. Defaults to {@code true} when {@link #enabled} is {@code true} or when
    * the deprecated {@link #packages} property is set and non-empty; {@code false} otherwise.
    */
   public boolean isRegisterNexusServiceBeans() {
     if (registerNexusServiceBeans != null) return registerNexusServiceBeans;
-    return Boolean.TRUE.equals(enable) || (packages != null && !packages.isEmpty());
+    return Boolean.TRUE.equals(enabled) || (packages != null && !packages.isEmpty());
   }
 
   /**

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -197,7 +197,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
         configureNexusServiceBeansByWorkerName(workers, autoDiscoveredNexusServiceBeans);
       }
 
-      // Workflow discovery: Spring-bean-based (enable: true) and/or classpath-scanning (packages).
+      // Workflow discovery: Spring-bean-based (enabled: true) and/or classpath-scanning (packages).
       // These two sources are unioned; duplicates are harmless because Set is used internally.
       Set<Class<?>> autoDiscoveredWorkflowImplementationClasses = new HashSet<>();
       if (autoDiscovery.isRegisterWorkflowManagedBeans()) {

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -21,6 +21,7 @@ import io.temporal.spring.boot.TemporalOptionsCustomizer;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.spring.boot.autoconfigure.properties.NamespaceProperties;
 import io.temporal.spring.boot.autoconfigure.properties.WorkerProperties;
+import io.temporal.spring.boot.autoconfigure.properties.WorkersAutoDiscoveryProperties;
 import io.temporal.worker.*;
 import io.temporal.workflow.DynamicWorkflow;
 import java.lang.reflect.Constructor;
@@ -179,22 +180,40 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
                   createWorkerFromAnExplicitConfig(workerFactory, workerProperties, workers));
     }
 
-    if (namespaceProperties.getWorkersAutoDiscovery() != null
-        && namespaceProperties.getWorkersAutoDiscovery().getPackages() != null) {
-      Collection<Class<?>> autoDiscoveredWorkflowImplementationClasses =
-          autoDiscoverWorkflowImplementations();
-      Map<String, Object> autoDiscoveredActivityBeans = autoDiscoverActivityBeans();
-      Map<String, Object> autoDiscoveredNexusServiceBeans = autoDiscoverNexusServiceBeans();
+    WorkersAutoDiscoveryProperties autoDiscovery = namespaceProperties.getWorkersAutoDiscovery();
+    if (autoDiscovery != null) {
+      // @ActivityImpl beans are Spring beans, discoverable without classpath scanning.
+      if (autoDiscovery.isRegisterActivityBeans()) {
+        Map<String, Object> autoDiscoveredActivityBeans = autoDiscoverActivityBeans();
+        configureActivityBeansByTaskQueue(workerFactory, workers, autoDiscoveredActivityBeans);
+        configureActivityBeansByWorkerName(workers, autoDiscoveredActivityBeans);
+      }
 
-      configureWorkflowImplementationsByTaskQueue(
-          workerFactory, workers, autoDiscoveredWorkflowImplementationClasses);
-      configureActivityBeansByTaskQueue(workerFactory, workers, autoDiscoveredActivityBeans);
-      configureNexusServiceBeansByTaskQueue(
-          workerFactory, workers, autoDiscoveredNexusServiceBeans);
-      configureWorkflowImplementationsByWorkerName(
-          workers, autoDiscoveredWorkflowImplementationClasses);
-      configureActivityBeansByWorkerName(workers, autoDiscoveredActivityBeans);
-      configureNexusServiceBeansByWorkerName(workers, autoDiscoveredNexusServiceBeans);
+      // @NexusServiceImpl beans are Spring beans, discoverable without classpath scanning.
+      if (autoDiscovery.isRegisterNexusServiceBeans()) {
+        Map<String, Object> autoDiscoveredNexusServiceBeans = autoDiscoverNexusServiceBeans();
+        configureNexusServiceBeansByTaskQueue(
+            workerFactory, workers, autoDiscoveredNexusServiceBeans);
+        configureNexusServiceBeansByWorkerName(workers, autoDiscoveredNexusServiceBeans);
+      }
+
+      // Workflow discovery: Spring-bean-based (enable: true) and/or classpath-scanning (packages).
+      // These two sources are unioned; duplicates are harmless because Set is used internally.
+      Set<Class<?>> autoDiscoveredWorkflowImplementationClasses = new HashSet<>();
+      if (autoDiscovery.isRegisterWorkflowManagedBeans()) {
+        autoDiscoveredWorkflowImplementationClasses.addAll(autoDiscoverWorkflowBeans());
+      }
+      List<String> workflowPackages = autoDiscovery.getEffectiveWorkflowPackages();
+      if (!workflowPackages.isEmpty()) {
+        autoDiscoveredWorkflowImplementationClasses.addAll(
+            autoDiscoverWorkflowImplementations(workflowPackages));
+      }
+      if (!autoDiscoveredWorkflowImplementationClasses.isEmpty()) {
+        configureWorkflowImplementationsByTaskQueue(
+            workerFactory, workers, autoDiscoveredWorkflowImplementationClasses);
+        configureWorkflowImplementationsByWorkerName(
+            workers, autoDiscoveredWorkflowImplementationClasses);
+      }
     }
 
     return workers.getWorkers();
@@ -350,12 +369,12 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
         });
   }
 
-  private Collection<Class<?>> autoDiscoverWorkflowImplementations() {
+  private Collection<Class<?>> autoDiscoverWorkflowImplementations(List<String> packages) {
     ClassPathScanningCandidateComponentProvider scanner =
         new ClassPathScanningCandidateComponentProvider(false, environment);
     scanner.addIncludeFilter(new AnnotationTypeFilter(WorkflowImpl.class));
     Set<Class<?>> implementations = new HashSet<>();
-    for (String pckg : namespaceProperties.getWorkersAutoDiscovery().getPackages()) {
+    for (String pckg : packages) {
       Set<BeanDefinition> candidateComponents = scanner.findCandidateComponents(pckg);
       for (BeanDefinition beanDefinition : candidateComponents) {
         try {
@@ -367,6 +386,12 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
       }
     }
     return implementations;
+  }
+
+  private Collection<Class<?>> autoDiscoverWorkflowBeans() {
+    return beanFactory.getBeansWithAnnotation(WorkflowImpl.class).values().stream()
+        .map(AopUtils::getTargetClass)
+        .collect(java.util.stream.Collectors.toSet());
   }
 
   private Map<String, Object> autoDiscoverActivityBeans() {

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryActivitiesOnlyTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryActivitiesOnlyTest.java
@@ -1,0 +1,78 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.temporal.spring.boot.autoconfigure.template.WorkersTemplate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Regression test for https://github.com/temporalio/sdk-java/issues/2780:
+ * {@code @ActivityImpl}-annotated beans should be auto-registered with workers even when no
+ * workflow packages are configured under {@code spring.temporal.workers-auto-discovery.packages}.
+ */
+@SpringBootTest(classes = AutoDiscoveryActivitiesOnlyTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-activities-only")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryActivitiesOnlyTest {
+
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired private WorkersTemplate workersTemplate;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testActivityBeansRegisteredWithoutWorkflowPackages() {
+    assertNotNull(workersTemplate);
+    Map<String, WorkersTemplate.RegisteredInfo> registeredInfoMap =
+        workersTemplate.getRegisteredInfo();
+
+    // One worker should have been created for the task queue specified in @ActivityImpl
+    assertEquals(1, registeredInfoMap.size());
+    registeredInfoMap.forEach(
+        (taskQueue, info) -> {
+          assertEquals("UnitTest", taskQueue);
+
+          // No workflow packages configured, so no workflows should be registered
+          assertTrue(
+              info.getRegisteredWorkflowInfo().isEmpty(),
+              "No workflows expected when packages: [] is configured");
+
+          // @ActivityImpl bean should be registered despite no packages being configured
+          assertFalse(
+              info.getRegisteredActivityInfo().isEmpty(),
+              "@ActivityImpl beans should be auto-registered without workflow packages");
+          assertEquals(1, info.getRegisteredActivityInfo().size());
+          assertEquals(
+              "io.temporal.spring.boot.autoconfigure.bytaskqueue.TestActivityImpl",
+              info.getRegisteredActivityInfo().get(0).getClassName());
+
+          // @NexusServiceImpl bean should also be registered
+          assertFalse(
+              info.getRegisteredNexusServiceInfos().isEmpty(),
+              "@NexusServiceImpl beans should be auto-registered without workflow packages");
+          assertEquals(1, info.getRegisteredNexusServiceInfos().size());
+        });
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByTaskQueueLegacyTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByTaskQueueLegacyTest.java
@@ -1,0 +1,58 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import io.temporal.api.nexus.v1.Endpoint;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.bytaskqueue.TestWorkflow;
+import io.temporal.testing.TestWorkflowEnvironment;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Verifies that the deprecated {@code workers-auto-discovery.packages} property still correctly
+ * registers workflows, activities, and nexus services (backward compatibility).
+ */
+@SpringBootTest(classes = AutoDiscoveryByTaskQueueLegacyTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-task-queue-legacy")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryByTaskQueueLegacyTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired TestWorkflowEnvironment testWorkflowEnvironment;
+
+  @Autowired WorkflowClient workflowClient;
+  Endpoint endpoint;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+    endpoint =
+        testWorkflowEnvironment.createNexusEndpoint("AutoDiscoveryByTaskQueueEndpoint", "UnitTest");
+  }
+
+  @AfterEach
+  void tearDown() {
+    testWorkflowEnvironment.deleteNexusEndpoint(endpoint);
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testAutoDiscovery() {
+    TestWorkflow testWorkflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue("UnitTest").build());
+    testWorkflow.execute("nexus");
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.byworkername\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryEnableTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryEnableTest.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * Verifies that {@code workers-auto-discovery.enable: true} auto-registers {@code @WorkflowImpl}
+ * Verifies that {@code workers-auto-discovery.enabled: true} auto-registers {@code @WorkflowImpl}
  * and {@code @ActivityImpl} Spring beans without any package scanning configured.
  */
 @SpringBootTest(classes = AutoDiscoveryEnableTest.Configuration.class)
@@ -44,20 +44,20 @@ public class AutoDiscoveryEnableTest {
     WorkersTemplate.RegisteredInfo info = registeredInfoMap.get("UnitTest");
     assertNotNull(info, "Expected worker on task queue 'UnitTest'");
 
-    // @WorkflowImpl Spring bean registered via enable: true (no packages configured)
+    // @WorkflowImpl Spring bean registered via enabled: true (no packages configured)
     assertEquals(
         1,
         info.getRegisteredWorkflowInfo().size(),
-        "@WorkflowImpl bean should be registered via enable: true without packages");
+        "@WorkflowImpl bean should be registered via enabled: true without packages");
     assertEquals(
         "io.temporal.spring.boot.autoconfigure.byenable.TestWorkflow",
         info.getRegisteredWorkflowInfo().get(0).getClassName());
 
-    // @ActivityImpl bean registered via enable: true
+    // @ActivityImpl bean registered via enabled: true
     assertEquals(
         1,
         info.getRegisteredActivityInfo().size(),
-        "@ActivityImpl bean should be registered via enable: true");
+        "@ActivityImpl bean should be registered via enabled: true");
     assertEquals(
         "io.temporal.spring.boot.autoconfigure.byenable.TestActivityImpl",
         info.getRegisteredActivityInfo().get(0).getClassName());

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryEnableTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryEnableTest.java
@@ -1,0 +1,75 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.temporal.spring.boot.autoconfigure.template.WorkersTemplate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Verifies that {@code workers-auto-discovery.enable: true} auto-registers {@code @WorkflowImpl}
+ * and {@code @ActivityImpl} Spring beans without any package scanning configured.
+ */
+@SpringBootTest(classes = AutoDiscoveryEnableTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-enable")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryEnableTest {
+
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired private WorkersTemplate workersTemplate;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testEnableRegistersWorkflowAndActivityBeans() {
+    assertNotNull(workersTemplate);
+    Map<String, WorkersTemplate.RegisteredInfo> registeredInfoMap =
+        workersTemplate.getRegisteredInfo();
+
+    assertEquals(1, registeredInfoMap.size());
+    WorkersTemplate.RegisteredInfo info = registeredInfoMap.get("UnitTest");
+    assertNotNull(info, "Expected worker on task queue 'UnitTest'");
+
+    // @WorkflowImpl Spring bean registered via enable: true (no packages configured)
+    assertEquals(
+        1,
+        info.getRegisteredWorkflowInfo().size(),
+        "@WorkflowImpl bean should be registered via enable: true without packages");
+    assertEquals(
+        "io.temporal.spring.boot.autoconfigure.byenable.TestWorkflow",
+        info.getRegisteredWorkflowInfo().get(0).getClassName());
+
+    // @ActivityImpl bean registered via enable: true
+    assertEquals(
+        1,
+        info.getRegisteredActivityInfo().size(),
+        "@ActivityImpl bean should be registered via enable: true");
+    assertEquals(
+        "io.temporal.spring.boot.autoconfigure.byenable.TestActivityImpl",
+        info.getRegisteredActivityInfo().get(0).getClassName());
+  }
+
+  // Exclude all test sub-packages except byenable to avoid interference from other test beans
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern =
+                  "io\\.temporal\\.spring\\.boot\\.autoconfigure\\."
+                      + "(bytaskqueue|byworkername|workerversioning)\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryMixedPropertiesRejectedTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryMixedPropertiesRejectedTest.java
@@ -1,0 +1,47 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+public class AutoDiscoveryMixedPropertiesRejectedTest {
+
+  @Test
+  void testPackagesMixedWithNewPropertiesIsRejected() {
+    assertThatThrownBy(
+            () ->
+                new SpringApplicationBuilder(Configuration.class)
+                    .profiles("auto-discovery-mixed-packages-rejected")
+                    .run()
+                    .close())
+        .satisfies(
+            t -> {
+              // Our IllegalStateException is wrapped by Spring's binding/condition machinery;
+              // walk the cause chain to find it.
+              Throwable cause = t;
+              while (cause != null) {
+                if (cause.getMessage() != null
+                    && cause
+                        .getMessage()
+                        .contains("packages is deprecated and cannot be combined")) {
+                  return;
+                }
+                cause = cause.getCause();
+              }
+              throw new AssertionError(
+                  "Expected cause chain to contain 'packages is deprecated and cannot be combined',"
+                      + " but it did not. Top-level message: "
+                      + t.getMessage());
+            });
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern = "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.by.*",
+              type = FilterType.REGEX))
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestActivity.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestActivity.java
@@ -1,0 +1,8 @@
+package io.temporal.spring.boot.autoconfigure.byenable;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface TestActivity {
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestActivityImpl.java
@@ -1,0 +1,15 @@
+package io.temporal.spring.boot.autoconfigure.byenable;
+
+import io.temporal.spring.boot.ActivityImpl;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("auto-discovery-enable")
+@ActivityImpl(workers = "mainWorker")
+public class TestActivityImpl implements TestActivity {
+  @Override
+  public String execute(String input) {
+    return input;
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestWorkflow.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestWorkflow.java
@@ -1,0 +1,10 @@
+package io.temporal.spring.boot.autoconfigure.byenable;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface TestWorkflow {
+  @WorkflowMethod
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestWorkflowImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * A workflow implementation that is a Spring bean (has {@code @Component}), used to verify that
- * {@code workers-auto-discovery.enable: true} can discover workflow beans without classpath
+ * {@code workers-auto-discovery.enabled: true} can discover workflow beans without classpath
  * scanning.
  */
 @Component

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byenable/TestWorkflowImpl.java
@@ -1,0 +1,28 @@
+package io.temporal.spring.boot.autoconfigure.byenable;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.spring.boot.WorkflowImpl;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * A workflow implementation that is a Spring bean (has {@code @Component}), used to verify that
+ * {@code workers-auto-discovery.enable: true} can discover workflow beans without classpath
+ * scanning.
+ */
+@Component
+@Profile("auto-discovery-enable")
+@WorkflowImpl(workers = "mainWorker")
+public class TestWorkflowImpl implements TestWorkflow {
+  @Override
+  public String execute(String input) {
+    return Workflow.newActivityStub(
+            TestActivity.class,
+            ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(1))
+                .validateAndBuildWithDefaults())
+        .execute(input);
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -28,7 +28,41 @@ spring.temporal:
 spring:
   config:
     activate:
-      on-profile: auto-discovery-by-task-queue
+      on-profile: auto-discovery-mixed-packages-rejected
+  temporal:
+    workers-auto-discovery:
+      # packages is deprecated and cannot be combined with register-activity-beans. This should fail.
+      packages:
+        - io.temporal.spring.boot.autoconfigure.bytaskqueue
+      register-activity-beans: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: auto-discovery-enable
+  temporal:
+    workers:
+      - task-queue: UnitTest
+        name: mainWorker
+    workers-auto-discovery:
+      enable: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: auto-discovery-activities-only
+  temporal:
+    workers-auto-discovery:
+      register-activity-beans: true
+      register-nexus-service-beans: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: auto-discovery-by-task-queue-legacy
   temporal:
     workers-auto-discovery:
       packages:
@@ -38,11 +72,25 @@ spring:
 spring:
   config:
     activate:
+      on-profile: auto-discovery-by-task-queue
+  temporal:
+    workers-auto-discovery:
+      workflow-packages:
+        - io.temporal.spring.boot.autoconfigure.bytaskqueue
+      register-activity-beans: true
+      register-nexus-service-beans: true
+
+---
+spring:
+  config:
+    activate:
       on-profile: auto-discovery-by-task-queue-dynamic-suffix
   temporal:
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.bytaskqueue
+      register-activity-beans: true
+      register-nexus-service-beans: true
 default-queue:
   name: PropertyResolverTest
 
@@ -56,8 +104,10 @@ spring:
       - task-queue: UnitTest
         name: mainWorker
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.byworkername
+      register-activity-beans: true
+      register-nexus-service-beans: true
 
 ---
 spring:
@@ -69,8 +119,9 @@ spring:
       - task-queue: UnitTest
         name: mainWorker
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.byworkername
+      register-activity-beans: true
 
 ---
 spring:
@@ -86,7 +137,7 @@ spring:
         activity-beans:
           - TestActivityImpl
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.byworkername
 
 ---
@@ -142,7 +193,7 @@ spring:
       on-profile: disable-start-workers
   temporal:
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.bytaskqueue
     start-workers: false
 
@@ -185,7 +236,7 @@ spring:
     test-server:
       enabled: false
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.workerversioning
     workers:
       - task-queue: UnitTest
@@ -204,7 +255,7 @@ spring:
   temporal:
     namespace: UnitTest
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.workerversioning
     workers:
       - task-queue: UnitTest
@@ -213,6 +264,7 @@ spring:
           # missing default is the key thing here
           deployment-version: "dname.bid"
           use-versioning: true
+
 ---
 spring:
   config:
@@ -221,7 +273,7 @@ spring:
   temporal:
     namespace: UnitTest
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.workerversioning
     workers:
       - task-queue: UnitTest
@@ -230,6 +282,7 @@ spring:
           use-versioning: true
           default-versioning-behavior: PINNED
           deployment-name: "dname"
+
 ---
 spring:
   config:
@@ -238,7 +291,7 @@ spring:
   temporal:
     namespace: UnitTest
     workers-auto-discovery:
-      packages:
+      workflow-packages:
         - io.temporal.spring.boot.autoconfigure.workerversioning
     workers:
       - task-queue: UnitTest

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -46,7 +46,7 @@ spring:
       - task-queue: UnitTest
         name: mainWorker
     workers-auto-discovery:
-      enable: true
+      enabled: true
 
 ---
 spring:


### PR DESCRIPTION
Fixes #2780.

## Problem

`@ActivityImpl`- and `@NexusServiceImpl`-annotated Spring beans were silently not registered with Temporal workers unless `spring.temporal.workers-auto-discovery.packages` was configured — even though that setting is only supposed to control workflow *classpath scanning*. The entire auto-discovery block (activities, nexus services, and workflows) was gated on `packages != null` in `WorkersTemplate.createWorkers()`.

## Solution

Separate the concerns with explicit opt-in flags under `spring.temporal.workers-auto-discovery`:

| Property | Type | Default | Description |
|---|---|---|---|
| `register-activity-beans` | `boolean` | `false` | Register `@ActivityImpl`-annotated Spring beans with matching workers |
| `register-nexus-service-beans` | `boolean` | `false` | Register `@NexusServiceImpl`-annotated Spring beans with matching workers |
| `workflow-packages` | `list` | — | Packages to scan for `@WorkflowImpl` classes (replaces `packages`) |
| `enable` | `boolean` | `false` | Convenience flag: registers all `@WorkflowImpl`, `@ActivityImpl`, and `@NexusServiceImpl` Spring-managed beans without package scanning |

The `enable: true` flag covers the common case where all implementations are Spring-managed beans. For more control, `register-activities` and `register-nexus-operations` can be set independently, and `workflow-packages` handles classpath scanning for workflow classes that are not Spring beans.

## Backward compatibility

The existing `packages` property is deprecated but fully preserved:
- If set and non-empty, it implies `register-activities: true`, `register-nexus-operations: true`, and its entries are treated as `workflow-packages`.
- Combining `packages` with any of the new properties throws `IllegalStateException` at startup with a clear migration message.

## Changes

- **`WorkersAutoDiscoveryProperties`** — new fields, deprecation logic, validation, computed accessors (`isRegisterActivities()`, `isRegisterNexusOperations()`, `isRegisterWorkflowBeans()`, `getEffectiveWorkflowPackages()`)
- **`WorkersTemplate`** — auto-discovery block rewritten to use the new property accessors independently; added `autoDiscoverWorkflowBeans()` for bean-based workflow discovery
- **`WorkersPresentCondition`** — binds `WorkersAutoDiscoveryProperties` as a whole (was binding only `packages`), so the condition fires for any `workers-auto-discovery` configuration
- **`application.yml`** (tests) — existing profiles migrated from `packages:` to `workflow-packages:` + explicit flags; legacy `packages` behavior tested via the new `auto-discovery-by-task-queue-legacy` profile
- **New tests**: `AutoDiscoveryActivitiesOnlyTest`, `AutoDiscoveryEnableTest`, `AutoDiscoveryByTaskQueueLegacyTest`, `AutoDiscoveryMixedPropertiesRejectedTest`