### PR TITLE
Test Server - Add history hints to workflow task started attributes

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -10,9 +10,11 @@ import io.temporal.api.common.v1.Priority;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.enums.v1.HistoryEventFilterType;
+import io.temporal.api.enums.v1.SuggestContinueAsNewReason;
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.history.v1.WorkflowTaskStartedEventAttributes;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
 import io.temporal.api.workflowservice.v1.*;
@@ -40,6 +42,8 @@ import org.slf4j.LoggerFactory;
 class TestWorkflowStoreImpl implements TestWorkflowStore {
 
   private static final Logger log = LoggerFactory.getLogger(TestWorkflowStoreImpl.class);
+  private static final long HISTORY_SIZE_SUGGEST_CONTINUE_AS_NEW = 4L * 1024 * 1024;
+  private static final long HISTORY_COUNT_SUGGEST_CONTINUE_AS_NEW = 4L * 1024;
 
   private final Lock lock = new ReentrantLock();
   private final Map<ExecutionId, HistoryStore> histories = new HashMap<>();
@@ -50,12 +54,33 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   private final Map<TaskQueueId, TaskQueue<NexusTask>> nexusTaskQueues = new HashMap<>();
   private final SelfAdvancingTimer selfAdvancingTimer;
 
+  private static void populateWorkflowTaskStartedEventAttributes(
+      WorkflowTaskStartedEventAttributes.Builder attributes,
+      long historySizeBytes,
+      long historyCount) {
+    // Size excludes the started event; count is the started event id.
+    attributes.setHistorySizeBytes(historySizeBytes);
+    if (historySizeBytes >= HISTORY_SIZE_SUGGEST_CONTINUE_AS_NEW) {
+      attributes.setSuggestContinueAsNew(true);
+      attributes.addSuggestContinueAsNewReasons(
+          SuggestContinueAsNewReason.SUGGEST_CONTINUE_AS_NEW_REASON_HISTORY_SIZE_TOO_LARGE);
+    }
+    if (historyCount >= HISTORY_COUNT_SUGGEST_CONTINUE_AS_NEW) {
+      attributes.setSuggestContinueAsNew(true);
+      attributes.addSuggestContinueAsNewReasons(
+          SuggestContinueAsNewReason.SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_HISTORY_EVENTS);
+    }
+  }
+
   private static class HistoryStore {
 
     private final ExecutionId id;
     private final Lock lock;
     private final Condition newEventsCondition;
     private final List<HistoryEvent> history = new ArrayList<>();
+
+    private long historySizeBytes;
+
     private boolean completed;
 
     private HistoryStore(ExecutionId id, Lock lock) {
@@ -91,8 +116,17 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
         if (Timestamps.toMillis(eBuilder.getEventTime()) == 0) {
           eBuilder.setEventTime(eventTime);
         }
-        history.add(eBuilder.build());
-        completed = completed || WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(eBuilder);
+        if (EventType.EVENT_TYPE_WORKFLOW_TASK_STARTED == eBuilder.getEventType()) {
+          populateWorkflowTaskStartedEventAttributes(
+              eBuilder.getWorkflowTaskStartedEventAttributesBuilder(),
+              historySizeBytes,
+              history.size() + 1L);
+        }
+        HistoryEvent historyEvent = eBuilder.build();
+        history.add(historyEvent);
+        historySizeBytes += historyEvent.getSerializedSize();
+        completed =
+            completed || WorkflowExecutionUtils.isWorkflowExecutionClosedEvent(historyEvent);
       }
       newEventsCondition.signalAll();
       return history.subList(currentSize, history.size());

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowTaskStartedAttributesTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/WorkflowTaskStartedAttributesTest.java
@@ -1,0 +1,169 @@
+package io.temporal.testserver.functional;
+
+import static io.temporal.internal.common.InternalUtils.createNormalTaskQueue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.ByteString;
+import io.temporal.api.command.v1.Command;
+import io.temporal.api.command.v1.RecordMarkerCommandAttributes;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.enums.v1.CommandType;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.enums.v1.SuggestContinueAsNewReason;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.history.v1.WorkflowTaskStartedEventAttributes;
+import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.internal.TestServiceUtils;
+import io.temporal.testserver.TestServer;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorkflowTaskStartedAttributesTest {
+
+  private static final long HISTORY_SIZE_SUGGEST_CONTINUE_AS_NEW = 4L * 1024 * 1024;
+  private static final long HISTORY_COUNT_SUGGEST_CONTINUE_AS_NEW = 4L * 1024;
+  private static final int MARKER_PAYLOAD_SIZE = 1024 * 1024;
+  private static final int MARKER_ITERATIONS = 5;
+
+  private final String NAMESPACE = "namespace";
+  private final String TASK_QUEUE = "taskQueue";
+  private final String WORKFLOW_TYPE = "wfType";
+
+  private TestServer.InProcessTestServer testServer;
+  private WorkflowServiceStubs workflowServiceStubs;
+
+  @Before
+  public void setUp() {
+    this.testServer = TestServer.createServer(true);
+    this.workflowServiceStubs =
+        WorkflowServiceStubs.newServiceStubs(
+            WorkflowServiceStubsOptions.newBuilder()
+                .setChannel(testServer.getChannel())
+                .validateAndBuildWithDefaults());
+  }
+
+  @After
+  public void tearDown() {
+    this.workflowServiceStubs.shutdownNow();
+    this.workflowServiceStubs.awaitTermination(1, TimeUnit.SECONDS);
+    this.testServer.close();
+  }
+
+  @Test
+  public void firstWorkflowTaskStartedReportsHistorySizeWithoutSuggestion() throws Exception {
+    TestServiceUtils.startWorkflowExecution(
+        NAMESPACE, TASK_QUEUE, WORKFLOW_TYPE, workflowServiceStubs);
+
+    PollWorkflowTaskQueueResponse response =
+        TestServiceUtils.pollWorkflowTaskQueue(
+            NAMESPACE, createNormalTaskQueue(TASK_QUEUE), workflowServiceStubs);
+
+    WorkflowTaskStartedEventAttributes startedAttributes = lastStartedAttributes(response);
+    assertTrue(startedAttributes.getHistorySizeBytes() > 0);
+    assertFalse(startedAttributes.getSuggestContinueAsNew());
+    assertTrue(startedAttributes.getSuggestContinueAsNewReasonsList().isEmpty());
+  }
+
+  @Test
+  public void historySizeAboveThresholdSuggestsContinueAsNew() throws Exception {
+    TestServiceUtils.startWorkflowExecution(
+        NAMESPACE, TASK_QUEUE, WORKFLOW_TYPE, workflowServiceStubs);
+
+    PollWorkflowTaskQueueResponse response =
+        TestServiceUtils.pollWorkflowTaskQueue(
+            NAMESPACE, createNormalTaskQueue(TASK_QUEUE), workflowServiceStubs);
+
+    for (int i = 0; i < MARKER_ITERATIONS; i++) {
+      workflowServiceStubs
+          .blockingStub()
+          .respondWorkflowTaskCompleted(
+              RespondWorkflowTaskCompletedRequest.newBuilder()
+                  .setTaskToken(response.getTaskToken())
+                  .addCommands(newLargeMarkerCommand())
+                  .build());
+      TestServiceUtils.signalWorkflow(
+          response.getWorkflowExecution(), NAMESPACE, workflowServiceStubs);
+      response =
+          TestServiceUtils.pollWorkflowTaskQueue(
+              NAMESPACE, createNormalTaskQueue(TASK_QUEUE), workflowServiceStubs);
+    }
+
+    WorkflowTaskStartedEventAttributes startedAttributes = lastStartedAttributes(response);
+    assertTrue(
+        "Expected history >= 4 MiB but was " + startedAttributes.getHistorySizeBytes(),
+        startedAttributes.getHistorySizeBytes() >= HISTORY_SIZE_SUGGEST_CONTINUE_AS_NEW);
+    assertSuggestsContinueAsNew(
+        startedAttributes,
+        SuggestContinueAsNewReason.SUGGEST_CONTINUE_AS_NEW_REASON_HISTORY_SIZE_TOO_LARGE);
+  }
+
+  @Test
+  public void historyCountAboveThresholdSuggestsContinueAsNew() throws Exception {
+    TestServiceUtils.startWorkflowExecution(
+        NAMESPACE, TASK_QUEUE, WORKFLOW_TYPE, workflowServiceStubs);
+
+    PollWorkflowTaskQueueResponse response =
+        TestServiceUtils.pollWorkflowTaskQueue(
+            NAMESPACE, createNormalTaskQueue(TASK_QUEUE), workflowServiceStubs);
+
+    RespondWorkflowTaskCompletedRequest.Builder completedRequest =
+        RespondWorkflowTaskCompletedRequest.newBuilder().setTaskToken(response.getTaskToken());
+    for (int i = 0; i < HISTORY_COUNT_SUGGEST_CONTINUE_AS_NEW; i++) {
+      completedRequest.addCommands(newMarkerCommand());
+    }
+    workflowServiceStubs.blockingStub().respondWorkflowTaskCompleted(completedRequest.build());
+    TestServiceUtils.signalWorkflow(
+        response.getWorkflowExecution(), NAMESPACE, workflowServiceStubs);
+
+    response =
+        TestServiceUtils.pollWorkflowTaskQueue(
+            NAMESPACE, createNormalTaskQueue(TASK_QUEUE), workflowServiceStubs);
+
+    WorkflowTaskStartedEventAttributes startedAttributes = lastStartedAttributes(response);
+    assertSuggestsContinueAsNew(
+        startedAttributes,
+        SuggestContinueAsNewReason.SUGGEST_CONTINUE_AS_NEW_REASON_TOO_MANY_HISTORY_EVENTS);
+  }
+
+  private static WorkflowTaskStartedEventAttributes lastStartedAttributes(
+      PollWorkflowTaskQueueResponse response) {
+    HistoryEvent last = response.getHistory().getEvents(response.getHistory().getEventsCount() - 1);
+    assertEquals(EventType.EVENT_TYPE_WORKFLOW_TASK_STARTED, last.getEventType());
+    return last.getWorkflowTaskStartedEventAttributes();
+  }
+
+  private static void assertSuggestsContinueAsNew(
+      WorkflowTaskStartedEventAttributes startedAttributes, SuggestContinueAsNewReason reason) {
+    assertTrue(startedAttributes.getSuggestContinueAsNew());
+    assertTrue(startedAttributes.getSuggestContinueAsNewReasonsList().contains(reason));
+  }
+
+  private static Command newLargeMarkerCommand() {
+    ByteString markerData = ByteString.copyFrom(new byte[MARKER_PAYLOAD_SIZE]);
+    Payloads markerPayloads =
+        Payloads.newBuilder().addPayloads(Payload.newBuilder().setData(markerData)).build();
+    return newMarkerCommand(markerPayloads);
+  }
+
+  private static Command newMarkerCommand() {
+    return newMarkerCommand(Payloads.getDefaultInstance());
+  }
+
+  private static Command newMarkerCommand(Payloads markerPayloads) {
+    return Command.newBuilder()
+        .setCommandType(CommandType.COMMAND_TYPE_RECORD_MARKER)
+        .setRecordMarkerCommandAttributes(
+            RecordMarkerCommandAttributes.newBuilder()
+                .setMarkerName("large-history-marker")
+                .putDetails("payload", markerPayloads))
+        .build();
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added history hint fields to `WorkflowTaskStarted` events generated by the in-memory test server.

The test server now populates:
- `historySizeBytes`
- `suggestContinueAsNew`
- `suggestContinueAsNewReasons`

when workflow history size or event count reaches the same default continue-as-new suggestion thresholds used by the Temporal server.

The update-registry-driven reason (`TOO_MANY_UPDATES`) is not included here. The test server does not currently track the registry's in-flight/completed update counts, so it would be better handled as a separate issue.

## Why?
The Java SDK exposes workflow history size and continue-as-new suggestions through workflow task started attributes. The in-memory test server did not populate these fields, so workflows running in tests could observe different values than they would against a real Temporal server.

This makes the test server behavior closer to Temporal server behavior and allows SDK tests to cover history-size and history-count based continue-as-new suggestions.

## Checklist
<!--- add/delete as needed --->

1. Closes #2661 

2. How was this tested:
- `./gradlew :temporal-test-server:test --offline --tests io.temporal.testserver.functional.WorkflowTaskStartedAttributesTest`

3. Any docs updates needed?
No docs updates needed. This is an internal test server behavior fix.
