### PR TITLE
Add GZIP compression defaulting to on

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/GrpcMessageTooLargeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GrpcMessageTooLargeTest.java
@@ -13,6 +13,8 @@ import io.temporal.failure.TerminatedFailure;
 import io.temporal.internal.replay.ReplayWorkflowTaskHandler;
 import io.temporal.internal.retryer.GrpcMessageTooLargeException;
 import io.temporal.internal.worker.PollerOptions;
+import io.temporal.serviceclient.GrpcCompression;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testUtils.LoggerUtils;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestActivities;
@@ -24,6 +26,8 @@ import org.junit.Test;
 public class GrpcMessageTooLargeTest {
   private static final String QUERY_ERROR_MESSAGE =
       "Failed to send query response: RESOURCE_EXHAUSTED: grpc: received message larger than max";
+  private static final WorkflowServiceStubsOptions GRPC_COMPRESSION_DISABLED =
+      WorkflowServiceStubsOptions.newBuilder().setGrpcCompression(GrpcCompression.NONE).build();
   private static final String VERY_LARGE_DATA;
 
   static {
@@ -39,21 +43,31 @@ public class GrpcMessageTooLargeTest {
   @Rule
   public SDKTestWorkflowRule activityStartWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
+          .setWorkflowServiceStubsOptions(GRPC_COMPRESSION_DISABLED)
           .setWorkflowTypes(ActivityStartWorkflowImpl.class)
           .setActivityImplementations(new TestActivityImpl())
           .build();
 
   @Rule
   public SDKTestWorkflowRule failureWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(FailureWorkflowImpl.class).build();
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowServiceStubsOptions(GRPC_COMPRESSION_DISABLED)
+          .setWorkflowTypes(FailureWorkflowImpl.class)
+          .build();
 
   @Rule
   public SDKTestWorkflowRule querySuccessWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(QuerySuccessWorkflowImpl.class).build();
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowServiceStubsOptions(GRPC_COMPRESSION_DISABLED)
+          .setWorkflowTypes(QuerySuccessWorkflowImpl.class)
+          .build();
 
   @Rule
   public SDKTestWorkflowRule queryFailureWorkflowRule =
-      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(QueryFailureWorkflowImpl.class).build();
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowServiceStubsOptions(GRPC_COMPRESSION_DISABLED)
+          .setWorkflowTypes(QueryFailureWorkflowImpl.class)
+          .build();
 
   @Test
   public void workflowStartTooLarge() {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ChannelManager.java
@@ -161,6 +161,7 @@ final class ChannelManager {
 
     return ClientInterceptors.intercept(
         channel,
+        new GrpcCompressionInterceptor(options.getGrpcCompression()),
         MetadataUtils.newAttachHeadersInterceptor(headers),
         new SystemInfoInterceptor(serverCapabilitiesFuture));
   }
@@ -205,6 +206,8 @@ final class ChannelManager {
     } else {
       builder.useTransportSecurity();
     }
+
+    builder.decompressorRegistry(options.getGrpcCompression().getDecompressorRegistry());
 
     // Disable built-in idleTimer until https://github.com/grpc/grpc-java/issues/8714 is resolved.
     // jsdk force-idles channels often anyway, so this is not needed until we stop doing

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompression.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompression.java
@@ -1,0 +1,31 @@
+package io.temporal.serviceclient;
+
+import io.grpc.Codec;
+import io.grpc.DecompressorRegistry;
+import javax.annotation.Nullable;
+
+/** Selects transport-level gRPC compression for service calls. */
+public enum GrpcCompression {
+  /** Do not compress requests or advertise support for compressed responses. */
+  NONE(null, DecompressorRegistry.emptyInstance().with(Codec.Identity.NONE, false)),
+
+  /** Gzip-compress outbound requests and accept gzip-compressed responses. */
+  GZIP("gzip", DecompressorRegistry.getDefaultInstance());
+
+  private final @Nullable String compressorName;
+  private final DecompressorRegistry decompressorRegistry;
+
+  GrpcCompression(@Nullable String compressorName, DecompressorRegistry decompressorRegistry) {
+    this.compressorName = compressorName;
+    this.decompressorRegistry = decompressorRegistry;
+  }
+
+  @Nullable
+  String getCompressorName() {
+    return compressorName;
+  }
+
+  DecompressorRegistry getDecompressorRegistry() {
+    return decompressorRegistry;
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
@@ -1,0 +1,21 @@
+package io.temporal.serviceclient;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+
+final class GrpcCompressionInterceptor implements ClientInterceptor {
+  private final GrpcCompression compression;
+
+  GrpcCompressionInterceptor(GrpcCompression compression) {
+    this.compression = compression;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return next.newCall(method, callOptions.withCompression(compression.getCompressorName()));
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -114,6 +114,9 @@ public class ServiceStubsOptions {
 
   protected final Scope metricsScope;
 
+  /** Transport-level gRPC compression. */
+  protected final GrpcCompression grpcCompression;
+
   ServiceStubsOptions(ServiceStubsOptions that) {
     this.channel = that.channel;
     this.target = that.target;
@@ -135,6 +138,7 @@ public class ServiceStubsOptions {
     this.grpcMetadataProviders = that.grpcMetadataProviders;
     this.grpcClientInterceptors = that.grpcClientInterceptors;
     this.metricsScope = that.metricsScope;
+    this.grpcCompression = that.grpcCompression;
   }
 
   ServiceStubsOptions(
@@ -157,7 +161,8 @@ public class ServiceStubsOptions {
       Metadata headers,
       Collection<GrpcMetadataProvider> grpcMetadataProviders,
       Collection<ClientInterceptor> grpcClientInterceptors,
-      Scope metricsScope) {
+      Scope metricsScope,
+      GrpcCompression grpcCompression) {
     this.channel = channel;
     this.target = target;
     this.channelInitializer = channelInitializer;
@@ -178,6 +183,7 @@ public class ServiceStubsOptions {
     this.grpcMetadataProviders = grpcMetadataProviders;
     this.grpcClientInterceptors = grpcClientInterceptors;
     this.metricsScope = metricsScope;
+    this.grpcCompression = grpcCompression;
   }
 
   /**
@@ -342,6 +348,15 @@ public class ServiceStubsOptions {
     return metricsScope;
   }
 
+  /**
+   * @return transport-level gRPC compression used for requests and response negotiation.
+   * @see Builder#setGrpcCompression(GrpcCompression)
+   */
+  @Nonnull
+  public GrpcCompression getGrpcCompression() {
+    return grpcCompression;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -366,7 +381,8 @@ public class ServiceStubsOptions {
         && Objects.equals(headers, that.headers)
         && Objects.equals(grpcMetadataProviders, that.grpcMetadataProviders)
         && Objects.equals(grpcClientInterceptors, that.grpcClientInterceptors)
-        && Objects.equals(metricsScope, that.metricsScope);
+        && Objects.equals(metricsScope, that.metricsScope)
+        && grpcCompression == that.grpcCompression;
   }
 
   @Override
@@ -391,7 +407,8 @@ public class ServiceStubsOptions {
         headers,
         grpcMetadataProviders,
         grpcClientInterceptors,
-        metricsScope);
+        metricsScope,
+        grpcCompression);
   }
 
   @Override
@@ -436,6 +453,8 @@ public class ServiceStubsOptions {
         + grpcClientInterceptors
         + ", metricsScope="
         + metricsScope
+        + ", grpcCompression="
+        + grpcCompression
         + '}';
   }
 
@@ -460,6 +479,7 @@ public class ServiceStubsOptions {
     private Collection<ClientInterceptor> grpcClientInterceptors;
     private Scope metricsScope;
     private boolean apiKeyProvided;
+    private GrpcCompression grpcCompression = GrpcCompression.GZIP;
 
     protected Builder() {}
 
@@ -491,6 +511,7 @@ public class ServiceStubsOptions {
               ? new ArrayList<>(options.grpcClientInterceptors)
               : null;
       this.metricsScope = options.metricsScope;
+      this.grpcCompression = options.grpcCompression;
     }
 
     /**
@@ -721,6 +742,22 @@ public class ServiceStubsOptions {
     }
 
     /**
+     * Sets transport-level gRPC compression. Defaults to {@link GrpcCompression#GZIP}. Set to
+     * {@link GrpcCompression#NONE} to opt out.
+     *
+     * <p>For SDK-created channels, this controls both request compression and the {@code
+     * grpc-accept-encoding} response negotiation header. For user-supplied channels, the SDK still
+     * controls request compression, but response decompression negotiation is configured by the
+     * supplied channel.
+     *
+     * @return {@code this}
+     */
+    public T setGrpcCompression(GrpcCompression grpcCompression) {
+      this.grpcCompression = Objects.requireNonNull(grpcCompression);
+      return self();
+    }
+
+    /**
      * Set the time to wait between service responses on each health check.
      *
      * @return {@code this}
@@ -853,7 +890,8 @@ public class ServiceStubsOptions {
           this.headers,
           this.grpcMetadataProviders,
           this.grpcClientInterceptors,
-          this.metricsScope);
+          this.metricsScope,
+          this.grpcCompression);
     }
 
     public ServiceStubsOptions validateAndBuildWithDefaults() {
@@ -916,7 +954,8 @@ public class ServiceStubsOptions {
           headers,
           grpcMetadataProviders,
           grpcClientInterceptors,
-          metricsScope);
+          metricsScope,
+          this.grpcCompression);
     }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/GrpcCompressionTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/GrpcCompressionTest.java
@@ -1,0 +1,91 @@
+package io.temporal.serviceclient;
+
+import static org.junit.Assert.*;
+
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.temporal.api.workflowservice.v1.GetSystemInfoRequest;
+import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GrpcCompressionTest {
+  private static final Metadata.Key<String> GRPC_ENCODING =
+      Metadata.Key.of("grpc-encoding", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> GRPC_ACCEPT_ENCODING =
+      Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER);
+
+  @Rule public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
+
+  @Test
+  public void gzipCompressionSendsAndAcceptsGzip() throws Exception {
+    Metadata headers = callGetSystemInfo(GrpcCompression.GZIP);
+
+    assertEquals("gzip", headers.get(GRPC_ENCODING));
+    assertTrue(headers.get(GRPC_ACCEPT_ENCODING).contains("gzip"));
+  }
+
+  @Test
+  public void noneCompressionDoesNotSendOrAcceptGzip() throws Exception {
+    Metadata headers = callGetSystemInfo(GrpcCompression.NONE);
+
+    assertNull(headers.get(GRPC_ENCODING));
+    assertNull(headers.get(GRPC_ACCEPT_ENCODING));
+  }
+
+  private Metadata callGetSystemInfo(GrpcCompression compression) throws Exception {
+    AtomicReference<Metadata> capturedHeaders = new AtomicReference<>();
+    ServerInterceptor captureHeadersInterceptor =
+        new ServerInterceptor() {
+          @Override
+          public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+              ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            capturedHeaders.set(headers);
+            return next.startCall(call, headers);
+          }
+        };
+    Server server =
+        grpcCleanupRule.register(
+            NettyServerBuilder.forPort(0)
+                .addService(
+                    ServerInterceptors.intercept(
+                        new TestWorkflowService(), captureHeadersInterceptor))
+                .build()
+                .start());
+
+    WorkflowServiceStubs serviceStubs =
+        WorkflowServiceStubs.newServiceStubs(
+            WorkflowServiceStubsOptions.newBuilder()
+                .setTarget("127.0.0.1:" + server.getPort())
+                .setEnableHttps(false)
+                .setGrpcCompression(compression)
+                .build());
+    try {
+      serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
+    } finally {
+      serviceStubs.shutdownNow();
+    }
+
+    assertNotNull(capturedHeaders.get());
+    return capturedHeaders.get();
+  }
+
+  private static final class TestWorkflowService
+      extends WorkflowServiceGrpc.WorkflowServiceImplBase {
+    @Override
+    public void getSystemInfo(
+        GetSystemInfoRequest request, StreamObserver<GetSystemInfoResponse> responseObserver) {
+      responseObserver.onNext(GetSystemInfoResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ServiceStubsOptionsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ServiceStubsOptionsTest.java
@@ -151,4 +151,30 @@ public class ServiceStubsOptionsTest {
         "TLS should be disabled when no API key and no explicit TLS setting",
         options3.getEnableHttps());
   }
+
+  @Test
+  public void testGrpcCompressionDefaultsToGzip() {
+    ServiceStubsOptions options =
+        WorkflowServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .validateAndBuildWithDefaults();
+
+    assertEquals(GrpcCompression.GZIP, options.getGrpcCompression());
+  }
+
+  @Test
+  public void testGrpcCompressionNonePassesThroughBuilderCopy() {
+    ServiceStubsOptions options =
+        WorkflowServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .setGrpcCompression(GrpcCompression.NONE)
+            .validateAndBuildWithDefaults();
+
+    assertEquals(GrpcCompression.NONE, options.getGrpcCompression());
+
+    ServiceStubsOptions copied =
+        WorkflowServiceStubsOptions.newBuilder(options).validateAndBuildWithDefaults();
+
+    assertEquals(GrpcCompression.NONE, copied.getGrpcCompression());
+  }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add gzip compression, defaulting on with opt-out

## Why?
Save on data! Parity with other SDKs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added simple unit test that headers are set properly. More comprehensive testing was performed in Core to validate server actually compresses bytes. Existing integ tests are verifying nothing is breaking, since this value defaults on.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
