### PR TITLE
Fix native-image CI docker build flake

### DIFF
--- a/.github/workflows/build-native-image.yml
+++ b/.github/workflows/build-native-image.yml
@@ -69,35 +69,37 @@ jobs:
           ref: ${{ env.INPUT_REF }}
 
       - name: Set up Java
-        if: matrix.os_family != 'Linux'
+        if: matrix.os_family != 'linux'
         uses: actions/setup-java@v5
         with:
           java-version: 23
           distribution: "graalvm"
 
       - name: Set up Gradle
-        if: matrix.os_family != 'Linux'
+        if: matrix.os_family != 'linux'
         uses: gradle/actions/setup-gradle@v5
 
       - name: Build native test server (non-Docker)
-        if: matrix.os_family != 'Linux'
+        if: matrix.os_family != 'linux'
         run: |
           ./gradlew -PnativeBuild :temporal-test-server:nativeCompile
 
       - name: Build native test server (Docker non-musl)
-        if: matrix.os_family == 'Linux' && matrix.musl == false
+        if: matrix.os_family == 'linux' && matrix.musl == false
         run: |
+          IMAGE_ID=$(docker build -q ./docker/native-image)
           docker run \
             --rm -w /github/workspace -v "$(pwd):/github/workspace" \
-            $(docker build -q ./docker/native-image) \
+            "$IMAGE_ID" \
             sh -c "./gradlew -PnativeBuild :temporal-test-server:nativeCompile"
 
       - name: Build native test server (Docker musl)
-        if: matrix.os_family == 'Linux' && matrix.musl == true
+        if: matrix.os_family == 'linux' && matrix.musl == true
         run: |
+          IMAGE_ID=$(docker build -q ./docker/native-image-musl)
           docker run \
             --rm -w /github/workspace -v "$(pwd):/github/workspace" \
-            $(docker build -q ./docker/native-image-musl) \
+            "$IMAGE_ID" \
             sh -c "./gradlew -PnativeBuild -PnativeBuildMusl  :temporal-test-server:nativeCompile"
       # path ends in a wildcard because on windows the file ends in '.exe'
       - name: Upload executable to workflow

--- a/.github/workflows/build-native-image.yml
+++ b/.github/workflows/build-native-image.yml
@@ -101,6 +101,7 @@ jobs:
             --rm -w /github/workspace -v "$(pwd):/github/workspace" \
             "$IMAGE_ID" \
             sh -c "./gradlew -PnativeBuild -PnativeBuildMusl  :temporal-test-server:nativeCompile"
+
       # path ends in a wildcard because on windows the file ends in '.exe'
       - name: Upload executable to workflow
         if: ${{ inputs.upload_artifact }}

--- a/docker/native-image/dockerfile
+++ b/docker/native-image/dockerfile
@@ -6,7 +6,7 @@ ENV JAVA_HOME=/usr/lib64/graalvm/graalvm-community-java23
 COPY --from=ghcr.io/graalvm/native-image-community:23 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN apt-get -y update --allow-releaseinfo-change && apt-get install -V -y software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update
 # We need to update gcc and g++ to 10 for Graal to work on ARM64
 RUN apt-get install -y git build-essential zlib1g-dev gcc-10 g++-10

--- a/docker/native-image/dockerfile
+++ b/docker/native-image/dockerfile
@@ -6,7 +6,7 @@ ENV JAVA_HOME=/usr/lib64/graalvm/graalvm-community-java23
 COPY --from=ghcr.io/graalvm/native-image-community:23 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN apt-get -y update --allow-releaseinfo-change && apt-get install -V -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
 RUN apt-get update
 # We need to update gcc and g++ to 10 for Graal to work on ARM64
 RUN apt-get install -y git build-essential zlib1g-dev gcc-10 g++-10


### PR DESCRIPTION
## Summary

- Fixed `os_family` conditionals in `build-native-image.yml`: the matrix sets `os_family: linux` (lowercase) but all `if:` checks compared against `'Linux'` (titlecase), causing Docker build steps to never run and non-Docker setup steps to run unconditionally on Linux.
- Split `docker build` out of the inlined `$(docker build -q ...)` command substitution inside `docker run`. Previously a build failure caused `docker run` to receive an empty image argument and attempt to pull `sh:latest`, obscuring the real error. Now build and run are separate lines so failures are explicit.