### PR TITLE
Grant explicit actions:read to features reusable-workflow caller

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 
 jobs:
   features-test:
+    permissions:
+      contents: read
+      actions: read
     uses: temporalio/features/.github/workflows/java.yaml@main
     with:
       java-repo-path: ${{github.event.pull_request.head.repo.full_name}}


### PR DESCRIPTION
## What 
Adds a job-level permissions block granting `contents: read` and `actions: read` to the job that calls the temporalio/features workflow. 

## Why
The org default GITHUB_TOKEN permissions are now restrictive (`actions: none`), so without this grant the reusable workflow fails validation at parse time and the check never starts.