### PR TITLE
Add Temporal Nexus Operation Handler

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusStartWorkflowHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusStartWorkflowHelper.java
@@ -1,0 +1,80 @@
+package io.temporal.internal.nexus;
+
+import static io.temporal.internal.common.LinkConverter.workflowEventToNexusLink;
+import static io.temporal.internal.common.NexusUtil.nexusProtoLinkToLink;
+
+import io.nexusrpc.handler.HandlerException;
+import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationStartDetails;
+import io.temporal.api.common.v1.Link;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.internal.client.NexusStartWorkflowRequest;
+import io.temporal.internal.client.NexusStartWorkflowResponse;
+import java.net.URISyntaxException;
+import java.util.function.Function;
+
+/**
+ * Shared helper for starting a workflow from a Nexus operation and attaching workflow links to the
+ * operation context. Used by both {@code WorkflowRunOperationImpl} and {@code TemporalNexusClient}.
+ */
+public class NexusStartWorkflowHelper {
+
+  /**
+   * Starts a workflow via the provided invoker function, attaches workflow links to the operation
+   * context, and returns the response.
+   *
+   * @param ctx the operation context (links will be attached as a side-effect)
+   * @param details the operation start details containing requestId, callback, links
+   * @param invoker function that starts the workflow given a {@link NexusStartWorkflowRequest}
+   * @return the {@link NexusStartWorkflowResponse} containing the operation token and workflow
+   *     execution
+   */
+  public static NexusStartWorkflowResponse startWorkflowAndAttachLinks(
+      OperationContext ctx,
+      OperationStartDetails details,
+      Function<NexusStartWorkflowRequest, NexusStartWorkflowResponse> invoker) {
+    InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
+
+    NexusStartWorkflowRequest nexusRequest =
+        new NexusStartWorkflowRequest(
+            details.getRequestId(),
+            details.getCallbackUrl(),
+            details.getCallbackHeaders(),
+            nexusCtx.getTaskQueue(),
+            details.getLinks());
+
+    NexusStartWorkflowResponse response = invoker.apply(nexusRequest);
+    WorkflowExecution workflowExec = response.getWorkflowExecution();
+
+    // If the start workflow response returned a link use it, otherwise
+    // create the link information about the new workflow and return to the caller.
+    Link.WorkflowEvent workflowEventLink =
+        nexusCtx.getStartWorkflowResponseLink().hasWorkflowEvent()
+            ? nexusCtx.getStartWorkflowResponseLink().getWorkflowEvent()
+            : null;
+    if (workflowEventLink == null) {
+      workflowEventLink =
+          Link.WorkflowEvent.newBuilder()
+              .setNamespace(nexusCtx.getNamespace())
+              .setWorkflowId(workflowExec.getWorkflowId())
+              .setRunId(workflowExec.getRunId())
+              .setEventRef(
+                  Link.WorkflowEvent.EventReference.newBuilder()
+                      .setEventType(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED))
+              .build();
+    }
+    io.temporal.api.nexus.v1.Link nexusLink = workflowEventToNexusLink(workflowEventLink);
+    if (nexusLink != null) {
+      try {
+        ctx.addLinks(nexusProtoLinkToLink(nexusLink));
+      } catch (URISyntaxException e) {
+        throw new HandlerException(HandlerException.ErrorType.INTERNAL, "failed to parse URI", e);
+      }
+    }
+
+    return response;
+  }
+
+  private NexusStartWorkflowHelper() {}
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusStartWorkflowHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusStartWorkflowHelper.java
@@ -16,7 +16,8 @@ import java.util.function.Function;
 
 /**
  * Shared helper for starting a workflow from a Nexus operation and attaching workflow links to the
- * operation context. Used by both {@code WorkflowRunOperationImpl} and {@code TemporalNexusClient}.
+ * operation context. Used by both {@code WorkflowRunOperationImpl} and {@code
+ * TemporalNexusClientImpl}.
  */
 public class NexusStartWorkflowHelper {
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationToken.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationToken.java
@@ -3,7 +3,8 @@ package io.temporal.internal.nexus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class WorkflowRunOperationToken {
+/** Deserialized representation of a Nexus operation token. */
+public class OperationToken {
   @JsonProperty("v")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final Integer version;
@@ -17,7 +18,7 @@ public class WorkflowRunOperationToken {
   @JsonProperty("wid")
   private final String workflowId;
 
-  public WorkflowRunOperationToken(
+  public OperationToken(
       @JsonProperty("t") Integer type,
       @JsonProperty("ns") String namespace,
       @JsonProperty("wid") String workflowId,
@@ -28,8 +29,8 @@ public class WorkflowRunOperationToken {
     this.version = version;
   }
 
-  public WorkflowRunOperationToken(String namespace, String workflowId) {
-    this.type = OperationTokenType.WORKFLOW_RUN;
+  public OperationToken(OperationTokenType type, String namespace, String workflowId) {
+    this.type = type;
     this.namespace = namespace;
     this.workflowId = workflowId;
     this.version = null;

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenUtil.java
@@ -15,33 +15,45 @@ public class OperationTokenUtil {
   private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
 
   /**
-   * Load a workflow run operation token from an operation token.
+   * Load and validate an operation token without asserting the token type. Use this for cancel
+   * dispatch where the token type determines the cancel behavior.
    *
-   * @throws IllegalArgumentException if the operation token is invalid
+   * @throws IllegalArgumentException if the operation token is malformed or has invalid structure
    */
-  public static WorkflowRunOperationToken loadWorkflowRunOperationToken(String operationToken) {
-    WorkflowRunOperationToken token;
+  public static OperationToken loadOperationToken(String operationToken) {
+    OperationToken token;
     try {
-      JavaType reference = mapper.getTypeFactory().constructType(WorkflowRunOperationToken.class);
+      JavaType reference = mapper.getTypeFactory().constructType(OperationToken.class);
       token = mapper.readValue(decoder.decode(operationToken), reference);
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to parse operation token: " + e.getMessage());
     }
-    if (!token.getType().equals(OperationTokenType.WORKFLOW_RUN)) {
-      throw new IllegalArgumentException(
-          "Invalid workflow run token: incorrect operation token type: " + token.getType());
-    }
     if (token.getVersion() != null && token.getVersion() != 0) {
-      throw new IllegalArgumentException("Invalid workflow run token: unexpected version field");
+      throw new IllegalArgumentException("Invalid operation token: unexpected version field");
     }
     if (Strings.isNullOrEmpty(token.getWorkflowId())) {
-      throw new IllegalArgumentException("Invalid workflow run token: missing workflow ID (wid)");
+      throw new IllegalArgumentException("Invalid operation token: missing workflow ID (wid)");
     }
     return token;
   }
 
   /**
-   * Attempt to extract the workflow Id from an operation token.
+   * Load a workflow run operation token, asserting that the token type is {@link
+   * OperationTokenType#WORKFLOW_RUN}.
+   *
+   * @throws IllegalArgumentException if the operation token is invalid or not a workflow run token
+   */
+  public static OperationToken loadWorkflowRunOperationToken(String operationToken) {
+    OperationToken token = loadOperationToken(operationToken);
+    if (!token.getType().equals(OperationTokenType.WORKFLOW_RUN)) {
+      throw new IllegalArgumentException(
+          "Invalid workflow run token: incorrect operation token type: " + token.getType());
+    }
+    return token;
+  }
+
+  /**
+   * Extract the workflow ID from a workflow run operation token.
    *
    * @throws IllegalArgumentException if the operation token is invalid
    */
@@ -52,7 +64,9 @@ public class OperationTokenUtil {
   /** Generate a workflow run operation token from a workflow ID and namespace. */
   public static String generateWorkflowRunOperationToken(String workflowId, String namespace)
       throws JsonProcessingException {
-    String json = ow.writeValueAsString(new WorkflowRunOperationToken(namespace, workflowId));
+    String json =
+        ow.writeValueAsString(
+            new OperationToken(OperationTokenType.WORKFLOW_RUN, namespace, workflowId));
     return encoder.encodeToString(json.getBytes());
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/CancelWorkflowRunInput.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/CancelWorkflowRunInput.java
@@ -1,0 +1,23 @@
+package io.temporal.nexus;
+
+import io.temporal.common.Experimental;
+import java.util.Objects;
+
+/**
+ * Input to {@link TemporalOperationHandler#cancelWorkflowRun} describing the workflow run to
+ * cancel.
+ */
+@Experimental
+public final class CancelWorkflowRunInput {
+
+  private final String workflowId;
+
+  public CancelWorkflowRunInput(String workflowId) {
+    this.workflowId = Objects.requireNonNull(workflowId);
+  }
+
+  /** Returns the workflow ID extracted from the operation token. */
+  public String getWorkflowId() {
+    return workflowId;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -1,0 +1,131 @@
+package io.temporal.nexus;
+
+import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationStartDetails;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.common.Experimental;
+import io.temporal.internal.client.NexusStartWorkflowResponse;
+import io.temporal.internal.nexus.NexusStartWorkflowHelper;
+import io.temporal.workflow.Functions;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
+ * Temporal workflows from within a Nexus operation handler.
+ *
+ * <p>Obtained via the {@link TemporalOperationHandler.StartFunction} parameter. The client creates
+ * workflow stubs internally — users pass the workflow class, a lambda that calls the workflow
+ * method, and workflow options.
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * @OperationImpl
+ * public OperationHandler<OrderInput, OrderResult> createOrder() {
+ *   return TemporalOperationHandler.from((context, client, input) -> {
+ *     return client.startWorkflow(
+ *         OrderWorkflow.class,
+ *         wf -> wf.processOrder(input),
+ *         WorkflowOptions.newBuilder()
+ *             .setWorkflowId("order-" + context.getRequestId())
+ *             .build());
+ *   });
+ * }
+ * }</pre>
+ *
+ * <p>For advanced use cases, the underlying {@link WorkflowClient} can be accessed via {@link
+ * #getWorkflowClient()}. For example, to send a signal and return a synchronous result:
+ *
+ * <pre>{@code
+ * @OperationImpl
+ * public OperationHandler<CancelOrderInput, Void> cancelOrder() {
+ *   return TemporalOperationHandler.from((context, client, input) -> {
+ *     client.getWorkflowClient()
+ *         .newUntypedWorkflowStub("order-" + input.getOrderId())
+ *         .signal("requestCancellation", input);
+ *     return TemporalOperationResult.sync(null);
+ *   });
+ * }
+ * }</pre>
+ */
+@Experimental
+public final class TemporalNexusClient {
+
+  private final WorkflowClient client;
+  private final OperationContext operationContext;
+  private final OperationStartDetails operationStartDetails;
+
+  TemporalNexusClient(
+      WorkflowClient client,
+      OperationContext operationContext,
+      OperationStartDetails operationStartDetails) {
+    this.client = Objects.requireNonNull(client);
+    this.operationContext = Objects.requireNonNull(operationContext);
+    this.operationStartDetails = Objects.requireNonNull(operationStartDetails);
+  }
+
+  /** Returns the underlying {@link WorkflowClient} for advanced use cases. */
+  public WorkflowClient getWorkflowClient() {
+    return client;
+  }
+
+  /**
+   * Starts a workflow by invoking a method on a workflow stub. The client creates the stub from the
+   * given class and options, then passes it to the provided consumer which should call exactly one
+   * workflow method. Works for both returning and void workflow methods.
+   *
+   * <p>Example (returning):
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, wf -> wf.run(input), options)
+   * }</pre>
+   *
+   * <p>Example (void):
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, wf -> wf.execute(input), options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowInvocation receives the workflow stub and calls exactly one workflow method
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <R> the workflow return type (inferred from calling context)
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  public <T, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass, Consumer<T> workflowInvocation, WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    Functions.Proc bound = () -> workflowInvocation.accept(stub);
+    return invokeAndReturn(WorkflowHandle.fromWorkflowMethod(bound));
+  }
+
+  /**
+   * Starts a workflow using an untyped workflow type name.
+   *
+   * @param workflowType the workflow type name string
+   * @param resultClass the expected result class
+   * @param args workflow arguments
+   * @param options workflow start options (must include workflowId)
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  public <R> TemporalOperationResult<R> startWorkflow(
+      String workflowType, Class<R> resultClass, Object[] args, WorkflowOptions options) {
+    WorkflowStub stub = client.newUntypedWorkflowStub(workflowType, options);
+    WorkflowHandle<R> handle = WorkflowHandle.fromWorkflowStub(stub, resultClass, args);
+    return invokeAndReturn(handle);
+  }
+
+  private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<?> handle) {
+    NexusStartWorkflowResponse response =
+        NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
+            operationContext,
+            operationStartDetails,
+            request -> handle.getInvoker().invoke(request));
+    return TemporalOperationResult.async(response.getOperationToken());
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -10,7 +10,6 @@ import io.temporal.internal.client.NexusStartWorkflowResponse;
 import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.workflow.Functions;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 /**
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
@@ -73,33 +72,33 @@ public final class TemporalNexusClient {
   }
 
   /**
-   * Starts a workflow by invoking a method on a workflow stub. The client creates the stub from the
-   * given class and options, then passes it to the provided consumer which should call exactly one
-   * workflow method. Works for both returning and void workflow methods.
+   * Starts a workflow by invoking a returning method on a workflow stub. The client creates the
+   * stub from the given class and options, then invokes the workflow method via the provided
+   * function.
    *
-   * <p>Example (returning):
+   * <p>Example:
    *
    * <pre>{@code
    * client.startWorkflow(MyWorkflow.class, wf -> wf.run(input), options)
    * }</pre>
    *
-   * <p>Example (void):
+   * <p>For void-returning workflow methods, use a block lambda that returns null:
    *
    * <pre>{@code
-   * client.startWorkflow(MyWorkflow.class, wf -> wf.execute(input), options)
+   * client.startWorkflow(MyWorkflow.class, wf -> { wf.execute(input); return null; }, options)
    * }</pre>
    *
    * @param workflowClass the workflow interface class
-   * @param workflowInvocation receives the workflow stub and calls exactly one workflow method
+   * @param workflowMethod receives the workflow stub and calls exactly one workflow method
    * @param options workflow start options (must include workflowId)
    * @param <T> the workflow interface type
-   * @param <R> the workflow return type (inferred from calling context)
+   * @param <R> the workflow return type
    * @return an async {@link TemporalOperationResult} with the workflow-run operation token
    */
   public <T, R> TemporalOperationResult<R> startWorkflow(
-      Class<T> workflowClass, Consumer<T> workflowInvocation, WorkflowOptions options) {
+      Class<T> workflowClass, Functions.Func1<T, R> workflowMethod, WorkflowOptions options) {
     T stub = client.newWorkflowStub(workflowClass, options);
-    Functions.Proc bound = () -> workflowInvocation.accept(stub);
+    Functions.Func<R> bound = () -> workflowMethod.apply(stub);
     return invokeAndReturn(WorkflowHandle.fromWorkflowMethod(bound));
   }
 
@@ -120,7 +119,7 @@ public final class TemporalNexusClient {
     return invokeAndReturn(handle);
   }
 
-  private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<?> handle) {
+  private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<R> handle) {
     NexusStartWorkflowResponse response =
         NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
             operationContext,

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -15,9 +15,7 @@ import java.util.Objects;
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
  * Temporal workflows from within a Nexus operation handler.
  *
- * <p>Obtained via the {@link TemporalOperationHandler.StartFunction} parameter. The client creates
- * workflow stubs internally — users pass the workflow class, a lambda that calls the workflow
- * method, and workflow options.
+ * <p>Obtained via the {@link TemporalOperationHandler.StartFunction} parameter.
  *
  * <p>Usage example:
  *
@@ -29,7 +27,7 @@ import java.util.Objects;
  *         OrderWorkflow.class,
  *         wf -> wf.processOrder(input),
  *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("order-" + context.getRequestId())
+ *             .setWorkflowId("order-" + input.getOrderId())
  *             .build());
  *   });
  * }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -1,33 +1,27 @@
 package io.temporal.nexus;
 
-import io.nexusrpc.handler.OperationContext;
-import io.nexusrpc.handler.OperationStartDetails;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.client.WorkflowStub;
 import io.temporal.common.Experimental;
-import io.temporal.internal.client.NexusStartWorkflowResponse;
-import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.workflow.Functions;
-import java.util.Objects;
 
 /**
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
- * Temporal workflows from within a Nexus operation handler.
+ * Temporal from within a Nexus operation handler.
  *
  * <p>Obtained via the {@link TemporalOperationHandler.StartFunction} parameter.
  *
- * <p>Usage example:
+ * <p>Example usage to start a workflow from an operation handler:
  *
  * <pre>{@code
  * @OperationImpl
- * public OperationHandler<OrderInput, OrderResult> createOrder() {
+ * public OperationHandler<TransferInput, TransferResult> startTransfer() {
  *   return TemporalOperationHandler.from((context, client, input) -> {
  *     return client.startWorkflow(
- *         OrderWorkflow.class,
- *         wf -> wf.processOrder(input),
+ *         TransferWorkflow.class,
+ *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
  *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("order-" + input.getOrderId())
+ *             .setWorkflowId("transfer-" + input.getTransferId())
  *             .build());
  *   });
  * }
@@ -49,80 +43,359 @@ import java.util.Objects;
  * }</pre>
  */
 @Experimental
-public final class TemporalNexusClient {
-
-  private final WorkflowClient client;
-  private final OperationContext operationContext;
-  private final OperationStartDetails operationStartDetails;
-
-  TemporalNexusClient(
-      WorkflowClient client,
-      OperationContext operationContext,
-      OperationStartDetails operationStartDetails) {
-    this.client = Objects.requireNonNull(client);
-    this.operationContext = Objects.requireNonNull(operationContext);
-    this.operationStartDetails = Objects.requireNonNull(operationStartDetails);
-  }
+public interface TemporalNexusClient {
 
   /** Returns the underlying {@link WorkflowClient} for advanced use cases. */
-  public WorkflowClient getWorkflowClient() {
-    return client;
-  }
+  WorkflowClient getWorkflowClient();
 
   /**
-   * Starts a workflow by invoking a returning method on a workflow stub. The client creates the
-   * stub from the given class and options, then invokes the workflow method via the provided
-   * function.
+   * Starts a zero-argument workflow that returns a value.
    *
    * <p>Example:
    *
    * <pre>{@code
-   * client.startWorkflow(MyWorkflow.class, wf -> wf.run(input), options)
-   * }</pre>
-   *
-   * <p>For void-returning workflow methods, use a block lambda that returns null:
-   *
-   * <pre>{@code
-   * client.startWorkflow(MyWorkflow.class, wf -> { wf.execute(input); return null; }, options)
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::run, options)
    * }</pre>
    *
    * @param workflowClass the workflow interface class
-   * @param workflowMethod receives the workflow stub and calls exactly one workflow method
+   * @param workflowMethod unbound method reference to the workflow method
    * @param options workflow start options (must include workflowId)
    * @param <T> the workflow interface type
    * @param <R> the workflow return type
    * @return an async {@link TemporalOperationResult} with the workflow-run operation token
    */
-  public <T, R> TemporalOperationResult<R> startWorkflow(
-      Class<T> workflowClass, Functions.Func1<T, R> workflowMethod, WorkflowOptions options) {
-    T stub = client.newWorkflowStub(workflowClass, options);
-    Functions.Func<R> bound = () -> workflowMethod.apply(stub);
-    return invokeAndReturn(WorkflowHandle.fromWorkflowMethod(bound));
-  }
+  <T, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass, Functions.Func1<T, R> workflowMethod, WorkflowOptions options);
+
+  /**
+   * Starts a one-argument workflow that returns a value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::processOrder, input, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func2<T, A1, R> workflowMethod,
+      A1 arg1,
+      WorkflowOptions options);
+
+  /**
+   * Starts a two-argument workflow that returns a value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::run, arg1, arg2, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func3<T, A1, A2, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      WorkflowOptions options);
+
+  /**
+   * Starts a three-argument workflow that returns a value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::run, arg1, arg2, arg3, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func4<T, A1, A2, A3, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      WorkflowOptions options);
+
+  /**
+   * Starts a four-argument workflow that returns a value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::run, arg1, arg2, arg3, arg4, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param arg4 fourth workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <A4> the type of the fourth workflow argument
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func5<T, A1, A2, A3, A4, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      WorkflowOptions options);
+
+  /**
+   * Starts a five-argument workflow that returns a value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::run, arg1, arg2, arg3, arg4, arg5, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param arg4 fourth workflow argument
+   * @param arg5 fifth workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <A4> the type of the fourth workflow argument
+   * @param <A5> the type of the fifth workflow argument
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func6<T, A1, A2, A3, A4, A5, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      WorkflowOptions options);
+
+  /**
+   * Starts a zero-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass, Functions.Proc1<T> workflowMethod, WorkflowOptions options);
+
+  /**
+   * Starts a one-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, input, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc2<T, A1> workflowMethod,
+      A1 arg1,
+      WorkflowOptions options);
+
+  /**
+   * Starts a two-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, arg1, arg2, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc3<T, A1, A2> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      WorkflowOptions options);
+
+  /**
+   * Starts a three-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, arg1, arg2, arg3, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc4<T, A1, A2, A3> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      WorkflowOptions options);
+
+  /**
+   * Starts a four-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, arg1, arg2, arg3, arg4, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param arg4 fourth workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <A4> the type of the fourth workflow argument
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc5<T, A1, A2, A3, A4> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      WorkflowOptions options);
+
+  /**
+   * Starts a five-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, arg1, arg2, arg3, arg4, arg5, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param arg4 fourth workflow argument
+   * @param arg5 fifth workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <A4> the type of the fourth workflow argument
+   * @param <A5> the type of the fifth workflow argument
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc6<T, A1, A2, A3, A4, A5> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      WorkflowOptions options);
 
   /**
    * Starts a workflow using an untyped workflow type name.
    *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow("MyWorkflow", String.class, options, input)
+   * }</pre>
+   *
    * @param workflowType the workflow type name string
    * @param resultClass the expected result class
-   * @param args workflow arguments
    * @param options workflow start options (must include workflowId)
+   * @param args workflow arguments
    * @param <R> the workflow return type
    * @return an async {@link TemporalOperationResult} with the workflow-run operation token
    */
-  public <R> TemporalOperationResult<R> startWorkflow(
-      String workflowType, Class<R> resultClass, Object[] args, WorkflowOptions options) {
-    WorkflowStub stub = client.newUntypedWorkflowStub(workflowType, options);
-    WorkflowHandle<R> handle = WorkflowHandle.fromWorkflowStub(stub, resultClass, args);
-    return invokeAndReturn(handle);
-  }
-
-  private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<R> handle) {
-    NexusStartWorkflowResponse response =
-        NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
-            operationContext,
-            operationStartDetails,
-            request -> handle.getInvoker().invoke(request));
-    return TemporalOperationResult.async(response.getOperationToken());
-  }
+  <R> TemporalOperationResult<R> startWorkflow(
+      String workflowType, Class<R> resultClass, WorkflowOptions options, Object... args);
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -9,14 +9,14 @@ import io.temporal.workflow.Functions;
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
  * Temporal from within a Nexus operation handler.
  *
- * <p>Obtained via the {@link TemporalOperationHandler.StartFunction} parameter.
+ * <p>Obtained via the {@link TemporalOperationHandler.StartHandler} parameter.
  *
  * <p>Example usage to start a workflow from an operation handler:
  *
  * <pre>{@code
  * @OperationImpl
  * public OperationHandler<TransferInput, TransferResult> startTransfer() {
- *   return TemporalOperationHandler.from((context, client, input) -> {
+ *   return TemporalOperationHandler.create((context, client, input) -> {
  *     return client.startWorkflow(
  *         TransferWorkflow.class,
  *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
@@ -27,13 +27,13 @@ import io.temporal.workflow.Functions;
  * }
  * }</pre>
  *
- * <p>For advanced use cases, the underlying {@link WorkflowClient} can be accessed via {@link
- * #getWorkflowClient()}. For example, to send a signal and return a synchronous result:
+ * <p>For synchronous operations, use {@link #getWorkflowClient()} directly and return a {@link
+ * TemporalOperationResult#sync} result. For example, to send a signal:
  *
  * <pre>{@code
  * @OperationImpl
  * public OperationHandler<CancelOrderInput, Void> cancelOrder() {
- *   return TemporalOperationHandler.from((context, client, input) -> {
+ *   return TemporalOperationHandler.create((context, client, input) -> {
  *     client.getWorkflowClient()
  *         .newUntypedWorkflowStub("order-" + input.getOrderId())
  *         .signal("requestCancellation", input);

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -4,6 +4,7 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.Experimental;
 import io.temporal.workflow.Functions;
+import java.lang.reflect.Type;
 
 /**
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
@@ -218,6 +219,45 @@ public interface TemporalNexusClient {
       WorkflowOptions options);
 
   /**
+   * Starts a six-argument workflow that returns a value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::run, arg1, arg2, arg3, arg4, arg5, arg6, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param arg4 fourth workflow argument
+   * @param arg5 fifth workflow argument
+   * @param arg6 sixth workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <A4> the type of the fourth workflow argument
+   * @param <A5> the type of the fifth workflow argument
+   * @param <A6> the type of the sixth workflow argument
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func7<T, A1, A2, A3, A4, A5, A6, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      WorkflowOptions options);
+
+  /**
    * Starts a zero-argument workflow with no return value.
    *
    * <p>Example:
@@ -381,6 +421,44 @@ public interface TemporalNexusClient {
       WorkflowOptions options);
 
   /**
+   * Starts a six-argument workflow with no return value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(MyWorkflow.class, MyWorkflow::execute, arg1, arg2, arg3, arg4, arg5, arg6, options)
+   * }</pre>
+   *
+   * @param workflowClass the workflow interface class
+   * @param workflowMethod unbound method reference to the workflow method
+   * @param arg1 first workflow argument
+   * @param arg2 second workflow argument
+   * @param arg3 third workflow argument
+   * @param arg4 fourth workflow argument
+   * @param arg5 fifth workflow argument
+   * @param arg6 sixth workflow argument
+   * @param options workflow start options (must include workflowId)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first workflow argument
+   * @param <A2> the type of the second workflow argument
+   * @param <A3> the type of the third workflow argument
+   * @param <A4> the type of the fourth workflow argument
+   * @param <A5> the type of the fifth workflow argument
+   * @param <A6> the type of the sixth workflow argument
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc7<T, A1, A2, A3, A4, A5, A6> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      WorkflowOptions options);
+
+  /**
    * Starts a workflow using an untyped workflow type name.
    *
    * <p>Example:
@@ -398,4 +476,35 @@ public interface TemporalNexusClient {
    */
   <R> TemporalOperationResult<R> startWorkflow(
       String workflowType, Class<R> resultClass, WorkflowOptions options, Object... args);
+
+  /**
+   * Starts a workflow using an untyped workflow type name, with both a result class and a generic
+   * {@link Type}. Use this overload when the workflow returns a generic type (e.g. {@code
+   * List<String>}) so the result can be deserialized correctly.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * client.startWorkflow(
+   *     "MyWorkflow",
+   *     List.class,
+   *     new TypeToken<List<String>>() {}.getType(),
+   *     options,
+   *     input)
+   * }</pre>
+   *
+   * @param workflowType the workflow type name string
+   * @param resultClass the expected result class
+   * @param resultType the expected result {@link Type} (carries generic parameters)
+   * @param options workflow start options (must include workflowId)
+   * @param args workflow arguments
+   * @param <R> the workflow return type
+   * @return an async {@link TemporalOperationResult} with the workflow-run operation token
+   */
+  <R> TemporalOperationResult<R> startWorkflow(
+      String workflowType,
+      Class<R> resultClass,
+      Type resultType,
+      WorkflowOptions options,
+      Object... args);
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -1,0 +1,204 @@
+package io.temporal.nexus;
+
+import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationStartDetails;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.internal.client.NexusStartWorkflowResponse;
+import io.temporal.internal.nexus.NexusStartWorkflowHelper;
+import io.temporal.workflow.Functions;
+import java.util.Objects;
+
+/** Package-private implementation of {@link TemporalNexusClient}. */
+final class TemporalNexusClientImpl implements TemporalNexusClient {
+
+  private final WorkflowClient client;
+  private final OperationContext operationContext;
+  private final OperationStartDetails operationStartDetails;
+
+  TemporalNexusClientImpl(
+      WorkflowClient client,
+      OperationContext operationContext,
+      OperationStartDetails operationStartDetails) {
+    this.client = Objects.requireNonNull(client);
+    this.operationContext = Objects.requireNonNull(operationContext);
+    this.operationStartDetails = Objects.requireNonNull(operationStartDetails);
+  }
+
+  @Override
+  public WorkflowClient getWorkflowClient() {
+    return client;
+  }
+
+  // ---------- Returning (Func) overloads ----------
+
+  @Override
+  public <T, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass, Functions.Func1<T, R> workflowMethod, WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub)));
+  }
+
+  @Override
+  public <T, A1, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func2<T, A1, R> workflowMethod,
+      A1 arg1,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub, arg1)));
+  }
+
+  @Override
+  public <T, A1, A2, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func3<T, A1, A2, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub, arg1, arg2)));
+  }
+
+  @Override
+  public <T, A1, A2, A3, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func4<T, A1, A2, A3, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub, arg1, arg2, arg3)));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func5<T, A1, A2, A3, A4, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(
+            () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4)));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func6<T, A1, A2, A3, A4, A5, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(
+            () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4, arg5)));
+  }
+
+  // ---------- Void (Proc) overloads ----------
+
+  @Override
+  public <T> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass, Functions.Proc1<T> workflowMethod, WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub)));
+  }
+
+  @Override
+  public <T, A1> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc2<T, A1> workflowMethod,
+      A1 arg1,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub, arg1)));
+  }
+
+  @Override
+  public <T, A1, A2> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc3<T, A1, A2> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub, arg1, arg2)));
+  }
+
+  @Override
+  public <T, A1, A2, A3> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc4<T, A1, A2, A3> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(() -> workflowMethod.apply(stub, arg1, arg2, arg3)));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc5<T, A1, A2, A3, A4> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(
+            () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4)));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc6<T, A1, A2, A3, A4, A5> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(
+            () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4, arg5)));
+  }
+
+  // ---------- Untyped ----------
+
+  @Override
+  public <R> TemporalOperationResult<R> startWorkflow(
+      String workflowType, Class<R> resultClass, WorkflowOptions options, Object... args) {
+    WorkflowStub stub = client.newUntypedWorkflowStub(workflowType, options);
+    WorkflowHandle<R> handle = WorkflowHandle.fromWorkflowStub(stub, resultClass, args);
+    return invokeAndReturn(handle);
+  }
+
+  private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<R> handle) {
+    NexusStartWorkflowResponse response =
+        NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
+            operationContext,
+            operationStartDetails,
+            request -> handle.getInvoker().invoke(request));
+    return TemporalOperationResult.async(response.getOperationToken());
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -5,12 +5,14 @@ import io.nexusrpc.handler.OperationStartDetails;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
+import io.temporal.common.Experimental;
 import io.temporal.internal.client.NexusStartWorkflowResponse;
 import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.workflow.Functions;
 import java.util.Objects;
 
 /** Package-private implementation of {@link TemporalNexusClient}. */
