### PR TITLE
Fix javadoc -Werror breakage on JDK 11

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -33,7 +33,11 @@ subprojects {
     javadoc {
         options.encoding = 'UTF-8'
         options.addStringOption('Xdoclint:reference', '-quiet')
-        options.addBooleanOption('Werror', true)
+        // -Werror for javadoc was added in JDK 15 (JDK-8232513). Skip on older JDKs
+        // otherwise the javadoc task rejects the flag (breaks the JDK 11 publish job).
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
+            options.addBooleanOption('Werror', true)
+        }
         if (JavaVersion.current().isJava9Compatible()) {
             options.addBooleanOption('html5', true)
         }


### PR DESCRIPTION
## Bug

Building javadoc (and therefore `javadocJar`, `publishToSonatype`, `publishToMavenLocal`) fails on JDK 11 with:

```
javadoc: error - invalid flag: -Werror
```

Reproducer from the root of the repo, running Gradle on JDK 11:

```sh
JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home \
  ./gradlew publishToMavenLocal
```

Every module's javadoc task rejects `-Werror`, so nothing can publish. This blocks the JDK-11 `publish-snapshot` and `prepare-release` workflows.

## Cause

`gradle/java.gradle` unconditionally passes `-Werror` to the javadoc tool. That flag was added to `javadoc` in JDK 15 ([JDK-8232513](https://bugs.openjdk.org/browse/JDK-8232513)); JDK 11's `javadoc` doesn't know it and errors.

The unconditional option was added in #2822 ("Claude fix all docstring problems & add check to CI"). That PR was developed against JDK 17+ (the `javadoc` CI job already runs on JDK 23), so the incompatibility with the publish job's JDK 11 was not caught.

## Fix

Gate the `addBooleanOption('Werror', true)` call on `JavaVersion.current().isCompatibleWith(VERSION_15)`. No change on JDK 15+ (the current javadoc CI job, and any future publish job running on a newer JDK); on JDK 11 the flag is simply omitted so the tool accepts the invocation.

Other `-Werror` uses in the file (`compileJava`/`compileTestJava`) are for `javac`, which has supported `-Werror` since Java 5 — no change needed there.

## Verification

Re-ran the reproducer after the fix:

```
$ JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home \
    ./gradlew publishToMavenLocal
...
BUILD SUCCESSFUL in 40s
168 actionable tasks: 83 executed, 85 up-to-date
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)