### PR TITLE
Remove Netty versions metadata from shaded jar

### DIFF
--- a/temporal-shaded/build.gradle
+++ b/temporal-shaded/build.gradle
@@ -69,6 +69,7 @@ configurations.shadow {
 
 shadowJar {
     configurations = [project.configurations.shadow]
+    exclude 'META-INF/io.netty.versions.properties'
 
     relocate 'gogoproto', 'io.temporal.shaded.gogoproto' // protobuf
     relocate 'com.google.rpc', 'io.temporal.shaded.com.google.rpc' // StatusUtils


### PR DESCRIPTION
## What changed?
- Exclude META-INF/io.netty.versions.properties from the temporal-shaded jar.

## Why?
grpc-netty-shaded contributes Netty's versions metadata to temporal-shaded. Consumers that scan classpaths for Netty version mismatches can treat temporal-shaded as another Netty distribution and emit inconsistent version warnings, even though the classes are relocated.

## Breaking changes?
No.

## Server PR
None.

## Testing
- JAVA_HOME=/nix/store/bp2gjhd8vfyv2hg0i90sba2wp47vvflg-zulu-ca-jdk-21.0.11 PATH=/nix/store/bp2gjhd8vfyv2hg0i90sba2wp47vvflg-zulu-ca-jdk-21.0.11/bin:/Users/nanne/.nix-profile/bin:/usr/bin:/bin:/usr/sbin:/sbin ./gradlew --gradle-user-home .gradle --offline :temporal-shaded:shadowJar
- Verified temporal-shaded/build/libs/temporal-shaded-unknown.jar does not contain META-INF/io.netty.versions.properties.
- Verified the shaded jar manifest still contains Multi-Release: true.