### PR TITLE
chore: bump workflowcheck asm version for latest JDK version support

### DIFF
--- a/temporal-workflowcheck/build.gradle
+++ b/temporal-workflowcheck/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description = 'Temporal Java WorkflowCheck Static Analyzer'
 
 dependencies {
-    implementation 'org.ow2.asm:asm:9.7'
+    implementation 'org.ow2.asm:asm:9.9.1'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation project(":temporal-sdk")
     testImplementation "junit:junit:${junitVersion}"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumps the asm dependency for `temporal-workflowcheck` to latest.

## Why?
The existing dependency only supports up to JDK22, whereas we have uses for JDK24.

## Checklist

How was this tested:

`./gradlew :temporal-workflowcheck:check`