### PR TITLE
Expose ShutdownManager poll interval to speed up TestWorkflowEnvironment teardown

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ShutdownManager.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ShutdownManager.java
@@ -21,7 +21,23 @@ public class ShutdownManager implements Closeable {
           new ExecutorThreadFactory(
               WorkerThreadsNameHelper.SHUTDOWN_MANAGER_THREAD_NAME_PREFIX, null));
 
-  private static final int CHECK_PERIOD_MS = 250;
+  private static final int DEFAULT_CHECK_PERIOD_MS = 250;
+  private final int checkPeriodMs;
+
+  public ShutdownManager() {
+    this(DEFAULT_CHECK_PERIOD_MS);
+  }
+
+  /**
+   * @param checkPeriodMs interval in milliseconds between shutdown-completion polls. Lower values
+   *     speed up teardown at the cost of more frequent polling. Must be positive.
+   */
+  public ShutdownManager(int checkPeriodMs) {
+    if (checkPeriodMs <= 0) {
+      throw new IllegalArgumentException("checkPeriodMs must be positive, was: " + checkPeriodMs);
+    }
+    this.checkPeriodMs = checkPeriodMs;
+  }
 
   /** executorToShutdown.shutdownNow() -&gt; timed wait for a graceful termination */
   public CompletableFuture<Void> shutdownExecutorNow(
@@ -97,7 +113,7 @@ public class ShutdownManager implements Closeable {
    */
   private CompletableFuture<Void> limitedWait(
       ExecutorService executorToShutdown, String executorName, Duration timeout) {
-    int attempts = (int) Math.ceil((double) timeout.toMillis() / CHECK_PERIOD_MS);
+    int attempts = (int) Math.ceil((double) timeout.toMillis() / checkPeriodMs);
 
     CompletableFuture<Void> future = new CompletableFuture<>();
     scheduledExecutorService.submit(
@@ -167,7 +183,7 @@ public class ShutdownManager implements Closeable {
         promise.complete(null);
         return;
       }
-      scheduledExecutorService.schedule(this, CHECK_PERIOD_MS, TimeUnit.MILLISECONDS);
+      scheduledExecutorService.schedule(this, checkPeriodMs, TimeUnit.MILLISECONDS);
     }
 
     abstract boolean isTerminated();
@@ -238,7 +254,7 @@ public class ShutdownManager implements Closeable {
           onSlowTermination();
         }
       }
-      scheduledExecutorService.schedule(this, CHECK_PERIOD_MS, TimeUnit.MILLISECONDS);
+      scheduledExecutorService.schedule(this, checkPeriodMs, TimeUnit.MILLISECONDS);
     }
 
     abstract boolean isTerminated();

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -411,7 +411,8 @@ public final class WorkerFactory {
 
   /** Internal method that actually shuts down workers. Called from the plugin chain. */
   private void doShutdown(boolean interruptUserTasks) {
-    ShutdownManager shutdownManager = new ShutdownManager();
+    ShutdownManager shutdownManager =
+        new ShutdownManager((int) factoryOptions.getShutdownCheckInterval().toMillis());
 
     // Shutdown each worker with plugin hooks
     List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>();

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactoryOptions.java
@@ -24,6 +24,7 @@ public class WorkerFactoryOptions {
 
   private static final int DEFAULT_WORKFLOW_CACHE_SIZE = 600;
   private static final int DEFAULT_MAX_WORKFLOW_THREAD_COUNT = 600;
+  private static final Duration DEFAULT_SHUTDOWN_CHECK_INTERVAL = Duration.ofMillis(250);
 
   private static final WorkerFactoryOptions DEFAULT_INSTANCE;
 
@@ -41,6 +42,7 @@ public class WorkerFactoryOptions {
     private boolean enableLoggingInReplay;
     private boolean usingVirtualWorkflowThreads;
     private ExecutorService overrideLocalActivityTaskExecutor;
+    private Duration shutdownCheckInterval;
 
     private Builder() {}
 
@@ -57,6 +59,7 @@ public class WorkerFactoryOptions {
       this.enableLoggingInReplay = options.enableLoggingInReplay;
       this.usingVirtualWorkflowThreads = options.usingVirtualWorkflowThreads;
       this.overrideLocalActivityTaskExecutor = options.overrideLocalActivityTaskExecutor;
+      this.shutdownCheckInterval = options.shutdownCheckInterval;
     }
 
     /**
@@ -155,6 +158,22 @@ public class WorkerFactoryOptions {
       return this;
     }
 
+    /**
+     * Sets the interval between polls when checking for executor termination during shutdown. Lower
+     * values speed up shutdown at the cost of more frequent polling.
+     *
+     * <p>Default is 250ms, which is suitable for production. For test environments, consider
+     * setting a much lower value (e.g., 1ms) to minimize teardown overhead.
+     *
+     * @param shutdownCheckInterval the interval between shutdown polls. Must be positive.
+     * @return this builder for chaining
+     */
+    @Experimental
+    public Builder setShutdownCheckInterval(Duration shutdownCheckInterval) {
+      this.shutdownCheckInterval = shutdownCheckInterval;
+      return this;
+    }
+
     public WorkerFactoryOptions build() {
       return new WorkerFactoryOptions(
           workflowCacheSize,
@@ -165,6 +184,7 @@ public class WorkerFactoryOptions {
           enableLoggingInReplay,
           usingVirtualWorkflowThreads,
           overrideLocalActivityTaskExecutor,
+          shutdownCheckInterval,
           false);
     }
 
@@ -189,6 +209,7 @@ public class WorkerFactoryOptions {
           enableLoggingInReplay,
           usingVirtualWorkflowThreads,
           overrideLocalActivityTaskExecutor,
+          shutdownCheckInterval,
           true);
     }
   }
@@ -201,6 +222,7 @@ public class WorkerFactoryOptions {
   private final boolean enableLoggingInReplay;
   private final boolean usingVirtualWorkflowThreads;
   private final ExecutorService overrideLocalActivityTaskExecutor;
+  private final Duration shutdownCheckInterval;
 
   private WorkerFactoryOptions(
       int workflowCacheSize,
@@ -211,6 +233,7 @@ public class WorkerFactoryOptions {
       boolean enableLoggingInReplay,
       boolean usingVirtualWorkflowThreads,
       ExecutorService overrideLocalActivityTaskExecutor,
+      Duration shutdownCheckInterval,
       boolean validate) {
     if (validate) {
       Preconditions.checkState(workflowCacheSize >= 0, "negative workflowCacheSize");
@@ -233,6 +256,13 @@ public class WorkerFactoryOptions {
       if (plugins == null) {
         plugins = new WorkerPlugin[0];
       }
+      if (shutdownCheckInterval != null) {
+        Preconditions.checkState(
+            !shutdownCheckInterval.isNegative() && !shutdownCheckInterval.isZero(),
+            "shutdownCheckInterval must be positive");
+      } else {
+        shutdownCheckInterval = DEFAULT_SHUTDOWN_CHECK_INTERVAL;
+      }
     }
     this.workflowCacheSize = workflowCacheSize;
     this.maxWorkflowThreadCount = maxWorkflowThreadCount;
@@ -243,6 +273,7 @@ public class WorkerFactoryOptions {
     this.enableLoggingInReplay = enableLoggingInReplay;
     this.usingVirtualWorkflowThreads = usingVirtualWorkflowThreads;
     this.overrideLocalActivityTaskExecutor = overrideLocalActivityTaskExecutor;
+    this.shutdownCheckInterval = shutdownCheckInterval;
   }
 
   public int getWorkflowCacheSize() {
@@ -289,6 +320,16 @@ public class WorkerFactoryOptions {
    */
   ExecutorService getOverrideLocalActivityTaskExecutor() {
     return overrideLocalActivityTaskExecutor;
+  }
+
+  /**
+   * Returns the interval between polls when checking for executor termination during shutdown.
+   *
+   * @return the configured shutdown check interval
+   */
+  @Experimental
+  public Duration getShutdownCheckInterval() {
+    return shutdownCheckInterval;
   }
 
   /**

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/ShutdownManagerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/ShutdownManagerTest.java
@@ -1,0 +1,16 @@
+package io.temporal.internal.worker;
+
+import org.junit.Test;
+
+public class ShutdownManagerTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void zeroPeriodIsRejected() {
+    new ShutdownManager(0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void negativePeriodIsRejected() {
+    new ShutdownManager(-1);
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerFactoryOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerFactoryOptionsTest.java
@@ -1,0 +1,56 @@
+package io.temporal.worker;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class WorkerFactoryOptionsTest {
+
+  @Test
+  public void shutdownCheckIntervalDefaultIs250ms() {
+    WorkerFactoryOptions options = WorkerFactoryOptions.newBuilder().validateAndBuildWithDefaults();
+    assertEquals(Duration.ofMillis(250), options.getShutdownCheckInterval());
+  }
+
+  @Test
+  public void shutdownCheckIntervalCanBeSet() {
+    Duration interval = Duration.ofMillis(5);
+    WorkerFactoryOptions options =
+        WorkerFactoryOptions.newBuilder().setShutdownCheckInterval(interval).build();
+    assertEquals(interval, options.getShutdownCheckInterval());
+  }
+
+  @Test
+  public void shutdownCheckIntervalSurvivesValidateAndBuild() {
+    Duration interval = Duration.ofMillis(10);
+    WorkerFactoryOptions options =
+        WorkerFactoryOptions.newBuilder()
+            .setShutdownCheckInterval(interval)
+            .validateAndBuildWithDefaults();
+    assertEquals(interval, options.getShutdownCheckInterval());
+  }
+
+  @Test
+  public void shutdownCheckIntervalSurvivesCopyBuilder() {
+    Duration interval = Duration.ofMillis(3);
+    WorkerFactoryOptions original =
+        WorkerFactoryOptions.newBuilder().setShutdownCheckInterval(interval).build();
+    WorkerFactoryOptions copy = WorkerFactoryOptions.newBuilder(original).build();
+    assertEquals(interval, copy.getShutdownCheckInterval());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shutdownCheckIntervalRejectsZero() {
+    WorkerFactoryOptions.newBuilder()
+        .setShutdownCheckInterval(Duration.ZERO)
+        .validateAndBuildWithDefaults();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shutdownCheckIntervalRejectsNegative() {
+    WorkerFactoryOptions.newBuilder()
+        .setShutdownCheckInterval(Duration.ofMillis(-1))
+        .validateAndBuildWithDefaults();
+  }
+}


### PR DESCRIPTION
## Summary

Makes the hard-coded 250ms `CHECK_PERIOD_MS` in `ShutdownManager` configurable through a new `WorkerFactoryOptions.Builder#setShutdownCheckInterval(Duration)` option.

## Motivation

Resolves #2869. In env-per-test setups the 250ms shutdown poll interval dominates teardown wall-time:

- **p50 = 506ms** (stock) → **7ms** (with a lower interval)
- ~257ms/test overhead reproduced internally

## Changes

| File | Change |
|------|--------|
| `ShutdownManager` | Convert `CHECK_PERIOD_MS` from a static constant to a configurable instance field. No-arg constructor preserves the 250ms default. New `ShutdownManager(int checkPeriodMs)` constructor with validation. |
| `WorkerFactoryOptions` | Add `shutdownCheckInterval` field + `Builder#setShutdownCheckInterval(Duration)` with positive-duration validation. |
| `WorkerFactory` | Wire the configured interval through to `ShutdownManager` in `doShutdown()`. |

## Usage

```java
// Production: no change needed, defaults to 250ms

// Test environment: set a fast interval
WorkerFactoryOptions factoryOptions = WorkerFactoryOptions.newBuilder()
    .setShutdownCheckInterval(Duration.ofMillis(1))
    .build();
TestEnvironmentOptions testOptions = TestEnvironmentOptions.newBuilder()
    .setWorkerFactoryOptions(factoryOptions)
    .build();
TestWorkflowEnvironment env = TestWorkflowEnvironment.newInstance(testOptions);
```

## Backward Compatibility

Fully backward compatible — the no-arg `ShutdownManager()` constructor and default `WorkerFactoryOptions` preserve the existing 250ms behavior.