### PR TITLE
Fix race in AsyncPollerTest.testSuspendPolling

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/AsyncPollerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/AsyncPollerTest.java
@@ -336,7 +336,15 @@ public class AsyncPollerTest {
   @Test
   public void testSuspendPolling()
       throws InterruptedException, ExecutionException, AsyncPoller.PollTaskAsyncAbort {
-    CountingSlotSupplier<SlotInfo> slotSupplierInner = new CountingSlotSupplier<>(1);
+    AtomicInteger reserveCalls = new AtomicInteger();
+    CountingSlotSupplier<SlotInfo> slotSupplierInner =
+        new CountingSlotSupplier<SlotInfo>(1) {
+          @Override
+          public SlotSupplierFuture reserveSlot(SlotReserveContext<SlotInfo> ctx) throws Exception {
+            reserveCalls.incrementAndGet();
+            return super.reserveSlot(ctx);
+          }
+        };
     TrackingSlotSupplier<?> slotSupplier =
         new TrackingSlotSupplier<>(slotSupplierInner, new NoopScope());
     DummyTaskExecutor executor = new DummyTaskExecutor(slotSupplier);
@@ -370,18 +378,21 @@ public class AsyncPollerTest {
     poller.resumePolling();
     assertFalse(poller.isSuspended());
     pollLatch.await();
-    assertEventually(
-        Duration.ofSeconds(1),
-        () -> {
-          assertEquals(0, executor.processed.get());
-          assertEquals(1, slotSupplierInner.reservedCount.get());
-          assertEquals(0, slotSupplier.getUsedSlots().size());
-        });
-    // Suspend polling again, this will not affect the already issued poll request
+    assertEquals(0, executor.processed.get());
+    assertEquals(1, slotSupplierInner.reservedCount.get());
+    assertEquals(0, slotSupplier.getUsedSlots().size());
+    // Wait for iter 2 of the poll loop to invoke reserveSlot. Completion of that reservation
+    // requires iter 1's slot to be released (via completePoll below) since the supplier has
+    // only one slot — but the *call* to reserveSlot happens as soon as iter 2 passes the
+    // suspend-latch check. Waiting on that call here removes a race where the suspendPolling
+    // below could otherwise strand iter 2 at the suspend latch before it reserves.
+    assertEventually(Duration.ofSeconds(5), () -> assertEquals(2, reserveCalls.get()));
+    // Suspend polling again, this will not affect the already issued poll request or the
+    // iter-2 reserveSlot call above (which is now waiting for the slot to free up).
     poller.suspendPolling();
     completePoll.get().apply();
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(1, executor.processed.get());
           assertEquals(2, slotSupplierInner.reservedCount.get());


### PR DESCRIPTION
## What was changed
Remove the race: override reserveSlot on the slot supplier to count invocations, and wait for reserveCalls == 2 before suspending. That's a direct signal that iter 2 has passed the suspend check and called reserveSlot (its future can't complete until iter 1's slot is released, but the call itself happens immediately). After this signal, iter 2 is pinned past the suspend check, so the subsequent suspendPolling() only affects iter 3+.

Also drop the now-redundant first assertEventually: once pollLatch counts down (inside the mocked poll()), iter 1's slot has already been issued, so reservedCount == 1 is synchronously visible.

## Why?
The test relied on the poller's second iteration racing past its suspend-latch check before the test thread called suspendPolling(). If the test thread won the race, iter 2 blocked at the suspend latch and never reached reserveSlot — so reservedCount stayed at 1 and the later `expected:<2> but was:<1>` assertion failed. Bumping the assertEventually timeout didn't help; the race either wins or loses deterministically on a given run.

## AI Transparency
This PR was fully generated by Claude, and I have not yet reviewed it for accuracy with regards to fixing the flakiness. Don't yet review until I review it more.
