### PR TITLE
fix flakey WorkflowUpdateTest.duplicateRejectedUpdate logic where ADMITTED was reported for updates that were actually COMPLETED.

### DIFF
--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -3172,13 +3172,18 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
     }
 
     public UpdateWorkflowExecutionLifecycleStage getStage() {
-      if (!accepted.isDone()) {
-        return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED;
-      } else if (!outcome.isDone()) {
+      // A resolved outcome is terminal (a success result or a rejection/failure), so it always
+      // means
+      // COMPLETED. Checking it first keeps stage derivation independent of the order in which the
+      // `accepted` and `outcome` futures complete. The `accepted` future only distinguishes
+      // ADMITTED
+      // from ACCEPTED.
+      if (outcome.isDone()) {
+        return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED;
+      } else if (accepted.isDone()) {
         return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED;
       }
-      return UpdateWorkflowExecutionLifecycleStage
-          .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED;
+      return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED;
     }
 
     public String getId() {

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowMutableStateImpl.java
@@ -3173,11 +3173,9 @@ class TestWorkflowMutableStateImpl implements TestWorkflowMutableState {
 
     public UpdateWorkflowExecutionLifecycleStage getStage() {
       // A resolved outcome is terminal (a success result or a rejection/failure), so it always
-      // means
-      // COMPLETED. Checking it first keeps stage derivation independent of the order in which the
-      // `accepted` and `outcome` futures complete. The `accepted` future only distinguishes
-      // ADMITTED
-      // from ACCEPTED.
+      // means COMPLETED. Checking it first keeps stage derivation independent of the order in
+      // which the `accepted` and `outcome` futures complete. The `accepted` future only
+      // distinguishes ADMITTED from ACCEPTED.
       if (outcome.isDone()) {
         return UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED;
       } else if (accepted.isDone()) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

`getStage()` in the test server now checks the terminal `outcome` future before `accepted`, so an update's reported lifecycle stage no longer depends on the order those two futures complete. This fixes the flaky duplicateRejectedUpdate test, which could observe ADMITTED instead of COMPLETED for a rejected update.

essentially, if it's done just say it's done and perform that logic check first.

## Why?

`WorkflowUpdateTest.duplicateRejectedUpdate` intermittently failed, expecting stage
`COMPLETED` but observing `ADMITTED`.

