### PR TITLE
Add option to let activities heartbeat during worker shutdown

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SingleWorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SingleWorkerOptions.java
@@ -41,6 +41,7 @@ public final class SingleWorkerOptions {
     private boolean usingVirtualThreads;
     private WorkerDeploymentOptions deploymentOptions;
     private String workerInstanceKey;
+    private boolean allowActivityHeartbeatDuringShutdown;
 
     private Builder() {}
 
@@ -66,6 +67,7 @@ public final class SingleWorkerOptions {
       this.usingVirtualThreads = options.isUsingVirtualThreads();
       this.deploymentOptions = options.getDeploymentOptions();
       this.workerInstanceKey = options.getWorkerInstanceKey();
+      this.allowActivityHeartbeatDuringShutdown = options.getAllowActivityHeartbeatDuringShutdown();
     }
 
     public Builder setIdentity(String identity) {
@@ -162,6 +164,12 @@ public final class SingleWorkerOptions {
       return this;
     }
 
+    public Builder setAllowActivityHeartbeatDuringShutdown(
+        boolean allowActivityHeartbeatDuringShutdown) {
+      this.allowActivityHeartbeatDuringShutdown = allowActivityHeartbeatDuringShutdown;
+      return this;
+    }
+
     public SingleWorkerOptions build() {
       PollerOptions pollerOptions = this.pollerOptions;
       if (pollerOptions == null) {
@@ -201,7 +209,8 @@ public final class SingleWorkerOptions {
           drainStickyTaskQueueTimeout,
           usingVirtualThreads,
           this.deploymentOptions,
-          this.workerInstanceKey);
+          this.workerInstanceKey,
+          this.allowActivityHeartbeatDuringShutdown);
     }
   }
 
@@ -223,6 +232,7 @@ public final class SingleWorkerOptions {
   private final boolean usingVirtualThreads;
   private final WorkerDeploymentOptions deploymentOptions;
   private final String workerInstanceKey;
+  private final boolean allowActivityHeartbeatDuringShutdown;
 
   private SingleWorkerOptions(
       String identity,
@@ -242,7 +252,8 @@ public final class SingleWorkerOptions {
       Duration drainStickyTaskQueueTimeout,
       boolean usingVirtualThreads,
       WorkerDeploymentOptions deploymentOptions,
-      String workerInstanceKey) {
+      String workerInstanceKey,
+      boolean allowActivityHeartbeatDuringShutdown) {
     this.identity = identity;
     this.binaryChecksum = binaryChecksum;
     this.buildId = buildId;
@@ -261,6 +272,7 @@ public final class SingleWorkerOptions {
     this.usingVirtualThreads = usingVirtualThreads;
     this.deploymentOptions = deploymentOptions;
     this.workerInstanceKey = workerInstanceKey;
+    this.allowActivityHeartbeatDuringShutdown = allowActivityHeartbeatDuringShutdown;
   }
 
   public String getIdentity() {
@@ -289,6 +301,10 @@ public final class SingleWorkerOptions {
 
   public Duration getDrainStickyTaskQueueTimeout() {
     return drainStickyTaskQueueTimeout;
+  }
+
+  public boolean getAllowActivityHeartbeatDuringShutdown() {
+    return allowActivityHeartbeatDuringShutdown;
   }
 
   public DataConverter getDataConverter() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncActivityWorker.java
@@ -26,6 +26,7 @@ public class SyncActivityWorker implements SuspendableWorker {
   private final ScheduledExecutorService heartbeatExecutor;
   private final ActivityTaskHandlerImpl taskHandler;
   private final ActivityWorker worker;
+  private final boolean allowActivityHeartbeatDuringShutdown;
 
   public SyncActivityWorker(
       WorkflowClient client,
@@ -38,6 +39,7 @@ public class SyncActivityWorker implements SuspendableWorker {
     this.identity = options.getIdentity();
     this.namespace = namespace;
     this.taskQueue = taskQueue;
+    this.allowActivityHeartbeatDuringShutdown = options.getAllowActivityHeartbeatDuringShutdown();
 
     this.heartbeatExecutor =
         Executors.newScheduledThreadPool(
@@ -89,16 +91,31 @@ public class SyncActivityWorker implements SuspendableWorker {
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
-    return shutdownManager
-        // we want to shut down heartbeatExecutor before activity worker, so in-flight activities
-        // could get an ActivityWorkerShutdownException from their heartbeat
-        .shutdownExecutor(heartbeatExecutor, this + "#heartbeatExecutor", Duration.ofSeconds(5))
-        .thenCompose(r -> worker.shutdown(shutdownManager, interruptTasks))
-        .exceptionally(
-            e -> {
-              log.error("[BUG] Unexpected exception during shutdown", e);
-              return null;
-            });
+    CompletableFuture<Void> shutdownFuture;
+    if (allowActivityHeartbeatDuringShutdown && !interruptTasks) {
+      // we want to shut down heartbeatExecutor only after all outstanding activity tasks have
+      // finished executing, so in-flight activities can keep heartbeating during the shutdown
+      shutdownFuture =
+          worker
+              .shutdown(shutdownManager, interruptTasks)
+              .thenCompose(r -> shutdownHeartbeatExecutor(shutdownManager));
+    } else {
+      // we want to shut down heartbeatExecutor before activity worker, so in-flight activities
+      // could get an ActivityWorkerShutdownException from their heartbeat
+      shutdownFuture =
+          shutdownHeartbeatExecutor(shutdownManager)
+              .thenCompose(r -> worker.shutdown(shutdownManager, interruptTasks));
+    }
+    return shutdownFuture.exceptionally(
+        e -> {
+          log.error("[BUG] Unexpected exception during shutdown", e);
+          return null;
+        });
+  }
+
+  private CompletableFuture<Void> shutdownHeartbeatExecutor(ShutdownManager shutdownManager) {
+    return shutdownManager.shutdownExecutor(
+        heartbeatExecutor, this + "#heartbeatExecutor", Duration.ofSeconds(5));
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -893,6 +893,7 @@ public final class Worker {
     return toSingleWorkerOptions(
             factoryOptions, options, clientOptions, contextPropagators, workerInstanceKey)
         .setUsingVirtualThreads(options.isUsingVirtualThreadsOnActivityWorker())
+        .setAllowActivityHeartbeatDuringShutdown(options.getAllowActivityHeartbeatDuringShutdown())
         .setPollerOptions(
             PollerOptions.newBuilder()
                 .setMaximumPollRatePerSecond(options.getMaxWorkerActivitiesPerSecond())

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -358,7 +358,9 @@ public final class WorkerFactory {
    * activity tasks are executed. <br>
    * After the shutdown, calls to {@link
    * io.temporal.activity.ActivityExecutionContext#heartbeat(Object)} start throwing {@link
-   * io.temporal.client.ActivityWorkerShutdownException}.<br>
+   * io.temporal.client.ActivityWorkerShutdownException}, unless {@link
+   * WorkerOptions.Builder#setAllowActivityHeartbeatDuringShutdown(boolean)} is enabled, in which
+   * case heartbeats keep working until the activity tasks finish executing.<br>
    * This method does not wait for the shutdown to complete. Use {@link #awaitTermination(long,
    * TimeUnit)} to do that.<br>
    * Invocation has no additional effect if already shut down.

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -77,6 +77,7 @@ public final class WorkerOptions {
     private PollerBehavior workflowTaskPollersBehavior;
     private PollerBehavior activityTaskPollersBehavior;
     private PollerBehavior nexusTaskPollersBehavior;
+    private boolean allowActivityHeartbeatDuringShutdown;
 
     private Builder() {}
 
@@ -112,6 +113,7 @@ public final class WorkerOptions {
       this.workflowTaskPollersBehavior = o.workflowTaskPollersBehavior;
       this.activityTaskPollersBehavior = o.activityTaskPollersBehavior;
       this.nexusTaskPollersBehavior = o.nexusTaskPollersBehavior;
+      this.allowActivityHeartbeatDuringShutdown = o.allowActivityHeartbeatDuringShutdown;
     }
 
     /**
@@ -524,6 +526,28 @@ public final class WorkerOptions {
       return this;
     }
 
+    /**
+     * If true, activities can keep heartbeating during graceful worker shutdown (see {@link
+     * io.temporal.worker.WorkerFactory#shutdown WorkerFactory.shutdown}). Defaults to false, which
+     * means that after graceful shutdown is requested, calling {@link
+     * io.temporal.activity.ActivityExecutionContext#heartbeat ActivityExecutionContext.heartbeat}
+     * does not send a heartbeat and instead throws {@link
+     * io.temporal.client.ActivityWorkerShutdownException ActivityWorkerShutdownException}. This
+     * option is ignored by non-graceful shutdown (see {@link
+     * io.temporal.worker.WorkerFactory#shutdownNow WorkerFactory.shutdownNow}).
+     *
+     * <p>Note that with this option enabled, activities are no longer notified of the worker
+     * shutdown by the {@link io.temporal.client.ActivityWorkerShutdownException
+     * ActivityWorkerShutdownException} exception, so they are expected to complete within the
+     * termination grace period on their own.
+     */
+    @Experimental
+    public Builder setAllowActivityHeartbeatDuringShutdown(
+        boolean allowActivityHeartbeatDuringShutdown) {
+      this.allowActivityHeartbeatDuringShutdown = allowActivityHeartbeatDuringShutdown;
+      return this;
+    }
+
     public WorkerOptions build() {
       return new WorkerOptions(
           maxWorkerActivitiesPerSecond,
@@ -553,7 +577,8 @@ public final class WorkerOptions {
           deploymentOptions,
           workflowTaskPollersBehavior,
           activityTaskPollersBehavior,
-          nexusTaskPollersBehavior);
+          nexusTaskPollersBehavior,
+          allowActivityHeartbeatDuringShutdown);
     }
 
     public WorkerOptions validateAndBuildWithDefaults() {
@@ -685,7 +710,8 @@ public final class WorkerOptions {
           deploymentOptions,
           workflowTaskPollersBehavior,
           activityTaskPollersBehavior,
-          nexusTaskPollersBehavior);
+          nexusTaskPollersBehavior,
+          allowActivityHeartbeatDuringShutdown);
     }
   }
 
@@ -717,6 +743,7 @@ public final class WorkerOptions {
   private final PollerBehavior workflowTaskPollersBehavior;
   private final PollerBehavior activityTaskPollersBehavior;
   private final PollerBehavior nexusTaskPollersBehavior;
+  private final boolean allowActivityHeartbeatDuringShutdown;
 
   private WorkerOptions(
       double maxWorkerActivitiesPerSecond,
@@ -746,7 +773,8 @@ public final class WorkerOptions {
       WorkerDeploymentOptions deploymentOptions,
       PollerBehavior workflowTaskPollersBehavior,
       PollerBehavior activityTaskPollersBehavior,
-      PollerBehavior nexusTaskPollersBehavior) {
+      PollerBehavior nexusTaskPollersBehavior,
+      boolean allowActivityHeartbeatDuringShutdown) {
     this.maxWorkerActivitiesPerSecond = maxWorkerActivitiesPerSecond;
     this.maxConcurrentActivityExecutionSize = maxConcurrentActivityExecutionSize;
     this.maxConcurrentWorkflowTaskExecutionSize = maxConcurrentWorkflowTaskExecutionSize;
@@ -775,6 +803,7 @@ public final class WorkerOptions {
     this.workflowTaskPollersBehavior = workflowTaskPollersBehavior;
     this.activityTaskPollersBehavior = activityTaskPollersBehavior;
     this.nexusTaskPollersBehavior = nexusTaskPollersBehavior;
+    this.allowActivityHeartbeatDuringShutdown = allowActivityHeartbeatDuringShutdown;
   }
 
   public double getMaxWorkerActivitiesPerSecond() {
@@ -912,6 +941,11 @@ public final class WorkerOptions {
     return nexusTaskPollersBehavior;
   }
 
+  @Experimental
+  public boolean getAllowActivityHeartbeatDuringShutdown() {
+    return allowActivityHeartbeatDuringShutdown;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -944,7 +978,8 @@ public final class WorkerOptions {
         && Objects.equals(deploymentOptions, that.deploymentOptions)
         && Objects.equals(workflowTaskPollersBehavior, that.workflowTaskPollersBehavior)
         && Objects.equals(activityTaskPollersBehavior, that.activityTaskPollersBehavior)
-        && Objects.equals(nexusTaskPollersBehavior, that.nexusTaskPollersBehavior);
+        && Objects.equals(nexusTaskPollersBehavior, that.nexusTaskPollersBehavior)
+        && allowActivityHeartbeatDuringShutdown == that.allowActivityHeartbeatDuringShutdown;
   }
 
   @Override
@@ -977,7 +1012,8 @@ public final class WorkerOptions {
         deploymentOptions,
         workflowTaskPollersBehavior,
         activityTaskPollersBehavior,
-        nexusTaskPollersBehavior);
+        nexusTaskPollersBehavior,
+        allowActivityHeartbeatDuringShutdown);
   }
 
   @Override
@@ -1040,6 +1076,8 @@ public final class WorkerOptions {
         + activityTaskPollersBehavior
         + ", nexusTaskPollersBehavior="
         + nexusTaskPollersBehavior
+        + ", allowActivityHeartbeatDuringShutdown="
+        + allowActivityHeartbeatDuringShutdown
         + '}';
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerOptionsTest.java
@@ -56,6 +56,7 @@ public class WorkerOptionsTest {
             .setBuildId("build-id")
             .setStickyTaskQueueDrainTimeout(Duration.ofSeconds(15))
             .setIdentity("worker-identity")
+            .setAllowActivityHeartbeatDuringShutdown(true)
             .build();
 
     WorkerOptions w2 = WorkerOptions.newBuilder(w1).build();
@@ -89,6 +90,8 @@ public class WorkerOptionsTest {
     assertEquals(w1.getBuildId(), w2.getBuildId());
     assertEquals(w1.getStickyTaskQueueDrainTimeout(), w2.getStickyTaskQueueDrainTimeout());
     assertEquals(w1.getIdentity(), w2.getIdentity());
+    assertEquals(
+        w1.getAllowActivityHeartbeatDuringShutdown(), w2.getAllowActivityHeartbeatDuringShutdown());
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/HeartbeatDuringWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/HeartbeatDuringWorkerShutdownTest.java
@@ -1,0 +1,143 @@
+package io.temporal.worker.shutdown;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import io.temporal.activity.Activity;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.client.ActivityClient;
+import io.temporal.client.ActivityClientOptions;
+import io.temporal.client.ActivityFailedException;
+import io.temporal.client.ActivityHandle;
+import io.temporal.client.ActivityWorkerShutdownException;
+import io.temporal.client.StartActivityOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.WorkerOptions;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for {@link WorkerOptions.Builder#setAllowActivityHeartbeatDuringShutdown(boolean)}. Gated
+ * behind {@link SDKTestWorkflowRule#useExternalService} because the embedded test server may not
+ * support the standalone activity APIs.
+ */
+public class HeartbeatDuringWorkerShutdownTest {
+
+  private static final String EXPECTED_RESULT = "completed";
+
+  private final Semaphore activityStarted = new Semaphore(0);
+  private final Semaphore shutdownTriggered = new Semaphore(0);
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setTestTimeoutSeconds(60)
+          .setWorkerOptions(
+              WorkerOptions.newBuilder().setAllowActivityHeartbeatDuringShutdown(true).build())
+          .setActivityImplementations(
+              new HeartbeatingActivityImpl(activityStarted, shutdownTriggered))
+          .build();
+
+  /**
+   * Tests that when {@link WorkerOptions.Builder#setAllowActivityHeartbeatDuringShutdown(boolean)}
+   * is enabled, heartbeats keep working after a graceful worker shutdown is initiated and the
+   * activity runs to completion instead of getting an {@link
+   * io.temporal.client.ActivityWorkerShutdownException}.
+   */
+  @Test
+  public void testHeartbeatingActivityCompletesDuringShutdown() throws InterruptedException {
+    assumeTrue(SDKTestWorkflowRule.useExternalService);
+    ActivityHandle<String> handle = startHeartbeatingActivity();
+
+    assertTrue(
+        "Activity did not start within 30s", activityStarted.tryAcquire(30, TimeUnit.SECONDS));
+    testWorkflowRule.getTestEnvironment().shutdown();
+    shutdownTriggered.release();
+
+    // a heartbeat failure would fail the activity and make getResult throw
+    assertEquals(EXPECTED_RESULT, handle.getResult());
+    testWorkflowRule.getTestEnvironment().awaitTermination(30, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Tests that {@link WorkerOptions.Builder#setAllowActivityHeartbeatDuringShutdown(boolean)} is
+   * ignored by {@link io.temporal.worker.WorkerFactory#shutdownNow()}: the heartbeat fails the
+   * activity with an {@link io.temporal.client.ActivityWorkerShutdownException} instead of letting
+   * it complete.
+   */
+  @Test
+  public void testHeartbeatingActivityFailsDuringShutdownNow() throws InterruptedException {
+    assumeTrue(SDKTestWorkflowRule.useExternalService);
+    ActivityHandle<String> handle = startHeartbeatingActivity();
+
+    assertTrue(
+        "Activity did not start within 30s", activityStarted.tryAcquire(30, TimeUnit.SECONDS));
+    testWorkflowRule.getTestEnvironment().shutdownNow();
+    shutdownTriggered.release();
+
+    // if heartbeating was incorrectly allowed, the activity would complete successfully and this
+    // assertion would fail
+    ActivityFailedException ex = assertThrows(ActivityFailedException.class, handle::getResult);
+    // the heartbeat is rejected with ActivityWorkerShutdownException, which crosses the server
+    // boundary as an ApplicationFailure whose type is the exception's class name
+    assertEquals(
+        ActivityWorkerShutdownException.class.getName(),
+        ((ApplicationFailure) ex.getCause()).getType());
+    testWorkflowRule.getTestEnvironment().awaitTermination(30, TimeUnit.SECONDS);
+  }
+
+  private ActivityHandle<String> startHeartbeatingActivity() {
+    ActivityClient client =
+        ActivityClient.newInstance(
+            testWorkflowRule.getWorkflowServiceStubs(),
+            ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+    StartActivityOptions options =
+        StartActivityOptions.newBuilder()
+            .setId("heartbeat-during-shutdown-" + UUID.randomUUID())
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .setScheduleToCloseTimeout(Duration.ofSeconds(30))
+            .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
+            .build();
+    return client.start(HeartbeatingActivity.class, HeartbeatingActivity::execute, options);
+  }
+
+  @ActivityInterface
+  public interface HeartbeatingActivity {
+    @ActivityMethod
+    String execute();
+  }
+
+  public static class HeartbeatingActivityImpl implements HeartbeatingActivity {
+    private final Semaphore activityStarted;
+    private final Semaphore shutdownTriggered;
+
+    public HeartbeatingActivityImpl(Semaphore activityStarted, Semaphore shutdownTriggered) {
+      this.activityStarted = activityStarted;
+      this.shutdownTriggered = shutdownTriggered;
+    }
+
+    @Override
+    public String execute() {
+      activityStarted.release();
+      try {
+        if (!shutdownTriggered.tryAcquire(30, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("Worker shutdown was not triggered within 30s");
+        }
+      } catch (InterruptedException e) {
+        // we ignore the interruption issued by shutdownNow and proceed to the heartbeat below,
+        // which is the signal under test
+      }
+      Activity.getExecutionContext().heartbeat("progress");
+      return EXPECTED_RESULT;
+    }
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Added an experimental worker option, `WorkerOptions.Builder#setAllowActivityHeartbeatDuringShutdown(boolean)` (default `false`, preserving the existing behavior).

- When **enabled**, on a graceful worker shutdown the activity heartbeat executor is shut down **only after all outstanding activity tasks have finished executing**, so in-flight activities keep heartbeating through the existing mechanism — no separate heartbeat code path.
- When **disabled** (default), or whenever `shutdownNow` is used, the behavior is unchanged: the heartbeat executor is shut down first, so `ActivityExecutionContext.heartbeat()` throws `ActivityWorkerShutdownException`.
- Gated by `allowActivityHeartbeatDuringShutdown && !interruptTasks`, so non-graceful shutdown (`WorkerFactory.shutdownNow`) always behaves as if the option were disabled.

Touched: `WorkerOptions`, `SingleWorkerOptions`, `Worker`, `SyncActivityWorker`.

## Why?

- **Before:** once a graceful shutdown was requested, `heartbeat()` threw `ActivityWorkerShutdownException` for the rest of the `awaitTermination` grace period. An activity that wanted to run to completion during that window could not refresh its server-side heartbeat deadline → the server timed it out and retried it → duplicate executions, even though the worker deliberately gave the activity time to finish.
- **After (opt-in):** with the option enabled, in-flight activities keep heartbeating during the grace period, so each call refreshes the heartbeat deadline and the server does not prematurely time out / retry the activity.
- **Design:** reuses the existing heartbeat path by only reordering executor shutdown — no new heartbeat logic. The default stays `false`, so existing behavior is preserved, and `shutdownNow` is intentionally excluded. Originates from #2075.

Note: with the option enabled, activities are no longer notified of shutdown via `ActivityWorkerShutdownException`, so they are expected to complete within the termination grace period on their own. This is documented on the setter.

## Checklist

1. Closes #2075

2. How was this tested:

   New `HeartbeatDuringWorkerShutdownTest` (standalone activity + two-semaphore handshake; gated behind `SDKTestWorkflowRule.useExternalService`):
   - `testHeartbeatingActivityCompletesDuringShutdown` — option enabled + graceful `shutdown()`: the activity heartbeats and runs to completion.
   - `testHeartbeatingActivityFailsDuringShutdownNow` — `shutdownNow()`: the option is ignored, and the heartbeat fails the activity.

   `WorkerOptionsTest` — copy-builder round-trips the new option.

   ```
   # the integration tests require an external server
   USE_EXTERNAL_SERVICE=true TEMPORAL_SERVICE_ADDRESS=localhost:7233 \
     ./gradlew :temporal-sdk:test --tests "io.temporal.worker.shutdown.HeartbeatDuringWorkerShutdownTest"
   ./gradlew :temporal-sdk:test --tests "io.temporal.worker.WorkerOptionsTest"
   ./gradlew :temporal-sdk:spotlessJavaCheck
   ```

3. Any docs updates needed?

   - The behavior is documented in the `WorkerOptions.Builder#setAllowActivityHeartbeatDuringShutdown` Javadoc.