### PR TITLE
Deprecate namespace field in ChildWorkflowOptions

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ChildWorkflowStateMachine.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/ChildWorkflowStateMachine.java
@@ -145,6 +145,7 @@ final class ChildWorkflowStateMachine
         attributes, metadata, startedCallback, completionCallback, commandSink, stateMachineSink);
   }
 
+  @SuppressWarnings("deprecation")
   private ChildWorkflowStateMachine(
       StartChildWorkflowExecutionCommandAttributes startAttributes,
       UserMetadata metadata,

--- a/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/statemachines/WorkflowStateMachines.java
@@ -971,6 +971,7 @@ public final class WorkflowStateMachines {
    * @param completionCallback invoked when child reports completion or failure
    * @return cancellation callback that should be invoked to cancel the child
    */
+  @SuppressWarnings("deprecation")
   public Functions.Proc startChildWorkflow(
       StartChildWorkflowExecutionParameters parameters,
       Functions.Proc2<WorkflowExecution, Exception> startedCallback,

--- a/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowOptions.java
@@ -62,6 +62,7 @@ public final class ChildWorkflowOptions {
 
     private Builder() {}
 
+    @SuppressWarnings("deprecation")
     private Builder(ChildWorkflowOptions options) {
       if (options == null) {
         return;
@@ -91,7 +92,13 @@ public final class ChildWorkflowOptions {
      * Specify namespace in which workflow should be started.
      *
      * <p>TODO: Resolve conflict with WorkflowClient namespace.
+     *
+     * @deprecated Cross-namespace child workflow execution is disabled by default in Temporal
+     *     Server since version 1.30.1 (via {@code system.enableCrossNamespaceCommands} dynamic
+     *     config flag). Setting this option will fail unless that flag is explicitly re-enabled on
+     *     the server. This field may be removed at some point in the future.
      */
+    @Deprecated
     public Builder setNamespace(String namespace) {
       this.namespace = namespace;
       return this;
@@ -447,6 +454,13 @@ public final class ChildWorkflowOptions {
     this.priority = priority;
   }
 
+  /**
+   * @deprecated Cross-namespace child workflow execution is disabled by default in Temporal Server
+   *     since version 1.30.1 (via {@code system.enableCrossNamespaceCommands} dynamic config flag).
+   *     Setting this option will fail unless that flag is explicitly re-enabled on the server. This
+   *     field may be removed at some point in the future.
+   */
+  @Deprecated
   public String getNamespace() {
     return namespace;
   }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1169,6 +1169,7 @@ class StateMachines {
     ctx.addEvent(event);
   }
 
+  @SuppressWarnings("deprecation")
   private static void initiateChildWorkflow(
       RequestContext ctx,
       ChildWorkflowData data,

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1670,6 +1670,7 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     }
   }
 
+  @SuppressWarnings("deprecation")
   public void signalExternalWorkflowExecution(
       String signalId,
       SignalExternalWorkflowExecutionCommandAttributes commandAttributes,


### PR DESCRIPTION
Closes #2826

## Summary

- Deprecates `ChildWorkflowOptions.Builder.setNamespace()` and `ChildWorkflowOptions.getNamespace()`
- These APIs enable cross-namespace child workflow execution, which has been disabled by default in Temporal Server since v1.30.1 (via the `system.enableCrossNamespaceCommands` dynamic config flag)
- Follows the proto-level deprecation added in [temporalio/api#751](https://github.com/temporalio/api/pull/751)