### PR TITLE
fix: add missing @TemporalDsl receiver annotation to setRetryOptions extensions

### DIFF
--- a/temporal-kotlin/src/main/kotlin/io/temporal/activity/ActivityOptionsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/activity/ActivityOptionsExt.kt
@@ -28,7 +28,7 @@ inline fun ActivityOptions.copy(
  * @see ActivityOptions.Builder.setRetryOptions
  * @see ActivityOptions.getRetryOptions
  */
-inline fun ActivityOptions.Builder.setRetryOptions(
+inline fun @TemporalDsl ActivityOptions.Builder.setRetryOptions(
   retryOptions: @TemporalDsl RetryOptions.Builder.() -> Unit
 ) {
   setRetryOptions(RetryOptions(retryOptions))

--- a/temporal-kotlin/src/main/kotlin/io/temporal/client/WorkflowOptionsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/client/WorkflowOptionsExt.kt
@@ -26,7 +26,7 @@ inline fun WorkflowOptions.copy(
  * @see WorkflowOptions.Builder.setRetryOptions
  * @see WorkflowOptions.getRetryOptions
  */
-inline fun WorkflowOptions.Builder.setRetryOptions(
+inline fun @TemporalDsl WorkflowOptions.Builder.setRetryOptions(
   retryOptions: @TemporalDsl RetryOptions.Builder.() -> Unit
 ) {
   setRetryOptions(RetryOptions(retryOptions))

--- a/temporal-kotlin/src/main/kotlin/io/temporal/workflow/ChildWorkflowOptionsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/workflow/ChildWorkflowOptionsExt.kt
@@ -26,7 +26,7 @@ inline fun ChildWorkflowOptions.copy(
  * @see ChildWorkflowOptions.Builder.setRetryOptions
  * @see ChildWorkflowOptions.getRetryOptions
  */
-inline fun ChildWorkflowOptions.Builder.setRetryOptions(
+inline fun @TemporalDsl ChildWorkflowOptions.Builder.setRetryOptions(
   retryOptions: @TemporalDsl RetryOptions.Builder.() -> Unit
 ) {
   setRetryOptions(RetryOptions(retryOptions))

--- a/temporal-kotlin/src/test/kotlin/io/temporal/activity/ActivityOptionsExtTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/activity/ActivityOptionsExtTest.kt
@@ -38,6 +38,27 @@ class ActivityOptionsExtTest {
   }
 
   @Test
+  fun `setRetryOptions DSL extension should work on ActivityOptions builder directly`() {
+    val builder = ActivityOptions.newBuilder().setTaskQueue("TestQueue")
+    builder.setRetryOptions {
+      setInitialInterval(Duration.ofMillis(50))
+      setMaximumAttempts(5)
+    }
+
+    val expected = ActivityOptions.newBuilder()
+      .setTaskQueue("TestQueue")
+      .setRetryOptions(
+        RetryOptions.newBuilder()
+          .setInitialInterval(Duration.ofMillis(50))
+          .setMaximumAttempts(5)
+          .build()
+      )
+      .build()
+
+    assertEquals(expected, builder.build())
+  }
+
+  @Test
   fun `ActivityOptions copy() DSL should merge override options`() {
     val sourceOptions = ActivityOptions {
       setTaskQueue("TestQueue")

--- a/temporal-kotlin/src/test/kotlin/io/temporal/client/WorkflowOptionsExtTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/client/WorkflowOptionsExtTest.kt
@@ -39,6 +39,27 @@ class WorkflowOptionsExtTest {
   }
 
   @Test
+  fun `setRetryOptions DSL extension should work on WorkflowOptions builder directly`() {
+    val builder = WorkflowOptions.newBuilder().setTaskQueue("TestQueue")
+    builder.setRetryOptions {
+      setInitialInterval(Duration.ofMillis(50))
+      setMaximumAttempts(5)
+    }
+
+    val expected = WorkflowOptions.newBuilder()
+      .setTaskQueue("TestQueue")
+      .setRetryOptions(
+        RetryOptions.newBuilder()
+          .setInitialInterval(Duration.ofMillis(50))
+          .setMaximumAttempts(5)
+          .build()
+      )
+      .build()
+
+    assertEquals(expected, builder.build())
+  }
+
+  @Test
   fun `WorkflowOptions copy() DSL should merge override options`() {
     val sourceOptions = WorkflowOptions {
       setWorkflowId("ID1")

--- a/temporal-kotlin/src/test/kotlin/io/temporal/workflow/ChildWorkflowOptionsExtTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/workflow/ChildWorkflowOptionsExtTest.kt
@@ -33,6 +33,27 @@ class ChildWorkflowOptionsExtTest {
   }
 
   @Test
+  fun `setRetryOptions DSL extension should work on ChildWorkflowOptions builder directly`() {
+    val builder = ChildWorkflowOptions.newBuilder().setTaskQueue("TestQueue")
+    builder.setRetryOptions {
+      setInitialInterval(Duration.ofMillis(50))
+      setMaximumAttempts(3)
+    }
+
+    val expected = ChildWorkflowOptions.newBuilder()
+      .setTaskQueue("TestQueue")
+      .setRetryOptions(
+        RetryOptions.newBuilder()
+          .setInitialInterval(Duration.ofMillis(50))
+          .setMaximumAttempts(3)
+          .build()
+      )
+      .build()
+
+    assertEquals(expected, builder.build())
+  }
+
+  @Test
   fun `ChildWorkflowOptions copy() DSL should merge override options`() {
     val sourceOptions = ChildWorkflowOptions {
       setTaskQueue("TestQueue")


### PR DESCRIPTION
**Problem**

Three `setRetryOptions` extension functions were missing `@TemporalDsl` on the receiver type:

```
// Before (missing annotation on receiver)
inline fun ActivityOptions.Builder.setRetryOptions(
  retryOptions: @TemporalDsl RetryOptions.Builder.() -> Unit
)
```

`LocalActivityOptionsExt` already had the correct pattern:

```
// Correct (receiver is annotated)
inline fun @TemporalDsl LocalActivityOptions.Builder.setRetryOptions(
  retryOptions: @TemporalDsl RetryOptions.Builder.() -> Unit
)
```

Without `@TemporalDsl `on the receiver, Kotlin's `@DslMarker` mechanism cannot enforce scope isolation. Inside a `setRetryOptions { }` block, the outer `ActivityOptions.Builder (or ChildWorkflowOptions.Builder / WorkflowOptions.Builder)` remains an implicit receiver, so callers can accidentally invoke outer-scope builder methods inside the nested lambda — exactly the problem `@TemporalDsl `is designed to prevent.

`Fix`

Added `@TemporalDsl `to the receiver of `setRetryOptions` in:
- `activity/ActivityOptionsExt.kt`
- `workflow/ChildWorkflowOptionsExt.kt`
- `client/WorkflowOptionsExt.kt`

**Tests**

Added a standalone test in each of the three corresponding test classes that calls `setRetryOptions` directly on a builder instance (rather than only through the outer DSL), covering the extension function in isolation.

**Notes**

This is a compile-time correctness fix — r Existing code that uses ```
setRetryOptions {
}
``` continues to compile and work correctly.

Thanks for review and feedback