### PR TITLE
Respect SDK flags already present in history regardless of server capability detection.

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlags.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlags.java
@@ -21,12 +21,9 @@ public final class SdkFlags {
   /**
    * Marks a flag as usable regardless of replay status.
    *
-   * @return True, as long as the server supports SDK flags
+   * @return True.
    */
   public boolean setSdkFlag(SdkFlag flag) {
-    if (!supportSdkMetadata) {
-      return false;
-    }
     sdkFlags.add(flag);
     return true;
   }
@@ -35,6 +32,10 @@ public final class SdkFlags {
    * @return True if this flag may currently be used.
    */
   public boolean tryUseSdkFlag(SdkFlag flag) {
+    if (sdkFlags.contains(flag)) {
+      return true;
+    }
+
     if (!supportSdkMetadata) {
       return false;
     }
@@ -52,10 +53,6 @@ public final class SdkFlags {
    * @return True if this flag is set.
    */
   public boolean checkSdkFlag(SdkFlag flag) {
-    if (!supportSdkMetadata) {
-      return false;
-    }
-
     return sdkFlags.contains(flag);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlags.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlags.java
@@ -18,14 +18,9 @@ public final class SdkFlags {
     this.replaying = replaying;
   }
 
-  /**
-   * Marks a flag as usable regardless of replay status.
-   *
-   * @return True.
-   */
-  public boolean setSdkFlag(SdkFlag flag) {
+  /** Marks a flag as usable regardless of replay status. */
+  public void setSdkFlag(SdkFlag flag) {
     sdkFlags.add(flag);
-    return true;
   }
 
   /**
@@ -40,13 +35,13 @@ public final class SdkFlags {
       return false;
     }
 
-    if (!replaying.apply()) {
-      sdkFlags.add(flag);
-      unsentSdkFlags.add(flag);
-      return true;
-    } else {
-      return sdkFlags.contains(flag);
+    if (replaying.apply()) {
+      return false;
     }
+
+    sdkFlags.add(flag);
+    unsentSdkFlags.add(flag);
+    return true;
   }
 
   /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlags.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/SdkFlags.java
@@ -53,6 +53,14 @@ public final class SdkFlags {
    * @return True if this flag is set.
    */
   public boolean checkSdkFlag(SdkFlag flag) {
+    if (sdkFlags.contains(flag)) {
+      return true;
+    }
+
+    if (!supportSdkMetadata) {
+      return false;
+    }
+
     return sdkFlags.contains(flag);
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/SdkFlagsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/SdkFlagsTest.java
@@ -33,6 +33,13 @@ public class SdkFlagsTest {
   }
 
   @Test
+  public void checkSdkFlagReturnsFalseForMissingFlagsWithoutMetadataCapability() {
+    SdkFlags flags = new SdkFlags(false, () -> false);
+
+    assertFalse(flags.checkSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));
+  }
+
+  @Test
   public void tryUseRecordsNewFlagsWithMetadataCapability() {
     SdkFlags flags = new SdkFlags(true, () -> false);
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/SdkFlagsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/SdkFlagsTest.java
@@ -1,0 +1,58 @@
+package io.temporal.internal.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+
+public class SdkFlagsTest {
+
+  @Test
+  public void setSdkFlagIsRespectedWithoutMetadataCapability() {
+    SdkFlags flags = new SdkFlags(false, () -> true);
+
+    assertTrue(flags.setSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));
+
+    assertTrue(flags.checkSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));
+    assertTrue(flags.tryUseSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));
+    assertEquals(Collections.emptySet(), flags.takeNewSdkFlags());
+  }
+
+  @Test
+  public void tryUseDoesNotRecordNewFlagsWithoutMetadataCapability() {
+    SdkFlags flags = new SdkFlags(false, () -> false);
+
+    assertFalse(flags.tryUseSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION));
+
+    assertFalse(flags.checkSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION));
+    assertEquals(Collections.emptySet(), flags.takeNewSdkFlags());
+  }
+
+  @Test
+  public void tryUseRecordsNewFlagsWithMetadataCapability() {
+    SdkFlags flags = new SdkFlags(true, () -> false);
+
+    assertTrue(flags.tryUseSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION));
+
+    assertTrue(flags.checkSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION));
+    assertEquals(EnumSet.of(SdkFlag.SKIP_YIELD_ON_VERSION), flags.takeNewSdkFlags());
+    assertEquals(Collections.emptySet(), flags.takeNewSdkFlags());
+  }
+
+  @Test
+  public void tryUseInReplayRequiresFlagInHistory() {
+    AtomicBoolean replaying = new AtomicBoolean(true);
+    SdkFlags flags = new SdkFlags(true, replaying::get);
+
+    assertFalse(flags.tryUseSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION));
+
+    flags.setSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION);
+
+    assertTrue(flags.tryUseSdkFlag(SdkFlag.SKIP_YIELD_ON_VERSION));
+    assertEquals(Collections.emptySet(), flags.takeNewSdkFlags());
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/common/SdkFlagsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/common/SdkFlagsTest.java
@@ -15,7 +15,7 @@ public class SdkFlagsTest {
   public void setSdkFlagIsRespectedWithoutMetadataCapability() {
     SdkFlags flags = new SdkFlags(false, () -> true);
 
-    assertTrue(flags.setSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));
+    flags.setSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER);
 
     assertTrue(flags.checkSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));
     assertTrue(flags.tryUseSdkFlag(SdkFlag.VERSION_WAIT_FOR_MARKER));

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInterleavedUpdateReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInterleavedUpdateReplayTest.java
@@ -140,16 +140,17 @@ public class GetVersionInterleavedUpdateReplayTest {
    * SDK metadata to select the fixed behavior.
    *
    * <p>The second replay runs the same history through a minimal gRPC proxy. The proxy forwards all
-   * WorkflowService RPCs to an in-memory test server except GetSystemInfo, which returns
-   * UNIMPLEMENTED. Current SDK code interprets that as default server capabilities. Default
-   * capabilities report sdkMetadata as unsupported, so the replay state machines ignore the
-   * langUsedFlags that are present in history and do not enable VERSION_WAIT_FOR_MARKER.
+   * WorkflowService RPCs to an in-memory test server except GetSystemInfo, which returns the
+   * UNIMPLEMENTED "unknown method" error shape used when the server is too old to know about the
+   * GetSystemInfo RPC. The SDK interprets that as default server capabilities. Default capabilities
+   * report sdkMetadata as unsupported, which previously caused the replay state machines to ignore
+   * langUsedFlags that are present in history and not enable VERSION_WAIT_FOR_MARKER.
    *
-   * <p>The intended behavior is that this replay still succeeds: a GetSystemInfo failure caused by
-   * an intermediary should not make a worker forget SDK flags already recorded in workflow history.
-   * On buggy code, this test fails with the same TMPRL1100 NonDeterministicException as the
-   * original unflagged fixture, which demonstrates that the proxy-induced default capabilities
-   * masked the recorded SDK flag.
+   * <p>The intended behavior is that this replay still succeeds: default server capabilities should
+   * only stop the worker from writing new SDK flag metadata; they should not make the worker forget
+   * SDK flags already recorded in workflow history. On buggy code, this test fails with the same
+   * TMPRL1100 NonDeterministicException as the original unflagged fixture, which demonstrates that
+   * default capabilities masked the recorded SDK flag.
    */
   @Test
   public void testGetSystemInfoUnimplementedDoesNotMaskSdkFlags() throws Exception {
@@ -346,7 +347,8 @@ public class GetVersionInterleavedUpdateReplayTest {
 
     private static RuntimeException unimplementedGetSystemInfo() {
       return Status.UNIMPLEMENTED
-          .withDescription("proxy intentionally hides getSystemInfo")
+          .withDescription(
+              "unknown method GetSystemInfo for service " + WorkflowServiceGrpc.SERVICE_NAME)
           .asRuntimeException();
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInterleavedUpdateReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInterleavedUpdateReplayTest.java
@@ -4,12 +4,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ServerCalls;
+import io.grpc.stub.StreamObserver;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
@@ -18,6 +30,7 @@ import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.history.VersionMarkerUtils;
 import io.temporal.internal.statemachines.WorkflowStateMachines;
+import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.WorkflowHistoryLoader;
 import io.temporal.testing.WorkflowReplayer;
@@ -27,6 +40,7 @@ import io.temporal.workflow.UpdateMethod;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -34,6 +48,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -113,6 +129,56 @@ public class GetVersionInterleavedUpdateReplayTest {
     }
   }
 
+  /**
+   * Regression test for the interaction between GetSystemInfo capability detection and SDK flags.
+   *
+   * <p>The base fixture is an old interleaved-update/getVersion history that fails replay unless
+   * replay waits for the real version marker event before resuming workflow code. That newer replay
+   * behavior is gated by {@link SdkFlag#VERSION_WAIT_FOR_MARKER}, so this test first edits the
+   * fixture in-memory to add that flag to every WorkflowTaskCompleted sdkMetadata.langUsedFlags
+   * field. The unproxied replay immediately after that edit proves the modified history has enough
+   * SDK metadata to select the fixed behavior.
+   *
+   * <p>The second replay runs the same history through a minimal gRPC proxy. The proxy forwards all
+   * WorkflowService RPCs to an in-memory test server except GetSystemInfo, which returns
+   * UNIMPLEMENTED. Current SDK code interprets that as default server capabilities. Default
+   * capabilities report sdkMetadata as unsupported, so the replay state machines ignore the
+   * langUsedFlags that are present in history and do not enable VERSION_WAIT_FOR_MARKER.
+   *
+   * <p>The intended behavior is that this replay still succeeds: a GetSystemInfo failure caused by
+   * an intermediary should not make a worker forget SDK flags already recorded in workflow history.
+   * On buggy code, this test fails with the same TMPRL1100 NonDeterministicException as the
+   * original unflagged fixture, which demonstrates that the proxy-induced default capabilities
+   * masked the recorded SDK flag.
+   */
+  @Test
+  public void testGetSystemInfoUnimplementedDoesNotMaskSdkFlags() throws Exception {
+    WorkflowExecutionHistory history =
+        withSdkFlag(
+            WorkflowHistoryLoader.readHistoryFromResource(HISTORY_RESOURCE),
+            SdkFlag.VERSION_WAIT_FOR_MARKER);
+    assertTrue(
+        "The modified history must advertise VERSION_WAIT_FOR_MARKER.",
+        hasSdkFlag(history, SdkFlag.VERSION_WAIT_FOR_MARKER));
+    WorkflowReplayer.replayWorkflowExecution(history, GreetingWorkflowImpl.class);
+
+    try (TestWorkflowEnvironment backingEnvironment = TestWorkflowEnvironment.newInstance();
+        GetSystemInfoUnimplementedProxy proxy =
+            GetSystemInfoUnimplementedProxy.start(
+                backingEnvironment.getWorkflowServiceStubs().getRawChannel());
+        TestWorkflowEnvironment proxiedEnvironment =
+            TestWorkflowEnvironment.newInstance(
+                TestEnvironmentOptions.newBuilder()
+                    .setUseExternalService(true)
+                    .setTarget(proxy.getTarget())
+                    .build())) {
+
+      WorkflowReplayer.replayWorkflowExecution(
+          history, proxiedEnvironment, GreetingWorkflowImpl.class);
+      assertTrue("Expected the proxy to receive GetSystemInfo.", proxy.getGetSystemInfoCalls() > 0);
+    }
+  }
+
   public static WorkflowExecutionHistory captureReplayableHistory() {
     List<SdkFlag> savedInitialFlags = WorkflowStateMachines.initialFlags;
     List<SdkFlag> replayableFlags = new ArrayList<>(savedInitialFlags);
@@ -182,6 +248,107 @@ public class GetVersionInterleavedUpdateReplayTest {
       }
     }
     return false;
+  }
+
+  private static WorkflowExecutionHistory withSdkFlag(
+      WorkflowExecutionHistory history, SdkFlag flag) {
+    io.temporal.api.history.v1.History.Builder historyBuilder = history.getHistory().toBuilder();
+    for (int i = 0; i < historyBuilder.getEventsCount(); i++) {
+      HistoryEvent.Builder event = historyBuilder.getEventsBuilder(i);
+      if (event.getEventType() != EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED) {
+        continue;
+      }
+      if (!event
+          .getWorkflowTaskCompletedEventAttributes()
+          .getSdkMetadata()
+          .getLangUsedFlagsList()
+          .contains(flag.getValue())) {
+        event
+            .getWorkflowTaskCompletedEventAttributesBuilder()
+            .getSdkMetadataBuilder()
+            .addLangUsedFlags(flag.getValue());
+      }
+    }
+    return new WorkflowExecutionHistory(
+        historyBuilder.build(), history.getWorkflowExecution().getWorkflowId());
+  }
+
+  private static final class GetSystemInfoUnimplementedProxy implements AutoCloseable {
+    private final Server server;
+    private final AtomicInteger getSystemInfoCalls;
+
+    private GetSystemInfoUnimplementedProxy(Server server, AtomicInteger getSystemInfoCalls) {
+      this.server = server;
+      this.getSystemInfoCalls = getSystemInfoCalls;
+    }
+
+    static GetSystemInfoUnimplementedProxy start(Channel target) throws IOException {
+      AtomicInteger getSystemInfoCalls = new AtomicInteger();
+      Server server =
+          NettyServerBuilder.forPort(0)
+              .addService(buildProxyService(target, getSystemInfoCalls))
+              .build()
+              .start();
+      return new GetSystemInfoUnimplementedProxy(server, getSystemInfoCalls);
+    }
+
+    String getTarget() {
+      return "127.0.0.1:" + server.getPort();
+    }
+
+    int getGetSystemInfoCalls() {
+      return getSystemInfoCalls.get();
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+      server.shutdownNow();
+      server.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    private static ServerServiceDefinition buildProxyService(
+        Channel target, AtomicInteger getSystemInfoCalls) {
+      ServerServiceDefinition.Builder builder =
+          ServerServiceDefinition.builder(WorkflowServiceGrpc.getServiceDescriptor());
+      for (MethodDescriptor<?, ?> method :
+          WorkflowServiceGrpc.getServiceDescriptor().getMethods()) {
+        addProxyMethod(builder, method, target, getSystemInfoCalls);
+      }
+      return builder.build();
+    }
+
+    private static <ReqT, RespT> void addProxyMethod(
+        ServerServiceDefinition.Builder builder,
+        MethodDescriptor<ReqT, RespT> method,
+        Channel target,
+        AtomicInteger getSystemInfoCalls) {
+      if (method
+          .getFullMethodName()
+          .equals(WorkflowServiceGrpc.getGetSystemInfoMethod().getFullMethodName())) {
+        builder.addMethod(
+            method,
+            ServerCalls.asyncUnaryCall(
+                (ReqT request, StreamObserver<RespT> responseObserver) -> {
+                  getSystemInfoCalls.incrementAndGet();
+                  responseObserver.onError(unimplementedGetSystemInfo());
+                }));
+        return;
+      }
+
+      builder.addMethod(
+          method,
+          ServerCalls.asyncUnaryCall(
+              (ReqT request, StreamObserver<RespT> responseObserver) -> {
+                ClientCall<ReqT, RespT> call = target.newCall(method, CallOptions.DEFAULT);
+                ClientCalls.asyncUnaryCall(call, request, responseObserver);
+              }));
+    }
+
+    private static RuntimeException unimplementedGetSystemInfo() {
+      return Status.UNIMPLEMENTED
+          .withDescription("proxy intentionally hides getSystemInfo")
+          .asRuntimeException();
+    }
   }
 
   public static class Request {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompression.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompression.java
@@ -7,7 +7,10 @@ public enum GrpcCompression {
   /** Do not compress requests. */
   NONE(null),
 
-  /** Gzip-compress requests. */
+  /**
+   * Gzip-compress requests. If a specific server RPC does not support gzip, the SDK may retry that
+   * RPC without compression and continue using gzip for other RPCs.
+   */
   GZIP("gzip");
 
   private final @Nullable String compressorName;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
@@ -38,8 +38,8 @@ final class GrpcCompressionInterceptor implements ClientInterceptor {
   }
 
   static boolean isCompressionUnsupported(Status status, GrpcCompression compression) {
-    String compressorName = compression.getCompressorName();
-    if (!Status.Code.UNIMPLEMENTED.equals(status.getCode()) || compressorName == null) {
+    if (!Status.Code.UNIMPLEMENTED.equals(status.getCode())
+        || compression.getCompressorName() == null) {
       return false;
     }
     String description = status.getDescription();
@@ -47,10 +47,9 @@ final class GrpcCompressionInterceptor implements ClientInterceptor {
       return false;
     }
     String lowerDescription = description.toLowerCase(Locale.ROOT);
-    return lowerDescription.contains(compressorName.toLowerCase(Locale.ROOT))
-        && (lowerDescription.contains("decompress")
-            || lowerDescription.contains("grpc-encoding")
-            || lowerDescription.contains("compressor"));
+    return lowerDescription.contains("decompress")
+        || lowerDescription.contains("grpc-encoding")
+        || lowerDescription.contains("compressor");
   }
 
   private static final class GrpcCompressionRetryingClientCall<ReqT, RespT>

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
@@ -9,7 +9,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -17,8 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 final class GrpcCompressionInterceptor implements ClientInterceptor {
   private final GrpcCompression compression;
-  private final Set<String> compressionUnsupportedMethods =
-      Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final Set<String> compressionUnsupportedMethods = ConcurrentHashMap.newKeySet();
 
   GrpcCompressionInterceptor(GrpcCompression compression) {
     this.compression = compression;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/GrpcCompressionInterceptor.java
@@ -4,10 +4,21 @@ import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 final class GrpcCompressionInterceptor implements ClientInterceptor {
   private final GrpcCompression compression;
+  private final Set<String> compressionUnsupportedMethods =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   GrpcCompressionInterceptor(GrpcCompression compression) {
     this.compression = compression;
@@ -16,6 +27,165 @@ final class GrpcCompressionInterceptor implements ClientInterceptor {
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
       MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-    return next.newCall(method, callOptions.withCompression(compression.getCompressorName()));
+    String compressorName = compression.getCompressorName();
+    if (compressorName == null
+        || compressionUnsupportedMethods.contains(method.getFullMethodName())) {
+      return next.newCall(method, callOptions.withCompression(null));
+    }
+    if (!MethodDescriptor.MethodType.UNARY.equals(method.getType())) {
+      return next.newCall(method, callOptions.withCompression(compressorName));
+    }
+    return new GrpcCompressionRetryingClientCall<>(
+        next, method, callOptions, compression, compressorName, compressionUnsupportedMethods);
+  }
+
+  static boolean isCompressionUnsupported(Status status, GrpcCompression compression) {
+    String compressorName = compression.getCompressorName();
+    if (!Status.Code.UNIMPLEMENTED.equals(status.getCode()) || compressorName == null) {
+      return false;
+    }
+    String description = status.getDescription();
+    if (description == null) {
+      return false;
+    }
+    String lowerDescription = description.toLowerCase(Locale.ROOT);
+    return lowerDescription.contains(compressorName.toLowerCase(Locale.ROOT))
+        && (lowerDescription.contains("decompress")
+            || lowerDescription.contains("grpc-encoding")
+            || lowerDescription.contains("compressor"));
+  }
+
+  private static final class GrpcCompressionRetryingClientCall<ReqT, RespT>
+      extends ClientCall<ReqT, RespT> {
+    private final Channel next;
+    private final MethodDescriptor<ReqT, RespT> method;
+    private final CallOptions callOptions;
+    private final GrpcCompression compression;
+    private final Set<String> compressionUnsupportedMethods;
+    private final List<ReqT> messages = new ArrayList<>(1);
+
+    private ClientCall<ReqT, RespT> delegate;
+    private Listener<RespT> responseListener;
+    private Metadata headers;
+    private int requestedMessages;
+    private boolean halfClosed;
+    private boolean cancelled;
+    private Boolean messageCompressionEnabled;
+
+    private GrpcCompressionRetryingClientCall(
+        Channel next,
+        MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions,
+        GrpcCompression compression,
+        String compressorName,
+        Set<String> compressionUnsupportedMethods) {
+      this.next = next;
+      this.method = method;
+      this.callOptions = callOptions;
+      this.compression = compression;
+      this.compressionUnsupportedMethods = compressionUnsupportedMethods;
+      this.delegate = next.newCall(method, callOptions.withCompression(compressorName));
+    }
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      this.responseListener = responseListener;
+      this.headers = headers;
+      delegate.start(new FirstAttemptListener(responseListener), headers);
+    }
+
+    @Override
+    public void request(int numMessages) {
+      requestedMessages += numMessages;
+      delegate.request(numMessages);
+    }
+
+    @Override
+    public void cancel(String message, Throwable cause) {
+      cancelled = true;
+      delegate.cancel(message, cause);
+    }
+
+    @Override
+    public void halfClose() {
+      halfClosed = true;
+      delegate.halfClose();
+    }
+
+    @Override
+    public void sendMessage(ReqT message) {
+      messages.add(message);
+      delegate.sendMessage(message);
+    }
+
+    @Override
+    public boolean isReady() {
+      return delegate.isReady();
+    }
+
+    @Override
+    public void setMessageCompression(boolean enabled) {
+      messageCompressionEnabled = enabled;
+      delegate.setMessageCompression(enabled);
+    }
+
+    private boolean retryWithoutCompression(Status status) {
+      if (cancelled || !isCompressionUnsupported(status, compression)) {
+        return false;
+      }
+      compressionUnsupportedMethods.add(method.getFullMethodName());
+      Metadata retryHeaders = new Metadata();
+      retryHeaders.merge(headers);
+      ClientCall<ReqT, RespT> retryCall = next.newCall(method, callOptions.withCompression(null));
+      delegate = retryCall;
+      retryCall.start(responseListener, retryHeaders);
+      if (messageCompressionEnabled != null) {
+        retryCall.setMessageCompression(messageCompressionEnabled);
+      }
+      if (requestedMessages > 0) {
+        retryCall.request(requestedMessages);
+      }
+      for (ReqT message : messages) {
+        retryCall.sendMessage(message);
+      }
+      if (halfClosed) {
+        retryCall.halfClose();
+      }
+      return true;
+    }
+
+    private final class FirstAttemptListener
+        extends ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT> {
+      private Metadata firstHeaders;
+      private final List<RespT> firstMessages = new ArrayList<>(1);
+
+      private FirstAttemptListener(Listener<RespT> responseListener) {
+        super(responseListener);
+      }
+
+      @Override
+      public void onHeaders(Metadata headers) {
+        firstHeaders = headers;
+      }
+
+      @Override
+      public void onMessage(RespT message) {
+        firstMessages.add(message);
+      }
+
+      @Override
+      public void onClose(Status status, Metadata trailers) {
+        if (firstMessages.isEmpty() && retryWithoutCompression(status)) {
+          return;
+        }
+        if (firstHeaders != null) {
+          super.onHeaders(firstHeaders);
+        }
+        for (RespT message : firstMessages) {
+          super.onMessage(message);
+        }
+        super.onClose(status, trailers);
+      }
+    }
   }
 }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -742,8 +742,10 @@ public class ServiceStubsOptions {
     }
 
     /**
-     * Sets outbound transport-level gRPC compression. Defaults to {@link GrpcCompression#GZIP}. Set
-     * to {@link GrpcCompression#NONE} to opt out of compressing requests.
+     * Sets outbound transport-level gRPC compression. Defaults to {@link GrpcCompression#GZIP}. If
+     * a specific server RPC does not support gzip, the SDK may retry that RPC without compression
+     * and continue using gzip for other RPCs. Set to {@link GrpcCompression#NONE} to opt out of
+     * compressing requests.
      *
      * <p>The SDK uses the default gRPC response decompression registry for all compression options,
      * so disabling request compression does not disable accepting compressed responses.

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SystemInfoInterceptor.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SystemInfoInterceptor.java
@@ -1,5 +1,6 @@
 package io.temporal.serviceclient;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.*;
 import io.temporal.api.workflowservice.v1.GetSystemInfoRequest;
 import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
@@ -119,6 +120,7 @@ public class SystemInfoInterceptor implements ClientInterceptor {
     }
   }
 
+  @VisibleForTesting
   static boolean isGetSystemInfoUnknownMethod(Status status) {
     if (!Status.Code.UNIMPLEMENTED.equals(status.getCode())) {
       return false;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SystemInfoInterceptor.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/SystemInfoInterceptor.java
@@ -48,7 +48,7 @@ public class SystemInfoInterceptor implements ClientInterceptor {
 
                   @Override
                   public void onClose(Status status, Metadata trailers) {
-                    if (Status.UNIMPLEMENTED.getCode().equals(status.getCode())) {
+                    if (isGetSystemInfoUnknownMethod(status)) {
                       serverCapabilitiesFuture.complete(Capabilities.getDefaultInstance());
                     }
                     super.onClose(status, trailers);
@@ -112,10 +112,25 @@ public class SystemInfoInterceptor implements ClientInterceptor {
           .getSystemInfo(GetSystemInfoRequest.newBuilder().build())
           .getCapabilities();
     } catch (StatusRuntimeException ex) {
-      if (Status.Code.UNIMPLEMENTED.equals(ex.getStatus().getCode())) {
+      if (isGetSystemInfoUnknownMethod(ex.getStatus())) {
         return Capabilities.getDefaultInstance();
       }
       throw ex;
     }
+  }
+
+  static boolean isGetSystemInfoUnknownMethod(Status status) {
+    if (!Status.Code.UNIMPLEMENTED.equals(status.getCode())) {
+      return false;
+    }
+    String description = status.getDescription();
+    if (description == null) {
+      return false;
+    }
+    String fullMethodName = WorkflowServiceGrpc.getGetSystemInfoMethod().getFullMethodName();
+    return description.contains(
+            "unknown method GetSystemInfo for service " + WorkflowServiceGrpc.SERVICE_NAME)
+        || description.contains("Method not found: " + fullMethodName)
+        || description.contains("Method not found: /" + fullMethodName);
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ChannelManagerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ChannelManagerTest.java
@@ -206,7 +206,7 @@ public class ChannelManagerTest {
       assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
       assertEquals(getSystemInfoUnimplementedDescription, e.getStatus().getDescription());
       assertEquals(0, getSystemInfoCount.get());
-      assertEquals(-1, getSystemInfoUnavailable.get());
+      assertEquals(-2, getSystemInfoUnavailable.get());
       assertTrue(getSystemInfoUnimplemented.get() >= 0);
     }
   }
@@ -273,7 +273,7 @@ public class ChannelManagerTest {
       assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
       assertEquals(getSystemInfoUnimplementedDescription, e.getStatus().getDescription());
       assertEquals(0, getSystemInfoCount.get());
-      assertEquals(-1, getSystemInfoUnavailable.get());
+      assertEquals(-2, getSystemInfoUnavailable.get());
       assertTrue(getSystemInfoUnimplemented.get() >= 0);
     }
   }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ChannelManagerTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ChannelManagerTest.java
@@ -1,6 +1,7 @@
 package io.temporal.serviceclient;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.grpc.ManagedChannel;
@@ -51,6 +52,7 @@ public class ChannelManagerTest {
   private final AtomicInteger getSystemInfoCount = new AtomicInteger(0);
   private final AtomicInteger getSystemInfoUnavailable = new AtomicInteger(0);
   private final AtomicInteger getSystemInfoUnimplemented = new AtomicInteger(0);
+  private String getSystemInfoUnimplementedDescription;
 
   private final HealthImplBase healthImpl =
       new HealthImplBase() {
@@ -76,7 +78,11 @@ public class ChannelManagerTest {
           if (getSystemInfoUnavailable.getAndDecrement() > 0) {
             responseObserver.onError(Status.fromCode(Status.Code.UNAVAILABLE).asException());
           } else if (getSystemInfoUnimplemented.getAndDecrement() > 0) {
-            responseObserver.onError(Status.fromCode(Status.Code.UNIMPLEMENTED).asException());
+            Status status = Status.fromCode(Status.Code.UNIMPLEMENTED);
+            if (getSystemInfoUnimplementedDescription != null) {
+              status = status.withDescription(getSystemInfoUnimplementedDescription);
+            }
+            responseObserver.onError(status.asException());
           } else {
             getSystemInfoCount.getAndIncrement();
             responseObserver.onNext(GET_SYSTEM_INFO_RESPONSE);
@@ -94,6 +100,7 @@ public class ChannelManagerTest {
     getSystemInfoCount.set(0);
     getSystemInfoUnavailable.set(0);
     getSystemInfoUnimplemented.set(0);
+    getSystemInfoUnimplementedDescription = null;
     String serverName = InProcessServerBuilder.generateName();
     grpcCleanupRule.register(
         InProcessServerBuilder.forName(serverName)
@@ -118,6 +125,28 @@ public class ChannelManagerTest {
     if (channelManager != null) {
       channelManager.shutdownNow();
     }
+  }
+
+  @Test
+  public void testGetSystemInfoUnknownMethodDescriptions() {
+    assertTrue(
+        SystemInfoInterceptor.isGetSystemInfoUnknownMethod(
+            Status.UNIMPLEMENTED.withDescription(
+                "unknown method GetSystemInfo for service "
+                    + "temporal.api.workflowservice.v1.WorkflowService")));
+    assertTrue(
+        SystemInfoInterceptor.isGetSystemInfoUnknownMethod(
+            Status.UNIMPLEMENTED.withDescription(
+                "Method not found: temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo")));
+    assertFalse(
+        SystemInfoInterceptor.isGetSystemInfoUnknownMethod(
+            Status.UNIMPLEMENTED.withDescription(
+                "grpc: Decompressor is not installed for grpc-encoding \"gzip\"")));
+    assertFalse(
+        SystemInfoInterceptor.isGetSystemInfoUnknownMethod(
+            Status.UNAVAILABLE.withDescription(
+                "unknown method GetSystemInfo for service "
+                    + "temporal.api.workflowservice.v1.WorkflowService")));
   }
 
   @Test
@@ -154,13 +183,32 @@ public class ChannelManagerTest {
   }
 
   @Test
-  public void testGetServerCapabilitiesUnimplemented() {
+  public void testGetServerCapabilitiesUnimplementedUnknownMethod() {
     getSystemInfoUnimplemented.set(1);
+    getSystemInfoUnimplementedDescription =
+        "unknown method GetSystemInfo for service temporal.api.workflowservice.v1.WorkflowService";
     Capabilities capabilities = channelManager.getServerCapabilities().get();
     assertEquals(Capabilities.getDefaultInstance(), capabilities);
     assertEquals(0, getSystemInfoCount.get());
     assertEquals(-1, getSystemInfoUnavailable.get());
     assertEquals(0, getSystemInfoUnimplemented.get());
+  }
+
+  @Test
+  public void testGetServerCapabilitiesUnimplementedOtherDescription() {
+    getSystemInfoUnimplemented.set(Integer.MAX_VALUE);
+    getSystemInfoUnimplementedDescription =
+        "grpc: Decompressor is not installed for grpc-encoding \"gzip\"";
+    try {
+      Capabilities unused = channelManager.getServerCapabilities().get();
+      Assert.fail("expected StatusRuntimeException");
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
+      assertEquals(getSystemInfoUnimplementedDescription, e.getStatus().getDescription());
+      assertEquals(0, getSystemInfoCount.get());
+      assertEquals(-1, getSystemInfoUnavailable.get());
+      assertTrue(getSystemInfoUnimplemented.get() >= 0);
+    }
   }
 
   @Test
@@ -200,13 +248,33 @@ public class ChannelManagerTest {
   }
 
   @Test
-  public void testGetServerCapabilitiesUnimplementedWithConnect() {
+  public void testGetServerCapabilitiesUnimplementedUnknownMethodWithConnect() {
     getSystemInfoUnimplemented.set(1);
+    getSystemInfoUnimplementedDescription =
+        "unknown method GetSystemInfo for service temporal.api.workflowservice.v1.WorkflowService";
     channelManager.connect(HEALTH_CHECK_NAME, Duration.ofMillis(100));
     Capabilities capabilities = channelManager.getServerCapabilities().get();
     assertEquals(Capabilities.getDefaultInstance(), capabilities);
     assertEquals(0, getSystemInfoCount.get());
     assertEquals(-1, getSystemInfoUnavailable.get());
     assertEquals(0, getSystemInfoUnimplemented.get());
+  }
+
+  @Test
+  public void testGetServerCapabilitiesUnimplementedOtherDescriptionWithConnect() {
+    getSystemInfoUnimplemented.set(Integer.MAX_VALUE);
+    getSystemInfoUnimplementedDescription =
+        "grpc: Decompressor is not installed for grpc-encoding \"gzip\"";
+    try {
+      channelManager.connect(HEALTH_CHECK_NAME, Duration.ofMillis(100));
+      Capabilities unused = channelManager.getServerCapabilities().get();
+      Assert.fail("expected StatusRuntimeException");
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
+      assertEquals(getSystemInfoUnimplementedDescription, e.getStatus().getDescription());
+      assertEquals(0, getSystemInfoCount.get());
+      assertEquals(-1, getSystemInfoUnavailable.get());
+      assertTrue(getSystemInfoUnimplemented.get() >= 0);
+    }
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/GrpcCompressionTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/GrpcCompressionTest.java
@@ -89,6 +89,27 @@ public class GrpcCompressionTest {
   }
 
   @Test
+  public void gzipCompressionDowngradesCompressionErrorWithoutEncodingName() throws Exception {
+    TestWorkflowService service = new TestWorkflowService();
+    service.rejectGzipGetSystemInfo = true;
+    service.rejectGzipGetSystemInfoDescription = "grpc: Decompressor is not installed";
+    CompressionHistoryInterceptor compressionHistory = new CompressionHistoryInterceptor();
+    Server server = startServer(service, compressionHistory);
+    WorkflowServiceStubs serviceStubs = newServiceStubs(server, GrpcCompression.GZIP);
+    try {
+      serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
+    } finally {
+      serviceStubs.shutdownNow();
+    }
+
+    List<String> getSystemInfoHistory =
+        compressionHistory.compressionHistoryForMethod(getSystemInfoMethod());
+    assertEquals(2, getSystemInfoHistory.size());
+    assertEquals("gzip", getSystemInfoHistory.get(0));
+    assertNull(getSystemInfoHistory.get(1));
+  }
+
+  @Test
   public void noneCompressionDoesNotInstallDowngrade() throws Exception {
     TestWorkflowService service = new TestWorkflowService();
     service.rejectGzipGetSystemInfo = true;
@@ -212,6 +233,8 @@ public class GrpcCompressionTest {
   private static final class TestWorkflowService
       extends WorkflowServiceGrpc.WorkflowServiceImplBase {
     private boolean rejectGzipGetSystemInfo;
+    private String rejectGzipGetSystemInfoDescription =
+        "grpc: Decompressor is not installed for grpc-encoding \"gzip\"";
     private Status getSystemInfoError;
 
     @Override
@@ -220,7 +243,7 @@ public class GrpcCompressionTest {
       if (rejectGzipGetSystemInfo && "gzip".equals(REQUEST_COMPRESSION.get())) {
         responseObserver.onError(
             Status.UNIMPLEMENTED
-                .withDescription("grpc: Decompressor is not installed for grpc-encoding \"gzip\"")
+                .withDescription(rejectGzipGetSystemInfoDescription)
                 .asRuntimeException());
         return;
       }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/GrpcCompressionTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/GrpcCompressionTest.java
@@ -2,19 +2,29 @@ package io.temporal.serviceclient;
 
 import static org.junit.Assert.*;
 
+import io.grpc.Context;
+import io.grpc.Contexts;
 import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.temporal.api.workflowservice.v1.GetSystemInfoRequest;
 import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.SignalWorkflowExecutionResponse;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -23,6 +33,7 @@ public class GrpcCompressionTest {
       Metadata.Key.of("grpc-encoding", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> GRPC_ACCEPT_ENCODING =
       Metadata.Key.of("grpc-accept-encoding", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Context.Key<String> REQUEST_COMPRESSION = Context.key("request-compression");
 
   @Rule public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
 
@@ -42,49 +53,190 @@ public class GrpcCompressionTest {
     assertTrue(headers.get(GRPC_ACCEPT_ENCODING).contains("gzip"));
   }
 
-  private Metadata callGetSystemInfo(GrpcCompression compression) throws Exception {
-    AtomicReference<Metadata> capturedHeaders = new AtomicReference<>();
-    ServerInterceptor captureHeadersInterceptor =
-        new ServerInterceptor() {
-          @Override
-          public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-              ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-            capturedHeaders.set(headers);
-            return next.startCall(call, headers);
-          }
-        };
-    Server server =
-        grpcCleanupRule.register(
-            NettyServerBuilder.forPort(0)
-                .addService(
-                    ServerInterceptors.intercept(
-                        new TestWorkflowService(), captureHeadersInterceptor))
-                .build()
-                .start());
+  @Test
+  public void gzipCompressionDowngradesUnsupportedMethod() throws Exception {
+    TestWorkflowService service = new TestWorkflowService();
+    service.rejectGzipGetSystemInfo = true;
+    CompressionHistoryInterceptor compressionHistory = new CompressionHistoryInterceptor();
+    Server server = startServer(service, compressionHistory);
+    WorkflowServiceStubs serviceStubs = newServiceStubs(server, GrpcCompression.GZIP);
+    try {
+      serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
+      List<String> getSystemInfoHistory =
+          compressionHistory.compressionHistoryForMethod(getSystemInfoMethod());
+      assertEquals(2, getSystemInfoHistory.size());
+      assertEquals("gzip", getSystemInfoHistory.get(0));
+      assertNull(getSystemInfoHistory.get(1));
 
-    WorkflowServiceStubs serviceStubs =
-        WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder()
-                .setTarget("127.0.0.1:" + server.getPort())
-                .setEnableHttps(false)
-                .setGrpcCompression(compression)
-                .build());
+      serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
+      getSystemInfoHistory = compressionHistory.compressionHistoryForMethod(getSystemInfoMethod());
+      assertEquals(3, getSystemInfoHistory.size());
+      assertEquals(1, Collections.frequency(getSystemInfoHistory, "gzip"));
+      assertNull(getSystemInfoHistory.get(2));
+
+      serviceStubs
+          .blockingStub()
+          .signalWorkflowExecution(
+              SignalWorkflowExecutionRequest.newBuilder()
+                  .setNamespace("test-namespace")
+                  .setSignalName("test-signal")
+                  .build());
+      assertEquals(
+          "gzip", compressionHistory.lastCompressionForMethod(signalWorkflowExecutionMethod()));
+    } finally {
+      serviceStubs.shutdownNow();
+    }
+  }
+
+  @Test
+  public void noneCompressionDoesNotInstallDowngrade() throws Exception {
+    TestWorkflowService service = new TestWorkflowService();
+    service.rejectGzipGetSystemInfo = true;
+    CompressionHistoryInterceptor compressionHistory = new CompressionHistoryInterceptor();
+    Server server = startServer(service, compressionHistory);
+    WorkflowServiceStubs serviceStubs = newServiceStubs(server, GrpcCompression.NONE);
+    try {
+      serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
+      List<String> getSystemInfoHistory =
+          compressionHistory.compressionHistoryForMethod(getSystemInfoMethod());
+      assertEquals(1, getSystemInfoHistory.size());
+      assertNull(getSystemInfoHistory.get(0));
+    } finally {
+      serviceStubs.shutdownNow();
+    }
+  }
+
+  @Test
+  public void gzipCompressionDoesNotDowngradeGenericUnimplemented() throws Exception {
+    TestWorkflowService service = new TestWorkflowService();
+    service.getSystemInfoError =
+        Status.UNIMPLEMENTED.withDescription("gzip feature is not implemented");
+    CompressionHistoryInterceptor compressionHistory = new CompressionHistoryInterceptor();
+    Server server = startServer(service, compressionHistory);
+    WorkflowServiceStubs serviceStubs = newServiceStubs(server, GrpcCompression.GZIP);
+    try {
+      serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
+      fail("expected StatusRuntimeException");
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
+    } finally {
+      serviceStubs.shutdownNow();
+    }
+    List<String> getSystemInfoHistory =
+        compressionHistory.compressionHistoryForMethod(getSystemInfoMethod());
+    assertEquals(1, getSystemInfoHistory.size());
+    assertEquals("gzip", getSystemInfoHistory.get(0));
+  }
+
+  private Metadata callGetSystemInfo(GrpcCompression compression) throws Exception {
+    CompressionHistoryInterceptor compressionHistory = new CompressionHistoryInterceptor();
+    Server server = startServer(new TestWorkflowService(), compressionHistory);
+    WorkflowServiceStubs serviceStubs = newServiceStubs(server, compression);
     try {
       serviceStubs.blockingStub().getSystemInfo(GetSystemInfoRequest.getDefaultInstance());
     } finally {
       serviceStubs.shutdownNow();
     }
 
-    assertNotNull(capturedHeaders.get());
-    return capturedHeaders.get();
+    assertNotNull(compressionHistory.lastHeaders());
+    return compressionHistory.lastHeaders();
+  }
+
+  private Server startServer(
+      TestWorkflowService service, CompressionHistoryInterceptor compressionHistory)
+      throws Exception {
+    return grpcCleanupRule.register(
+        NettyServerBuilder.forPort(0)
+            .addService(ServerInterceptors.intercept(service, compressionHistory))
+            .build()
+            .start());
+  }
+
+  private WorkflowServiceStubs newServiceStubs(Server server, GrpcCompression compression) {
+    return WorkflowServiceStubs.newServiceStubs(
+        WorkflowServiceStubsOptions.newBuilder()
+            .setTarget("127.0.0.1:" + server.getPort())
+            .setEnableHttps(false)
+            .setGrpcCompression(compression)
+            .build());
+  }
+
+  private static String getSystemInfoMethod() {
+    return WorkflowServiceGrpc.getGetSystemInfoMethod().getFullMethodName();
+  }
+
+  private static String signalWorkflowExecutionMethod() {
+    return WorkflowServiceGrpc.getSignalWorkflowExecutionMethod().getFullMethodName();
+  }
+
+  private static final class CompressionHistoryInterceptor implements ServerInterceptor {
+    private final Map<String, List<String>> compressionHistoryByMethod = new HashMap<>();
+    private Metadata lastHeaders;
+
+    @Override
+    public synchronized <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+      String compression = headers.get(GRPC_ENCODING);
+      String methodName = call.getMethodDescriptor().getFullMethodName();
+      List<String> compressionHistory = compressionHistoryByMethod.get(methodName);
+      if (compressionHistory == null) {
+        compressionHistory = new ArrayList<>();
+        compressionHistoryByMethod.put(methodName, compressionHistory);
+      }
+      compressionHistory.add(compression);
+      lastHeaders = headers;
+      return Contexts.interceptCall(
+          Context.current().withValue(REQUEST_COMPRESSION, compression), call, headers, next);
+    }
+
+    synchronized Metadata lastHeaders() {
+      return lastHeaders;
+    }
+
+    synchronized List<String> compressionHistoryForMethod(String methodName) {
+      List<String> compressionHistory = compressionHistoryByMethod.get(methodName);
+      return compressionHistory == null
+          ? Collections.emptyList()
+          : new ArrayList<>(compressionHistory);
+    }
+
+    synchronized String lastCompressionForMethod(String methodName) {
+      List<String> compressionHistory = compressionHistoryByMethod.get(methodName);
+      if (compressionHistory == null || compressionHistory.isEmpty()) {
+        return null;
+      }
+      return compressionHistory.get(compressionHistory.size() - 1);
+    }
   }
 
   private static final class TestWorkflowService
       extends WorkflowServiceGrpc.WorkflowServiceImplBase {
+    private boolean rejectGzipGetSystemInfo;
+    private Status getSystemInfoError;
+
     @Override
     public void getSystemInfo(
         GetSystemInfoRequest request, StreamObserver<GetSystemInfoResponse> responseObserver) {
+      if (rejectGzipGetSystemInfo && "gzip".equals(REQUEST_COMPRESSION.get())) {
+        responseObserver.onError(
+            Status.UNIMPLEMENTED
+                .withDescription("grpc: Decompressor is not installed for grpc-encoding \"gzip\"")
+                .asRuntimeException());
+        return;
+      }
+      if (getSystemInfoError != null) {
+        responseObserver.onError(getSystemInfoError.asRuntimeException());
+        return;
+      }
       responseObserver.onNext(GetSystemInfoResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void signalWorkflowExecution(
+        SignalWorkflowExecutionRequest request,
+        StreamObserver<SignalWorkflowExecutionResponse> responseObserver) {
+      responseObserver.onNext(SignalWorkflowExecutionResponse.getDefaultInstance());
       responseObserver.onCompleted();
     }
   }

--- a/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestActivityEnvironmentInternal.java
@@ -11,6 +11,8 @@ import io.temporal.api.common.v1.ActivityType;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.RetryState;
+import io.temporal.api.workflowservice.v1.GetSystemInfoRequest;
+import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
 import io.temporal.api.workflowservice.v1.PollActivityTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatRequest;
 import io.temporal.api.workflowservice.v1.RecordActivityTaskHeartbeatResponse;
@@ -119,6 +121,13 @@ public final class TestActivityEnvironmentInternal implements TestActivityEnviro
   }
 
   private class HeartbeatInterceptingService extends WorkflowServiceGrpc.WorkflowServiceImplBase {
+    @Override
+    public void getSystemInfo(
+        GetSystemInfoRequest request, StreamObserver<GetSystemInfoResponse> responseObserver) {
+      responseObserver.onNext(GetSystemInfoResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+
     @Override
     public void recordActivityTaskHeartbeat(
         RecordActivityTaskHeartbeatRequest request,


### PR DESCRIPTION
## What was changed

Respect SDK flags already present in history regardless of server capability detection.

Only default `GetSystemInfo` capabilities for true unknown-method `UNIMPLEMENTED` errors.

Retry gzip-compressed unary RPCs once without compression on compression-related `UNIMPLEMENTED` errors, then cache that downgrade per RPC method.

## Why?

A gzip-incompatible gRPC endpoint or proxy can return `UNIMPLEMENTED` for `GetSystemInfo`. That should not be confused with an old server missing the RPC, and default capabilities should not mask SDK flags already recorded in history.

## Checklist

1. Closes N/A.

2. How was this tested:

Added service-client coverage for per-RPC gzip downgrade, method-level downgrade caching, `GrpcCompression.NONE`, and generic `UNIMPLEMENTED` errors that must not downgrade.

Updated capability tests to distinguish unknown-method `GetSystemInfo` failures from gzip/decompression `UNIMPLEMENTED` failures.

Added replay regression coverage for histories whose SDK flags must still be respected when `GetSystemInfo` falls back to default capabilities.

3. Any docs updates needed?

No external docs updates. Javadocs for gRPC compression were updated.

