### PR TITLE
Add @TemporalOperation annotation for Nexus operations    

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     grpcVersion = '1.76.0' // [1.38.0,) Needed for io.grpc.protobuf.services.HealthStatusManager
     jacksonVersion = '2.15.4' // [2.9.0,)
     jackson3Version = '3.0.4'
-    nexusVersion = '0.5.0-alpha'
+    nexusVersion = '0.6.0-alpha'
     // we don't upgrade to 1.10.x because it requires kotlin 1.6. Users may use 1.10.x in their environments though.
     micrometerVersion = project.hasProperty("edgeDepsTest") ? '1.13.6' : '1.9.9' // [1.0.0,)
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name='temporal-java-sdk'
+includeBuild('../nexus/nexus-sdk-java')
 include 'temporal-bom'
 include 'temporal-serviceclient'
 include 'temporal-sdk'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,4 @@
 rootProject.name='temporal-java-sdk'
-includeBuild('../nexus/nexus-sdk-java')
 include 'temporal-bom'
 include 'temporal-serviceclient'
 include 'temporal-sdk'

--- a/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinTemporalOperationTest.kt
+++ b/temporal-kotlin/src/test/kotlin/io/temporal/workflow/KotlinTemporalOperationTest.kt
@@ -1,0 +1,83 @@
+
+package io.temporal.workflow
+
+import io.nexusrpc.Operation
+import io.nexusrpc.Service
+import io.nexusrpc.handler.ServiceImpl
+import io.temporal.client.WorkflowClientOptions
+import io.temporal.client.WorkflowOptions
+import io.temporal.common.converter.DefaultDataConverter
+import io.temporal.common.converter.JacksonJsonPayloadConverter
+import io.temporal.common.converter.KotlinObjectMapperFactory
+import io.temporal.nexus.TemporalNexusClient
+import io.temporal.nexus.TemporalOperation
+import io.temporal.nexus.TemporalOperationResult
+import io.temporal.nexus.TemporalOperationStartContext
+import io.temporal.testing.internal.SDKTestWorkflowRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.time.Duration
+
+class KotlinTemporalOperationTest {
+
+  @Rule
+  @JvmField
+  var testWorkflowRule: SDKTestWorkflowRule = SDKTestWorkflowRule.newBuilder()
+    .setWorkflowTypes(CallerWorkflowImpl::class.java)
+    .setNexusServiceImplementation(KotlinSugarServiceImpl())
+    .setWorkflowClientOptions(
+      WorkflowClientOptions.newBuilder()
+        .setDataConverter(DefaultDataConverter(JacksonJsonPayloadConverter(KotlinObjectMapperFactory.new())))
+        .build()
+    )
+    .build()
+
+  @Service
+  interface KotlinSugarService {
+    @Operation
+    fun greet(input: String): String
+  }
+
+  @ServiceImpl(service = KotlinSugarService::class)
+  class KotlinSugarServiceImpl {
+    @TemporalOperation
+    fun greet(
+      ctx: TemporalOperationStartContext,
+      client: TemporalNexusClient,
+      input: String
+    ): TemporalOperationResult<String> {
+      return TemporalOperationResult.sync("kotlin-$input")
+    }
+  }
+
+  @WorkflowInterface
+  interface CallerWorkflow {
+    @WorkflowMethod
+    fun execute(arg: String): String
+  }
+
+  class CallerWorkflowImpl : CallerWorkflow {
+    override fun execute(arg: String): String {
+      val stub = Workflow.newNexusServiceStub(
+        KotlinSugarService::class.java,
+        NexusServiceOptions {
+          setOperationOptions(
+            NexusOperationOptions {
+              setScheduleToCloseTimeout(Duration.ofSeconds(10))
+            }
+          )
+        }
+      )
+      return stub.greet(arg)
+    }
+  }
+
+  @Test
+  fun temporalOperationSugar_endToEnd() {
+    val client = testWorkflowRule.workflowClient
+    val options = WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.taskQueue).build()
+    val workflowStub = client.newWorkflowStub(CallerWorkflow::class.java, options)
+    assertEquals("kotlin-hi", workflowStub.execute("hi"))
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
@@ -403,7 +403,7 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
     if (nexusService instanceof Class) {
       throw new IllegalArgumentException("Nexus service object instance expected, not the class");
     }
-    ServiceImplInstance instance = ServiceImplInstance.fromInstance(nexusService);
+    ServiceImplInstance instance = TemporalOperationProcessor.process(nexusService);
     InternalUtils.checkMethodName(instance);
     if (serviceImplInstances.put(instance.getDefinition().getName(), instance) != null) {
       throw new TypeAlreadyRegisteredException(

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
@@ -394,7 +394,7 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
     if (nexusService instanceof Class) {
       throw new IllegalArgumentException("Nexus service object instance expected, not the class");
     }
-    ServiceImplInstance instance = ServiceImplInstance.fromInstance(nexusService);
+    ServiceImplInstance instance = TemporalOperationProcessor.process(nexusService);
     InternalUtils.checkMethodName(instance);
     if (serviceImplInstances.put(instance.getDefinition().getName(), instance) != null) {
       throw new TypeAlreadyRegisteredException(

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalOperationProcessor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalOperationProcessor.java
@@ -1,0 +1,178 @@
+package io.temporal.internal.nexus;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
+import io.nexusrpc.OperationDefinition;
+import io.nexusrpc.ServiceDefinition;
+import io.nexusrpc.handler.MethodExtension;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImplInstance;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Entry point for registering a Nexus service instance whose class may contain {@link
+ * TemporalOperation}-annotated methods. Delegates to {@link
+ * ServiceImplInstance#fromInstance(Object, java.util.List)} with a single {@link MethodExtension}
+ * that recognizes {@link TemporalOperation} alongside the built-in {@link OperationImpl}.
+ */
+public final class TemporalOperationProcessor {
+
+  private static final ImmutableList<MethodExtension> EXTENSIONS =
+      ImmutableList.of(new TemporalOperationExtension());
+
+  private TemporalOperationProcessor() {}
+
+  public static ServiceImplInstance process(Object instance) {
+    return ServiceImplInstance.fromInstance(instance, EXTENSIONS);
+  }
+
+  /** Recognizes {@link TemporalOperation}-annotated methods during nexusrpc service scanning. */
+  private static final class TemporalOperationExtension implements MethodExtension {
+    @Override
+    public Result extract(Object instance, Method method, ServiceDefinition serviceDefinition) {
+      if (method.getDeclaredAnnotation(TemporalOperation.class) == null) {
+        return null;
+      }
+      if (method.isAnnotationPresent(OperationImpl.class)) {
+        throw new IllegalArgumentException(
+            "@TemporalOperation and @OperationImpl cannot be combined on method "
+                + method.getName());
+      }
+
+      validateSignature(method);
+
+      OperationDefinition operationDefinition =
+          serviceDefinition.getOperations().values().stream()
+              .filter(o -> method.getName().equals(o.getMethodName()))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "No matching @Operation on service "
+                              + serviceDefinition.getName()
+                              + " for @TemporalOperation method "
+                              + method.getName()));
+
+      validateTypes(method, operationDefinition);
+
+      MethodHandle handle;
+      try {
+        handle = MethodHandles.lookup().unreflect(method).bindTo(instance);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(
+            "Failed to obtain method handle for @TemporalOperation method " + method.getName(), e);
+      }
+
+      TemporalOperationHandler.StartHandler<Object, Object> startHandler =
+          (ctx, client, input) -> invokeStartHandler(handle, ctx, client, input);
+
+      return new Result(
+          operationDefinition.getName(),
+          new TemporalOperationHandler<Object, Object>(startHandler) {});
+    }
+  }
+
+  private static void validateSignature(Method method) {
+    if (!Modifier.isPublic(method.getModifiers())) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method " + method.getName() + " must be public");
+    }
+    if (Modifier.isStatic(method.getModifiers())) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method " + method.getName() + " must not be static");
+    }
+    Class<?>[] paramTypes = method.getParameterTypes();
+    if (paramTypes.length != 3
+        || !TemporalOperationStartContext.class.equals(paramTypes[0])
+        || !TemporalNexusClient.class.equals(paramTypes[1])) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method "
+              + method.getName()
+              + " must accept (TemporalOperationStartContext, TemporalNexusClient, I); got "
+              + describeSignature(method));
+    }
+    if (!TemporalOperationResult.class.equals(method.getReturnType())) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method "
+              + method.getName()
+              + " must return TemporalOperationResult<?>; got "
+              + method.getGenericReturnType().getTypeName()
+              + ". Use @OperationImpl for custom handler shapes.");
+    }
+  }
+
+  private static void validateTypes(Method method, OperationDefinition operationDefinition) {
+    Type expectedInputType = operationDefinition.getInputType();
+    Type declaredInputType = method.getGenericParameterTypes()[2];
+    if (!typesMatch(declaredInputType, expectedInputType)) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method "
+              + method.getName()
+              + " input type mismatch: expected "
+              + expectedInputType.getTypeName()
+              + " but got "
+              + declaredInputType.getTypeName());
+    }
+    Type returnType = method.getGenericReturnType();
+    if (!(returnType instanceof ParameterizedType)) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method "
+              + method.getName()
+              + " must use parameterized TemporalOperationResult<R>, not the raw type.");
+    }
+    Type resultTypeArg = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+    if (!typesMatch(resultTypeArg, operationDefinition.getOutputType())) {
+      throw new IllegalArgumentException(
+          "@TemporalOperation method "
+              + method.getName()
+              + " output type mismatch: expected "
+              + operationDefinition.getOutputType().getTypeName()
+              + " but got "
+              + resultTypeArg.getTypeName());
+    }
+  }
+
+  // Package-private for testing.
+  @SuppressWarnings("unchecked")
+  static TemporalOperationResult<Object> invokeStartHandler(
+      MethodHandle handle,
+      TemporalOperationStartContext ctx,
+      TemporalNexusClient client,
+      Object input) {
+    try {
+      return (TemporalOperationResult<Object>) handle.invoke(ctx, client, input);
+    } catch (RuntimeException | Error e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new RuntimeException("@TemporalOperation method threw checked exception", t);
+    }
+  }
+
+  private static boolean typesMatch(Type declared, Type expected) {
+    if (declared.equals(expected)) {
+      return true;
+    }
+    if (declared instanceof Class && expected instanceof Class) {
+      return Primitives.wrap((Class<?>) declared).equals(Primitives.wrap((Class<?>) expected));
+    }
+    return false;
+  }
+
+  private static String describeSignature(Method method) {
+    return Arrays.stream(method.getParameterTypes())
+        .map(Class::getSimpleName)
+        .collect(Collectors.joining(", ", "(", ")"));
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalOperationProcessor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalOperationProcessor.java
@@ -4,9 +4,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 import io.nexusrpc.OperationDefinition;
 import io.nexusrpc.OperationException;
-import io.nexusrpc.ServiceDefinition;
 import io.nexusrpc.handler.HandlerException;
 import io.nexusrpc.handler.MethodExtension;
+import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImplInstance;
 import io.temporal.nexus.TemporalNexusClient;
@@ -43,29 +43,13 @@ public final class TemporalOperationProcessor {
   /** Recognizes {@link TemporalOperation}-annotated methods during nexusrpc service scanning. */
   private static final class TemporalOperationExtension implements MethodExtension {
     @Override
-    public Result extract(Object instance, Method method, ServiceDefinition serviceDefinition) {
+    public OperationHandler<?, ?> extract(
+        Object instance, Method method, OperationDefinition operationDefinition) {
       if (method.getDeclaredAnnotation(TemporalOperation.class) == null) {
         return null;
       }
-      if (method.isAnnotationPresent(OperationImpl.class)) {
-        throw new IllegalArgumentException(
-            "@TemporalOperation and @OperationImpl cannot be combined on method "
-                + method.getName());
-      }
 
       validateSignature(method);
-
-      OperationDefinition operationDefinition =
-          serviceDefinition.getOperations().values().stream()
-              .filter(o -> method.getName().equals(o.getMethodName()))
-              .findFirst()
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "No matching @Operation on service "
-                              + serviceDefinition.getName()
-                              + " for @TemporalOperation method "
-                              + method.getName()));
 
       validateTypes(method, operationDefinition);
 
@@ -80,9 +64,7 @@ public final class TemporalOperationProcessor {
       TemporalOperationHandler.StartHandler<Object, Object> startHandler =
           (ctx, client, input) -> invokeStartHandler(handle, ctx, client, input);
 
-      return new Result(
-          operationDefinition.getName(),
-          new TemporalOperationHandler<Object, Object>(startHandler) {});
+      return new TemporalOperationHandler<Object, Object>(startHandler) {};
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalOperationProcessor.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/TemporalOperationProcessor.java
@@ -3,7 +3,9 @@ package io.temporal.internal.nexus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 import io.nexusrpc.OperationDefinition;
+import io.nexusrpc.OperationException;
 import io.nexusrpc.ServiceDefinition;
+import io.nexusrpc.handler.HandlerException;
 import io.nexusrpc.handler.MethodExtension;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImplInstance;
@@ -111,6 +113,19 @@ public final class TemporalOperationProcessor {
               + method.getGenericReturnType().getTypeName()
               + ". Use @OperationImpl for custom handler shapes.");
     }
+    for (Class<?> declared : method.getExceptionTypes()) {
+      if (!RuntimeException.class.isAssignableFrom(declared)
+          && !Error.class.isAssignableFrom(declared)
+          && !OperationException.class.isAssignableFrom(declared)
+          && !HandlerException.class.isAssignableFrom(declared)) {
+        throw new IllegalArgumentException(
+            "@TemporalOperation method "
+                + method.getName()
+                + " may only declare OperationException or HandlerException as checked"
+                + " exceptions; found "
+                + declared.getName());
+      }
+    }
   }
 
   private static void validateTypes(Method method, OperationDefinition operationDefinition) {
@@ -150,13 +165,17 @@ public final class TemporalOperationProcessor {
       MethodHandle handle,
       TemporalOperationStartContext ctx,
       TemporalNexusClient client,
-      Object input) {
+      Object input)
+      throws OperationException {
     try {
       return (TemporalOperationResult<Object>) handle.invoke(ctx, client, input);
-    } catch (RuntimeException | Error e) {
+    } catch (RuntimeException | Error | OperationException e) {
+      // HandlerException is a RuntimeException and falls into the RuntimeException arm.
       throw e;
     } catch (Throwable t) {
-      throw new RuntimeException("@TemporalOperation method threw checked exception", t);
+      // Unreachable: validateSignature rejects @TemporalOperation methods that declare
+      // any other checked exception, so MethodHandle.invoke cannot surface one here.
+      throw new AssertionError("@TemporalOperation method threw unexpected checked exception", t);
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -10,21 +10,22 @@ import java.lang.reflect.Type;
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
  * Temporal from within a Nexus operation handler.
  *
- * <p>Obtained via the {@link TemporalOperationHandler.StartHandler} parameter.
+ * <p>Passed to {@link TemporalOperation}-annotated methods (and {@link
+ * TemporalOperationHandler.StartHandler} implementations) alongside the start context and input.
  *
- * <p>Example usage to start a workflow from an operation handler:
+ * <p>Example usage to start a workflow from an operation:
  *
  * <pre>{@code
- * @OperationImpl
- * public OperationHandler<TransferInput, TransferResult> startTransfer() {
- *   return TemporalOperationHandler.create((context, client, input) -> {
- *     return client.startWorkflow(
- *         TransferWorkflow.class,
- *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
- *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("transfer-" + input.getTransferId())
- *             .build());
- *   });
+ * @TemporalOperation
+ * public TemporalOperationResult<TransferResult> startTransfer(
+ *     TemporalOperationStartContext ctx, TemporalNexusClient client, TransferInput input) {
+ *   return client.startWorkflow(
+ *       TransferWorkflow.class,
+ *       TransferWorkflow::transfer,
+ *       input,
+ *       WorkflowOptions.newBuilder()
+ *           .setWorkflowId("transfer-" + input.getTransferId())
+ *           .build());
  * }
  * }</pre>
  *
@@ -32,14 +33,13 @@ import java.lang.reflect.Type;
  * TemporalOperationResult#sync} result. For example, to send a signal:
  *
  * <pre>{@code
- * @OperationImpl
- * public OperationHandler<CancelOrderInput, Void> cancelOrder() {
- *   return TemporalOperationHandler.create((context, client, input) -> {
- *     client.getWorkflowClient()
- *         .newUntypedWorkflowStub("order-" + input.getOrderId())
- *         .signal("requestCancellation", input);
- *     return TemporalOperationResult.sync(null);
- *   });
+ * @TemporalOperation
+ * public TemporalOperationResult<Void> cancelOrder(
+ *     TemporalOperationStartContext ctx, TemporalNexusClient client, CancelOrderInput input) {
+ *   client.getWorkflowClient()
+ *       .newUntypedWorkflowStub("order-" + input.getOrderId())
+ *       .signal("requestCancellation", input);
+ *   return TemporalOperationResult.sync(null);
  * }
  * }</pre>
  */

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -14,21 +14,22 @@ import java.lang.reflect.Type;
  * Nexus-aware client wrapping {@link WorkflowClient}. Provides methods for interacting with
  * Temporal from within a Nexus operation handler.
  *
- * <p>Obtained via the {@link TemporalOperationHandler.StartHandler} parameter.
+ * <p>Passed to {@link TemporalOperation}-annotated methods (and {@link
+ * TemporalOperationHandler.StartHandler} implementations) alongside the start context and input.
  *
- * <p>Example usage to start a workflow from an operation handler:
+ * <p>Example usage to start a workflow from an operation:
  *
  * <pre>{@code
- * @OperationImpl
- * public OperationHandler<TransferInput, TransferResult> startTransfer() {
- *   return TemporalOperationHandler.create((context, client, input) -> {
- *     return client.startWorkflow(
- *         TransferWorkflow.class,
- *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
- *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("transfer-" + input.getTransferId())
- *             .build());
- *   });
+ * @TemporalOperation
+ * public TemporalOperationResult<TransferResult> startTransfer(
+ *     TemporalOperationStartContext ctx, TemporalNexusClient client, TransferInput input) {
+ *   return client.startWorkflow(
+ *       TransferWorkflow.class,
+ *       TransferWorkflow::transfer,
+ *       input,
+ *       WorkflowOptions.newBuilder()
+ *           .setWorkflowId("transfer-" + input.getTransferId())
+ *           .build());
  * }
  * }</pre>
  *
@@ -36,14 +37,13 @@ import java.lang.reflect.Type;
  * TemporalOperationResult#sync} result. For example, to send a signal:
  *
  * <pre>{@code
- * @OperationImpl
- * public OperationHandler<CancelOrderInput, Void> cancelOrder() {
- *   return TemporalOperationHandler.create((context, client, input) -> {
- *     client.getWorkflowClient()
- *         .newUntypedWorkflowStub("order-" + input.getOrderId())
- *         .signal("requestCancellation", input);
- *     return TemporalOperationResult.sync(null);
- *   });
+ * @TemporalOperation
+ * public TemporalOperationResult<Void> cancelOrder(
+ *     TemporalOperationStartContext ctx, TemporalNexusClient client, CancelOrderInput input) {
+ *   client.getWorkflowClient()
+ *       .newUntypedWorkflowStub("order-" + input.getOrderId())
+ *       .signal("requestCancellation", input);
+ *   return TemporalOperationResult.sync(null);
  * }
  * }</pre>
  */

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperation.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperation.java
@@ -1,0 +1,53 @@
+package io.temporal.nexus;
+
+import io.nexusrpc.handler.OperationCancelDetails;
+import io.nexusrpc.handler.OperationContext;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.common.Experimental;
+import java.lang.annotation.*;
+
+/**
+ * Marks a method on a {@link ServiceImpl}-annotated class as a Temporal-backed Nexus operation. The
+ * method body <i>is</i> the start handler — the framework wraps it in a {@link
+ * TemporalOperationHandler} at registration time, with default cancel behavior matching {@link
+ * TemporalOperationHandler#cancel(OperationContext, OperationCancelDetails)}.
+ *
+ * <p>The method must:
+ *
+ * <ul>
+ *   <li>be {@code public},
+ *   <li>accept exactly three parameters: {@link TemporalOperationStartContext}, {@link
+ *       TemporalNexusClient}, and the operation input type,
+ *   <li>return {@link TemporalOperationResult}.
+ * </ul>
+ *
+ * <p>Workflow-run example:
+ *
+ * <pre>{@code
+ * @ServiceImpl(service = TransferService.class)
+ * public class TransferServiceImpl {
+ *   @TemporalOperation
+ *   public TemporalOperationResult<TransferResult> transfer(
+ *       TemporalOperationStartContext ctx, TemporalNexusClient client, TransferInput input) {
+ *     return client.startWorkflow(
+ *         TransferWorkflow.class,
+ *         TransferWorkflow::transfer,
+ *         input,
+ *         WorkflowOptions.newBuilder()
+ *             .setWorkflowId("transfer-" + input.getTransferId())
+ *             .build());
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>For custom cancel, or any other handler composition, use {@link OperationImpl} with a {@link
+ * TemporalOperationHandler} subclass that overrides {@link
+ * TemporalOperationHandler#cancelWorkflowRun}. Both annotations can coexist on the same {@link
+ * ServiceImpl} class, but never on the same method.
+ */
+@Experimental
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TemporalOperation {}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperation.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperation.java
@@ -13,7 +13,8 @@ import java.lang.annotation.*;
  * TemporalOperationHandler} at registration time, with default cancel behavior matching {@link
  * TemporalOperationHandler#cancel(OperationContext, OperationCancelDetails)}.
  *
- * <p>The method must:
+ * <p>The declaring {@link ServiceImpl}-annotated class must be {@code public} so the annotated
+ * method can be accessed at registration time. The method must:
  *
  * <ul>
  *   <li>be {@code public},

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -13,25 +13,34 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  * Generic Nexus operation handler backed by Temporal. Implements {@link OperationHandler} and
  * provides a composable way to map Temporal operations (start workflow, etc.) to Nexus operations.
  *
- * <p>Usage example:
+ * <p>For the common case (default cancel behavior), prefer {@link TemporalOperation}, which
+ * collapses the operation factory into the method itself. Subclass this class only when you need to
+ * customize cancel behavior. Override {@link #cancelWorkflowRun} to change how workflow-run
+ * cancellations are handled. The {@link #start} and {@link #cancel} methods should not be
+ * overridden — they contain the core dispatch logic.
+ *
+ * <p>Custom-cancel example:
  *
  * <pre>{@code
  * @OperationImpl
  * public OperationHandler<TransferInput, TransferResult> startTransfer() {
- *   return TemporalOperationHandler.create((context, client, input) -> {
- *     return client.startWorkflow(
- *         TransferWorkflow.class,
- *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
- *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("transfer-" + input.getTransferId())
- *             .build());
- *   });
+ *   return new TemporalOperationHandler<TransferInput, TransferResult>(
+ *       (context, client, input) ->
+ *           client.startWorkflow(
+ *               TransferWorkflow.class,
+ *               TransferWorkflow::transfer,
+ *               input,
+ *               WorkflowOptions.newBuilder()
+ *                   .setWorkflowId("transfer-" + input.getTransferId())
+ *                   .build())) {
+ *     @Override
+ *     protected void cancelWorkflowRun(
+ *         TemporalOperationCancelContext ctx, CancelWorkflowRunInput input) {
+ *       // custom logic
+ *     }
+ *   };
  * }
  * }</pre>
- *
- * <p>This class supports subclassing to customize cancel behavior. Override {@link
- * #cancelWorkflowRun} to change how workflow-run cancellations are handled. The {@link #start} and
- * {@link #cancel} methods should not be overridden — they contain the core dispatch logic.
  *
  * @param <T> the input type
  * @param <R> the result type
@@ -55,17 +64,6 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   protected TemporalOperationHandler(StartHandler<T, R> startHandler) {
     this.startHandler = startHandler;
-  }
-
-  /**
-   * Creates a {@link TemporalOperationHandler} from a start handler. Subclass and override {@link
-   * #cancelWorkflowRun} to customize cancel behavior.
-   *
-   * @param startHandler the handler to invoke on start operation requests
-   * @return an operation handler backed by the given start handler
-   */
-  public static <T, R> TemporalOperationHandler<T, R> create(StartHandler<T, R> startHandler) {
-    return new TemporalOperationHandler<>(startHandler);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -62,7 +62,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
   public interface StartHandler<T, R> {
     TemporalOperationResult<R> apply(
         TemporalOperationStartContext context, TemporalNexusClient client, T input)
-        throws OperationException;
+        throws OperationException, HandlerException;
   }
 
   private final StartHandler<T, R> startHandler;
@@ -73,7 +73,8 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   @Override
   public final OperationStartResult<R> start(
-      OperationContext ctx, OperationStartDetails details, T input) throws OperationException {
+      OperationContext ctx, OperationStartDetails details, T input)
+      throws OperationException, HandlerException {
     InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
     TemporalNexusClient client =
         new TemporalNexusClientImpl(nexusCtx.getWorkflowClient(), ctx, details);

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -16,27 +16,35 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  * provides a composable way to map Temporal operations (start workflow, start activity, etc.) to
  * Nexus operations.
  *
- * <p>Usage example:
+ * <p>For the common case (default cancel behavior), prefer {@link TemporalOperation}, which
+ * collapses the operation factory into the method itself. Subclass this class only when you need to
+ * customize cancel behavior. Override {@link #cancelWorkflowRun}, {@link #cancelUpdateWorkflow},
+ * or {@link #cancelActivityExecution} to change how the corresponding cancellation is handled. The
+ * {@link #start} and {@link #cancel} methods should not be overridden — they contain the core
+ * dispatch logic.
+ *
+ * <p>Custom-cancel example:
  *
  * <pre>{@code
  * @OperationImpl
  * public OperationHandler<TransferInput, TransferResult> startTransfer() {
- *   return TemporalOperationHandler.create((context, client, input) -> {
- *     return client.startWorkflow(
- *         TransferWorkflow.class,
- *         TransferWorkflow::transfer, input.getFromAccount(), input.getToAccount(),
- *         WorkflowOptions.newBuilder()
- *             .setWorkflowId("transfer-" + input.getTransferId())
- *             .build());
- *   });
+ *   return new TemporalOperationHandler<TransferInput, TransferResult>(
+ *       (context, client, input) ->
+ *           client.startWorkflow(
+ *               TransferWorkflow.class,
+ *               TransferWorkflow::transfer,
+ *               input,
+ *               WorkflowOptions.newBuilder()
+ *                   .setWorkflowId("transfer-" + input.getTransferId())
+ *                   .build())) {
+ *     @Override
+ *     protected void cancelWorkflowRun(
+ *         TemporalOperationCancelContext ctx, CancelWorkflowRunInput input) {
+ *       // custom logic
+ *     }
+ *   };
  * }
  * }</pre>
- *
- * <p>This class supports subclassing to customize cancel behavior. Override {@link
- * #cancelWorkflowRun} to change how workflow-run (token type {@code t:1}) cancellations are
- * handled, or {@link #cancelActivityExecution} to change how activity-execution (token type {@code
- * t:2}) cancellations are handled. The {@link #start} and {@link #cancel} methods should not be
- * overridden — they contain the core dispatch logic.
  *
  * @param <T> the input type
  * @param <R> the result type
@@ -61,17 +69,6 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   protected TemporalOperationHandler(StartHandler<T, R> startHandler) {
     this.startHandler = startHandler;
-  }
-
-  /**
-   * Creates a {@link TemporalOperationHandler} from a start handler. Subclass and override {@link
-   * #cancelWorkflowRun} or {@link #cancelActivityExecution} to customize cancel behavior.
-   *
-   * @param startHandler the handler to invoke on start operation requests
-   * @return an operation handler backed by the given start handler
-   */
-  public static <T, R> TemporalOperationHandler<T, R> create(StartHandler<T, R> startHandler) {
-    return new TemporalOperationHandler<>(startHandler);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -18,8 +18,8 @@ import io.temporal.internal.nexus.OperationTokenUtil;
  *
  * <p>For the common case (default cancel behavior), prefer {@link TemporalOperation}, which
  * collapses the operation factory into the method itself. Subclass this class only when you need to
- * customize cancel behavior. Override {@link #cancelWorkflowRun}, {@link #cancelUpdateWorkflow},
- * or {@link #cancelActivityExecution} to change how the corresponding cancellation is handled. The
+ * customize cancel behavior. Override {@link #cancelWorkflowRun}, {@link #cancelUpdateWorkflow}, or
+ * {@link #cancelActivityExecution} to change how the corresponding cancellation is handled. The
  * {@link #start} and {@link #cancel} methods should not be overridden — they contain the core
  * dispatch logic.
  *
@@ -69,6 +69,18 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   protected TemporalOperationHandler(StartHandler<T, R> startHandler) {
     this.startHandler = startHandler;
+  }
+
+  /**
+   * Creates a {@link TemporalOperationHandler} from a start handler. Subclass and override {@link
+   * #cancelWorkflowRun}, {@link #cancelUpdateWorkflow}, or {@link #cancelActivityExecution} to
+   * customize cancel behavior.
+   *
+   * @param startHandler the handler to invoke on start operation requests
+   * @return an operation handler backed by the given start handler
+   */
+  public static <T, R> TemporalOperationHandler<T, R> create(StartHandler<T, R> startHandler) {
+    return new TemporalOperationHandler<>(startHandler);
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
@@ -27,6 +27,12 @@ public class TemporalOperationProcessorTest {
     java.util.List<String> compose(java.util.Map<String, Integer> input);
   }
 
+  @Service
+  public interface VoidIoService {
+    @Operation
+    Void op();
+  }
+
   @Test
   public void happyPath_registersTemporalOperation() {
     TemporalOperationProcessor.process(new ValidSugar());
@@ -38,6 +44,13 @@ public class TemporalOperationProcessorTest {
   public void happyPath_compositeGenerics() {
     // Validation must traverse parameterized types (List<String>, Map<String, Integer>).
     TemporalOperationProcessor.process(new CompositeOk());
+  }
+
+  @Test
+  public void happyPath_voidInputAndOutput() {
+    // A no-input @Operation (Void op()) must register: declared Void param matches Void input,
+    // and a Void result type matches the operation's Void output.
+    TemporalOperationProcessor.process(new VoidIo());
   }
 
   @Test
@@ -235,6 +248,15 @@ public class TemporalOperationProcessorTest {
     public TemporalOperationResult<String> op(
         TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
       throw new IllegalStateException("user-thrown");
+    }
+  }
+
+  @ServiceImpl(service = VoidIoService.class)
+  public static class VoidIo {
+    @TemporalOperation
+    public TemporalOperationResult<Void> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, Void input) {
+      return TemporalOperationResult.sync(null);
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
@@ -1,0 +1,250 @@
+package io.temporal.internal.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TemporalOperationProcessorTest {
+
+  @Service
+  public interface SingleOpService {
+    @Operation
+    String op(String input);
+  }
+
+  @Service
+  public interface CompositeGenericService {
+    @Operation
+    java.util.List<String> compose(java.util.Map<String, Integer> input);
+  }
+
+  @Test
+  public void happyPath_registersTemporalOperation() {
+    TemporalOperationProcessor.process(new ValidSugar());
+    // No exception → registration succeeded. End-to-end behavior is covered in
+    // TemporalOperationAnnotationTest.
+  }
+
+  @Test
+  public void happyPath_compositeGenerics() {
+    // Validation must traverse parameterized types (List<String>, Map<String, Integer>).
+    TemporalOperationProcessor.process(new CompositeOk());
+  }
+
+  @Test
+  public void rejects_compositeGenericInputMismatch() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new CompositeBadInput()));
+    Assert.assertTrue(e.getMessage(), e.getMessage().contains("input type mismatch"));
+  }
+
+  @Test
+  public void rejects_compositeGenericOutputMismatch() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new CompositeBadOutput()));
+    Assert.assertTrue(e.getMessage(), e.getMessage().contains("output type mismatch"));
+  }
+
+  @Test
+  public void rejects_rawReturnType() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new RawReturnType()));
+    Assert.assertTrue(
+        e.getMessage(), e.getMessage().contains("must use parameterized TemporalOperationResult"));
+  }
+
+  @Test
+  public void rejects_nonPublicMethod() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new NonPublicMethod()));
+    Assert.assertTrue(e.getMessage(), e.getMessage().contains("must be public"));
+  }
+
+  @Test
+  public void rejects_staticMethod() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new StaticMethod()));
+    Assert.assertTrue(e.getMessage(), e.getMessage().contains("must not be static"));
+  }
+
+  @Test
+  public void invokeStartHandler_propagatesRuntimeExceptionUnwrapped() throws Exception {
+    // A RuntimeException thrown from a user @TemporalOperation method must arrive at the
+    // caller without an InvocationTargetException or RuntimeException wrapper inserted by the
+    // dispatch path.
+    ThrowingHandler instance = new ThrowingHandler();
+    java.lang.reflect.Method m =
+        ThrowingHandler.class.getMethod(
+            "op", TemporalOperationStartContext.class, TemporalNexusClient.class, String.class);
+    java.lang.invoke.MethodHandle handle =
+        java.lang.invoke.MethodHandles.lookup().unreflect(m).bindTo(instance);
+    IllegalStateException thrown =
+        Assert.assertThrows(
+            IllegalStateException.class,
+            () -> TemporalOperationProcessor.invokeStartHandler(handle, null, null, "in"));
+    Assert.assertEquals("user-thrown", thrown.getMessage());
+    // First user frame is at the top — no reflective wrapper class in between.
+    Assert.assertEquals(ThrowingHandler.class.getName(), thrown.getStackTrace()[0].getClassName());
+  }
+
+  @Test
+  public void rejects_badReturnType() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new BadReturnType()));
+    Assert.assertTrue(
+        e.getMessage(), e.getMessage().contains("must return TemporalOperationResult"));
+  }
+
+  @Test
+  public void rejects_badArity() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new BadArity()));
+    Assert.assertTrue(
+        e.getMessage(),
+        e.getMessage()
+            .contains("must accept (TemporalOperationStartContext, TemporalNexusClient, I)"));
+  }
+
+  @Test
+  public void rejects_dualAnnotation() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new DualAnnotated()));
+    Assert.assertTrue(
+        e.getMessage(),
+        e.getMessage().contains("@TemporalOperation and @OperationImpl cannot be combined"));
+  }
+
+  // ----- Fixtures -----
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class ValidSugar {
+    @TemporalOperation
+    public TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class BadReturnType {
+    @TemporalOperation
+    public String op(TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return input;
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class BadArity {
+    @TemporalOperation
+    public TemporalOperationResult<String> op(TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = CompositeGenericService.class)
+  public static class CompositeOk {
+    @TemporalOperation
+    public TemporalOperationResult<java.util.List<String>> compose(
+        TemporalOperationStartContext ctx,
+        TemporalNexusClient client,
+        java.util.Map<String, Integer> input) {
+      return TemporalOperationResult.sync(java.util.Collections.emptyList());
+    }
+  }
+
+  @ServiceImpl(service = CompositeGenericService.class)
+  public static class CompositeBadInput {
+    // Map value type is String instead of Integer.
+    @TemporalOperation
+    public TemporalOperationResult<java.util.List<String>> compose(
+        TemporalOperationStartContext ctx,
+        TemporalNexusClient client,
+        java.util.Map<String, String> input) {
+      return TemporalOperationResult.sync(java.util.Collections.emptyList());
+    }
+  }
+
+  @ServiceImpl(service = CompositeGenericService.class)
+  public static class CompositeBadOutput {
+    // Result list element type is Integer instead of String.
+    @TemporalOperation
+    public TemporalOperationResult<java.util.List<Integer>> compose(
+        TemporalOperationStartContext ctx,
+        TemporalNexusClient client,
+        java.util.Map<String, Integer> input) {
+      return TemporalOperationResult.sync(java.util.Collections.emptyList());
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @ServiceImpl(service = SingleOpService.class)
+  public static class RawReturnType {
+    @TemporalOperation
+    public TemporalOperationResult op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class NonPublicMethod {
+    @TemporalOperation
+    TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class StaticMethod {
+    @TemporalOperation
+    public static TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class ThrowingHandler {
+    @TemporalOperation
+    public TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      throw new IllegalStateException("user-thrown");
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class DualAnnotated {
+    @TemporalOperation
+    @OperationImpl
+    public OperationHandler<String, String> op() {
+      return new TemporalOperationHandler<String, String>(
+          (ctx, client, input) -> TemporalOperationResult.sync(input)) {};
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
@@ -56,27 +56,21 @@ public class TemporalOperationProcessorTest {
   @Test
   public void rejects_compositeGenericInputMismatch() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new CompositeBadInput()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new CompositeBadInput()));
     Assert.assertTrue(e.getMessage(), e.getMessage().contains("input type mismatch"));
   }
 
   @Test
   public void rejects_compositeGenericOutputMismatch() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new CompositeBadOutput()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new CompositeBadOutput()));
     Assert.assertTrue(e.getMessage(), e.getMessage().contains("output type mismatch"));
   }
 
   @Test
   public void rejects_rawReturnType() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new RawReturnType()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new RawReturnType()));
     Assert.assertTrue(
         e.getMessage(), e.getMessage().contains("must use parameterized TemporalOperationResult"));
   }
@@ -84,18 +78,14 @@ public class TemporalOperationProcessorTest {
   @Test
   public void rejects_nonPublicMethod() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new NonPublicMethod()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new NonPublicMethod()));
     Assert.assertTrue(e.getMessage(), e.getMessage().contains("must be public"));
   }
 
   @Test
   public void rejects_staticMethod() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new StaticMethod()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new StaticMethod()));
     Assert.assertTrue(e.getMessage(), e.getMessage().contains("must not be static"));
   }
 
@@ -137,9 +127,7 @@ public class TemporalOperationProcessorTest {
   @Test
   public void rejects_badReturnType() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new BadReturnType()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new BadReturnType()));
     Assert.assertTrue(
         e.getMessage(), e.getMessage().contains("must return TemporalOperationResult"));
   }
@@ -147,9 +135,7 @@ public class TemporalOperationProcessorTest {
   @Test
   public void rejects_badArity() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new BadArity()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new BadArity()));
     Assert.assertTrue(
         e.getMessage(),
         e.getMessage()
@@ -159,9 +145,7 @@ public class TemporalOperationProcessorTest {
   @Test
   public void rejects_checkedExceptionInThrows() {
     IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new DeclaresCheckedException()));
+        assertInvalid(() -> TemporalOperationProcessor.process(new DeclaresCheckedException()));
     Assert.assertTrue(
         e.getMessage(),
         e.getMessage()
@@ -183,14 +167,15 @@ public class TemporalOperationProcessorTest {
   }
 
   @Test
-  public void rejects_dualAnnotation() {
-    IllegalArgumentException e =
-        Assert.assertThrows(
-            IllegalArgumentException.class,
-            () -> TemporalOperationProcessor.process(new DualAnnotated()));
-    Assert.assertTrue(
-        e.getMessage(),
-        e.getMessage().contains("@TemporalOperation and @OperationImpl cannot be combined"));
+  public void operationImpl_takesPrecedenceOverTemporalOperation() {
+    Assert.assertEquals(
+        1, TemporalOperationProcessor.process(new DualAnnotated()).getOperationHandlers().size());
+  }
+
+  private static IllegalArgumentException assertInvalid(Runnable action) {
+    RuntimeException wrapper = Assert.assertThrows(RuntimeException.class, action::run);
+    Assert.assertTrue(wrapper.getCause() instanceof IllegalArgumentException);
+    return (IllegalArgumentException) wrapper.getCause();
   }
 
   // ----- Fixtures -----

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/TemporalOperationProcessorTest.java
@@ -100,6 +100,21 @@ public class TemporalOperationProcessorTest {
   }
 
   @Test
+  public void invokeStartHandler_readsInstanceField() throws Exception {
+    // The method handle must be bound to the @ServiceImpl instance so the user's method can
+    // read constructor-injected dependencies (workflow client, config, etc.) off `this`.
+    StatefulHandler instance = new StatefulHandler("injected");
+    java.lang.reflect.Method m =
+        StatefulHandler.class.getMethod(
+            "op", TemporalOperationStartContext.class, TemporalNexusClient.class, String.class);
+    java.lang.invoke.MethodHandle handle =
+        java.lang.invoke.MethodHandles.lookup().unreflect(m).bindTo(instance);
+    TemporalOperationResult<Object> result =
+        TemporalOperationProcessor.invokeStartHandler(handle, null, null, "input");
+    Assert.assertEquals("injected:input", result.getSyncResult());
+  }
+
+  @Test
   public void invokeStartHandler_propagatesRuntimeExceptionUnwrapped() throws Exception {
     // A RuntimeException thrown from a user @TemporalOperation method must arrive at the
     // caller without an InvocationTargetException or RuntimeException wrapper inserted by the
@@ -139,6 +154,32 @@ public class TemporalOperationProcessorTest {
         e.getMessage(),
         e.getMessage()
             .contains("must accept (TemporalOperationStartContext, TemporalNexusClient, I)"));
+  }
+
+  @Test
+  public void rejects_checkedExceptionInThrows() {
+    IllegalArgumentException e =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> TemporalOperationProcessor.process(new DeclaresCheckedException()));
+    Assert.assertTrue(
+        e.getMessage(),
+        e.getMessage()
+            .contains("may only declare OperationException or HandlerException as checked"));
+    Assert.assertTrue(e.getMessage(), e.getMessage().contains(java.io.IOException.class.getName()));
+  }
+
+  @Test
+  public void allows_runtimeExceptionInThrows() {
+    // Unchecked exceptions in the throws clause are fine — they don't constrain callers.
+    TemporalOperationProcessor.process(new DeclaresRuntimeException());
+  }
+
+  @Test
+  public void allows_nexusrpcCheckedExceptionsInThrows() {
+    // OperationException and HandlerException are the nexusrpc-sanctioned checked exceptions on
+    // OperationHandler.start, so we let them through.
+    TemporalOperationProcessor.process(new DeclaresNexusrpcCheckedExceptions());
   }
 
   @Test
@@ -243,6 +284,21 @@ public class TemporalOperationProcessorTest {
   }
 
   @ServiceImpl(service = SingleOpService.class)
+  public static class StatefulHandler {
+    private final String prefix;
+
+    public StatefulHandler(String prefix) {
+      this.prefix = prefix;
+    }
+
+    @TemporalOperation
+    public TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync(prefix + ":" + input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
   public static class ThrowingHandler {
     @TemporalOperation
     public TemporalOperationResult<String> op(
@@ -257,6 +313,36 @@ public class TemporalOperationProcessorTest {
     public TemporalOperationResult<Void> op(
         TemporalOperationStartContext ctx, TemporalNexusClient client, Void input) {
       return TemporalOperationResult.sync(null);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class DeclaresCheckedException {
+    @TemporalOperation
+    public TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input)
+        throws java.io.IOException {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class DeclaresRuntimeException {
+    @TemporalOperation
+    public TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input)
+        throws IllegalStateException {
+      return TemporalOperationResult.sync(input);
+    }
+  }
+
+  @ServiceImpl(service = SingleOpService.class)
+  public static class DeclaresNexusrpcCheckedExceptions {
+    @TemporalOperation
+    public TemporalOperationResult<String> op(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input)
+        throws io.nexusrpc.OperationException, io.nexusrpc.handler.HandlerException {
+      return TemporalOperationResult.sync(input);
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
@@ -2,8 +2,6 @@ package io.temporal.workflow.nexus;
 
 import io.nexusrpc.Operation;
 import io.nexusrpc.Service;
-import io.nexusrpc.handler.OperationHandler;
-import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.client.WorkflowFailedException;
@@ -11,7 +9,10 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.internal.Signal;
-import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.time.Duration;
@@ -121,17 +122,16 @@ public class GenericHandlerCancelTest extends BaseNexusTest {
 
   @ServiceImpl(service = TestNexusCancelService.class)
   public class TestNexusServiceImpl {
-    @OperationImpl
-    public OperationHandler<String, Void> operation() {
-      return TemporalOperationHandler.create(
-          (context, client, input) ->
-              client.startWorkflow(
-                  WaitForCancelWorkflowInterface.class,
-                  WaitForCancelWorkflowInterface::execute,
-                  input,
-                  WorkflowOptions.newBuilder()
-                      .setWorkflowId("generic-cancel-test-" + context.getService())
-                      .build()));
+    @TemporalOperation
+    public TemporalOperationResult<Void> operation(
+        TemporalOperationStartContext context, TemporalNexusClient client, String input) {
+      return client.startWorkflow(
+          WaitForCancelWorkflowInterface.class,
+          WaitForCancelWorkflowInterface::execute,
+          input,
+          WorkflowOptions.newBuilder()
+              .setWorkflowId("generic-cancel-test-" + context.getService())
+              .build());
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
@@ -3,14 +3,15 @@ package io.temporal.workflow.nexus;
 import io.nexusrpc.Operation;
 import io.nexusrpc.Service;
 import io.nexusrpc.handler.HandlerException;
-import io.nexusrpc.handler.OperationHandler;
-import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
-import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -94,27 +95,25 @@ public class GenericHandlerDoubleStartTest {
 
   @ServiceImpl(service = TestNexusServiceDoubleStart.class)
   public class TestNexusServiceImpl {
-    @OperationImpl
-    public OperationHandler<String, String> operation() {
-      return TemporalOperationHandler.create(
-          (context, client, input) -> {
-            // First start should succeed but the workflow blocks indefinitely
-            client.startWorkflow(
-                BlockingWorkflow.class,
-                BlockingWorkflow::execute,
-                input,
-                WorkflowOptions.newBuilder()
-                    .setWorkflowId("double-start-first-" + context.getService())
-                    .build());
-            // Second start should throw
-            return client.startWorkflow(
-                BlockingWorkflow.class,
-                BlockingWorkflow::execute,
-                input,
-                WorkflowOptions.newBuilder()
-                    .setWorkflowId("double-start-second-" + context.getService())
-                    .build());
-          });
+    @TemporalOperation
+    public TemporalOperationResult<String> operation(
+        TemporalOperationStartContext context, TemporalNexusClient client, String input) {
+      // First start should succeed but the workflow blocks indefinitely
+      client.startWorkflow(
+          BlockingWorkflow.class,
+          BlockingWorkflow::execute,
+          input,
+          WorkflowOptions.newBuilder()
+              .setWorkflowId("double-start-first-" + context.getService())
+              .build());
+      // Second start should throw
+      return client.startWorkflow(
+          BlockingWorkflow.class,
+          BlockingWorkflow::execute,
+          input,
+          WorkflowOptions.newBuilder()
+              .setWorkflowId("double-start-second-" + context.getService())
+              .build());
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
@@ -2,11 +2,11 @@ package io.temporal.workflow.nexus;
 
 import io.nexusrpc.Operation;
 import io.nexusrpc.Service;
-import io.nexusrpc.handler.OperationHandler;
-import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
-import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -55,10 +55,10 @@ public class GenericHandlerSyncResultTest {
 
   @ServiceImpl(service = TestNexusSyncService.class)
   public class TestNexusServiceImpl {
-    @OperationImpl
-    public OperationHandler<String, String> operation() {
-      return TemporalOperationHandler.create(
-          (context, client, input) -> TemporalOperationResult.sync("sync-" + input));
+    @TemporalOperation
+    public TemporalOperationResult<String> operation(
+        TemporalOperationStartContext context, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync("sync-" + input);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -2,11 +2,12 @@ package io.temporal.workflow.nexus;
 
 import io.nexusrpc.Operation;
 import io.nexusrpc.Service;
-import io.nexusrpc.handler.OperationHandler;
-import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -60,75 +61,72 @@ public class GenericHandlerTypedProcTest {
 
   @ServiceImpl(service = TestNexusServiceProc.class)
   public class TestNexusServiceImpl {
-    @OperationImpl
-    public OperationHandler<Integer, Void> operation() {
-      return TemporalOperationHandler.create(
-          (context, client, input) -> {
-            String prefix = "generic-handler-test-proc" + input + "-";
-            String workflowId = prefix + context.getService() + "-" + context.getOperation();
-            WorkflowOptions options =
-                WorkflowOptions.newBuilder().setWorkflowId(workflowId).build();
-            switch (input) {
-              case 0:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc::proc,
-                    options);
-              case 1:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowProc::proc1,
-                    "input",
-                    options);
-              case 2:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowProc::proc2,
-                    "input",
-                    2,
-                    options);
-              case 3:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowProc::proc3,
-                    "input",
-                    2,
-                    3,
-                    options);
-              case 4:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowProc::proc4,
-                    "input",
-                    2,
-                    3,
-                    4,
-                    options);
-              case 5:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowProc::proc5,
-                    "input",
-                    2,
-                    3,
-                    4,
-                    5,
-                    options);
-              case 6:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowProc.class,
-                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowProc::proc6,
-                    "input",
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    options);
-              default:
-                throw new IllegalArgumentException("unexpected input: " + input);
-            }
-          });
+    @TemporalOperation
+    public TemporalOperationResult<Void> operation(
+        TemporalOperationStartContext context, TemporalNexusClient client, Integer input) {
+      String prefix = "generic-handler-test-proc" + input + "-";
+      String workflowId = prefix + context.getService() + "-" + context.getOperation();
+      WorkflowOptions options = WorkflowOptions.newBuilder().setWorkflowId(workflowId).build();
+      switch (input) {
+        case 0:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.TestNoArgsWorkflowProc::proc,
+              options);
+        case 1:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test1ArgWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.Test1ArgWorkflowProc::proc1,
+              "input",
+              options);
+        case 2:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test2ArgWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.Test2ArgWorkflowProc::proc2,
+              "input",
+              2,
+              options);
+        case 3:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test3ArgWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.Test3ArgWorkflowProc::proc3,
+              "input",
+              2,
+              3,
+              options);
+        case 4:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test4ArgWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.Test4ArgWorkflowProc::proc4,
+              "input",
+              2,
+              3,
+              4,
+              options);
+        case 5:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test5ArgWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.Test5ArgWorkflowProc::proc5,
+              "input",
+              2,
+              3,
+              4,
+              5,
+              options);
+        case 6:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test6ArgWorkflowProc.class,
+              TestMultiArgWorkflowFunctions.Test6ArgWorkflowProc::proc6,
+              "input",
+              2,
+              3,
+              4,
+              5,
+              6,
+              options);
+        default:
+          throw new IllegalArgumentException("unexpected input: " + input);
+      }
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
@@ -2,11 +2,12 @@ package io.temporal.workflow.nexus;
 
 import io.nexusrpc.Operation;
 import io.nexusrpc.Service;
-import io.nexusrpc.handler.OperationHandler;
-import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -61,75 +62,72 @@ public class GenericHandlerTypedStartWorkflowTest {
 
   @ServiceImpl(service = TestNexusServiceGeneric.class)
   public class TestNexusServiceImpl {
-    @OperationImpl
-    public OperationHandler<Integer, String> operation() {
-      return TemporalOperationHandler.create(
-          (context, client, input) -> {
-            String prefix = "generic-handler-test-func" + input + "-";
-            String workflowId = prefix + context.getService() + "-" + context.getOperation();
-            WorkflowOptions options =
-                WorkflowOptions.newBuilder().setWorkflowId(workflowId).build();
-            switch (input) {
-              case 0:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc::func,
-                    options);
-              case 1:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
-                    "input",
-                    options);
-              case 2:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc::func2,
-                    "input",
-                    2,
-                    options);
-              case 3:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.Test3ArgWorkflowFunc::func3,
-                    "input",
-                    2,
-                    3,
-                    options);
-              case 4:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.Test4ArgWorkflowFunc::func4,
-                    "input",
-                    2,
-                    3,
-                    4,
-                    options);
-              case 5:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.Test5ArgWorkflowFunc::func5,
-                    "input",
-                    2,
-                    3,
-                    4,
-                    5,
-                    options);
-              case 6:
-                return client.startWorkflow(
-                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowFunc.class,
-                    TestMultiArgWorkflowFunctions.Test6ArgWorkflowFunc::func6,
-                    "input",
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    options);
-              default:
-                throw new IllegalArgumentException("unexpected input: " + input);
-            }
-          });
+    @TemporalOperation
+    public TemporalOperationResult<String> operation(
+        TemporalOperationStartContext context, TemporalNexusClient client, Integer input) {
+      String prefix = "generic-handler-test-func" + input + "-";
+      String workflowId = prefix + context.getService() + "-" + context.getOperation();
+      WorkflowOptions options = WorkflowOptions.newBuilder().setWorkflowId(workflowId).build();
+      switch (input) {
+        case 0:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.TestNoArgsWorkflowFunc::func,
+              options);
+        case 1:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.Test1ArgWorkflowFunc::func1,
+              "input",
+              options);
+        case 2:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.Test2ArgWorkflowFunc::func2,
+              "input",
+              2,
+              options);
+        case 3:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test3ArgWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.Test3ArgWorkflowFunc::func3,
+              "input",
+              2,
+              3,
+              options);
+        case 4:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test4ArgWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.Test4ArgWorkflowFunc::func4,
+              "input",
+              2,
+              3,
+              4,
+              options);
+        case 5:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test5ArgWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.Test5ArgWorkflowFunc::func5,
+              "input",
+              2,
+              3,
+              4,
+              5,
+              options);
+        case 6:
+          return client.startWorkflow(
+              TestMultiArgWorkflowFunctions.Test6ArgWorkflowFunc.class,
+              TestMultiArgWorkflowFunctions.Test6ArgWorkflowFunc::func6,
+              "input",
+              2,
+              3,
+              4,
+              5,
+              6,
+              options);
+        default:
+          throw new IllegalArgumentException("unexpected input: " + input);
+      }
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
@@ -2,11 +2,12 @@ package io.temporal.workflow.nexus;
 
 import io.nexusrpc.Operation;
 import io.nexusrpc.Service;
-import io.nexusrpc.handler.OperationHandler;
-import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -57,21 +58,17 @@ public class GenericHandlerUntypedStartWorkflowTest {
 
   @ServiceImpl(service = TestNexusServiceUntyped.class)
   public class TestNexusServiceImpl {
-    @OperationImpl
-    public OperationHandler<String, String> operation() {
-      return TemporalOperationHandler.create(
-          (context, client, input) ->
-              client.startWorkflow(
-                  "func1",
-                  String.class,
-                  WorkflowOptions.newBuilder()
-                      .setWorkflowId(
-                          "generic-handler-untyped-"
-                              + context.getService()
-                              + "-"
-                              + context.getOperation())
-                      .build(),
-                  input));
+    @TemporalOperation
+    public TemporalOperationResult<String> operation(
+        TemporalOperationStartContext context, TemporalNexusClient client, String input) {
+      return client.startWorkflow(
+          "func1",
+          String.class,
+          WorkflowOptions.newBuilder()
+              .setWorkflowId(
+                  "generic-handler-untyped-" + context.getService() + "-" + context.getOperation())
+              .build(),
+          input);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/TemporalOperationAnnotationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/TemporalOperationAnnotationTest.java
@@ -1,0 +1,175 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.nexus.TemporalNexusClient;
+import io.temporal.nexus.TemporalOperation;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.nexus.TemporalOperationResult;
+import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** End-to-end coverage of the {@link TemporalOperation} sugar. */
+public class TemporalOperationAnnotationTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(SugarCaller.class, MixedCaller.class, SugarTargetWorkflowImpl.class)
+          .setNexusServiceImplementation(
+              new SugarServiceImpl(), new SyncSugarServiceImpl(), new MixedServiceImpl())
+          .build();
+
+  @Test
+  public void workflowRunSugar_endToEnd() {
+    TestWorkflows.TestWorkflow1 stub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+    Assert.assertEquals("workflow:wf-input", stub.execute("wf-input"));
+  }
+
+  @Test
+  public void syncSugar_endToEnd() {
+    SyncCallerWorkflow stub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(SyncCallerWorkflow.class);
+    Assert.assertEquals("sync:hi", stub.execute("hi"));
+  }
+
+  @Test
+  public void mixedClass_bothOperationsReachable() {
+    MixedCallerWorkflow stub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(MixedCallerWorkflow.class);
+    Assert.assertEquals("workflow:mixed-input|legacy:legacy-input", stub.execute("mixed-input"));
+  }
+
+  // ----- Caller workflows -----
+
+  @WorkflowInterface
+  public interface SyncCallerWorkflow {
+    @WorkflowMethod
+    String execute(String arg);
+  }
+
+  @WorkflowInterface
+  public interface MixedCallerWorkflow {
+    @WorkflowMethod
+    String execute(String arg);
+  }
+
+  @WorkflowInterface
+  public interface SugarTargetWorkflow {
+    @WorkflowMethod
+    String run(String arg);
+  }
+
+  public static class SugarTargetWorkflowImpl implements SugarTargetWorkflow {
+    @Override
+    public String run(String arg) {
+      return "workflow:" + arg;
+    }
+  }
+
+  /** Drives the workflow-run sugar test via {@link TestWorkflows.TestWorkflow1}. */
+  public static class SugarCaller implements TestWorkflows.TestWorkflow1, SyncCallerWorkflow {
+    @Override
+    public String execute(String input) {
+      NexusServiceOptions options = defaultServiceOptions();
+      // SyncCallerWorkflow re-uses the same impl method via the SyncCallerWorkflow interface;
+      // distinguish by sentinel input so each test exercises one path.
+      if ("hi".equals(input)) {
+        return Workflow.newNexusServiceStub(SyncSugarService.class, options).greet(input);
+      }
+      return Workflow.newNexusServiceStub(SugarService.class, options).start(input);
+    }
+  }
+
+  public static class MixedCaller implements MixedCallerWorkflow {
+    @Override
+    public String execute(String input) {
+      MixedService stub = Workflow.newNexusServiceStub(MixedService.class, defaultServiceOptions());
+      return stub.workflowOp(input) + "|" + stub.legacyOp("legacy-input");
+    }
+  }
+
+  private static NexusServiceOptions defaultServiceOptions() {
+    return NexusServiceOptions.newBuilder()
+        .setOperationOptions(
+            NexusOperationOptions.newBuilder()
+                .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+                .build())
+        .build();
+  }
+
+  // ----- Nexus services -----
+
+  @Service
+  public interface SugarService {
+    @Operation
+    String start(String input);
+  }
+
+  @Service
+  public interface SyncSugarService {
+    @Operation
+    String greet(String input);
+  }
+
+  @Service
+  public interface MixedService {
+    @Operation
+    String workflowOp(String input);
+
+    @Operation
+    String legacyOp(String input);
+  }
+
+  @ServiceImpl(service = SugarService.class)
+  public static class SugarServiceImpl {
+    @TemporalOperation
+    public TemporalOperationResult<String> start(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return client.startWorkflow(
+          SugarTargetWorkflow.class,
+          SugarTargetWorkflow::run,
+          input,
+          WorkflowOptions.newBuilder().setWorkflowId("sugar-" + ctx.getRequestId()).build());
+    }
+  }
+
+  @ServiceImpl(service = SyncSugarService.class)
+  public static class SyncSugarServiceImpl {
+    @TemporalOperation
+    public TemporalOperationResult<String> greet(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return TemporalOperationResult.sync("sync:" + input);
+    }
+  }
+
+  @ServiceImpl(service = MixedService.class)
+  public static class MixedServiceImpl {
+    @TemporalOperation
+    public TemporalOperationResult<String> workflowOp(
+        TemporalOperationStartContext ctx, TemporalNexusClient client, String input) {
+      return client.startWorkflow(
+          SugarTargetWorkflow.class,
+          SugarTargetWorkflow::run,
+          input,
+          WorkflowOptions.newBuilder().setWorkflowId("mixed-" + ctx.getRequestId()).build());
+    }
+
+    @OperationImpl
+    public OperationHandler<String, String> legacyOp() {
+      return new TemporalOperationHandler<String, String>(
+          (ctx, client, input) -> TemporalOperationResult.sync("legacy:" + input)) {};
+    }
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -453,8 +453,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
                 AopUtils.getTargetClass(bean),
                 taskQueue);
             worker.registerNexusServiceImplementation(bean);
-            ServiceDefinition definition =
-                TemporalOperationProcessor.process(bean).getDefinition();
+            ServiceDefinition definition = TemporalOperationProcessor.process(bean).getDefinition();
             addRegisteredNexusServiceImpl(worker, beanName, bean.getClass().getName(), definition);
           });
     }

--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -4,7 +4,6 @@ import static io.temporal.serviceclient.CheckedExceptionWrapper.wrap;
 
 import com.google.common.base.Preconditions;
 import io.nexusrpc.ServiceDefinition;
-import io.nexusrpc.handler.ServiceImplInstance;
 import io.opentracing.Tracer;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.Experimental;
@@ -14,6 +13,7 @@ import io.temporal.common.metadata.POJOActivityImplMetadata;
 import io.temporal.common.metadata.POJOWorkflowImplMetadata;
 import io.temporal.common.metadata.POJOWorkflowMethodMetadata;
 import io.temporal.internal.common.env.ReflectionUtils;
+import io.temporal.internal.nexus.TemporalOperationProcessor;
 import io.temporal.internal.sync.POJOWorkflowImplementationFactory;
 import io.temporal.spring.boot.ActivityImpl;
 import io.temporal.spring.boot.NexusServiceImpl;
@@ -453,7 +453,8 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
                 AopUtils.getTargetClass(bean),
                 taskQueue);
             worker.registerNexusServiceImplementation(bean);
-            ServiceDefinition definition = ServiceImplInstance.fromInstance(bean).getDefinition();
+            ServiceDefinition definition =
+                TemporalOperationProcessor.process(bean).getDefinition();
             addRegisteredNexusServiceImpl(worker, beanName, bean.getClass().getName(), definition);
           });
     }
@@ -531,7 +532,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
           worker,
           beanName,
           bean.getClass().getName(),
-          ServiceImplInstance.fromInstance(bean).getDefinition());
+          TemporalOperationProcessor.process(bean).getDefinition());
       if (log.isInfoEnabled()) {
         log.info(
             "Registering auto-discovered nexus service bean '{}' of class {} on a worker {} with a task queue '{}'",

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/TestServiceUtils.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/TestServiceUtils.java
@@ -3,7 +3,6 @@ package io.temporal.testing.internal;
 import static io.temporal.internal.common.InternalUtils.createNormalTaskQueue;
 
 import com.google.protobuf.ByteString;
-import io.nexusrpc.handler.ServiceImplInstance;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
@@ -15,6 +14,7 @@ import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
 import io.temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.StartWorkflowExecutionRequest;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.internal.nexus.TemporalOperationProcessor;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.WorkflowImplementationOptions;
 import io.temporal.workflow.NexusServiceOptions;
@@ -33,7 +33,8 @@ public class TestServiceUtils {
       String endpoint) {
     Map<String, NexusServiceOptions> newNexusServiceOptions = new HashMap<>();
     for (Object nexusService : nexusServiceImplementations) {
-      String serviceName = ServiceImplInstance.fromInstance(nexusService).getDefinition().getName();
+      String serviceName =
+          TemporalOperationProcessor.process(nexusService).getDefinition().getName();
       NexusServiceOptions serviceOptionWithEndpoint =
           options.getNexusServiceOptions().get(serviceName);
       if (serviceOptionWithEndpoint == null) {


### PR DESCRIPTION
## What changed?

Introduces `@TemporalOperation`, a method-level annotation that declares a Temporal-backed Nexus operation directly on a `@ServiceImpl` class. The annotated method becomes the operation start handler with Temporal's default cancellation behavior, removing the separate operation-handler factory required by the common case.

The integration uses the Nexus SDK's custom-annotation extension contract:

- Nexus matches service methods to `OperationDefinition`s and owns operation naming.
- The Temporal extension validates recognized `@TemporalOperation` methods and returns their handlers.
- `@OperationImpl` takes precedence when both annotations are present on the same method.
- Extensions are considered in registration order, consistently with the Nexus Java and .NET SDKs.

`TemporalOperationHandler` remains available for custom cancellation and handler composition, including its `create` factory used by existing Nexus operation integrations.

## Why?

Defining a Temporal-backed Nexus operation currently requires boilerplate that obscures the operation's start logic. `@TemporalOperation` puts the start handler directly on the service implementation while retaining `@OperationImpl` for advanced composition and custom cancellation.

## Breaking changes?

This adds experimental API and requires the revised `MethodExtension` contract from [nexus-rpc/sdk-java#46](https://github.com/nexus-rpc/sdk-java/pull/46). Existing `@OperationImpl` service implementations are unchanged.

Within this unmerged feature, a method carrying both annotations now follows the shared SDK rule that `@OperationImpl` wins instead of failing registration.

## Server PR

None.

## Testing

- `TemporalOperationProcessorTest` — 16 passing tests.
- `TemporalOperationAnnotationTest` — 3 passing end-to-end tests.
- `:temporal-sdk:javadoc`.
- `:temporal-sdk:spotlessApply`.

The full repository test suite was not run locally; CI covers the remaining matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Nexus operation registration and dispatch on workers and Spring Boot; behavior is additive for @OperationImpl users but depends on nexus-rpc 0.6.0-alpha MethodExtension semantics.
> 
> **Overview**
> Adds experimental **`@TemporalOperation`** so Temporal-backed Nexus operations can be declared as ordinary methods on `@ServiceImpl` classes instead of `@OperationImpl` factories that return `TemporalOperationHandler.create(...)`.
> 
> **`TemporalOperationProcessor`** plugs into Nexus’s `MethodExtension` API (`nexusVersion` **0.6.0-alpha**): it validates the method shape `(TemporalOperationStartContext, TemporalNexusClient, input) → TemporalOperationResult<R>`, binds the instance with a `MethodHandle`, and wraps the body in `TemporalOperationHandler` with default cancel behavior. **`@OperationImpl` wins** when both annotations are on the same method. Worker, Spring Boot, and test harness registration now call `TemporalOperationProcessor.process` instead of `ServiceImplInstance.fromInstance` alone.
> 
> `TemporalOperationHandler.StartHandler` / `start` now allow **`HandlerException`** alongside `OperationException`. Docs and existing generic-handler tests are migrated to `@TemporalOperation`; new unit and E2E tests (including Kotlin) cover validation and mixed `@OperationImpl` + `@TemporalOperation` services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5e2aba348a5327e68e443455e6a653f1a1ad6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->