### PR TITLE
Add OpenTracing interceptor for standalone activities

### DIFF
--- a/contrib/temporal-opentracing/README.md
+++ b/contrib/temporal-opentracing/README.md
@@ -6,7 +6,7 @@ This module provides a set of Interceptors that adds support for OpenTracing Spa
 
 You want to register two interceptors - one on the Temporal client side, another on the worker side:
 
-1. Client configuration:
+1. Workflow Client configuration:
     ```java
     WorkflowClientOptions.newBuilder()
        //...
@@ -19,6 +19,16 @@ You want to register two interceptors - one on the Temporal client side, another
        //...
        .setWorkerInterceptors(new OpenTracingWorkerInterceptor())
        .build();
+    ```
+
+3. Standalone Activity Client configuration:
+    ```java
+    ActivityClientOptions activityClientOptions =
+        ActivityClientOptions.newBuilder()
+            //...
+            .setInterceptors(Collections.singletonList(new OpenTracingActivityClientInterceptor()))
+            .build();
+    ActivityClient activityClient = ActivityClient.newInstance(service, activityClientOptions);
     ```
 
 ## [OpenTelemetry](https://opentelemetry.io/)
@@ -37,5 +47,4 @@ to hook their OpenTelemetry setup and make it available for OpenTracing API:
     //or io.opentracing.Tracer tracer = OpenTracingShim.createTracerShim(openTelemetry);
     GlobalTracer.registerIfAbsent(tracer);
 ```
-
 

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingActivityClientInterceptor.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/OpenTracingActivityClientInterceptor.java
@@ -1,0 +1,30 @@
+package io.temporal.opentracing;
+
+import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
+import io.temporal.common.interceptors.ActivityClientInterceptorBase;
+import io.temporal.opentracing.internal.ContextAccessor;
+import io.temporal.opentracing.internal.OpenTracingActivityClientCallsInterceptor;
+import io.temporal.opentracing.internal.SpanFactory;
+
+public class OpenTracingActivityClientInterceptor extends ActivityClientInterceptorBase {
+  private final OpenTracingOptions options;
+  private final SpanFactory spanFactory;
+  private final ContextAccessor contextAccessor;
+
+  public OpenTracingActivityClientInterceptor() {
+    this(OpenTracingOptions.getDefaultInstance());
+  }
+
+  public OpenTracingActivityClientInterceptor(OpenTracingOptions options) {
+    this.options = options;
+    this.spanFactory = new SpanFactory(options);
+    this.contextAccessor = new ContextAccessor(options);
+  }
+
+  @Override
+  public ActivityClientCallsInterceptor activityClientCallsInterceptor(
+      ActivityClientCallsInterceptor next) {
+    return new OpenTracingActivityClientCallsInterceptor(
+        next, options, spanFactory, contextAccessor);
+  }
+}

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanCreationContext.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanCreationContext.java
@@ -14,6 +14,7 @@ public class SpanCreationContext {
   private final String runId;
   private final String parentWorkflowId;
   private final String parentRunId;
+  private final String activityId;
 
   private SpanCreationContext(
       SpanOperationType spanOperationType,
@@ -21,13 +22,15 @@ public class SpanCreationContext {
       String workflowId,
       String runId,
       String parentWorkflowId,
-      String parentRunId) {
+      String parentRunId,
+      String activityId) {
     this.spanOperationType = spanOperationType;
     this.actionName = actionName;
     this.workflowId = workflowId;
     this.runId = runId;
     this.parentWorkflowId = parentWorkflowId;
     this.parentRunId = parentRunId;
+    this.activityId = activityId;
   }
 
   public SpanOperationType getSpanOperationType() {
@@ -59,6 +62,10 @@ public class SpanCreationContext {
     return parentRunId;
   }
 
+  public @Nullable String getActivityId() {
+    return activityId;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -70,6 +77,7 @@ public class SpanCreationContext {
     private String runId;
     private String parentWorkflowId;
     private String parentRunId;
+    private String activityId;
 
     private Builder() {}
 
@@ -103,9 +111,20 @@ public class SpanCreationContext {
       return this;
     }
 
+    public Builder setActivityId(String activityId) {
+      this.activityId = activityId;
+      return this;
+    }
+
     public SpanCreationContext build() {
       return new SpanCreationContext(
-          spanOperationType, actionName, workflowId, runId, parentWorkflowId, parentRunId);
+          spanOperationType,
+          actionName,
+          workflowId,
+          runId,
+          parentWorkflowId,
+          parentRunId,
+          activityId);
     }
   }
 }

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanOperationType.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanOperationType.java
@@ -16,14 +16,6 @@ public enum SpanOperationType {
   HANDLE_SIGNAL("HandleSignal"),
   HANDLE_UPDATE("HandleUpdate"),
   START_NEXUS_OPERATION("StartNexusOperation"),
-  START_STANDALONE_ACTIVITY("StartStandaloneActivity"),
-  RUN_STANDALONE_ACTIVITY("RunStandaloneActivity"),
-  GET_STANDALONE_ACTIVITY_RESULT("GetStandaloneActivityResult"),
-  DESCRIBE_STANDALONE_ACTIVITY("DescribeStandaloneActivity"),
-  CANCEL_STANDALONE_ACTIVITY("CancelStandaloneActivity"),
-  TERMINATE_STANDALONE_ACTIVITY("TerminateStandaloneActivity"),
-  LIST_STANDALONE_ACTIVITIES("ListStandaloneActivities"),
-  COUNT_STANDALONE_ACTIVITIES("CountStandaloneActivities"),
   RUN_START_NEXUS_OPERATION("RunStartNexusOperationHandler"),
   RUN_CANCEL_NEXUS_OPERATION("RunCancelNexusOperationHandler");
 

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanOperationType.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/SpanOperationType.java
@@ -16,6 +16,14 @@ public enum SpanOperationType {
   HANDLE_SIGNAL("HandleSignal"),
   HANDLE_UPDATE("HandleUpdate"),
   START_NEXUS_OPERATION("StartNexusOperation"),
+  START_STANDALONE_ACTIVITY("StartStandaloneActivity"),
+  RUN_STANDALONE_ACTIVITY("RunStandaloneActivity"),
+  GET_STANDALONE_ACTIVITY_RESULT("GetStandaloneActivityResult"),
+  DESCRIBE_STANDALONE_ACTIVITY("DescribeStandaloneActivity"),
+  CANCEL_STANDALONE_ACTIVITY("CancelStandaloneActivity"),
+  TERMINATE_STANDALONE_ACTIVITY("TerminateStandaloneActivity"),
+  LIST_STANDALONE_ACTIVITIES("ListStandaloneActivities"),
+  COUNT_STANDALONE_ACTIVITIES("CountStandaloneActivities"),
   RUN_START_NEXUS_OPERATION("RunStartNexusOperationHandler"),
   RUN_CANCEL_NEXUS_OPERATION("RunCancelNexusOperationHandler");
 

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/StandardTagNames.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/StandardTagNames.java
@@ -3,6 +3,7 @@ package io.temporal.opentracing;
 public class StandardTagNames {
   public static final String WORKFLOW_ID = "workflowId";
   public static final String RUN_ID = "runId";
+  public static final String ACTIVITY_ID = "activityId";
   public static final String PARENT_WORKFLOW_ID = "parentWorkflowId";
   public static final String PARENT_RUN_ID = "parentRunId";
 

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
@@ -66,8 +66,6 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
             StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.PARENT_RUN_ID, context.getParentRunId());
       case RUN_WORKFLOW:
-      case START_ACTIVITY:
-      case RUN_ACTIVITY:
       case SIGNAL_EXTERNAL_WORKFLOW:
       case SIGNAL_WORKFLOW:
       case UPDATE_WORKFLOW:
@@ -80,19 +78,23 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
         return ImmutableMap.of(
             StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.RUN_ID, context.getRunId());
+      case START_ACTIVITY:
+      case RUN_ACTIVITY:
+        ImmutableMap.Builder<String, String> tags = ImmutableMap.builder();
+        if (context.getActivityId() != null) {
+          tags.put(StandardTagNames.ACTIVITY_ID, context.getActivityId());
+        }
+        if (context.getWorkflowId() != null) {
+          tags.put(StandardTagNames.WORKFLOW_ID, context.getWorkflowId());
+        }
+        if (context.getRunId() != null) {
+          tags.put(StandardTagNames.RUN_ID, context.getRunId());
+        }
+        return tags.build();
       case START_NEXUS_OPERATION:
         return ImmutableMap.of(
             StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.RUN_ID, context.getRunId());
-      case START_STANDALONE_ACTIVITY:
-      case RUN_STANDALONE_ACTIVITY:
-      case GET_STANDALONE_ACTIVITY_RESULT:
-      case DESCRIBE_STANDALONE_ACTIVITY:
-      case CANCEL_STANDALONE_ACTIVITY:
-      case TERMINATE_STANDALONE_ACTIVITY:
-        return ImmutableMap.of(StandardTagNames.ACTIVITY_ID, context.getActivityId());
-      case LIST_STANDALONE_ACTIVITIES:
-      case COUNT_STANDALONE_ACTIVITIES:
       case RUN_START_NEXUS_OPERATION:
       case RUN_CANCEL_NEXUS_OPERATION:
       case HANDLE_QUERY:

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/ActionTypeAndNameSpanBuilderProvider.java
@@ -84,6 +84,15 @@ public class ActionTypeAndNameSpanBuilderProvider implements SpanBuilderProvider
         return ImmutableMap.of(
             StandardTagNames.WORKFLOW_ID, context.getWorkflowId(),
             StandardTagNames.RUN_ID, context.getRunId());
+      case START_STANDALONE_ACTIVITY:
+      case RUN_STANDALONE_ACTIVITY:
+      case GET_STANDALONE_ACTIVITY_RESULT:
+      case DESCRIBE_STANDALONE_ACTIVITY:
+      case CANCEL_STANDALONE_ACTIVITY:
+      case TERMINATE_STANDALONE_ACTIVITY:
+        return ImmutableMap.of(StandardTagNames.ACTIVITY_ID, context.getActivityId());
+      case LIST_STANDALONE_ACTIVITIES:
+      case COUNT_STANDALONE_ACTIVITIES:
       case RUN_START_NEXUS_OPERATION:
       case RUN_CANCEL_NEXUS_OPERATION:
       case HANDLE_QUERY:

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityClientCallsInterceptor.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityClientCallsInterceptor.java
@@ -6,9 +6,6 @@ import io.opentracing.Tracer;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptorBase;
 import io.temporal.opentracing.OpenTracingOptions;
-import io.temporal.opentracing.SpanOperationType;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 
 public class OpenTracingActivityClientCallsInterceptor extends ActivityClientCallsInterceptorBase {
   private final SpanFactory spanFactory;
@@ -32,8 +29,8 @@ public class OpenTracingActivityClientCallsInterceptor extends ActivityClientCal
         contextAccessor.writeSpanContextToHeader(
             () ->
                 spanFactory
-                    .createStandaloneActivityStartSpan(
-                        tracer, input.getActivityType(), input.getOptions().getId())
+                    .createActivityStartSpan(
+                        tracer, input.getActivityType(), null, null, input.getOptions().getId())
                     .start(),
             input.getHeader(),
             tracer);
@@ -41,111 +38,6 @@ public class OpenTracingActivityClientCallsInterceptor extends ActivityClientCal
       return super.startActivity(input);
     } finally {
       activityStartSpan.finish();
-    }
-  }
-
-  @Override
-  public <R> GetActivityResultOutput<R> getActivityResult(GetActivityResultInput<R> input)
-      throws TimeoutException {
-    Span span =
-        spanFactory
-            .createStandaloneActivityOperationSpan(
-                tracer, SpanOperationType.GET_STANDALONE_ACTIVITY_RESULT, input.getActivityId())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.getActivityResult(input);
-    } finally {
-      span.finish();
-    }
-  }
-
-  @Override
-  public <R> CompletableFuture<GetActivityResultOutput<R>> getActivityResultAsync(
-      GetActivityResultInput<R> input) {
-    Span span =
-        spanFactory
-            .createStandaloneActivityOperationSpan(
-                tracer, SpanOperationType.GET_STANDALONE_ACTIVITY_RESULT, input.getActivityId())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.getActivityResultAsync(input)
-          .whenComplete(
-              (result, throwable) -> {
-                span.finish();
-              });
-    } catch (Throwable t) {
-      span.finish();
-      throw t;
-    }
-  }
-
-  @Override
-  public DescribeActivityOutput describeActivity(DescribeActivityInput input) {
-    Span span =
-        spanFactory
-            .createStandaloneActivityOperationSpan(
-                tracer, SpanOperationType.DESCRIBE_STANDALONE_ACTIVITY, input.getId())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.describeActivity(input);
-    } finally {
-      span.finish();
-    }
-  }
-
-  @Override
-  public CancelActivityOutput cancelActivity(CancelActivityInput input) {
-    Span span =
-        spanFactory
-            .createStandaloneActivityOperationSpan(
-                tracer, SpanOperationType.CANCEL_STANDALONE_ACTIVITY, input.getId())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.cancelActivity(input);
-    } finally {
-      span.finish();
-    }
-  }
-
-  @Override
-  public TerminateActivityOutput terminateActivity(TerminateActivityInput input) {
-    Span span =
-        spanFactory
-            .createStandaloneActivityOperationSpan(
-                tracer, SpanOperationType.TERMINATE_STANDALONE_ACTIVITY, input.getId())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.terminateActivity(input);
-    } finally {
-      span.finish();
-    }
-  }
-
-  @Override
-  public ListActivitiesOutput listActivities(ListActivitiesInput input) {
-    Span span =
-        spanFactory
-            .createStandaloneActivityQuerySpan(
-                tracer, SpanOperationType.LIST_STANDALONE_ACTIVITIES, input.getQuery())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.listActivities(input);
-    } finally {
-      span.finish();
-    }
-  }
-
-  @Override
-  public CountActivitiesOutput countActivities(CountActivitiesInput input) {
-    Span span =
-        spanFactory
-            .createStandaloneActivityQuerySpan(
-                tracer, SpanOperationType.COUNT_STANDALONE_ACTIVITIES, input.getQuery())
-            .start();
-    try (Scope ignored = tracer.scopeManager().activate(span)) {
-      return super.countActivities(input);
-    } finally {
-      span.finish();
     }
   }
 }

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityClientCallsInterceptor.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityClientCallsInterceptor.java
@@ -1,0 +1,151 @@
+package io.temporal.opentracing.internal;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
+import io.temporal.common.interceptors.ActivityClientCallsInterceptorBase;
+import io.temporal.opentracing.OpenTracingOptions;
+import io.temporal.opentracing.SpanOperationType;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+public class OpenTracingActivityClientCallsInterceptor extends ActivityClientCallsInterceptorBase {
+  private final SpanFactory spanFactory;
+  private final Tracer tracer;
+  private final ContextAccessor contextAccessor;
+
+  public OpenTracingActivityClientCallsInterceptor(
+      ActivityClientCallsInterceptor next,
+      OpenTracingOptions options,
+      SpanFactory spanFactory,
+      ContextAccessor contextAccessor) {
+    super(next);
+    this.spanFactory = spanFactory;
+    this.tracer = options.getTracer();
+    this.contextAccessor = contextAccessor;
+  }
+
+  @Override
+  public StartActivityOutput startActivity(StartActivityInput input) {
+    Span activityStartSpan =
+        contextAccessor.writeSpanContextToHeader(
+            () ->
+                spanFactory
+                    .createStandaloneActivityStartSpan(
+                        tracer, input.getActivityType(), input.getOptions().getId())
+                    .start(),
+            input.getHeader(),
+            tracer);
+    try (Scope ignored = tracer.scopeManager().activate(activityStartSpan)) {
+      return super.startActivity(input);
+    } finally {
+      activityStartSpan.finish();
+    }
+  }
+
+  @Override
+  public <R> GetActivityResultOutput<R> getActivityResult(GetActivityResultInput<R> input)
+      throws TimeoutException {
+    Span span =
+        spanFactory
+            .createStandaloneActivityOperationSpan(
+                tracer, SpanOperationType.GET_STANDALONE_ACTIVITY_RESULT, input.getActivityId())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.getActivityResult(input);
+    } finally {
+      span.finish();
+    }
+  }
+
+  @Override
+  public <R> CompletableFuture<GetActivityResultOutput<R>> getActivityResultAsync(
+      GetActivityResultInput<R> input) {
+    Span span =
+        spanFactory
+            .createStandaloneActivityOperationSpan(
+                tracer, SpanOperationType.GET_STANDALONE_ACTIVITY_RESULT, input.getActivityId())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.getActivityResultAsync(input)
+          .whenComplete(
+              (result, throwable) -> {
+                span.finish();
+              });
+    } catch (Throwable t) {
+      span.finish();
+      throw t;
+    }
+  }
+
+  @Override
+  public DescribeActivityOutput describeActivity(DescribeActivityInput input) {
+    Span span =
+        spanFactory
+            .createStandaloneActivityOperationSpan(
+                tracer, SpanOperationType.DESCRIBE_STANDALONE_ACTIVITY, input.getId())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.describeActivity(input);
+    } finally {
+      span.finish();
+    }
+  }
+
+  @Override
+  public CancelActivityOutput cancelActivity(CancelActivityInput input) {
+    Span span =
+        spanFactory
+            .createStandaloneActivityOperationSpan(
+                tracer, SpanOperationType.CANCEL_STANDALONE_ACTIVITY, input.getId())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.cancelActivity(input);
+    } finally {
+      span.finish();
+    }
+  }
+
+  @Override
+  public TerminateActivityOutput terminateActivity(TerminateActivityInput input) {
+    Span span =
+        spanFactory
+            .createStandaloneActivityOperationSpan(
+                tracer, SpanOperationType.TERMINATE_STANDALONE_ACTIVITY, input.getId())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.terminateActivity(input);
+    } finally {
+      span.finish();
+    }
+  }
+
+  @Override
+  public ListActivitiesOutput listActivities(ListActivitiesInput input) {
+    Span span =
+        spanFactory
+            .createStandaloneActivityQuerySpan(
+                tracer, SpanOperationType.LIST_STANDALONE_ACTIVITIES, input.getQuery())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.listActivities(input);
+    } finally {
+      span.finish();
+    }
+  }
+
+  @Override
+  public CountActivitiesOutput countActivities(CountActivitiesInput input) {
+    Span span =
+        spanFactory
+            .createStandaloneActivityQuerySpan(
+                tracer, SpanOperationType.COUNT_STANDALONE_ACTIVITIES, input.getQuery())
+            .start();
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
+      return super.countActivities(input);
+    } finally {
+      span.finish();
+    }
+  }
+}

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -46,22 +46,15 @@ public class OpenTracingActivityInboundCallsInterceptor
         contextAccessor.readSpanContextFromHeader(input.getHeader(), tracer);
     ActivityInfo activityInfo = activityExecutionContext.getInfo();
     Span activityRunSpan =
-        activityInfo.isInWorkflow()
-            ? spanFactory
-                .createActivityRunSpan(
-                    tracer,
-                    activityInfo.getActivityType(),
-                    activityInfo.getWorkflowId(),
-                    activityInfo.getWorkflowRunId(),
-                    rootSpanContext)
-                .start()
-            : spanFactory
-                .createStandaloneActivityRunSpan(
-                    tracer,
-                    activityInfo.getActivityType(),
-                    activityInfo.getActivityId(),
-                    rootSpanContext)
-                .start();
+        spanFactory
+            .createActivityRunSpan(
+                tracer,
+                activityInfo.getActivityType(),
+                activityInfo.getWorkflowId(),
+                activityInfo.getWorkflowRunId(),
+                activityInfo.getActivityId(),
+                rootSpanContext)
+            .start();
     try (Scope scope = tracer.scopeManager().activate(activityRunSpan)) {
       return super.execute(input);
     } catch (Throwable t) {

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingActivityInboundCallsInterceptor.java
@@ -46,14 +46,22 @@ public class OpenTracingActivityInboundCallsInterceptor
         contextAccessor.readSpanContextFromHeader(input.getHeader(), tracer);
     ActivityInfo activityInfo = activityExecutionContext.getInfo();
     Span activityRunSpan =
-        spanFactory
-            .createActivityRunSpan(
-                tracer,
-                activityInfo.getActivityType(),
-                activityInfo.getWorkflowId(),
-                activityInfo.getWorkflowRunId(),
-                rootSpanContext)
-            .start();
+        activityInfo.isInWorkflow()
+            ? spanFactory
+                .createActivityRunSpan(
+                    tracer,
+                    activityInfo.getActivityType(),
+                    activityInfo.getWorkflowId(),
+                    activityInfo.getWorkflowRunId(),
+                    rootSpanContext)
+                .start()
+            : spanFactory
+                .createStandaloneActivityRunSpan(
+                    tracer,
+                    activityInfo.getActivityType(),
+                    activityInfo.getActivityId(),
+                    rootSpanContext)
+                .start();
     try (Scope scope = tracer.scopeManager().activate(activityRunSpan)) {
       return super.execute(input);
     } catch (Throwable t) {

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowOutboundCallsInterceptor.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/OpenTracingWorkflowOutboundCallsInterceptor.java
@@ -251,7 +251,7 @@ public class OpenTracingWorkflowOutboundCallsInterceptor
   private Tracer.SpanBuilder createActivityStartSpanBuilder(String activityName) {
     WorkflowInfo workflowInfo = Workflow.getInfo();
     return spanFactory.createActivityStartSpan(
-        tracer, activityName, workflowInfo.getWorkflowId(), workflowInfo.getRunId());
+        tracer, activityName, workflowInfo.getWorkflowId(), workflowInfo.getRunId(), null);
   }
 
   private <R> Tracer.SpanBuilder createChildWorkflowStartSpanBuilder(ChildWorkflowInput<R> input) {

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -140,12 +140,22 @@ public class SpanFactory {
 
   public Tracer.SpanBuilder createActivityStartSpan(
       Tracer tracer, String activityType, String workflowId, String runId) {
+    return createActivityStartSpan(tracer, activityType, workflowId, runId, null);
+  }
+
+  public Tracer.SpanBuilder createActivityStartSpan(
+      Tracer tracer,
+      String activityType,
+      @Nullable String workflowId,
+      @Nullable String runId,
+      @Nullable String activityId) {
     SpanCreationContext context =
         SpanCreationContext.newBuilder()
             .setSpanOperationType(SpanOperationType.START_ACTIVITY)
             .setActionName(activityType)
             .setWorkflowId(workflowId)
             .setRunId(runId)
+            .setActivityId(activityId)
             .build();
     return createSpan(context, tracer, null, References.CHILD_OF);
   }
@@ -153,8 +163,9 @@ public class SpanFactory {
   public Tracer.SpanBuilder createActivityRunSpan(
       Tracer tracer,
       String activityType,
-      String workflowId,
-      String runId,
+      @Nullable String workflowId,
+      @Nullable String runId,
+      @Nullable String activityId,
       SpanContext activityStartSpanContext) {
     SpanCreationContext context =
         SpanCreationContext.newBuilder()
@@ -162,6 +173,7 @@ public class SpanFactory {
             .setActionName(activityType)
             .setWorkflowId(workflowId)
             .setRunId(runId)
+            .setActivityId(activityId)
             .build();
     return createSpan(context, tracer, activityStartSpanContext, References.FOLLOWS_FROM);
   }
@@ -184,52 +196,6 @@ public class SpanFactory {
             .setActionName(serviceName + "/" + operationName)
             .build();
     return createSpan(context, tracer, nexusStartSpanContext, References.FOLLOWS_FROM);
-  }
-
-  public Tracer.SpanBuilder createStandaloneActivityStartSpan(
-      Tracer tracer, String activityType, String activityId) {
-    SpanCreationContext context =
-        SpanCreationContext.newBuilder()
-            .setSpanOperationType(SpanOperationType.START_STANDALONE_ACTIVITY)
-            .setActionName(activityType)
-            .setActivityId(activityId)
-            .build();
-    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
-  }
-
-  public Tracer.SpanBuilder createStandaloneActivityRunSpan(
-      Tracer tracer,
-      String activityType,
-      String activityId,
-      SpanContext activityStartSpanContext) {
-    SpanCreationContext context =
-        SpanCreationContext.newBuilder()
-            .setSpanOperationType(SpanOperationType.RUN_STANDALONE_ACTIVITY)
-            .setActionName(activityType)
-            .setActivityId(activityId)
-            .build();
-    return createSpan(context, tracer, activityStartSpanContext, References.FOLLOWS_FROM);
-  }
-
-  public Tracer.SpanBuilder createStandaloneActivityOperationSpan(
-      Tracer tracer, SpanOperationType operationType, String activityId) {
-    SpanCreationContext context =
-        SpanCreationContext.newBuilder()
-            .setSpanOperationType(operationType)
-            .setActionName("StandaloneActivity")
-            .setActivityId(activityId)
-            .build();
-    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
-  }
-
-  public Tracer.SpanBuilder createStandaloneActivityQuerySpan(
-      Tracer tracer, SpanOperationType operationType, String query) {
-    SpanCreationContext context =
-        SpanCreationContext.newBuilder()
-            .setSpanOperationType(operationType)
-            .setActionName(query)
-            .build();
-    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
   }
 
   public Tracer.SpanBuilder createWorkflowStartUpdateSpan(

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -186,6 +186,52 @@ public class SpanFactory {
     return createSpan(context, tracer, nexusStartSpanContext, References.FOLLOWS_FROM);
   }
 
+  public Tracer.SpanBuilder createStandaloneActivityStartSpan(
+      Tracer tracer, String activityType, String activityId) {
+    SpanCreationContext context =
+        SpanCreationContext.newBuilder()
+            .setSpanOperationType(SpanOperationType.START_STANDALONE_ACTIVITY)
+            .setActionName(activityType)
+            .setActivityId(activityId)
+            .build();
+    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
+  }
+
+  public Tracer.SpanBuilder createStandaloneActivityRunSpan(
+      Tracer tracer,
+      String activityType,
+      String activityId,
+      SpanContext activityStartSpanContext) {
+    SpanCreationContext context =
+        SpanCreationContext.newBuilder()
+            .setSpanOperationType(SpanOperationType.RUN_STANDALONE_ACTIVITY)
+            .setActionName(activityType)
+            .setActivityId(activityId)
+            .build();
+    return createSpan(context, tracer, activityStartSpanContext, References.FOLLOWS_FROM);
+  }
+
+  public Tracer.SpanBuilder createStandaloneActivityOperationSpan(
+      Tracer tracer, SpanOperationType operationType, String activityId) {
+    SpanCreationContext context =
+        SpanCreationContext.newBuilder()
+            .setSpanOperationType(operationType)
+            .setActionName("StandaloneActivity")
+            .setActivityId(activityId)
+            .build();
+    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
+  }
+
+  public Tracer.SpanBuilder createStandaloneActivityQuerySpan(
+      Tracer tracer, SpanOperationType operationType, String query) {
+    SpanCreationContext context =
+        SpanCreationContext.newBuilder()
+            .setSpanOperationType(operationType)
+            .setActionName(query)
+            .build();
+    return createSpan(context, tracer, null, References.FOLLOWS_FROM);
+  }
+
   public Tracer.SpanBuilder createWorkflowStartUpdateSpan(
       Tracer tracer, String updateName, String workflowId, String runId) {
     SpanCreationContext context =

--- a/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
+++ b/contrib/temporal-opentracing/src/main/java/io/temporal/opentracing/internal/SpanFactory.java
@@ -139,11 +139,6 @@ public class SpanFactory {
   }
 
   public Tracer.SpanBuilder createActivityStartSpan(
-      Tracer tracer, String activityType, String workflowId, String runId) {
-    return createActivityStartSpan(tracer, activityType, workflowId, runId, null);
-  }
-
-  public Tracer.SpanBuilder createActivityStartSpan(
       Tracer tracer,
       String activityType,
       @Nullable String workflowId,

--- a/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityClientTracingTest.java
+++ b/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityClientTracingTest.java
@@ -24,11 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link OpenTracingActivityClientCallsInterceptor}. Verifies that each intercepted
- * method creates a span with the expected operation name and tags. Uses a stub next-interceptor so
- * no server is required.
- */
+/** Unit tests for standalone activity tracing on the client side. */
 public class StandaloneActivityClientTracingTest {
 
   private final MockTracer mockTracer =
@@ -73,135 +69,9 @@ public class StandaloneActivityClientTracingTest {
     List<MockSpan> spans = mockTracer.finishedSpans();
     assertEquals(1, spans.size());
     MockSpan span = spans.get(0);
-    assertEquals("StartStandaloneActivity:MyActivity", span.operationName());
+    assertEquals("StartActivity:MyActivity", span.operationName());
     assertEquals("act-123", span.tags().get("activityId"));
     assertFalse("Trace context should be propagated into header", header.getValues().isEmpty());
-  }
-
-  @Test
-  public void testGetActivityResultCreatesSpan() throws TimeoutException {
-    ActivityClientCallsInterceptor.GetActivityResultInput<String> input =
-        new ActivityClientCallsInterceptor.GetActivityResultInput<>("act-456", null, String.class);
-
-    interceptor.getActivityResult(input);
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("GetStandaloneActivityResult:StandaloneActivity", span.operationName());
-    assertEquals("act-456", span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testGetActivityResultAsyncCreatesSpan() throws Exception {
-    ActivityClientCallsInterceptor.GetActivityResultInput<String> input =
-        new ActivityClientCallsInterceptor.GetActivityResultInput<>("act-789", null, String.class);
-
-    CompletableFuture<ActivityClientCallsInterceptor.GetActivityResultOutput<String>> future =
-        interceptor.getActivityResultAsync(input);
-    future.get();
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("GetStandaloneActivityResult:StandaloneActivity", span.operationName());
-    assertEquals("act-789", span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testGetActivityResultAsyncFinishesSpanWhenNextThrowsSynchronously() {
-    OpenTracingActivityClientCallsInterceptor throwingInterceptor =
-        new OpenTracingActivityClientCallsInterceptor(
-            new SynchronouslyThrowingActivityClientCallsInterceptor(),
-            otOptions,
-            new SpanFactory(otOptions),
-            new ContextAccessor(otOptions));
-    ActivityClientCallsInterceptor.GetActivityResultInput<String> input =
-        new ActivityClientCallsInterceptor.GetActivityResultInput<>(
-            "act-throws", null, String.class);
-
-    try {
-      throwingInterceptor.getActivityResultAsync(input);
-      fail("Expected getActivityResultAsync to throw");
-    } catch (IllegalStateException expected) {
-      assertEquals("sync failure", expected.getMessage());
-    }
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("GetStandaloneActivityResult:StandaloneActivity", span.operationName());
-    assertEquals("act-throws", span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testDescribeActivityCreatesSpan() {
-    ActivityClientCallsInterceptor.DescribeActivityInput input =
-        new ActivityClientCallsInterceptor.DescribeActivityInput("act-desc", null);
-
-    interceptor.describeActivity(input);
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("DescribeStandaloneActivity:StandaloneActivity", span.operationName());
-    assertEquals("act-desc", span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testCancelActivityCreatesSpan() {
-    ActivityClientCallsInterceptor.CancelActivityInput input =
-        new ActivityClientCallsInterceptor.CancelActivityInput("act-cancel", null, "reason");
-
-    interceptor.cancelActivity(input);
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("CancelStandaloneActivity:StandaloneActivity", span.operationName());
-    assertEquals("act-cancel", span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testTerminateActivityCreatesSpan() {
-    ActivityClientCallsInterceptor.TerminateActivityInput input =
-        new ActivityClientCallsInterceptor.TerminateActivityInput("act-term", null, "reason");
-
-    interceptor.terminateActivity(input);
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("TerminateStandaloneActivity:StandaloneActivity", span.operationName());
-    assertEquals("act-term", span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testListActivitiesCreatesSpan() {
-    ActivityClientCallsInterceptor.ListActivitiesInput input =
-        new ActivityClientCallsInterceptor.ListActivitiesInput("TaskQueue = 'tq'");
-
-    interceptor.listActivities(input);
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("ListStandaloneActivities:TaskQueue = 'tq'", span.operationName());
-    assertNull(span.tags().get("activityId"));
-  }
-
-  @Test
-  public void testCountActivitiesCreatesSpan() {
-    ActivityClientCallsInterceptor.CountActivitiesInput input =
-        new ActivityClientCallsInterceptor.CountActivitiesInput("TaskQueue = 'tq'");
-
-    interceptor.countActivities(input);
-
-    List<MockSpan> spans = mockTracer.finishedSpans();
-    assertEquals(1, spans.size());
-    MockSpan span = spans.get(0);
-    assertEquals("CountStandaloneActivities:TaskQueue = 'tq'", span.operationName());
-    assertNull(span.tags().get("activityId"));
   }
 
   @Test
@@ -225,8 +95,30 @@ public class StandaloneActivityClientTracingTest {
     assertEquals(2, spans.size());
 
     MockSpan activitySpan = spans.get(0);
-    assertEquals("StartStandaloneActivity:MyActivity", activitySpan.operationName());
+    assertEquals("StartActivity:MyActivity", activitySpan.operationName());
     assertEquals(parentSpan.context().spanId(), activitySpan.parentId());
+  }
+
+  @Test
+  public void testManagementCallsDoNotCreateSpans() throws TimeoutException {
+    interceptor.getActivityResult(
+        new ActivityClientCallsInterceptor.GetActivityResultInput<>(
+            "act-result", null, String.class));
+    interceptor.getActivityResultAsync(
+        new ActivityClientCallsInterceptor.GetActivityResultInput<>(
+            "act-result-async", null, String.class));
+    interceptor.describeActivity(
+        new ActivityClientCallsInterceptor.DescribeActivityInput("act-desc", null));
+    interceptor.cancelActivity(
+        new ActivityClientCallsInterceptor.CancelActivityInput("act-cancel", null, "reason"));
+    interceptor.terminateActivity(
+        new ActivityClientCallsInterceptor.TerminateActivityInput("act-term", null, "reason"));
+    interceptor.listActivities(
+        new ActivityClientCallsInterceptor.ListActivitiesInput("TaskQueue = 'tq'"));
+    interceptor.countActivities(
+        new ActivityClientCallsInterceptor.CountActivitiesInput("TaskQueue = 'tq'"));
+
+    assertTrue(mockTracer.finishedSpans().isEmpty());
   }
 
   private static class StubActivityClientCallsInterceptor
@@ -277,20 +169,6 @@ public class StandaloneActivityClientTracingTest {
     public CountActivitiesOutput countActivities(CountActivitiesInput input) {
       return new CountActivitiesOutput(
           new ActivityExecutionCount(CountActivityExecutionsResponse.getDefaultInstance()));
-    }
-  }
-
-  private static class SynchronouslyThrowingActivityClientCallsInterceptor
-      extends ActivityClientCallsInterceptorBase {
-
-    SynchronouslyThrowingActivityClientCallsInterceptor() {
-      super(null);
-    }
-
-    @Override
-    public <R> CompletableFuture<GetActivityResultOutput<R>> getActivityResultAsync(
-        GetActivityResultInput<R> input) {
-      throw new IllegalStateException("sync failure");
     }
   }
 }

--- a/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityClientTracingTest.java
+++ b/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityClientTracingTest.java
@@ -1,0 +1,296 @@
+package io.temporal.opentracing;
+
+import static org.junit.Assert.*;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.temporal.api.workflowservice.v1.CountActivityExecutionsResponse;
+import io.temporal.client.ActivityExecutionCount;
+import io.temporal.client.StartActivityOptions;
+import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
+import io.temporal.common.interceptors.ActivityClientCallsInterceptorBase;
+import io.temporal.common.interceptors.Header;
+import io.temporal.opentracing.internal.ContextAccessor;
+import io.temporal.opentracing.internal.OpenTracingActivityClientCallsInterceptor;
+import io.temporal.opentracing.internal.SpanFactory;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link OpenTracingActivityClientCallsInterceptor}. Verifies that each intercepted
+ * method creates a span with the expected operation name and tags. Uses a stub next-interceptor so
+ * no server is required.
+ */
+public class StandaloneActivityClientTracingTest {
+
+  private final MockTracer mockTracer =
+      new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
+
+  private final OpenTracingOptions otOptions =
+      OpenTracingOptions.newBuilder().setTracer(mockTracer).build();
+
+  private OpenTracingActivityClientCallsInterceptor interceptor;
+
+  @Before
+  public void setUp() {
+    mockTracer.reset();
+    interceptor =
+        new OpenTracingActivityClientCallsInterceptor(
+            new StubActivityClientCallsInterceptor(),
+            otOptions,
+            new SpanFactory(otOptions),
+            new ContextAccessor(otOptions));
+  }
+
+  @After
+  public void tearDown() {
+    mockTracer.reset();
+  }
+
+  @Test
+  public void testStartActivityCreatesSpanWithHeaderPropagation() {
+    StartActivityOptions opts =
+        StartActivityOptions.newBuilder()
+            .setId("act-123")
+            .setTaskQueue("tq")
+            .setScheduleToCloseTimeout(Duration.ofMinutes(1))
+            .build();
+    Header header = Header.empty();
+    ActivityClientCallsInterceptor.StartActivityInput input =
+        new ActivityClientCallsInterceptor.StartActivityInput(
+            "MyActivity", Collections.emptyList(), opts, header);
+
+    interceptor.startActivity(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("StartStandaloneActivity:MyActivity", span.operationName());
+    assertEquals("act-123", span.tags().get("activityId"));
+    assertFalse("Trace context should be propagated into header", header.getValues().isEmpty());
+  }
+
+  @Test
+  public void testGetActivityResultCreatesSpan() throws TimeoutException {
+    ActivityClientCallsInterceptor.GetActivityResultInput<String> input =
+        new ActivityClientCallsInterceptor.GetActivityResultInput<>("act-456", null, String.class);
+
+    interceptor.getActivityResult(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("GetStandaloneActivityResult:StandaloneActivity", span.operationName());
+    assertEquals("act-456", span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testGetActivityResultAsyncCreatesSpan() throws Exception {
+    ActivityClientCallsInterceptor.GetActivityResultInput<String> input =
+        new ActivityClientCallsInterceptor.GetActivityResultInput<>("act-789", null, String.class);
+
+    CompletableFuture<ActivityClientCallsInterceptor.GetActivityResultOutput<String>> future =
+        interceptor.getActivityResultAsync(input);
+    future.get();
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("GetStandaloneActivityResult:StandaloneActivity", span.operationName());
+    assertEquals("act-789", span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testGetActivityResultAsyncFinishesSpanWhenNextThrowsSynchronously() {
+    OpenTracingActivityClientCallsInterceptor throwingInterceptor =
+        new OpenTracingActivityClientCallsInterceptor(
+            new SynchronouslyThrowingActivityClientCallsInterceptor(),
+            otOptions,
+            new SpanFactory(otOptions),
+            new ContextAccessor(otOptions));
+    ActivityClientCallsInterceptor.GetActivityResultInput<String> input =
+        new ActivityClientCallsInterceptor.GetActivityResultInput<>(
+            "act-throws", null, String.class);
+
+    try {
+      throwingInterceptor.getActivityResultAsync(input);
+      fail("Expected getActivityResultAsync to throw");
+    } catch (IllegalStateException expected) {
+      assertEquals("sync failure", expected.getMessage());
+    }
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("GetStandaloneActivityResult:StandaloneActivity", span.operationName());
+    assertEquals("act-throws", span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testDescribeActivityCreatesSpan() {
+    ActivityClientCallsInterceptor.DescribeActivityInput input =
+        new ActivityClientCallsInterceptor.DescribeActivityInput("act-desc", null);
+
+    interceptor.describeActivity(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("DescribeStandaloneActivity:StandaloneActivity", span.operationName());
+    assertEquals("act-desc", span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testCancelActivityCreatesSpan() {
+    ActivityClientCallsInterceptor.CancelActivityInput input =
+        new ActivityClientCallsInterceptor.CancelActivityInput("act-cancel", null, "reason");
+
+    interceptor.cancelActivity(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("CancelStandaloneActivity:StandaloneActivity", span.operationName());
+    assertEquals("act-cancel", span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testTerminateActivityCreatesSpan() {
+    ActivityClientCallsInterceptor.TerminateActivityInput input =
+        new ActivityClientCallsInterceptor.TerminateActivityInput("act-term", null, "reason");
+
+    interceptor.terminateActivity(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("TerminateStandaloneActivity:StandaloneActivity", span.operationName());
+    assertEquals("act-term", span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testListActivitiesCreatesSpan() {
+    ActivityClientCallsInterceptor.ListActivitiesInput input =
+        new ActivityClientCallsInterceptor.ListActivitiesInput("TaskQueue = 'tq'");
+
+    interceptor.listActivities(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("ListStandaloneActivities:TaskQueue = 'tq'", span.operationName());
+    assertNull(span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testCountActivitiesCreatesSpan() {
+    ActivityClientCallsInterceptor.CountActivitiesInput input =
+        new ActivityClientCallsInterceptor.CountActivitiesInput("TaskQueue = 'tq'");
+
+    interceptor.countActivities(input);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    MockSpan span = spans.get(0);
+    assertEquals("CountStandaloneActivities:TaskQueue = 'tq'", span.operationName());
+    assertNull(span.tags().get("activityId"));
+  }
+
+  @Test
+  public void testStartActivitySpanIsChildOfActiveSpan() {
+    MockSpan parentSpan = mockTracer.buildSpan("ClientFunction").start();
+    try (io.opentracing.Scope ignored = mockTracer.scopeManager().activate(parentSpan)) {
+      StartActivityOptions opts =
+          StartActivityOptions.newBuilder()
+              .setId("act-child")
+              .setTaskQueue("tq")
+              .setScheduleToCloseTimeout(Duration.ofMinutes(1))
+              .build();
+      interceptor.startActivity(
+          new ActivityClientCallsInterceptor.StartActivityInput(
+              "MyActivity", Collections.emptyList(), opts, Header.empty()));
+    } finally {
+      parentSpan.finish();
+    }
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(2, spans.size());
+
+    MockSpan activitySpan = spans.get(0);
+    assertEquals("StartStandaloneActivity:MyActivity", activitySpan.operationName());
+    assertEquals(parentSpan.context().spanId(), activitySpan.parentId());
+  }
+
+  private static class StubActivityClientCallsInterceptor
+      extends ActivityClientCallsInterceptorBase {
+
+    StubActivityClientCallsInterceptor() {
+      super(null);
+    }
+
+    @Override
+    public StartActivityOutput startActivity(StartActivityInput input) {
+      return new StartActivityOutput(input.getOptions().getId(), null);
+    }
+
+    @Override
+    public <R> GetActivityResultOutput<R> getActivityResult(GetActivityResultInput<R> input)
+        throws TimeoutException {
+      return new GetActivityResultOutput<>(null);
+    }
+
+    @Override
+    public <R> CompletableFuture<GetActivityResultOutput<R>> getActivityResultAsync(
+        GetActivityResultInput<R> input) {
+      return CompletableFuture.completedFuture(new GetActivityResultOutput<>(null));
+    }
+
+    @Override
+    public DescribeActivityOutput describeActivity(DescribeActivityInput input) {
+      return new DescribeActivityOutput(null);
+    }
+
+    @Override
+    public CancelActivityOutput cancelActivity(CancelActivityInput input) {
+      return new CancelActivityOutput();
+    }
+
+    @Override
+    public TerminateActivityOutput terminateActivity(TerminateActivityInput input) {
+      return new TerminateActivityOutput();
+    }
+
+    @Override
+    public ListActivitiesOutput listActivities(ListActivitiesInput input) {
+      return new ListActivitiesOutput(Stream.empty());
+    }
+
+    @Override
+    public CountActivitiesOutput countActivities(CountActivitiesInput input) {
+      return new CountActivitiesOutput(
+          new ActivityExecutionCount(CountActivityExecutionsResponse.getDefaultInstance()));
+    }
+  }
+
+  private static class SynchronouslyThrowingActivityClientCallsInterceptor
+      extends ActivityClientCallsInterceptorBase {
+
+    SynchronouslyThrowingActivityClientCallsInterceptor() {
+      super(null);
+    }
+
+    @Override
+    public <R> CompletableFuture<GetActivityResultOutput<R>> getActivityResultAsync(
+        GetActivityResultInput<R> input) {
+      throw new IllegalStateException("sync failure");
+    }
+  }
+}

--- a/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityWorkerTracingTest.java
+++ b/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityWorkerTracingTest.java
@@ -1,6 +1,7 @@
 package io.temporal.opentracing;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,8 +54,8 @@ public class StandaloneActivityWorkerTracingTest {
         contextAccessor.writeSpanContextToHeader(
             () ->
                 spanFactory
-                    .createStandaloneActivityStartSpan(
-                        mockTracer, "MyStandaloneActivity", "act-run")
+                    .createActivityStartSpan(
+                        mockTracer, "MyStandaloneActivity", null, null, "act-run")
                     .start(),
             header,
             mockTracer);
@@ -72,10 +73,11 @@ public class StandaloneActivityWorkerTracingTest {
 
     OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
     MockSpan startSpan =
-        spansHelper.getSpanByOperationName("StartStandaloneActivity:MyStandaloneActivity");
-    MockSpan runSpan =
-        spansHelper.getSpanByOperationName("RunStandaloneActivity:MyStandaloneActivity");
+        spansHelper.getSpanByOperationName("StartActivity:MyStandaloneActivity");
+    MockSpan runSpan = spansHelper.getSpanByOperationName("RunActivity:MyStandaloneActivity");
     assertEquals("act-run", runSpan.tags().get("activityId"));
+    assertNull(runSpan.tags().get("workflowId"));
+    assertNull(runSpan.tags().get("runId"));
     assertEquals(startSpan.context().spanId(), runSpan.parentId());
   }
 

--- a/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityWorkerTracingTest.java
+++ b/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityWorkerTracingTest.java
@@ -1,0 +1,92 @@
+package io.temporal.opentracing;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.temporal.activity.ActivityExecutionContext;
+import io.temporal.activity.ActivityInfo;
+import io.temporal.common.interceptors.ActivityInboundCallsInterceptor;
+import io.temporal.common.interceptors.Header;
+import io.temporal.opentracing.internal.ContextAccessor;
+import io.temporal.opentracing.internal.OpenTracingActivityInboundCallsInterceptor;
+import io.temporal.opentracing.internal.SpanFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Unit tests for standalone activity tracing on the worker side. */
+public class StandaloneActivityWorkerTracingTest {
+
+  private final MockTracer mockTracer =
+      new MockTracer(new ThreadLocalScopeManager(), MockTracer.Propagator.TEXT_MAP);
+
+  private final OpenTracingOptions otOptions =
+      OpenTracingOptions.newBuilder().setTracer(mockTracer).build();
+
+  private final SpanFactory spanFactory = new SpanFactory(otOptions);
+  private final ContextAccessor contextAccessor = new ContextAccessor(otOptions);
+
+  private OpenTracingActivityInboundCallsInterceptor interceptor;
+
+  @Before
+  public void setUp() {
+    mockTracer.reset();
+    interceptor =
+        new OpenTracingActivityInboundCallsInterceptor(
+            new StubActivityInboundCallsInterceptor(), otOptions, spanFactory, contextAccessor);
+  }
+
+  @After
+  public void tearDown() {
+    mockTracer.reset();
+  }
+
+  @Test
+  public void testStandaloneActivityRunCreatesSpanWithActivityId() {
+    Header header = Header.empty();
+    Span activityStartSpan =
+        contextAccessor.writeSpanContextToHeader(
+            () ->
+                spanFactory
+                    .createStandaloneActivityStartSpan(
+                        mockTracer, "MyStandaloneActivity", "act-run")
+                    .start(),
+            header,
+            mockTracer);
+    activityStartSpan.finish();
+
+    ActivityExecutionContext executionContext = mock(ActivityExecutionContext.class);
+    ActivityInfo activityInfo = mock(ActivityInfo.class);
+    when(activityInfo.isInWorkflow()).thenReturn(false);
+    when(activityInfo.getActivityType()).thenReturn("MyStandaloneActivity");
+    when(activityInfo.getActivityId()).thenReturn("act-run");
+    when(executionContext.getInfo()).thenReturn(activityInfo);
+
+    interceptor.init(executionContext);
+    interceptor.execute(new ActivityInboundCallsInterceptor.ActivityInput(header, new Object[0]));
+
+    OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
+    MockSpan startSpan =
+        spansHelper.getSpanByOperationName("StartStandaloneActivity:MyStandaloneActivity");
+    MockSpan runSpan =
+        spansHelper.getSpanByOperationName("RunStandaloneActivity:MyStandaloneActivity");
+    assertEquals("act-run", runSpan.tags().get("activityId"));
+    assertEquals(startSpan.context().spanId(), runSpan.parentId());
+  }
+
+  private static class StubActivityInboundCallsInterceptor
+      implements ActivityInboundCallsInterceptor {
+    @Override
+    public void init(ActivityExecutionContext context) {}
+
+    @Override
+    public ActivityOutput execute(ActivityInput input) {
+      return new ActivityOutput(null);
+    }
+  }
+}

--- a/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityWorkerTracingTest.java
+++ b/contrib/temporal-opentracing/src/test/java/io/temporal/opentracing/StandaloneActivityWorkerTracingTest.java
@@ -72,8 +72,7 @@ public class StandaloneActivityWorkerTracingTest {
     interceptor.execute(new ActivityInboundCallsInterceptor.ActivityInput(header, new Object[0]));
 
     OpenTracingSpansHelper spansHelper = new OpenTracingSpansHelper(mockTracer.finishedSpans());
-    MockSpan startSpan =
-        spansHelper.getSpanByOperationName("StartActivity:MyStandaloneActivity");
+    MockSpan startSpan = spansHelper.getSpanByOperationName("StartActivity:MyStandaloneActivity");
     MockSpan runSpan = spansHelper.getSpanByOperationName("RunActivity:MyStandaloneActivity");
     assertEquals("act-run", runSpan.tags().get("activityId"));
     assertNull(runSpan.tags().get("workflowId"));


### PR DESCRIPTION
## What was changed

  Added OpenTracing support for standalone activity client operations.

  ## Why?

  Standalone activities can be started and managed through ActivityClient, but the OpenTracing contrib module did not trace those client operations. This adds tracing
  coverage consistent with the existing workflow client and worker tracing patterns.

  Standalone activity execution also needs its own worker-side run span because standalone activities do not have workflow IDs or workflow run IDs.

  ##  How was this tested:

  See 2 UT files for Client and Worker respectively.
