### PR TITLE
Expose Nexus Endpoint on Nexus Info

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/InternalNexusOperationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/InternalNexusOperationContext.java
@@ -10,15 +10,21 @@ import io.temporal.nexus.NexusOperationInfo;
 public class InternalNexusOperationContext {
   private final String namespace;
   private final String taskQueue;
+  private final String endpoint;
   private final Scope metricScope;
   private final WorkflowClient client;
   NexusOperationOutboundCallsInterceptor outboundCalls;
   Link startWorkflowResponseLink;
 
   public InternalNexusOperationContext(
-      String namespace, String taskQueue, Scope metricScope, WorkflowClient client) {
+      String namespace,
+      String taskQueue,
+      String endpoint,
+      Scope metricScope,
+      WorkflowClient client) {
     this.namespace = namespace;
     this.taskQueue = taskQueue;
+    this.endpoint = endpoint;
     this.metricScope = metricScope;
     this.client = client;
   }
@@ -37,6 +43,10 @@ public class InternalNexusOperationContext {
 
   public String getNamespace() {
     return namespace;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
   }
 
   public void setOutboundInterceptor(NexusOperationOutboundCallsInterceptor outboundCalls) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusInfoImpl.java
@@ -5,10 +5,12 @@ import io.temporal.nexus.NexusOperationInfo;
 class NexusInfoImpl implements NexusOperationInfo {
   private final String namespace;
   private final String taskQueue;
+  private final String endpoint;
 
-  NexusInfoImpl(String namespace, String taskQueue) {
+  NexusInfoImpl(String namespace, String taskQueue, String endpoint) {
     this.namespace = namespace;
     this.taskQueue = taskQueue;
+    this.endpoint = endpoint;
   }
 
   @Override
@@ -19,5 +21,10 @@ class NexusInfoImpl implements NexusOperationInfo {
   @Override
   public String getTaskQueue() {
     return taskQueue;
+  }
+
+  @Override
+  public String getEndpoint() {
+    return endpoint;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
@@ -116,7 +116,8 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
       }
 
       CurrentNexusOperationContext.set(
-          new InternalNexusOperationContext(namespace, taskQueue, metricsScope, client));
+          new InternalNexusOperationContext(
+              namespace, taskQueue, request.getEndpoint(), metricsScope, client));
 
       switch (request.getVariantCase()) {
         case START_OPERATION:

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalInterceptorMiddleware.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalInterceptorMiddleware.java
@@ -29,7 +29,9 @@ public class TemporalInterceptorMiddleware implements OperationMiddleware {
             temporalNexusContext.getMetricsScope(),
             temporalNexusContext.getWorkflowClient(),
             new NexusInfoImpl(
-                temporalNexusContext.getNamespace(), temporalNexusContext.getTaskQueue())));
+                temporalNexusContext.getNamespace(),
+                temporalNexusContext.getTaskQueue(),
+                temporalNexusContext.getEndpoint())));
     return new OperationInterceptorConverter(inboundCallsInterceptor);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/NexusOperationInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/NexusOperationInfo.java
@@ -14,4 +14,10 @@ public interface NexusOperationInfo {
    * @return Nexus Task Queue of the worker that is executing the Nexus Operation
    */
   String getTaskQueue();
+
+  /**
+   * @return Endpoint that the Nexus request was addressed to before being forwarded to this worker.
+   *     Supported from server v1.30.0.
+   */
+  String getEndpoint();
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationInfoTest.java
@@ -25,8 +25,9 @@ public class NexusOperationInfoTest {
   public void testOperationHeaders() {
     TestWorkflows.TestWorkflow1 workflowStub =
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String expectedEndpoint = testWorkflowRule.getNexusEndpoint().getSpec().getName();
     Assert.assertEquals(
-        "UnitTest:" + testWorkflowRule.getTaskQueue(),
+        "UnitTest:" + testWorkflowRule.getTaskQueue() + ":" + expectedEndpoint,
         workflowStub.execute(testWorkflowRule.getTaskQueue()));
   }
 
@@ -47,7 +48,7 @@ public class NexusOperationInfoTest {
       return OperationHandler.sync(
           (context, details, input) -> {
             NexusOperationInfo info = Nexus.getOperationContext().getInfo();
-            return info.getNamespace() + ":" + info.getTaskQueue();
+            return info.getNamespace() + ":" + info.getTaskQueue() + ":" + info.getEndpoint();
           });
     }
   }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -740,6 +740,7 @@ class StateMachines {
             .setTaskToken(taskToken.toBytes())
             .setRequest(
                 io.temporal.api.nexus.v1.Request.newBuilder()
+                    .setEndpoint(attr.getEndpoint())
                     .setScheduledTime(ctx.currentTime())
                     .setCapabilities(
                         io.temporal.api.nexus.v1.Request.Capabilities.newBuilder()
@@ -998,6 +999,7 @@ class StateMachines {
             .setTaskToken(taskToken.toBytes())
             .setRequest(
                 io.temporal.api.nexus.v1.Request.newBuilder()
+                    .setEndpoint(data.scheduledEvent.getEndpoint())
                     .putAllHeader(data.scheduledEvent.getNexusHeaderMap())
                     .setCancelOperation(
                         CancelOperationRequest.newBuilder()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Expose the Nexus Endpoint to the SDK.

## Why?
So the handler knows what endpoint the request originally came from for visibility and per endpoint encryption

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

closes: https://github.com/temporalio/sdk-java/issues/2836

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new method to the public `NexusOperationInfo` interface and threads a new field through Nexus task handling; this is moderately risky due to potential downstream source/binary compatibility impacts and reliance on server-provided endpoint values.
> 
> **Overview**
> Exposes the *original Nexus endpoint name* on the SDK-side operation context by adding `getEndpoint()` to `NexusOperationInfo` and plumbing the `Request.endpoint` value through `InternalNexusOperationContext` into `NexusInfoImpl`.
> 
> Updates the Nexus task handler/middleware to populate this field and adjusts the test server plus `NexusOperationInfoTest` assertions to ensure the endpoint is carried for both start and cancel Nexus task requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2b4bca1da16c4529a7d84469515d9ac49ebb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->