### PR TITLE
Fix metric tags for Start Standalone Activity

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/external/GenericWorkflowClientImpl.java
@@ -547,13 +547,22 @@ public final class GenericWorkflowClientImpl implements GenericWorkflowClient {
 
   @Override
   public StartActivityExecutionResponse startActivity(StartActivityExecutionRequest request) {
+    Map<String, String> tags = tagsForStartActivity(request);
+    Scope scope = metricsScope.tagged(tags);
     return grpcRetryer.retryWithResult(
         () ->
             service
                 .blockingStub()
-                .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
+                .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, scope)
                 .startActivityExecution(request),
         grpcRetryerOptions);
+  }
+
+  private static Map<String, String> tagsForStartActivity(StartActivityExecutionRequest request) {
+    return new ImmutableMap.Builder<String, String>(2)
+        .put(MetricsTag.ACTIVITY_TYPE, request.getActivityType().getName())
+        .put(MetricsTag.TASK_QUEUE, request.getTaskQueue().getName())
+        .build();
   }
 
   @Override

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/MetricsTest.java
@@ -3,6 +3,7 @@ package io.temporal.client.functional;
 import static io.temporal.testUtils.Eventually.assertEventually;
 import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static junit.framework.TestCase.*;
+import static org.junit.Assume.assumeTrue;
 
 import com.uber.m3.tally.RootScopeBuilder;
 import io.micrometer.core.instrument.*;
@@ -12,9 +13,7 @@ import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.WorkflowTaskFailedCause;
-import io.temporal.client.WorkflowFailedException;
-import io.temporal.client.WorkflowOptions;
-import io.temporal.client.WorkflowStub;
+import io.temporal.client.*;
 import io.temporal.common.reporter.MicrometerClientStatsReporter;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.CanceledFailure;
@@ -45,12 +44,17 @@ public class MetricsTest {
   public final SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
           .setWorkflowTypes(QuicklyCompletingWorkflowImpl.class, MultiScenarioWorkflowImpl.class)
-          .setActivityImplementations(runCallbackActivity)
+          .setActivityImplementations(runCallbackActivity, new StandaloneMetricsActivityImpl())
           .setMetricsScope(
               new RootScopeBuilder()
                   .reporter(new MicrometerClientStatsReporter(registry))
                   .reportEvery(com.uber.m3.util.Duration.ofMillis(REPORTING_FLUSH_TIME >> 1)))
           .build();
+
+  private final ActivityClient activityClient =
+      ActivityClient.newInstance(
+          testWorkflowRule.getWorkflowServiceStubs(),
+          ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
 
   private static final List<Tag> TAGS_NAMESPACE =
       MetricsTag.defaultTags(NAMESPACE).entrySet().stream()
@@ -135,6 +139,35 @@ public class MetricsTest {
           assertIntCounter(
               1, registry.counter(MetricsType.TEMPORAL_LONG_REQUEST, longPollRequestTags));
         });
+  }
+
+  @Test
+  public void testStandaloneActivityStartRequestTags() {
+    // SAA is not supported by in-mem test server yet
+    assumeTrue(SDKTestWorkflowRule.useExternalService);
+
+    activityClient.execute(
+        StandaloneMetricsActivity.class,
+        StandaloneMetricsActivity::run,
+        StartActivityOptions.newBuilder()
+            .setId("metrics-standalone-act-" + UUID.randomUUID())
+            .setTaskQueue(testWorkflowRule.getTaskQueue())
+            .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+            .build());
+
+    List<Tag> startActivityRequestTags =
+        replaceTags(
+            tagsNamespaceQueue,
+            MetricsTag.OPERATION_NAME,
+            "StartActivityExecution",
+            MetricsTag.ACTIVITY_TYPE,
+            "StandaloneMetricsActivity");
+
+    assertEventually(
+        Duration.ofSeconds(2),
+        () ->
+            assertIntCounter(
+                1, registry.counter(MetricsType.TEMPORAL_REQUEST, startActivityRequestTags)));
   }
 
   @Test
@@ -368,5 +401,16 @@ public class MetricsTest {
         toRun.run();
       }
     }
+  }
+
+  @ActivityInterface
+  public interface StandaloneMetricsActivity {
+    @ActivityMethod(name = "StandaloneMetricsActivity")
+    void run();
+  }
+
+  public static class StandaloneMetricsActivityImpl implements StandaloneMetricsActivity {
+    @Override
+    public void run() {}
   }
 }


### PR DESCRIPTION
## What was changed
Add `activity_type` and `task_queue` tags into metrics from Start Standalone Activity grpc calls

## Why?
Equivalent tags are applicable to Start Workflow metrics, but missing for Standalone Activity.

## How was this tested:
Standalone Activity is yet supported by in-mem test server, I plan to run the new case in `MetricsTest` on Temporal external servers in CICD stages.