### PR TITLE
Fix misleading docstring in preferred version PR

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/PreferredVersionProvider.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/PreferredVersionProvider.java
@@ -22,8 +22,7 @@ public interface PreferredVersionProvider {
    *
    * <p>This method is invoked on the workflow thread. Any exception it throws propagates out of the
    * {@code getVersion} call and fails the current workflow task, which will be retried; a provider
-   * that always throws will therefore block the workflow. Implementations should be deterministic
-   * and side-effect free.
+   * that always throws will therefore block the workflow.
    */
   @Nullable
   VersionPreference getPreferredVersion(@Nonnull PreferredVersionProviderInput input);


### PR DESCRIPTION
While porting to Go saw this misleading docstring. The whole point of this API is that it could involve a side-effect.