### PR TITLE
Fix deadlock detection error message to reflect user-configured timeout

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
@@ -26,15 +26,25 @@ public class PotentialDeadlockException extends RuntimeException {
    * @param threadName name of the thread that is in a potential deadlock state
    * @param workflowThreadContext context of the thread that is in a potential deadlock state
    * @param detectionTimestamp a timestamp the deadlock was detected
+   * @param timeoutMillis configured deadlock detection timeout in milliseconds
    */
   PotentialDeadlockException(
-      String threadName, WorkflowThreadContext workflowThreadContext, long detectionTimestamp) {
+      String threadName, WorkflowThreadContext workflowThreadContext, long detectionTimestamp, long timeoutMillis) {
     super(
         "[TMPRL1101] Potential deadlock detected. Workflow thread \""
             + threadName
-            + "\" didn't yield control for over a second.");
+            + "\" didn't yield control for over "
+            + formatTimeout(timeoutMillis)
+            + ".");
     this.workflowThreadContext = workflowThreadContext;
     this.detectionTimestamp = detectionTimestamp;
+  }
+
+  private static String formatTimeout(long timeoutMillis) {
+    if (timeoutMillis % 1000 == 0) {
+      return timeoutMillis / 1000 + "s";
+    }
+    return timeoutMillis + "ms";
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/PotentialDeadlockException.java
@@ -29,7 +29,10 @@ public class PotentialDeadlockException extends RuntimeException {
    * @param timeoutMillis configured deadlock detection timeout in milliseconds
    */
   PotentialDeadlockException(
-      String threadName, WorkflowThreadContext workflowThreadContext, long detectionTimestamp, long timeoutMillis) {
+      String threadName,
+      WorkflowThreadContext workflowThreadContext,
+      long detectionTimestamp,
+      long timeoutMillis) {
     super(
         "[TMPRL1101] Potential deadlock detected. Workflow thread \""
             + threadName

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -238,14 +238,14 @@ class WorkflowThreadContext {
       if (WorkflowThreadScheduler.WaitForYieldResult.DEADLOCK_DETECTED.equals(yieldResult)) {
         long detectionTimestamp = System.currentTimeMillis();
         if (currentThread != null) {
-          throw new PotentialDeadlockException(currentThread.getName(), this, detectionTimestamp);
+          throw new PotentialDeadlockException(currentThread.getName(), this, detectionTimestamp, deadlockDetectionTimeoutMs);
         } else {
           // This should never happen.
           // We clear currentThread only after setting the status to DONE.
           // And we check for it by the status condition check after waking up on the condition
           // and acquiring the lock back
           log.warn("Illegal State: WorkflowThreadContext has no currentThread in {} state", status);
-          throw new PotentialDeadlockException("UnknownThread", this, detectionTimestamp);
+          throw new PotentialDeadlockException("UnknownThread", this, detectionTimestamp, deadlockDetectionTimeoutMs);
         }
       }
       Preconditions.checkState(

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -238,14 +238,16 @@ class WorkflowThreadContext {
       if (WorkflowThreadScheduler.WaitForYieldResult.DEADLOCK_DETECTED.equals(yieldResult)) {
         long detectionTimestamp = System.currentTimeMillis();
         if (currentThread != null) {
-          throw new PotentialDeadlockException(currentThread.getName(), this, detectionTimestamp, deadlockDetectionTimeoutMs);
+          throw new PotentialDeadlockException(
+              currentThread.getName(), this, detectionTimestamp, deadlockDetectionTimeoutMs);
         } else {
           // This should never happen.
           // We clear currentThread only after setting the status to DONE.
           // And we check for it by the status condition check after waking up on the condition
           // and acquiring the lock back
           log.warn("Illegal State: WorkflowThreadContext has no currentThread in {} state", status);
-          throw new PotentialDeadlockException("UnknownThread", this, detectionTimestamp, deadlockDetectionTimeoutMs);
+          throw new PotentialDeadlockException(
+              "UnknownThread", this, detectionTimestamp, deadlockDetectionTimeoutMs);
         }
       }
       Preconditions.checkState(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/deadlockdetector/DeadlockDetectorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/deadlockdetector/DeadlockDetectorTest.java
@@ -78,6 +78,7 @@ public class DeadlockDetectorTest {
         failure = failure.getCause();
       }
       assertTrue(failure.getMessage().contains("Potential deadlock detected"));
+      assertTrue(failure.getMessage().contains("1s"));
       assertTrue(failure.getMessage().contains("Workflow.await"));
     }
   }
@@ -100,6 +101,7 @@ public class DeadlockDetectorTest {
         failure = failure.getCause();
       }
       assertTrue(failure.getMessage().contains("Potential deadlock detected"));
+      assertTrue(failure.getMessage().contains("500ms"));
       assertTrue(failure.getMessage().contains("Workflow.await"));
     }
   }


### PR DESCRIPTION
## What was changed
Fix deadlock detection error message to match the user-configured timeout

## Why?
Error message was misleading

## Checklist
<!--- add/delete as needed --->

1. Based on https://github.com/temporalio/sdk-go/issues/2418

2. How was this tested: Updated the deadlock detection timeout tests

3. Any docs updates needed? No