+@Experimental
 final class TemporalNexusClientImpl implements TemporalNexusClient {
 
   private final WorkflowClient client;

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -1,5 +1,6 @@
 package io.temporal.nexus;
 
+import io.nexusrpc.handler.HandlerException;
 import io.nexusrpc.handler.OperationContext;
 import io.nexusrpc.handler.OperationStartDetails;
 import io.temporal.client.WorkflowClient;
@@ -18,6 +19,7 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   private final WorkflowClient client;
   private final OperationContext operationContext;
   private final OperationStartDetails operationStartDetails;
+  private boolean asyncOperationStarted;
 
   TemporalNexusClientImpl(
       WorkflowClient client,
@@ -196,11 +198,21 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   }
 
   private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<R> handle) {
+    if (asyncOperationStarted) {
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST,
+          new IllegalStateException(
+              "Only one async operation can be started per operation handler invocation. "
+                  + "Use getWorkflowClient() for additional workflow interactions."));
+    }
     NexusStartWorkflowResponse response =
         NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
             operationContext,
             operationStartDetails,
             request -> handle.getInvoker().invoke(request));
+    // Set after successful start so that if startWorkflowAndAttachLinks throws,
+    // the handler can retry without being blocked by the guard.
+    asyncOperationStarted = true;
     return TemporalOperationResult.async(response.getOperationToken());
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -10,6 +10,7 @@ import io.temporal.common.Experimental;
 import io.temporal.internal.client.NexusStartWorkflowResponse;
 import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.workflow.Functions;
