### PR TITLE
Fixed a bug with spaces in WorkflowIds when creating links in the UI.

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
@@ -32,11 +32,19 @@ public class LinkConverter {
 
   public static io.temporal.api.nexus.v1.Link workflowEventToNexusLink(Link.WorkflowEvent we) {
     try {
+
       String url =
           String.format(
               linkPathFormat,
               URLEncoder.encode(we.getNamespace(), StandardCharsets.UTF_8.toString()),
-              URLEncoder.encode(we.getWorkflowId(), StandardCharsets.UTF_8.toString()),
+              // The 'replace' below handles spaces - the encoder will convert them to a plus,
+              // which the UI then handles as a plus, thus breaking the link as the
+              // space is lost.
+              // It's a known quirk with the URLEncoder as it encodes for forms, not general URIs.
+              // Only done for the WorkflowId as the other two are values we control,
+              // and will never have spaces.
+              URLEncoder.encode(we.getWorkflowId(), StandardCharsets.UTF_8.toString())
+                  .replace("+", "%20"),
               URLEncoder.encode(we.getRunId(), StandardCharsets.UTF_8.toString()));
 
       List<Map.Entry<String, String>> queryParams = new ArrayList<>();

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/LinkConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/LinkConverterTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.*;
 
 import io.temporal.api.common.v1.Link;
 import io.temporal.api.enums.v1.EventType;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 public class LinkConverterTest {
@@ -96,6 +99,35 @@ public class LinkConverterTest {
 
     io.temporal.api.nexus.v1.Link actual = workflowEventToNexusLink(input);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testConvertWorkflowEventToNexus_ValidSpace() throws UnsupportedEncodingException {
+    Link.WorkflowEvent input =
+        Link.WorkflowEvent.newBuilder()
+            .setNamespace("ns")
+            .setWorkflowId("wf space+plus")
+            .setRunId("run-id")
+            .setEventRef(
+                Link.WorkflowEvent.EventReference.newBuilder()
+                    .setEventId(1)
+                    .setEventType(EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED))
+            .build();
+
+    io.temporal.api.nexus.v1.Link expected =
+        io.temporal.api.nexus.v1.Link.newBuilder()
+            .setUrl(
+                "temporal:///namespaces/ns/workflows/wf%20space%2Bplus/run-id/history?referenceType=EventReference&eventID=1&eventType=WorkflowExecutionStarted")
+            .setType("temporal.api.common.v1.Link.WorkflowEvent")
+            .build();
+
+    io.temporal.api.nexus.v1.Link actual = workflowEventToNexusLink(input);
+    assertEquals(expected, actual);
+
+    String decoded = URLDecoder.decode(actual.getUrl(), StandardCharsets.UTF_8.toString());
+    assertEquals(
+        "temporal:///namespaces/ns/workflows/wf space+plus/run-id/history?referenceType=EventReference&eventID=1&eventType=WorkflowExecutionStarted",
+        decoded);
   }
 
   @Test


### PR DESCRIPTION
I used a workflow id that had a space in it, and realized that the links to it in the UI workflow step were broken. They should have linked to "workflow%20id" for example, but instead linked to "workflow%2Bid". This will only show up if you have a space in the workflow ID, so that is why it was missed.

The root issue turns out to be that the URLEncoder is meant for forms, where this is evidently the standard. 

The solution used here is to encode the string, then replace any "+" values with "%20". If the string has a plus, it will be converted to "%2B" by the call, so will not be affected by the replace (that is being double checked by the unit test.)