### PR TITLE
Propagate memo on continue-as-new in the test server

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/workflow/ContinueAsNewTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ContinueAsNewTest.java
@@ -77,6 +77,13 @@ public class ContinueAsNewTest {
         assertEquals(5, Workflow.getInfo().getRetryOptions().getMaximumAttempts());
         assertEquals("foo1", Workflow.getTypedSearchAttributes().get(CUSTOM_KEYWORD_SA));
       }
+      // The memo is set on every continue-as-new below, so every run after the
+      // first one should observe it once the test server propagates it.
+      if (count <= INITIAL_COUNT - 2) {
+        assertEquals("MyValue", Workflow.getMemo("myKey", String.class));
+      } else {
+        Assert.assertNull(Workflow.getMemo("myKey", String.class));
+      }
       if (count == 0) {
         assertEquals(continueAsNewTaskQueue, taskQueue);
         return 111;

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1467,6 +1467,9 @@ class StateMachines {
     if (d.hasSearchAttributes()) {
       a.setSearchAttributes(d.getSearchAttributes());
     }
+    if (d.hasMemo()) {
+      a.setMemo(d.getMemo());
+    }
     a.setNewExecutionRunId(UUID.randomUUID().toString());
     HistoryEvent event =
         HistoryEvent.newBuilder()

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1757,6 +1757,9 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
     if (ea.hasSearchAttributes()) {
       startRequestBuilder.setSearchAttributes(ea.getSearchAttributes());
     }
+    if (ea.hasMemo()) {
+      startRequestBuilder.setMemo(ea.getMemo());
+    }
     StartWorkflowExecutionRequest startRequest = startRequestBuilder.build();
     lock.lock();
     Optional<Failure> lastFail =


### PR DESCRIPTION
## What changed?

The in-memory test server carries over search attributes and the header on continue-as-new but drops the memo. As a result, a workflow that sets a memo on continue-as-new cannot read it back on the new run under the test environment, even though this works against a real server.

This sets the memo on the `ContinuedAsNew` event attributes (`StateMachines`) and on the new run's start request (`TestWorkflowService`), mirroring the existing search-attribute handling added in #2731. `ContinueAsNewTest` already set a memo on each continue-as-new but never asserted it downstream; it now asserts the memo is visible on the runs that follow.

## Why?

Reported in #2863. We run the Java SDK in production and rely on memo continuity across continue-as-new; the test server behaving differently from the real server makes it impossible to cover that behavior in workflow tests.

## Breaking changes?

No. Test-server only; behavior now matches the real server.

## Server PR

Not required.

Closes #2863