+import java.lang.reflect.Type;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -112,6 +113,23 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
             () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4, arg5)));
   }
 
+  @Override
+  public <T, A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Func7<T, A1, A2, A3, A4, A5, A6, R> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(
+            () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4, arg5, arg6)));
+  }
+
   // ---------- Void (Proc) overloads ----------
 
   @Override
@@ -188,11 +206,38 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
             () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4, arg5)));
   }
 
+  @Override
+  public <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflow(
+      Class<T> workflowClass,
+      Functions.Proc7<T, A1, A2, A3, A4, A5, A6> workflowMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      WorkflowOptions options) {
+    T stub = client.newWorkflowStub(workflowClass, options);
+    return invokeAndReturn(
+        WorkflowHandle.fromWorkflowMethod(
+            () -> workflowMethod.apply(stub, arg1, arg2, arg3, arg4, arg5, arg6)));
+  }
+
   // ---------- Untyped ----------
 
   @Override
   public <R> TemporalOperationResult<R> startWorkflow(
       String workflowType, Class<R> resultClass, WorkflowOptions options, Object... args) {
+    return startWorkflow(workflowType, resultClass, null, options, args);
+  }
+
+  @Override
+  public <R> TemporalOperationResult<R> startWorkflow(
+      String workflowType,
+      Class<R> resultClass,
+      Type resultType,
+      WorkflowOptions options,
+      Object... args) {
     WorkflowStub stub = client.newUntypedWorkflowStub(workflowType, options);
     WorkflowHandle<R> handle = WorkflowHandle.fromWorkflowStub(stub, resultClass, args);
     return invokeAndReturn(handle);

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -11,6 +11,7 @@ import io.temporal.internal.client.NexusStartWorkflowResponse;
 import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.workflow.Functions;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /** Package-private implementation of {@link TemporalNexusClient}. */
 @Experimental
@@ -19,7 +20,7 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   private final WorkflowClient client;
   private final OperationContext operationContext;
   private final OperationStartDetails operationStartDetails;
-  private boolean asyncOperationStarted;
+  private final AtomicBoolean asyncOperationStarted = new AtomicBoolean(false);
 
   TemporalNexusClientImpl(
       WorkflowClient client,
@@ -198,21 +199,25 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   }
 
   private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<R> handle) {
-    if (asyncOperationStarted) {
+    if (!asyncOperationStarted.compareAndSet(false, true)) {
       throw new HandlerException(
           HandlerException.ErrorType.BAD_REQUEST,
           new IllegalStateException(
               "Only one async operation can be started per operation handler invocation. "
                   + "Use getWorkflowClient() for additional workflow interactions."));
     }
-    NexusStartWorkflowResponse response =
-        NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
-            operationContext,
-            operationStartDetails,
-            request -> handle.getInvoker().invoke(request));
-    // Set after successful start so that if startWorkflowAndAttachLinks throws,
-    // the handler can retry without being blocked by the guard.
-    asyncOperationStarted = true;
-    return TemporalOperationResult.async(response.getOperationToken());
+    try {
+      NexusStartWorkflowResponse response =
+          NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
+              operationContext,
+              operationStartDetails,
+              request -> handle.getInvoker().invoke(request));
+      return TemporalOperationResult.async(response.getOperationToken());
+    } catch (Throwable t) {
+      // Reset on failure so that if startWorkflowAndAttachLinks throws,
+      // the handler can retry without being blocked by the guard.
+      asyncOperationStarted.set(false);
+      throw t;
+    }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationCancelContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationCancelContext.java
@@ -6,9 +6,8 @@ import io.temporal.common.Experimental;
 import java.util.Objects;
 
 /**
- * Context for a Nexus cancel operation. Combines the {@link OperationContext} and {@link
- * OperationCancelDetails} into a single object passed to cancel methods on {@link
- * TemporalOperationHandler}.
+ * Context for a Nexus cancel operation request, passed to {@link
+ * TemporalOperationHandler#cancelWorkflowRun}.
  */
 @Experimental
 public final class TemporalOperationCancelContext {

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationCancelContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationCancelContext.java
@@ -1,0 +1,49 @@
+package io.temporal.nexus;
+
+import io.nexusrpc.handler.OperationCancelDetails;
+import io.nexusrpc.handler.OperationContext;
+import io.temporal.common.Experimental;
+import java.util.Objects;
+
+/**
+ * Context for a Nexus cancel operation. Combines the {@link OperationContext} and {@link
+ * OperationCancelDetails} into a single object passed to cancel methods on {@link
+ * TemporalOperationHandler}.
+ */
+@Experimental
+public final class TemporalOperationCancelContext {
+
+  private final OperationContext operationContext;
+  private final OperationCancelDetails operationCancelDetails;
+
+  TemporalOperationCancelContext(
+      OperationContext operationContext, OperationCancelDetails operationCancelDetails) {
+    this.operationContext = Objects.requireNonNull(operationContext);
+    this.operationCancelDetails = Objects.requireNonNull(operationCancelDetails);
+  }
+
+  /** Returns the service name for this operation. */
+  public String getService() {
+    return operationContext.getService();
+  }
+
+  /** Returns the operation name. */
+  public String getOperation() {
+    return operationContext.getOperation();
+  }
+
+  /** Returns the operation token identifying the operation to cancel. */
+  public String getOperationToken() {
+    return operationCancelDetails.getOperationToken();
+  }
+
+  /** Returns the underlying {@link OperationContext} for advanced use cases. */
+  public OperationContext getOperationContext() {
+    return operationContext;
+  }
+
+  /** Returns the underlying {@link OperationCancelDetails} for advanced use cases. */
+  public OperationCancelDetails getOperationCancelDetails() {
+    return operationCancelDetails;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationCancelContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationCancelContext.java
@@ -2,8 +2,12 @@ package io.temporal.nexus;
 
 import io.nexusrpc.handler.OperationCancelDetails;
 import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationMethodCancellationListener;
 import io.temporal.common.Experimental;
+import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Context for a Nexus cancel operation request, passed to {@link
@@ -31,18 +35,54 @@ public final class TemporalOperationCancelContext {
     return operationContext.getOperation();
   }
 
+  /** Returns the headers for this cancel request. The returned map is case-insensitive. */
+  public Map<String, String> getHeaders() {
+    return operationContext.getHeaders();
+  }
+
+  /**
+   * Returns the deadline for the operation handler method. This is the time by which the method
+   * should complete. This is not the operation's deadline.
+   */
+  public @Nullable Instant getDeadline() {
+    return operationContext.getDeadline();
+  }
+
   /** Returns the operation token identifying the operation to cancel. */
   public String getOperationToken() {
     return operationCancelDetails.getOperationToken();
   }
 
-  /** Returns the underlying {@link OperationContext} for advanced use cases. */
-  public OperationContext getOperationContext() {
-    return operationContext;
+  /**
+   * True if the handler method has been cancelled. Note, this is method cancellation, unrelated to
+   * operation cancellation.
+   */
+  public boolean isMethodCancelled() {
+    return operationContext.isMethodCancelled();
   }
 
-  /** Returns the underlying {@link OperationCancelDetails} for advanced use cases. */
-  public OperationCancelDetails getOperationCancelDetails() {
-    return operationCancelDetails;
+  /**
+   * Reason the handler method was cancelled, or null if not cancelled. Note, this is method
+   * cancellation, unrelated to operation cancellation.
+   */
+  public @Nullable String getMethodCancellationReason() {
+    return operationContext.getMethodCancellationReason();
+  }
+
+  /**
+   * Add a listener for method cancellation. The listener is invoked immediately before this method
+   * returns if the method is already cancelled. The listener must not block and must not be
+   * registered from within another cancellation listener.
+   */
+  public void addMethodCancellationListener(OperationMethodCancellationListener listener) {
+    operationContext.addMethodCancellationListener(listener);
+  }
+
+  /**
+   * Remove a method cancellation listener, if present. Must not be called from within another
+   * cancellation listener.
+   */
+  public void removeMethodCancellationListener(OperationMethodCancellationListener listener) {
+    operationContext.removeMethodCancellationListener(listener);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -18,13 +18,13 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  *
  * <pre>{@code
  * @OperationImpl
- * public OperationHandler<OrderInput, OrderResult> createOrder() {
+ * public OperationHandler<TransferInput, TransferResult> startTransfer() {
  *   return TemporalOperationHandler.from((context, client, input) -> {
  *     return client.startWorkflow(
- *         OrderWorkflow.class,
- *         wf -> wf.processOrder(input),
+ *         TransferWorkflow.class,
+ *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
  *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("order-" + input.getOrderId())
+ *             .setWorkflowId("transfer-" + input.getTransferId())
  *             .build());
  *   });
  * }
@@ -70,7 +70,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
   }
 
   @Override
-  public OperationStartResult<R> start(
+  public final OperationStartResult<R> start(
       OperationContext ctx, OperationStartDetails details, T input) {
     InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
     TemporalNexusClient client =
@@ -91,7 +91,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
   }
 
   @Override
-  public void cancel(OperationContext ctx, OperationCancelDetails details) {
+  public final void cancel(OperationContext ctx, OperationCancelDetails details) {
     OperationToken token;
     try {
       token = OperationTokenUtil.loadOperationToken(details.getOperationToken());

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -74,7 +74,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
       OperationContext ctx, OperationStartDetails details, T input) {
     InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
     TemporalNexusClient client =
-        new TemporalNexusClient(nexusCtx.getWorkflowClient(), ctx, details);
+        new TemporalNexusClientImpl(nexusCtx.getWorkflowClient(), ctx, details);
 
     TemporalOperationStartContext startContext = new TemporalOperationStartContext(ctx, details);
     TemporalOperationResult<R> result = startFunction.apply(startContext, client, input);

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -1,0 +1,124 @@
+package io.temporal.nexus;
+
+import io.nexusrpc.handler.*;
+import io.nexusrpc.handler.OperationHandler;
+import io.temporal.client.WorkflowClient;
+import io.temporal.common.Experimental;
+import io.temporal.internal.nexus.CurrentNexusOperationContext;
+import io.temporal.internal.nexus.InternalNexusOperationContext;
+import io.temporal.internal.nexus.OperationToken;
+import io.temporal.internal.nexus.OperationTokenType;
+import io.temporal.internal.nexus.OperationTokenUtil;
+
+/**
+ * Generic Nexus operation handler backed by Temporal. Implements {@link OperationHandler} and
+ * provides a composable way to map Temporal operations (start workflow, etc.) to Nexus operations.
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * @OperationImpl
+ * public OperationHandler<OrderInput, OrderResult> createOrder() {
+ *   return TemporalOperationHandler.from((context, client, input) -> {
+ *     return client.startWorkflow(
+ *         OrderWorkflow.class,
+ *         wf -> wf.processOrder(input),
+ *         WorkflowOptions.newBuilder()
+ *             .setWorkflowId("order-" + context.getRequestId())
+ *             .build());
+ *   });
+ * }
+ * }</pre>
+ *
+ * <p>The cancel behavior is overridable. By default, canceling an operation backed by a
+ * workflow-run token cancels the underlying workflow.
+ *
+ * @param <T> the input type
+ * @param <R> the result type
+ */
+@Experimental
+public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
+
+  /**
+   * Function invoked when a Nexus start operation request is received.
+   *
+   * @param <T> the input type
+   * @param <R> the result type
+   */
+  @FunctionalInterface
+  public interface StartFunction<T, R> {
+    TemporalOperationResult<R> apply(
+        TemporalOperationStartContext context, TemporalNexusClient client, T input);
+  }
+
+  private final StartFunction<T, R> startFunction;
+
+  private TemporalOperationHandler(StartFunction<T, R> startFunction) {
+    this.startFunction = startFunction;
+  }
+
+  /**
+   * Creates an {@link OperationHandler} from a start function.
+   *
+   * @param startFunction the function to invoke on start operation requests
+   * @return an operation handler backed by the given start function
+   */
+  public static <T, R> OperationHandler<T, R> from(StartFunction<T, R> startFunction) {
+    return new TemporalOperationHandler<>(startFunction);
+  }
+
+  @Override
+  public OperationStartResult<R> start(
+      OperationContext ctx, OperationStartDetails details, T input) {
+    InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
+    TemporalNexusClient client =
+        new TemporalNexusClient(nexusCtx.getWorkflowClient(), ctx, details);
+
+    TemporalOperationStartContext startContext = new TemporalOperationStartContext(ctx, details);
+    TemporalOperationResult<R> result = startFunction.apply(startContext, client, input);
+
+    if (result.isSync()) {
+      return OperationStartResult.newSyncBuilder(result.getSyncResult()).build();
+    } else if (result.isAsync()) {
+      return OperationStartResult.<R>newAsyncBuilder(result.getAsyncOperationToken()).build();
+    } else {
+      throw new HandlerException(
+          HandlerException.ErrorType.INTERNAL,
+          new IllegalStateException("TemporalOperationResult must be either sync or async"));
+    }
+  }
+
+  @Override
+  public void cancel(OperationContext ctx, OperationCancelDetails details) {
+    OperationToken token;
+    try {
+      token = OperationTokenUtil.loadOperationToken(details.getOperationToken());
+    } catch (IllegalArgumentException e) {
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST, "failed to parse operation token", e);
+    }
+
+    TemporalOperationCancelContext cancelContext = new TemporalOperationCancelContext(ctx, details);
+    if (token.getType() == OperationTokenType.WORKFLOW_RUN) {
+      cancelWorkflowRun(cancelContext, token.getWorkflowId());
+    } else {
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST,
+          new IllegalArgumentException("unsupported operation token type: " + token.getType()));
+    }
+  }
+
+  /**
+   * Called when a cancel request is received for a workflow-run token (type=1). Override to
+   * customize cancel behavior.
+   *
+   * <p>Default behavior: cancels the underlying workflow.
+   *
+   * @param context the cancel context
+   * @param workflowId the workflow ID extracted from the operation token
+   */
+  protected void cancelWorkflowRun(TemporalOperationCancelContext context, String workflowId) {
+    WorkflowClient client = CurrentNexusOperationContext.get().getWorkflowClient();
+    client.newUntypedWorkflowStub(workflowId).cancel();
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -19,7 +19,7 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  * <pre>{@code
  * @OperationImpl
  * public OperationHandler<TransferInput, TransferResult> startTransfer() {
- *   return TemporalOperationHandler.from((context, client, input) -> {
+ *   return TemporalOperationHandler.create((context, client, input) -> {
  *     return client.startWorkflow(
  *         TransferWorkflow.class,
  *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
@@ -41,32 +41,32 @@ import io.temporal.internal.nexus.OperationTokenUtil;
 public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   /**
-   * Function invoked when a Nexus start operation request is received.
+   * Handler invoked when a Nexus start operation request is received.
    *
    * @param <T> the input type
    * @param <R> the result type
    */
   @FunctionalInterface
-  public interface StartFunction<T, R> {
+  public interface StartHandler<T, R> {
     TemporalOperationResult<R> apply(
         TemporalOperationStartContext context, TemporalNexusClient client, T input);
   }
 
-  private final StartFunction<T, R> startFunction;
+  private final StartHandler<T, R> startHandler;
 
-  protected TemporalOperationHandler(StartFunction<T, R> startFunction) {
-    this.startFunction = startFunction;
+  protected TemporalOperationHandler(StartHandler<T, R> startHandler) {
+    this.startHandler = startHandler;
   }
 
   /**
-   * Creates a {@link TemporalOperationHandler} from a start function. Subclass and override {@link
+   * Creates a {@link TemporalOperationHandler} from a start handler. Subclass and override {@link
    * #cancelWorkflowRun} to customize cancel behavior.
    *
-   * @param startFunction the function to invoke on start operation requests
-   * @return an operation handler backed by the given start function
+   * @param startHandler the handler to invoke on start operation requests
+   * @return an operation handler backed by the given start handler
    */
-  public static <T, R> TemporalOperationHandler<T, R> from(StartFunction<T, R> startFunction) {
-    return new TemporalOperationHandler<>(startFunction);
+  public static <T, R> TemporalOperationHandler<T, R> create(StartHandler<T, R> startHandler) {
+    return new TemporalOperationHandler<>(startHandler);
   }
 
   @Override
@@ -77,7 +77,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
         new TemporalNexusClientImpl(nexusCtx.getWorkflowClient(), ctx, details);
 
     TemporalOperationStartContext startContext = new TemporalOperationStartContext(ctx, details);
-    TemporalOperationResult<R> result = startFunction.apply(startContext, client, input);
+    TemporalOperationResult<R> result = startHandler.apply(startContext, client, input);
 
     if (result.isSync()) {
       return OperationStartResult.newSyncBuilder(result.getSyncResult()).build();

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -24,7 +24,7 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  *         OrderWorkflow.class,
  *         wf -> wf.processOrder(input),
  *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("order-" + context.getRequestId())
+ *             .setWorkflowId("order-" + input.getOrderId())
  *             .build());
  *   });
  * }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -30,8 +30,9 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  * }
  * }</pre>
  *
- * <p>The cancel behavior is overridable. By default, canceling an operation backed by a
- * workflow-run token cancels the underlying workflow.
+ * <p>This class supports subclassing to customize cancel behavior. Override {@link
+ * #cancelWorkflowRun} to change how workflow-run cancellations are handled. The {@link #start} and
+ * {@link #cancel} methods should not be overridden — they contain the core dispatch logic.
  *
  * @param <T> the input type
  * @param <R> the result type
@@ -53,17 +54,18 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   private final StartFunction<T, R> startFunction;
 
-  private TemporalOperationHandler(StartFunction<T, R> startFunction) {
+  protected TemporalOperationHandler(StartFunction<T, R> startFunction) {
     this.startFunction = startFunction;
   }
 
   /**
-   * Creates an {@link OperationHandler} from a start function.
+   * Creates a {@link TemporalOperationHandler} from a start function. Subclass and override {@link
+   * #cancelWorkflowRun} to customize cancel behavior.
    *
    * @param startFunction the function to invoke on start operation requests
    * @return an operation handler backed by the given start function
    */
-  public static <T, R> OperationHandler<T, R> from(StartFunction<T, R> startFunction) {
+  public static <T, R> TemporalOperationHandler<T, R> from(StartFunction<T, R> startFunction) {
     return new TemporalOperationHandler<>(startFunction);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -1,7 +1,6 @@
 package io.temporal.nexus;
 
 import io.nexusrpc.handler.*;
-import io.nexusrpc.handler.OperationHandler;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.Experimental;
 import io.temporal.internal.nexus.CurrentNexusOperationContext;

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -102,7 +102,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
     TemporalOperationCancelContext cancelContext = new TemporalOperationCancelContext(ctx, details);
     if (token.getType() == OperationTokenType.WORKFLOW_RUN) {
-      cancelWorkflowRun(cancelContext, token.getWorkflowId());
+      cancelWorkflowRun(cancelContext, new CancelWorkflowRunInput(token.getWorkflowId()));
     } else {
       throw new HandlerException(
           HandlerException.ErrorType.BAD_REQUEST,
@@ -117,10 +117,11 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
    * <p>Default behavior: cancels the underlying workflow.
    *
    * @param context the cancel context
-   * @param workflowId the workflow ID extracted from the operation token
+   * @param input describes the workflow run to cancel
    */
-  protected void cancelWorkflowRun(TemporalOperationCancelContext context, String workflowId) {
+  protected void cancelWorkflowRun(
+      TemporalOperationCancelContext context, CancelWorkflowRunInput input) {
     WorkflowClient client = CurrentNexusOperationContext.get().getWorkflowClient();
-    client.newUntypedWorkflowStub(workflowId).cancel();
+    client.newUntypedWorkflowStub(input.getWorkflowId()).cancel();
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationResult.java
@@ -1,0 +1,82 @@
+package io.temporal.nexus;
+
+import com.google.common.base.Strings;
+import io.temporal.common.Experimental;
+import javax.annotation.Nullable;
+
+/**
+ * Unified result type for Temporal-backed Nexus operations. Encapsulates either a synchronous
+ * result or an async operation token.
+ *
+ * <p>Use {@link #sync(Object)} for operations that complete immediately (e.g., signals). Use {@link
+ * #async(String)} for operations that return an operation token for async completion (e.g., start
+ * workflow).
+ */
+@Experimental
+public final class TemporalOperationResult<R> {
+
+  private final boolean isSync;
+  @Nullable private final R syncResult;
+  @Nullable private final String asyncOperationToken;
+
+  private TemporalOperationResult(
+      boolean isSync, @Nullable R syncResult, @Nullable String asyncOperationToken) {
+    this.isSync = isSync;
+    this.syncResult = syncResult;
+    this.asyncOperationToken = asyncOperationToken;
+  }
+
+  /**
+   * Creates a synchronous result.
+   *
+   * @param value the result value, may be null
+   * @return a sync result wrapping the given value
+   */
+  public static <R> TemporalOperationResult<R> sync(@Nullable R value) {
+    return new TemporalOperationResult<>(true, value, null);
+  }
+
+  /**
+   * Creates an asynchronous result backed by an operation token.
+   *
+   * @param operationToken the operation token identifying the async operation
+   * @return an async result wrapping the given token
+   * @throws IllegalArgumentException if operationToken is null or empty
+   */
+  public static <R> TemporalOperationResult<R> async(String operationToken) {
+    if (Strings.isNullOrEmpty(operationToken)) {
+      throw new IllegalArgumentException("operationToken must not be null or empty");
+    }
+    return new TemporalOperationResult<>(false, null, operationToken);
+  }
+
+  /** Returns true if this is a synchronous result. */
+  public boolean isSync() {
+    return isSync;
+  }
+
+  /** Returns true if this is an asynchronous result backed by an operation token. */
+  public boolean isAsync() {
+    return !isSync;
+  }
+
+  /**
+   * Returns the synchronous result value, or null if this is an async result.
+   *
+   * @return the sync result value, or null
+   */
+  @Nullable
+  public R getSyncResult() {
+    return syncResult;
+  }
+
+  /**
+   * Returns the async operation token, or null if this is a sync result.
+   *
+   * @return the operation token, or null
+   */
+  @Nullable
+  public String getAsyncOperationToken() {
+    return asyncOperationToken;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationResult.java
@@ -61,22 +61,31 @@ public final class TemporalOperationResult<R> {
   }
 
   /**
-   * Returns the synchronous result value, or null if this is an async result.
+   * Returns the synchronous result value.
    *
-   * @return the sync result value, or null
+   * @return the sync result value (may be null if the operation produced a null sync value)
+   * @throws IllegalStateException if this is an async result; check {@link #isSync()} first
    */
   @Nullable
   public R getSyncResult() {
+    if (!isSync) {
+      throw new IllegalStateException(
+          "getSyncResult() called on async result; use getAsyncOperationToken() instead");
+    }
     return syncResult;
   }
 
   /**
-   * Returns the async operation token, or null if this is a sync result.
+   * Returns the async operation token.
    *
-   * @return the operation token, or null
+   * @return the operation token
+   * @throws IllegalStateException if this is a sync result; check {@link #isAsync()} first
    */
-  @Nullable
   public String getAsyncOperationToken() {
+    if (isSync) {
+      throw new IllegalStateException(
+          "getAsyncOperationToken() called on sync result; use getSyncResult() instead");
+    }
     return asyncOperationToken;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 /**
  * Context for a Nexus start operation request, passed to {@link
- * TemporalOperationHandler.StartFunction} alongside the {@link TemporalNexusClient} and input.
+ * TemporalOperationHandler.StartHandler} alongside the {@link TemporalNexusClient} and input.
  */
 @Experimental
 public final class TemporalOperationStartContext {

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
@@ -6,9 +6,8 @@ import io.temporal.common.Experimental;
 import java.util.Objects;
 
 /**
- * Context for a Nexus start operation. Combines the {@link OperationContext} and {@link
- * OperationStartDetails} into a single object passed to {@link
- * TemporalOperationHandler.StartFunction}.
+ * Context for a Nexus start operation request, passed to {@link
+ * TemporalOperationHandler.StartFunction} alongside the {@link TemporalNexusClient} and input.
  */
 @Experimental
 public final class TemporalOperationStartContext {
@@ -32,7 +31,7 @@ public final class TemporalOperationStartContext {
     return operationContext.getOperation();
   }
 
-  /** Returns the request ID, commonly used as a workflow ID for idempotency. */
+  /** Returns the request ID for this operation. */
   public String getRequestId() {
     return operationStartDetails.getRequestId();
   }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
@@ -1,0 +1,49 @@
+package io.temporal.nexus;
+
+import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationStartDetails;
+import io.temporal.common.Experimental;
+import java.util.Objects;
+
+/**
+ * Context for a Nexus start operation. Combines the {@link OperationContext} and {@link
+ * OperationStartDetails} into a single object passed to {@link
+ * TemporalOperationHandler.StartFunction}.
+ */
+@Experimental
+public final class TemporalOperationStartContext {
+
+  private final OperationContext operationContext;
+  private final OperationStartDetails operationStartDetails;
+
+  TemporalOperationStartContext(
+      OperationContext operationContext, OperationStartDetails operationStartDetails) {
+    this.operationContext = Objects.requireNonNull(operationContext);
+    this.operationStartDetails = Objects.requireNonNull(operationStartDetails);
+  }
+
+  /** Returns the service name for this operation. */
+  public String getService() {
+    return operationContext.getService();
+  }
+
+  /** Returns the operation name. */
+  public String getOperation() {
+    return operationContext.getOperation();
+  }
+
+  /** Returns the request ID, commonly used as a workflow ID for idempotency. */
+  public String getRequestId() {
+    return operationStartDetails.getRequestId();
+  }
+
+  /** Returns the underlying {@link OperationContext} for advanced use cases. */
+  public OperationContext getOperationContext() {
+    return operationContext;
+  }
+
+  /** Returns the underlying {@link OperationStartDetails} for advanced use cases. */
+  public OperationStartDetails getOperationStartDetails() {
+    return operationStartDetails;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationStartContext.java
@@ -1,9 +1,15 @@
 package io.temporal.nexus;
 
+import io.nexusrpc.Link;
 import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationMethodCancellationListener;
 import io.nexusrpc.handler.OperationStartDetails;
 import io.temporal.common.Experimental;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Context for a Nexus start operation request, passed to {@link
@@ -31,18 +37,81 @@ public final class TemporalOperationStartContext {
     return operationContext.getOperation();
   }
 
+  /** Returns the headers for this operation request. The returned map is case-insensitive. */
+  public Map<String, String> getHeaders() {
+    return operationContext.getHeaders();
+  }
+
+  /**
+   * Returns the deadline for the operation handler method. This is the time by which the method
+   * should complete. This is not the operation's deadline.
+   */
+  public @Nullable Instant getDeadline() {
+    return operationContext.getDeadline();
+  }
+
   /** Returns the request ID for this operation. */
   public String getRequestId() {
     return operationStartDetails.getRequestId();
   }
 
-  /** Returns the underlying {@link OperationContext} for advanced use cases. */
-  public OperationContext getOperationContext() {
-    return operationContext;
+  /**
+   * Optional callback URL for asynchronous operations to deliver results to. If present and the
+   * implementation is asynchronous, the implementation should ensure this callback is invoked with
+   * the result upon completion.
+   */
+  public @Nullable String getCallbackUrl() {
+    return operationStartDetails.getCallbackUrl();
   }
 
-  /** Returns the underlying {@link OperationStartDetails} for advanced use cases. */
-  public OperationStartDetails getOperationStartDetails() {
-    return operationStartDetails;
+  /** Headers to use on the callback if {@link #getCallbackUrl} is used. */
+  public Map<String, String> getCallbackHeaders() {
+    return operationStartDetails.getCallbackHeaders();
+  }
+
+  /** Links sent by the caller. Handlers may use these as metadata on associated resources. */
+  public List<Link> getLinks() {
+    return operationStartDetails.getLinks();
+  }
+
+  /**
+   * True if the handler method has been cancelled. Note, this is method cancellation, unrelated to
+   * operation cancellation.
+   */
+  public boolean isMethodCancelled() {
+    return operationContext.isMethodCancelled();
+  }
+
+  /**
+   * Reason the handler method was cancelled, or null if not cancelled. Note, this is method
+   * cancellation, unrelated to operation cancellation.
+   */
+  public @Nullable String getMethodCancellationReason() {
+    return operationContext.getMethodCancellationReason();
+  }
+
+  /**
+   * Add a listener for method cancellation. The listener is invoked immediately before this method
+   * returns if the method is already cancelled. The listener must not block and must not be
+   * registered from within another cancellation listener.
+   */
+  public void addMethodCancellationListener(OperationMethodCancellationListener listener) {
+    operationContext.addMethodCancellationListener(listener);
+  }
+
+  /**
+   * Remove a method cancellation listener, if present. Must not be called from within another
+   * cancellation listener.
+   */
+  public void removeMethodCancellationListener(OperationMethodCancellationListener listener) {
+    operationContext.removeMethodCancellationListener(listener);
+  }
+
+  /**
+   * Associates links with the current operation to be propagated back to the caller. Links are only
+   * attached on successful responses.
+   */
+  public void addResponseLinks(Link... links) {
+    operationContext.addLinks(links);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/WorkflowRunOperationImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/WorkflowRunOperationImpl.java
@@ -1,20 +1,12 @@
 package io.temporal.nexus;
 
-import static io.temporal.internal.common.LinkConverter.workflowEventToNexusLink;
-import static io.temporal.internal.common.NexusUtil.nexusProtoLinkToLink;
-
 import io.nexusrpc.handler.*;
 import io.nexusrpc.handler.OperationHandler;
-import io.temporal.api.common.v1.Link;
-import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.api.enums.v1.EventType;
 import io.temporal.client.WorkflowClient;
-import io.temporal.internal.client.NexusStartWorkflowRequest;
 import io.temporal.internal.client.NexusStartWorkflowResponse;
 import io.temporal.internal.nexus.CurrentNexusOperationContext;
-import io.temporal.internal.nexus.InternalNexusOperationContext;
+import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.internal.nexus.OperationTokenUtil;
-import java.net.URISyntaxException;
 
 class WorkflowRunOperationImpl<T, R> implements OperationHandler<T, R> {
   private final WorkflowHandleFactory<T, R> handleFactory;
@@ -26,52 +18,13 @@ class WorkflowRunOperationImpl<T, R> implements OperationHandler<T, R> {
   @Override
   public OperationStartResult<R> start(
       OperationContext ctx, OperationStartDetails operationStartDetails, T input) {
-    InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
-
     WorkflowHandle<R> handle = handleFactory.apply(ctx, operationStartDetails, input);
 
-    NexusStartWorkflowRequest nexusRequest =
-        new NexusStartWorkflowRequest(
-            operationStartDetails.getRequestId(),
-            operationStartDetails.getCallbackUrl(),
-            operationStartDetails.getCallbackHeaders(),
-            nexusCtx.getTaskQueue(),
-            operationStartDetails.getLinks());
+    NexusStartWorkflowResponse response =
+        NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
+            ctx, operationStartDetails, request -> handle.getInvoker().invoke(request));
 
-    NexusStartWorkflowResponse nexusStartWorkflowResponse =
-        handle.getInvoker().invoke(nexusRequest);
-    WorkflowExecution workflowExec = nexusStartWorkflowResponse.getWorkflowExecution();
-
-    // If the start workflow response returned a link use it, otherwise
-    // create the link information about the new workflow and return to the caller.
-    Link.WorkflowEvent workflowEventLink =
-        nexusCtx.getStartWorkflowResponseLink().hasWorkflowEvent()
-            ? nexusCtx.getStartWorkflowResponseLink().getWorkflowEvent()
-            : null;
-    if (workflowEventLink == null) {
-      workflowEventLink =
-          Link.WorkflowEvent.newBuilder()
-              .setNamespace(nexusCtx.getNamespace())
-              .setWorkflowId(workflowExec.getWorkflowId())
-              .setRunId(workflowExec.getRunId())
-              .setEventRef(
-                  Link.WorkflowEvent.EventReference.newBuilder()
-                      .setEventType(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED))
-              .build();
-    }
-    io.temporal.api.nexus.v1.Link nexusLink = workflowEventToNexusLink(workflowEventLink);
-    // Attach the link to the operation result.
-    OperationStartResult.Builder<R> result =
-        OperationStartResult.newAsyncBuilder(nexusStartWorkflowResponse.getOperationToken());
-    if (nexusLink != null) {
-      try {
-        ctx.addLinks(nexusProtoLinkToLink(nexusLink));
-      } catch (URISyntaxException e) {
-        // Not expected as the link is constructed by the SDK.
-        throw new HandlerException(HandlerException.ErrorType.INTERNAL, "failed to parse URI", e);
-      }
-    }
-    return result.build();
+    return OperationStartResult.<R>newAsyncBuilder(response.getOperationToken()).build();
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/WorkflowRunTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/WorkflowRunTokenTest.java
@@ -119,12 +119,20 @@ public class WorkflowRunTokenTest {
             OperationTokenUtil.loadOperationToken(
                 encoder.encodeToString(badTokenUnknownVersion.getBytes())));
 
-    // Bad token, unknown version
+    // Bad token, unknown type (also has bad version, so loadOperationToken rejects on version)
     String badTokenUnknownType = "{\"t\":4,\"ns\":\"namespace\", \"wid\":\"workflowId\", \"v\":1}";
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
             OperationTokenUtil.loadOperationToken(
                 encoder.encodeToString(badTokenUnknownType.getBytes())));
+
+    // Bad token, unknown type with valid version — loadWorkflowRunOperationToken rejects on type
+    String badTokenWrongType = "{\"t\":4,\"ns\":\"namespace\", \"wid\":\"workflowId\"}";
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            OperationTokenUtil.loadWorkflowRunOperationToken(
+                encoder.encodeToString(badTokenWrongType.getBytes())));
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/WorkflowRunTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/WorkflowRunTokenTest.java
@@ -17,7 +17,8 @@ public class WorkflowRunTokenTest {
 
   @Test
   public void serializeWorkflowRunToken() throws JsonProcessingException {
-    WorkflowRunOperationToken token = new WorkflowRunOperationToken("namespace", "workflowId");
+    OperationToken token =
+        new OperationToken(OperationTokenType.WORKFLOW_RUN, "namespace", "workflowId");
     String json = ow.writeValueAsString(token);
     final JsonNode node = new ObjectMapper().readTree(json);
     System.out.println(json);
@@ -32,9 +33,8 @@ public class WorkflowRunTokenTest {
   @Test
   public void deserializeWorkflowRunTokenWithVersion() throws IOException {
     String json = "{\"t\":1,\"ns\":\"namespace\",\"wid\":\"workflowId\",\"v\":1}";
-    JavaType reference =
-        new ObjectMapper().getTypeFactory().constructType(WorkflowRunOperationToken.class);
-    WorkflowRunOperationToken token = new ObjectMapper().readValue(json.getBytes(), reference);
+    JavaType reference = new ObjectMapper().getTypeFactory().constructType(OperationToken.class);
+    OperationToken token = new ObjectMapper().readValue(json.getBytes(), reference);
     // Assert that the serialized JSON is as expected
     Assert.assertEquals(OperationTokenType.WORKFLOW_RUN, token.getType());
     Assert.assertEquals(new Integer(1), token.getVersion());
@@ -45,9 +45,8 @@ public class WorkflowRunTokenTest {
   @Test
   public void deserializeWorkflowRunToken() throws IOException {
     String json = "{\"t\":1,\"ns\":\"namespace\",\"wid\":\"workflowId\"}";
-    JavaType reference =
-        new ObjectMapper().getTypeFactory().constructType(WorkflowRunOperationToken.class);
-    WorkflowRunOperationToken token = new ObjectMapper().readValue(json.getBytes(), reference);
+    JavaType reference = new ObjectMapper().getTypeFactory().constructType(OperationToken.class);
+    OperationToken token = new ObjectMapper().readValue(json.getBytes(), reference);
     // Assert that the serialized JSON is as expected
     Assert.assertEquals(OperationTokenType.WORKFLOW_RUN, token.getType());
     Assert.assertNull(null, token.getVersion());
@@ -67,8 +66,8 @@ public class WorkflowRunTokenTest {
   public void loadWorkflowIdFromOperationToken() {
     String json = "{\"t\":1,\"ns\":\"namespace\",\"wid\":\"workflowId\"}";
 
-    WorkflowRunOperationToken token =
-        OperationTokenUtil.loadWorkflowRunOperationToken(encoder.encodeToString(json.getBytes()));
+    OperationToken token =
+        OperationTokenUtil.loadOperationToken(encoder.encodeToString(json.getBytes()));
     Assert.assertEquals("workflowId", token.getWorkflowId());
     Assert.assertEquals("namespace", token.getNamespace());
     Assert.assertNull(token.getVersion());
@@ -86,8 +85,7 @@ public class WorkflowRunTokenTest {
     // across SDKs.
     String goOperationToken = "eyJ2IjowLCJ0IjoxLCJucyI6Im5zIiwid2lkIjoidyJ9";
 
-    WorkflowRunOperationToken token =
-        OperationTokenUtil.loadWorkflowRunOperationToken(goOperationToken);
+    OperationToken token = OperationTokenUtil.loadOperationToken(goOperationToken);
     Assert.assertEquals("w", token.getWorkflowId());
     Assert.assertEquals("ns", token.getNamespace());
     Assert.assertEquals(Integer.valueOf(0), token.getVersion());
@@ -101,7 +99,7 @@ public class WorkflowRunTokenTest {
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            OperationTokenUtil.loadWorkflowRunOperationToken(
+            OperationTokenUtil.loadOperationToken(
                 encoder.encodeToString(badTokenEmptyJson.getBytes())));
 
     // Bad token, missing the "wid" field
@@ -109,7 +107,7 @@ public class WorkflowRunTokenTest {
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            OperationTokenUtil.loadWorkflowRunOperationToken(
+            OperationTokenUtil.loadOperationToken(
                 encoder.encodeToString(badTokenMissingWorkflow.getBytes())));
 
     // Bad token, unknown version
@@ -118,7 +116,7 @@ public class WorkflowRunTokenTest {
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            OperationTokenUtil.loadWorkflowRunOperationToken(
+            OperationTokenUtil.loadOperationToken(
                 encoder.encodeToString(badTokenUnknownVersion.getBytes())));
 
     // Bad token, unknown version
@@ -126,7 +124,7 @@ public class WorkflowRunTokenTest {
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            OperationTokenUtil.loadWorkflowRunOperationToken(
+            OperationTokenUtil.loadOperationToken(
                 encoder.encodeToString(badTokenUnknownType.getBytes())));
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
@@ -75,7 +75,7 @@ public class AsyncWorkflowOperationTest extends BaseNexusTest {
       // Result should only be completed if the operation is completed
       Assert.assertFalse("Result should not be completed", asyncOpHandle.getResult().isCompleted());
       OperationToken token =
-          OperationTokenUtil.loadOperationToken(asyncExec.getOperationToken().get());
+          OperationTokenUtil.loadWorkflowRunOperationToken(asyncExec.getOperationToken().get());
       Assert.assertTrue(token.getWorkflowId().startsWith(WORKFLOW_ID_PREFIX));
       // Unblock the operation
       Workflow.newExternalWorkflowStub(OperationWorkflow.class, token.getWorkflowId()).unblock();
@@ -87,7 +87,7 @@ public class AsyncWorkflowOperationTest extends BaseNexusTest {
       } catch (NexusOperationFailure e) {
         Assert.assertEquals("TestNexusService1", e.getService());
         Assert.assertEquals("operation", e.getOperation());
-        token = OperationTokenUtil.loadOperationToken(e.getOperationToken());
+        token = OperationTokenUtil.loadWorkflowRunOperationToken(e.getOperationToken());
         Assert.assertTrue(token.getWorkflowId().startsWith(WORKFLOW_ID_PREFIX));
         Assert.assertTrue(e.getCause() instanceof ApplicationFailure);
         ApplicationFailure applicationFailure = (ApplicationFailure) e.getCause();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
@@ -6,8 +6,8 @@ import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
+import io.temporal.internal.nexus.OperationToken;
 import io.temporal.internal.nexus.OperationTokenUtil;
-import io.temporal.internal.nexus.WorkflowRunOperationToken;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
 import io.temporal.testing.WorkflowReplayer;
@@ -74,8 +74,8 @@ public class AsyncWorkflowOperationTest extends BaseNexusTest {
           "Operation token should be present", asyncExec.getOperationToken().isPresent());
       // Result should only be completed if the operation is completed
       Assert.assertFalse("Result should not be completed", asyncOpHandle.getResult().isCompleted());
-      WorkflowRunOperationToken token =
-          OperationTokenUtil.loadWorkflowRunOperationToken(asyncExec.getOperationToken().get());
+      OperationToken token =
+          OperationTokenUtil.loadOperationToken(asyncExec.getOperationToken().get());
       Assert.assertTrue(token.getWorkflowId().startsWith(WORKFLOW_ID_PREFIX));
       // Unblock the operation
       Workflow.newExternalWorkflowStub(OperationWorkflow.class, token.getWorkflowId()).unblock();
@@ -87,7 +87,7 @@ public class AsyncWorkflowOperationTest extends BaseNexusTest {
       } catch (NexusOperationFailure e) {
         Assert.assertEquals("TestNexusService1", e.getService());
         Assert.assertEquals("operation", e.getOperation());
-        token = OperationTokenUtil.loadWorkflowRunOperationToken(e.getOperationToken());
+        token = OperationTokenUtil.loadOperationToken(e.getOperationToken());
         Assert.assertTrue(token.getWorkflowId().startsWith(WORKFLOW_ID_PREFIX));
         Assert.assertTrue(e.getCause() instanceof ApplicationFailure);
         ApplicationFailure applicationFailure = (ApplicationFailure) e.getCause();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
@@ -1,0 +1,136 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.internal.Signal;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericHandlerCancelTest extends BaseNexusTest {
+
+  private static final Signal opStarted = new Signal();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestCancelWorkflow.class, WaitForCancelWorkflow.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  @Override
+  protected SDKTestWorkflowRule getTestWorkflowRule() {
+    return testWorkflowRule;
+  }
+
+  @Override
+  public void setUp() {
+    super.setUp();
+    opStarted.clearSignal();
+  }
+
+  @Test
+  public void cancelGenericHandlerOperation() {
+    WorkflowStub stub = testWorkflowRule.newUntypedWorkflowStubTimeoutOptions("TestCancelWorkflow");
+    stub.start(false);
+    try {
+      opStarted.waitForSignal();
+    } catch (Exception e) {
+      Assert.fail("test timed out waiting for operation to start.");
+    }
+    stub.cancel();
+    Assert.assertThrows(WorkflowFailedException.class, () -> stub.getResult(Void.class));
+    // Verify the nexus operation cancel was dispatched and completed successfully.
+    // The parent workflow completes as cancelled (CanceledFailure), same as with
+    // WorkflowRunOperation — the cancel handler correctly cancels the handler workflow.
+    testWorkflowRule.assertHistoryEvent(
+        stub.getExecution().getWorkflowId(), EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED);
+  }
+
+  @WorkflowInterface
+  public interface TestCancelWorkflowInterface {
+    @WorkflowMethod(name = "TestCancelWorkflow")
+    void execute(boolean cancelImmediately);
+  }
+
+  public static class TestCancelWorkflow implements TestCancelWorkflowInterface {
+    @Override
+    public void execute(boolean cancelImmediately) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .setCancellationType(NexusOperationCancellationType.WAIT_COMPLETED)
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder()
+              .setEndpoint(getEndpointName())
+              .setOperationOptions(options)
+              .build();
+
+      TestNexusCancelService serviceStub =
+          Workflow.newNexusServiceStub(TestNexusCancelService.class, serviceOptions);
+
+      NexusOperationHandle<Void> handle =
+          Workflow.startNexusOperation(serviceStub::operation, "cancel-test");
+      handle.getExecution().get();
+      opStarted.signal();
+
+      try {
+        Workflow.await(() -> false);
+      } catch (CanceledFailure f) {
+        Workflow.newDetachedCancellationScope(() -> handle.getResult().get()).run();
+      }
+    }
+  }
+
+  @WorkflowInterface
+  public interface WaitForCancelWorkflowInterface {
+    @WorkflowMethod
+    Void execute(String input);
+  }
+
+  public static class WaitForCancelWorkflow implements WaitForCancelWorkflowInterface {
+    @Override
+    public Void execute(String input) {
+      try {
+        Workflow.await(() -> false);
+      } catch (CanceledFailure f) {
+        // workflow was cancelled as expected
+      }
+      return null;
+    }
+  }
+
+  @Service
+  public interface TestNexusCancelService {
+    @Operation
+    Void operation(String input);
+  }
+
+  @ServiceImpl(service = TestNexusCancelService.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, Void> operation() {
+      return TemporalOperationHandler.from(
+          (context, client, input) ->
+              client.startWorkflow(
+                  WaitForCancelWorkflowInterface.class,
+                  wf -> wf.execute(input),
+                  WorkflowOptions.newBuilder()
+                      .setWorkflowId("generic-cancel-test-" + context.getService())
+                      .build()));
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
@@ -127,7 +127,8 @@ public class GenericHandlerCancelTest extends BaseNexusTest {
           (context, client, input) ->
               client.startWorkflow(
                   WaitForCancelWorkflowInterface.class,
-                  wf -> wf.execute(input),
+                  WaitForCancelWorkflowInterface::execute,
+                  input,
                   WorkflowOptions.newBuilder()
                       .setWorkflowId("generic-cancel-test-" + context.getService())
                       .build()));

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
@@ -123,7 +123,7 @@ public class GenericHandlerCancelTest extends BaseNexusTest {
   public class TestNexusServiceImpl {
     @OperationImpl
     public OperationHandler<String, Void> operation() {
-      return TemporalOperationHandler.from(
+      return TemporalOperationHandler.create(
           (context, client, input) ->
               client.startWorkflow(
                   WaitForCancelWorkflowInterface.class,

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
@@ -1,0 +1,106 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.HandlerException;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.NexusOperationFailure;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericHandlerDoubleStartTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  private static final String EXPECTED_MESSAGE =
+      "Only one async operation can be started per operation handler "
+          + "invocation. Use getWorkflowClient() for additional workflow interactions.";
+
+  @Test
+  public void doubleStartThrows() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+
+    WorkflowFailedException e =
+        Assert.assertThrows(
+            WorkflowFailedException.class,
+            () -> workflowStub.execute(testWorkflowRule.getTaskQueue()));
+
+    Assert.assertTrue(e.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) e.getCause();
+
+    Assert.assertTrue(nexusFailure.getCause() instanceof HandlerException);
+    HandlerException handlerException = (HandlerException) nexusFailure.getCause();
+    Assert.assertEquals("handler error: " + EXPECTED_MESSAGE, handlerException.getMessage());
+
+    Assert.assertTrue(handlerException.getCause() instanceof ApplicationFailure);
+    ApplicationFailure appFailure = (ApplicationFailure) handlerException.getCause();
+    Assert.assertEquals("java.lang.IllegalStateException", appFailure.getType());
+    Assert.assertEquals(EXPECTED_MESSAGE, appFailure.getOriginalMessage());
+  }
+
+  public static class TestNexus implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
+
+      TestNexusServiceDoubleStart serviceStub =
+          Workflow.newNexusServiceStub(TestNexusServiceDoubleStart.class, serviceOptions);
+      return serviceStub.operation("input");
+    }
+  }
+
+  @Service
+  public interface TestNexusServiceDoubleStart {
+    @Operation
+    String operation(String input);
+  }
+
+  @ServiceImpl(service = TestNexusServiceDoubleStart.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, String> operation() {
+      return TemporalOperationHandler.create(
+          (context, client, input) -> {
+            // First start should succeed
+            client.startWorkflow(
+                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
+                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
+                input,
+                WorkflowOptions.newBuilder()
+                    .setWorkflowId("double-start-first-" + context.getService())
+                    .build());
+            // Second start should throw
+            return client.startWorkflow(
+                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
+                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
+                input,
+                WorkflowOptions.newBuilder()
+                    .setWorkflowId("double-start-second-" + context.getService())
+                    .build());
+          });
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
@@ -13,7 +13,6 @@ import io.temporal.failure.NexusOperationFailure;
 import io.temporal.nexus.TemporalOperationHandler;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
-import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
 import org.junit.Assert;
@@ -24,8 +23,7 @@ public class GenericHandlerDoubleStartTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(
-              TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
+          .setWorkflowTypes(TestNexus.class, BlockingWorkflowImpl.class)
           .setNexusServiceImplementation(new TestNexusServiceImpl())
           .build();
 
@@ -68,7 +66,23 @@ public class GenericHandlerDoubleStartTest {
 
       TestNexusServiceDoubleStart serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceDoubleStart.class, serviceOptions);
-      return serviceStub.operation("input");
+      return serviceStub.operation(input);
+    }
+  }
+
+  @WorkflowInterface
+  public interface BlockingWorkflow {
+    @WorkflowMethod
+    String execute(String input);
+  }
+
+  public static class BlockingWorkflowImpl implements BlockingWorkflow {
+    @Override
+    public String execute(String input) {
+      // Block forever so the nexus operation doesn't complete via callback
+      // before the handler error propagates
+      Workflow.await(() -> false);
+      return input;
     }
   }
 
@@ -84,18 +98,18 @@ public class GenericHandlerDoubleStartTest {
     public OperationHandler<String, String> operation() {
       return TemporalOperationHandler.create(
           (context, client, input) -> {
-            // First start should succeed
+            // First start should succeed but the workflow blocks indefinitely
             client.startWorkflow(
-                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
-                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
+                BlockingWorkflow.class,
+                BlockingWorkflow::execute,
                 input,
                 WorkflowOptions.newBuilder()
                     .setWorkflowId("double-start-first-" + context.getService())
                     .build());
             // Second start should throw
             return client.startWorkflow(
-                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
-                TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
+                BlockingWorkflow.class,
+                BlockingWorkflow::execute,
                 input,
                 WorkflowOptions.newBuilder()
                     .setWorkflowId("double-start-second-" + context.getService())

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
@@ -1,0 +1,64 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericHandlerSyncResultTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestNexus.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  @Test
+  public void syncResultTest() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("sync-hello", result);
+  }
+
+  public static class TestNexus implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
+
+      TestNexusSyncService serviceStub =
+          Workflow.newNexusServiceStub(TestNexusSyncService.class, serviceOptions);
+      return serviceStub.operation("hello");
+    }
+  }
+
+  @Service
+  public interface TestNexusSyncService {
+    @Operation
+    String operation(String input);
+  }
+
+  @ServiceImpl(service = TestNexusSyncService.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, String> operation() {
+      return TemporalOperationHandler.from(
+          (context, client, input) -> TemporalOperationResult.sync("sync-" + input));
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
@@ -57,7 +57,7 @@ public class GenericHandlerSyncResultTest {
   public class TestNexusServiceImpl {
     @OperationImpl
     public OperationHandler<String, String> operation() {
-      return TemporalOperationHandler.from(
+      return TemporalOperationHandler.create(
           (context, client, input) -> TemporalOperationResult.sync("sync-" + input));
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -1,0 +1,77 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericHandlerTypedProcTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  @Test
+  public void typedProcStartWorkflowTest() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("done", result);
+  }
+
+  public static class TestNexus implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
+
+      TestNexusServiceProc serviceStub =
+          Workflow.newNexusServiceStub(TestNexusServiceProc.class, serviceOptions);
+      serviceStub.operation("input");
+      return "done";
+    }
+  }
+
+  @Service
+  public interface TestNexusServiceProc {
+    @Operation
+    Void operation(String input);
+  }
+
+  @ServiceImpl(service = TestNexusServiceProc.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, Void> operation() {
+      return TemporalOperationHandler.from(
+          (context, client, input) ->
+              client.startWorkflow(
+                  TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc.class,
+                  wf -> wf.proc(),
+                  WorkflowOptions.newBuilder()
+                      .setWorkflowId(
+                          "generic-handler-proc-"
+                              + context.getService()
+                              + "-"
+                              + context.getOperation())
+                      .build()));
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -64,7 +64,10 @@ public class GenericHandlerTypedProcTest {
           (context, client, input) ->
               client.startWorkflow(
                   TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc.class,
-                  wf -> wf.proc(),
+                  wf -> {
+                    wf.proc();
+                    return null;
+                  },
                   WorkflowOptions.newBuilder()
                       .setWorkflowId(
                           "generic-handler-proc-"

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -45,7 +45,9 @@ public class GenericHandlerTypedProcTest {
 
       TestNexusServiceProc serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceProc.class, serviceOptions);
-      serviceStub.operation("input");
+      for (int i = 0; i < 6; i++) {
+        serviceStub.operation(i);
+      }
       return "done";
     }
   }
@@ -53,28 +55,69 @@ public class GenericHandlerTypedProcTest {
   @Service
   public interface TestNexusServiceProc {
     @Operation
-    Void operation(String input);
+    Void operation(Integer input);
   }
 
   @ServiceImpl(service = TestNexusServiceProc.class)
   public class TestNexusServiceImpl {
     @OperationImpl
-    public OperationHandler<String, Void> operation() {
+    public OperationHandler<Integer, Void> operation() {
       return TemporalOperationHandler.from(
-          (context, client, input) ->
-              client.startWorkflow(
-                  TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc.class,
-                  wf -> {
-                    wf.proc();
-                    return null;
-                  },
-                  WorkflowOptions.newBuilder()
-                      .setWorkflowId(
-                          "generic-handler-proc-"
-                              + context.getService()
-                              + "-"
-                              + context.getOperation())
-                      .build()));
+          (context, client, input) -> {
+            String prefix = "generic-handler-test-proc" + input + "-";
+            String workflowId = prefix + context.getService() + "-" + context.getOperation();
+            WorkflowOptions options =
+                WorkflowOptions.newBuilder().setWorkflowId(workflowId).build();
+            switch (input) {
+              case 0:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc::proc,
+                    options);
+              case 1:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowProc::proc1,
+                    "input",
+                    options);
+              case 2:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowProc::proc2,
+                    "input",
+                    2,
+                    options);
+              case 3:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowProc::proc3,
+                    "input",
+                    2,
+                    3,
+                    options);
+              case 4:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowProc::proc4,
+                    "input",
+                    2,
+                    3,
+                    4,
+                    options);
+              case 5:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowProc::proc5,
+                    "input",
+                    2,
+                    3,
+                    4,
+                    5,
+                    options);
+              default:
+                throw new IllegalArgumentException("unexpected input: " + input);
+            }
+          });
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -62,7 +62,7 @@ public class GenericHandlerTypedProcTest {
   public class TestNexusServiceImpl {
     @OperationImpl
     public OperationHandler<Integer, Void> operation() {
-      return TemporalOperationHandler.from(
+      return TemporalOperationHandler.create(
           (context, client, input) -> {
             String prefix = "generic-handler-test-proc" + input + "-";
             String workflowId = prefix + context.getService() + "-" + context.getOperation();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -45,7 +45,7 @@ public class GenericHandlerTypedProcTest {
 
       TestNexusServiceProc serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceProc.class, serviceOptions);
-      for (int i = 0; i < 6; i++) {
+      for (int i = 0; i < 7; i++) {
         serviceStub.operation(i);
       }
       return "done";
@@ -113,6 +113,17 @@ public class GenericHandlerTypedProcTest {
                     3,
                     4,
                     5,
+                    options);
+              case 6:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowProc.class,
+                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowProc::proc6,
+                    "input",
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
                     options);
               default:
                 throw new IllegalArgumentException("unexpected input: " + input);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
@@ -1,0 +1,108 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericHandlerTypedStartWorkflowTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  @Test
+  public void typedStartWorkflowTests() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("funcinputinput2", result);
+  }
+
+  public static class TestNexus implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
+
+      TestNexusServiceGeneric serviceStub =
+          Workflow.newNexusServiceStub(TestNexusServiceGeneric.class, serviceOptions);
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < 3; i++) {
+        result.append(serviceStub.operation(i));
+      }
+      return result.toString();
+    }
+  }
+
+  @Service
+  public interface TestNexusServiceGeneric {
+    @Operation
+    String operation(Integer input);
+  }
+
+  @ServiceImpl(service = TestNexusServiceGeneric.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<Integer, String> operation() {
+      return TemporalOperationHandler.from(
+          (context, client, input) -> {
+            switch (input) {
+              case 0:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc.class,
+                    wf -> wf.func(),
+                    WorkflowOptions.newBuilder()
+                        .setWorkflowId(
+                            "generic-handler-test-func0-"
+                                + context.getService()
+                                + "-"
+                                + context.getOperation())
+                        .build());
+              case 1:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
+                    wf -> wf.func1("input"),
+                    WorkflowOptions.newBuilder()
+                        .setWorkflowId(
+                            "generic-handler-test-func1-"
+                                + context.getService()
+                                + "-"
+                                + context.getOperation())
+                        .build());
+              case 2:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc.class,
+                    wf -> wf.func2("input", 2),
+                    WorkflowOptions.newBuilder()
+                        .setWorkflowId(
+                            "generic-handler-test-func2-"
+                                + context.getService()
+                                + "-"
+                                + context.getOperation())
+                        .build());
+              default:
+                throw new IllegalArgumentException("unexpected input: " + input);
+            }
+          });
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
@@ -63,7 +63,7 @@ public class GenericHandlerTypedStartWorkflowTest {
   public class TestNexusServiceImpl {
     @OperationImpl
     public OperationHandler<Integer, String> operation() {
-      return TemporalOperationHandler.from(
+      return TemporalOperationHandler.create(
           (context, client, input) -> {
             String prefix = "generic-handler-test-func" + input + "-";
             String workflowId = prefix + context.getService() + "-" + context.getOperation();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
@@ -30,7 +30,7 @@ public class GenericHandlerTypedStartWorkflowTest {
     TestWorkflows.TestWorkflow1 workflowStub =
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
-    Assert.assertEquals("funcinputinput2", result);
+    Assert.assertEquals("funcinputinput2input23input234input2345", result);
   }
 
   public static class TestNexus implements TestWorkflows.TestWorkflow1 {
@@ -46,7 +46,7 @@ public class GenericHandlerTypedStartWorkflowTest {
       TestNexusServiceGeneric serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceGeneric.class, serviceOptions);
       StringBuilder result = new StringBuilder();
-      for (int i = 0; i < 3; i++) {
+      for (int i = 0; i < 6; i++) {
         result.append(serviceStub.operation(i));
       }
       return result.toString();
@@ -65,40 +65,56 @@ public class GenericHandlerTypedStartWorkflowTest {
     public OperationHandler<Integer, String> operation() {
       return TemporalOperationHandler.from(
           (context, client, input) -> {
+            String prefix = "generic-handler-test-func" + input + "-";
+            String workflowId = prefix + context.getService() + "-" + context.getOperation();
+            WorkflowOptions options =
+                WorkflowOptions.newBuilder().setWorkflowId(workflowId).build();
             switch (input) {
               case 0:
                 return client.startWorkflow(
                     TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc.class,
-                    wf -> wf.func(),
-                    WorkflowOptions.newBuilder()
-                        .setWorkflowId(
-                            "generic-handler-test-func0-"
-                                + context.getService()
-                                + "-"
-                                + context.getOperation())
-                        .build());
+                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc::func,
+                    options);
               case 1:
                 return client.startWorkflow(
                     TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
-                    wf -> wf.func1("input"),
-                    WorkflowOptions.newBuilder()
-                        .setWorkflowId(
-                            "generic-handler-test-func1-"
-                                + context.getService()
-                                + "-"
-                                + context.getOperation())
-                        .build());
+                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
+                    "input",
+                    options);
               case 2:
                 return client.startWorkflow(
                     TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc.class,
-                    wf -> wf.func2("input", 2),
-                    WorkflowOptions.newBuilder()
-                        .setWorkflowId(
-                            "generic-handler-test-func2-"
-                                + context.getService()
-                                + "-"
-                                + context.getOperation())
-                        .build());
+                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc::func2,
+                    "input",
+                    2,
+                    options);
+              case 3:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowFunc.class,
+                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowFunc::func3,
+                    "input",
+                    2,
+                    3,
+                    options);
+              case 4:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowFunc.class,
+                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowFunc::func4,
+                    "input",
+                    2,
+                    3,
+                    4,
+                    options);
+              case 5:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowFunc.class,
+                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowFunc::func5,
+                    "input",
+                    2,
+                    3,
+                    4,
+                    5,
+                    options);
               default:
                 throw new IllegalArgumentException("unexpected input: " + input);
             }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
@@ -30,7 +30,7 @@ public class GenericHandlerTypedStartWorkflowTest {
     TestWorkflows.TestWorkflow1 workflowStub =
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
-    Assert.assertEquals("funcinputinput2input23input234input2345", result);
+    Assert.assertEquals("funcinputinput2input23input234input2345input23456", result);
   }
 
   public static class TestNexus implements TestWorkflows.TestWorkflow1 {
@@ -46,7 +46,7 @@ public class GenericHandlerTypedStartWorkflowTest {
       TestNexusServiceGeneric serviceStub =
           Workflow.newNexusServiceStub(TestNexusServiceGeneric.class, serviceOptions);
       StringBuilder result = new StringBuilder();
-      for (int i = 0; i < 6; i++) {
+      for (int i = 0; i < 7; i++) {
         result.append(serviceStub.operation(i));
       }
       return result.toString();
@@ -114,6 +114,17 @@ public class GenericHandlerTypedStartWorkflowTest {
                     3,
                     4,
                     5,
+                    options);
+              case 6:
+                return client.startWorkflow(
+                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowFunc.class,
+                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowFunc::func6,
+                    "input",
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
                     options);
               default:
                 throw new IllegalArgumentException("unexpected input: " + input);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
@@ -1,0 +1,77 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericHandlerUntypedStartWorkflowTest {
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(
+              TestNexus.class, TestMultiArgWorkflowFunctions.TestMultiArgWorkflowImpl.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .build();
+
+  @Test
+  public void untypedStartWorkflowTest() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
+    Assert.assertEquals("input", result);
+  }
+
+  public static class TestNexus implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder().setOperationOptions(options).build();
+
+      TestNexusServiceUntyped serviceStub =
+          Workflow.newNexusServiceStub(TestNexusServiceUntyped.class, serviceOptions);
+      return serviceStub.operation("input");
+    }
+  }
+
+  @Service
+  public interface TestNexusServiceUntyped {
+    @Operation
+    String operation(String input);
+  }
+
+  @ServiceImpl(service = TestNexusServiceUntyped.class)
+  public class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, String> operation() {
+      return TemporalOperationHandler.from(
+          (context, client, input) ->
+              client.startWorkflow(
+                  "func1",
+                  String.class,
+                  new Object[] {input},
+                  WorkflowOptions.newBuilder()
+                      .setWorkflowId(
+                          "generic-handler-untyped-"
+                              + context.getService()
+                              + "-"
+                              + context.getOperation())
+                      .build()));
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
@@ -59,7 +59,7 @@ public class GenericHandlerUntypedStartWorkflowTest {
   public class TestNexusServiceImpl {
     @OperationImpl
     public OperationHandler<String, String> operation() {
-      return TemporalOperationHandler.from(
+      return TemporalOperationHandler.create(
           (context, client, input) ->
               client.startWorkflow(
                   "func1",

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
@@ -64,14 +64,14 @@ public class GenericHandlerUntypedStartWorkflowTest {
               client.startWorkflow(
                   "func1",
                   String.class,
-                  new Object[] {input},
                   WorkflowOptions.newBuilder()
                       .setWorkflowId(
                           "generic-handler-untyped-"
                               + context.getService()
                               + "-"
                               + context.getOperation())
-                      .build()));
+                      .build(),
+                  input));
     }
   }
 }


### PR DESCRIPTION
  ## Add TemporalOperationHandler for generic Nexus operations

 ### Goal

Provide a new base to make it easy to expose more Temporal actions as Nexus Operations

  ### Summary

  - Adds TemporalOperationHandler, a generic OperationHandler implementation that maps Nexus operations to Temporal workflows via a composable StartFunction
  - Adds TemporalNexusClient for starting workflows (typed and untyped) from within Nexus operation handlers
  - Supports subclassing TemporalOperationHandler to customize cancel behavior by overriding cancelWorkflowRun
  - Extracts shared workflow start logic into NexusStartWorkflowHelper, reused by both WorkflowRunOperation and the new handler

  ### Test plan

  - GenericHandlerTypedStartWorkflowTest — typed workflow with return value
  - GenericHandlerTypedProcTest — typed void workflow
  - GenericHandlerUntypedStartWorkflowTest — untyped workflow start
  - GenericHandlerSyncResultTest — synchronous result path
  - GenericHandlerCancelTest — cancel with default and custom behavior



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Nexus operation start/cancel and workflow lifecycle from handlers; behavior changes are mostly additive behind experimental APIs, but refactors WorkflowRunOperationImpl and token parsing used on cancel paths.
> 
> **Overview**
> Adds **`TemporalOperationHandler`**, a composable Nexus `OperationHandler` that wires a user-defined start lambda to Temporal via **`TemporalNexusClient`** (typed/untyped `startWorkflow` overloads) and **`TemporalOperationResult`** (sync vs async operation token). Cancel paths parse tokens with a generalized **`OperationToken`** / **`loadOperationToken`**, dispatch workflow-run cancels through overridable **`cancelWorkflowRun`**, and default behavior cancels the backing workflow.
> 
> Shared “start workflow + attach Nexus links” logic moves into **`NexusStartWorkflowHelper`**, which **`WorkflowRunOperationImpl`** now uses instead of inlined code. **`TemporalNexusClientImpl`** enforces **one async start per handler invocation** (extra starts fail with `BAD_REQUEST`; the guard resets if start fails).
> 
> All new public Nexus APIs are marked **`@Experimental`**. Integration tests cover typed/untyped starts, void workflows, sync results, cancel, and double-start rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ab56fba235d9680c07e8d17145746507e8638f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->