### PR TITLE
Update Temporal Java SDK version in Spring AI README

### DIFF
--- a/temporal-spring-ai/README.md
+++ b/temporal-spring-ai/README.md
@@ -9,7 +9,7 @@ Integrates [Spring AI](https://docs.spring.io/spring-ai/reference/) with [Tempor
 | Java              | 17              |
 | Spring Boot       | 3.x             |
 | Spring AI         | 1.1.0           |
-| Temporal Java SDK | 1.33.0          |
+| Temporal Java SDK | 1.35.0          |
 
 ## Quick Start
 


### PR DESCRIPTION
## What was changed
Update Required Temporal Java SDK version in Spring AI README to next upcoming release

## Why?
1.33.0 was incorrect. 1.35.0 will be correct, once 1.35.0 is published.
