### PR TITLE
Add cooldown on dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 14
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
## What was changed

- Add a 14-day cooldown period on dependabot's config.

## Why?

- Replicate security config applied on other SDKs by security team