### PR TITLE
Upgraded gRPC to 1.76.0 and Guava to 33.4.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 
 ext {
     // Platforms
-    grpcVersion = '1.75.0' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
+    grpcVersion = '1.76.0' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.15.4' // [2.9.0,)
     jackson3Version = '3.0.4'
     nexusVersion = '0.5.0-alpha'
@@ -39,7 +39,7 @@ ext {
     // For more information see: https://github.com/grpc/grpc-java/issues/11015#issuecomment-2560196695
     protoVersion = '3.25.8'
     annotationApiVersion = '1.3.2'
-    guavaVersion = '32.0.1-jre' // [10.0,)
+    guavaVersion = '33.4.8-android' // [10.0,)
     tallyVersion = '0.13.0' // [0.4.0,)
 
     gsonVersion = '2.10.1' // [2.0,)
@@ -67,7 +67,7 @@ ext {
     // Edge Dependencies are used by tests to validate the SDK with the latest version of various libraries.
     // Not just the version of the library the SDK is built against.
     protoVersionEdge = '4.32.1'
-    grpcVersionEdge = '1.75.0'
+    grpcVersionEdge = '1.80.0'
 }
 
 apply from: "$rootDir/gradle/versioning.gradle"

--- a/temporal-envconfig/src/test/java/io/temporal/envconfig/ClientConfigProfileTest.java
+++ b/temporal-envconfig/src/test/java/io/temporal/envconfig/ClientConfigProfileTest.java
@@ -1,12 +1,12 @@
 package io.temporal.envconfig;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import io.grpc.Metadata;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import org.junit.Assert;
@@ -116,7 +116,7 @@ public class ClientConfigProfileTest {
     // Put some data in temp file and set the env var to use that file
     File temp = File.createTempFile("envConfigTest", "");
     temp.deleteOnExit();
-    Files.asCharSink(temp, Charsets.UTF_8)
+    Files.asCharSink(temp, StandardCharsets.UTF_8)
         .write(
             "[profile.default]\n" + "address = \"my-address\"\n" + "namespace = \"my-namespace\"");
     // Explicitly set

--- a/temporal-sdk/src/test/java/io/temporal/internal/statemachines/CommandsGeneratePlantUMLStateDiagramsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/statemachines/CommandsGeneratePlantUMLStateDiagramsTest.java
@@ -1,6 +1,5 @@
 package io.temporal.internal.statemachines;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharSink;
 import com.google.common.io.Files;
 import io.temporal.workflow.Functions;
@@ -8,6 +7,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +66,7 @@ public class CommandsGeneratePlantUMLStateDiagramsTest {
     String diagramFile =
         (projectPath + "/" + fullRelativePath).replace("/", File.separator) + ".puml";
     File file = new File(diagramFile);
-    CharSink sink = Files.asCharSink(file, Charsets.UTF_8);
+    CharSink sink = Files.asCharSink(file, StandardCharsets.UTF_8);
     StringBuilder content = new StringBuilder();
     try {
       content.append("` PlantUML <plantuml.com> State Diagram.\n");


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Upgraded gRPC library to version 1.76.0 and Guava library to version 33.4.8-android.
- Set gRPC edge version to 1.80.0, current latest.
- Replaced deprecated `com.google.common.base.Charsets` with `java.nio.charset.StandardCharsets` in tests.

## Why?
<!-- Tell your future self why have you made these changes -->
gRPC 1.75 has a data corruption bug that's fixed in 1.76.0, see #2843. The new gRPC version requires Guava minimum version 33.4.8-android. The new Guava version gives deprecation warnings for `com.google.common.base.Charsets` class.

## Checklist
<!--- add/delete as needed --->

1. Closes #2843

2. How was this tested:
Build and tests pass.
