### PR TITLE
NEXUS-485: Support Workflow Update as a Nexus Operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
               --dynamic-config-value history.enableChasm=true \
               --dynamic-config-value history.enableCHASMSignalBacklinks=true \
               --dynamic-config-value history.enableTransitionHistory=true \
+              --dynamic-config-value history.enableUpdateCallbacks=true \
+              --dynamic-config-value history.enableCHASMCallbacks=true \
               --dynamic-config-value frontend.enableCancelWorkerPollsOnShutdown=true \
               --dynamic-config-value frontend.workerCommandsEnabled=true \
               --dynamic-config-value system.enableCancelActivityWorkerCommand=true &

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -521,9 +521,8 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                     .setIdentity(clientOptions.getIdentity()))
             .setInput(updateInput);
 
-    // If this update is being issued from inside a Nexus operation handler via
-    // TemporalNexusClientImpl.startWorkflowUpdate, set the fields the server needs
-    // to deliver the Nexus completion callback.
+    // If this update is being issued via TemporalNexusClientImpl.startWorkflowUpdate,
+    // set the fields the server needs to deliver the Nexus completion callback
     if (CurrentNexusOperationContext.isNexusContext()) {
       InternalNexusOperationContext nexusContext = CurrentNexusOperationContext.get();
       // already in a Nexus operation context, dont need to check nexusContext again
@@ -549,10 +548,9 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                     nexusOperationMetadata.operationToken,
                     requestLinks))
             .addAllLinks(requestLinks);
-      } else {
-        log.error("unexpected error fetching nexusOperationMetadata");
-        // maybe throw an exception but should never really happen as its all sdk
       }
+      // If no NexusOperationMetadata was found, but there is a NexusContext, then the
+      // update was likely trigger via Operation handler directly
     }
 
     Request request = requestBuilder.build();

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -5,6 +5,7 @@ import static io.temporal.api.workflowservice.v1.ExecuteMultiOperationResponse.R
 import static io.temporal.internal.common.HeaderUtils.intoPayloadMap;
 import static io.temporal.internal.common.WorkflowExecutionUtils.makeUserMetaData;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Iterators;
 import io.grpc.Deadline;
 import io.grpc.Status;
@@ -23,7 +24,11 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.internal.client.external.GenericWorkflowClient;
 import io.temporal.internal.common.HeaderUtils;
+import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.nexus.CurrentNexusOperationContext;
+import io.temporal.internal.nexus.InternalNexusOperationContext;
+import io.temporal.internal.nexus.NexusOperationMetadata;
+import io.temporal.internal.nexus.OperationTokenUtil;
 import io.temporal.internal.worker.WorkerVersioningProtoUtils;
 import io.temporal.payload.context.WorkflowSerializationContext;
 import io.temporal.serviceclient.StatusUtils;
@@ -473,6 +478,19 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
       }
     } while (updateNotYetDurable(input, result));
 
+    // If triggered by a Nexus Operation, set necessary fields- link, result
+    if (CurrentNexusOperationContext.isNexusContext()) {
+      NexusOperationMetadata nexusOperationMetadata =
+          CurrentNexusOperationContext.get().getNexusOperationMetadata();
+      if (nexusOperationMetadata != null) {
+        if (result.hasLink()) {
+          // add forward links for caller->handler
+          CurrentNexusOperationContext.get().addResponseLink(result.getLink());
+        }
+        nexusOperationMetadata.operationCompleted = result.hasOutcome();
+      }
+    }
+
     return toUpdateHandle(input, result, dataConverterWithWorkflowContext);
   }
 
@@ -495,14 +513,49 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
             .setName(input.getUpdateName());
     inputArgs.ifPresent(updateInput::setArgs);
 
-    Request request =
+    Request.Builder requestBuilder =
         Request.newBuilder()
             .setMeta(
                 Meta.newBuilder()
                     .setUpdateId(input.getUpdateId())
                     .setIdentity(clientOptions.getIdentity()))
-            .setInput(updateInput)
-            .build();
+            .setInput(updateInput);
+
+    // If this update is being issued from inside a Nexus operation handler via
+    // TemporalNexusClientImpl.startWorkflowUpdate, set the fields the server needs
+    // to deliver the Nexus completion callback.
+    if (CurrentNexusOperationContext.isNexusContext()) {
+      InternalNexusOperationContext nexusContext = CurrentNexusOperationContext.get();
+      // already in a Nexus operation context, dont need to check nexusContext again
+      NexusOperationMetadata nexusOperationMetadata = nexusContext.getNexusOperationMetadata();
+      if (nexusOperationMetadata != null) {
+        try {
+          nexusOperationMetadata.operationToken =
+              OperationTokenUtil.generateWorkflowUpdateOperationToken(
+                  clientOptions.getNamespace(),
+                  input.getWorkflowExecution().getWorkflowId(),
+                  input.getWorkflowExecution().getRunId(),
+                  input.getUpdateId());
+        } catch (JsonProcessingException e) {
+          throw new IllegalStateException("failed to generate update operation token", e);
+        }
+        List<Link> requestLinks = nexusContext.getRequestLinks();
+        requestBuilder
+            .setRequestId(nexusOperationMetadata.requestId)
+            .addCompletionCallbacks(
+                InternalUtils.buildNexusCallback(
+                    nexusOperationMetadata.callbackHeaders,
+                    nexusOperationMetadata.callbackUrl,
+                    nexusOperationMetadata.operationToken,
+                    requestLinks))
+            .addAllLinks(requestLinks);
+      } else {
+        log.error("unexpected error fetching nexusOperationMetadata");
+        // maybe throw an exception but should never really happen as its all sdk
+      }
+    }
+
+    Request request = requestBuilder.build();
 
     return UpdateWorkflowExecutionRequest.newBuilder()
         .setNamespace(clientOptions.getNamespace())

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootWorkflowClientInvoker.java
@@ -5,7 +5,6 @@ import static io.temporal.api.workflowservice.v1.ExecuteMultiOperationResponse.R
 import static io.temporal.internal.common.HeaderUtils.intoPayloadMap;
 import static io.temporal.internal.common.WorkflowExecutionUtils.makeUserMetaData;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Iterators;
 import io.grpc.Deadline;
 import io.grpc.Status;
@@ -535,7 +534,7 @@ public class RootWorkflowClientInvoker implements WorkflowClientCallsInterceptor
                   input.getWorkflowExecution().getWorkflowId(),
                   input.getWorkflowExecution().getRunId(),
                   input.getUpdateId());
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
           throw new IllegalStateException("failed to generate update operation token", e);
         }
         List<Link> requestLinks = nexusContext.getRequestLinks();

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/InternalUtils.java
@@ -157,6 +157,31 @@ public final class InternalUtils {
     return name.startsWith(WORKFLOW_STREAM_RESERVED_PREFIX);
   }
 
+  /** Helper to build a Nexus Callback from the provided input. */
+  public static Callback buildNexusCallback(
+      Map<String, String> callbackHeaders,
+      String callbackUrl,
+      String operationToken,
+      List<Link> links) {
+    Map<String, String> headers =
+        callbackHeaders.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    (k) -> k.getKey().toLowerCase(),
+                    Map.Entry::getValue,
+                    (a, b) -> a,
+                    TreeMap::new));
+    headers.put(Header.OPERATION_TOKEN.toLowerCase(), operationToken);
+    Callback.Builder cbBuilder =
+        Callback.newBuilder()
+            .setNexus(
+                Callback.Nexus.newBuilder().setUrl(callbackUrl).putAllHeader(headers).build());
+    if (links != null) {
+      cbBuilder.addAllLinks(links);
+    }
+    return cbBuilder.build();
+  }
+
   /** Check the method name for reserved prefixes or names. */
   public static void checkMethodName(POJOWorkflowMethodMetadata methodMetadata) {
     boolean workflowStreamExempt =

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
@@ -19,6 +19,7 @@ public class LinkConverter {
 
   private static final Logger log = LoggerFactory.getLogger(LinkConverter.class);
 
+  private static final String temporalUrlScheme = "temporal";
   private static final String linkPathFormat = "temporal:///namespaces/%s/workflows/%s/%s/history";
   private static final String nexusOperationLinkPathFormat =
       "temporal:///namespaces/%s/nexus-operations/%s/%s/details";
@@ -35,6 +36,7 @@ public class LinkConverter {
       Link.WorkflowEvent.getDescriptor().getFullName();
   private static final String nexusOperationLinkType =
       Link.NexusOperation.getDescriptor().getFullName();
+  private static final String workflowLinkType = Link.Workflow.getDescriptor().getFullName();
 
   public static io.temporal.api.nexus.v1.Link workflowEventToNexusLink(Link.WorkflowEvent we) {
     try {
@@ -91,6 +93,24 @@ public class LinkConverter {
       log.error("Failed to encode Nexus link URL", e);
     }
     return null;
+  }
+
+  public static io.temporal.api.nexus.v1.Link workflowLinkToNexusLink(Link.Workflow w) {
+    try {
+      String namespace = URLEncoder.encode(w.getNamespace(), StandardCharsets.UTF_8.toString());
+      String workflowId =
+          URLEncoder.encode(w.getWorkflowId(), StandardCharsets.UTF_8.toString())
+              .replace("+", "%20"); // handle workflowIds supporting spaces
+      String runId = URLEncoder.encode(w.getRunId(), StandardCharsets.UTF_8.toString());
+      String url = String.format(linkPathFormat, namespace, workflowId, runId);
+      return io.temporal.api.nexus.v1.Link.newBuilder()
+          .setUrl(url)
+          .setType(workflowLinkType)
+          .build();
+    } catch (UnsupportedEncodingException e) {
+      log.error("Failed to encode Nexus link URL", e);
+      return null;
+    }
   }
 
   public static Link nexusLinkToWorkflowEvent(io.temporal.api.nexus.v1.Link nexusLink) {
@@ -166,6 +186,43 @@ public class LinkConverter {
     return link.build();
   }
 
+  public static Link nexusLinkToWorkflowLink(io.temporal.api.nexus.v1.Link nexusLink) {
+    Link.Builder link = Link.newBuilder();
+    try {
+      URI uri = new URI(nexusLink.getUrl());
+      if (!uri.getScheme().equals(temporalUrlScheme)) {
+        log.error("Failed to parse Nexus link URL: invalid scheme: {}", uri.getScheme());
+        return null;
+      }
+      StringTokenizer st = new StringTokenizer(uri.getRawPath(), "/");
+      // maybe add constants for "namespaces", "workflows" too
+      if (!st.nextToken().equals("namespaces")) {
+        log.error("Failed to parse Nexus link URL: invalid path: {}", uri.getRawPath());
+        return null;
+      }
+      String namespace = URLDecoder.decode(st.nextToken(), StandardCharsets.UTF_8.toString());
+      if (!st.nextToken().equals("workflows")) {
+        log.error("Failed to parse Nexus link URL: invalid path: {}", uri.getRawPath());
+        return null;
+      }
+      String workflowID = URLDecoder.decode(st.nextToken(), StandardCharsets.UTF_8.toString());
+      if (!st.hasMoreTokens()) {
+        log.error("Failed to parse Nexus link URL: invalid path: {}", uri.getRawPath());
+        return null;
+      }
+      String runID = URLDecoder.decode(st.nextToken(), StandardCharsets.UTF_8.toString());
+      link.setWorkflow(
+          Link.Workflow.newBuilder()
+              .setNamespace(namespace)
+              .setWorkflowId(workflowID)
+              .setRunId(runID));
+    } catch (Exception e) {
+      log.error("Failed to parse Nexus link URL", e);
+      return null;
+    }
+    return link.build();
+  }
+
   /**
    * Dispatches on the oneof variant of {@code commonLink} and converts to the matching {@link
    * io.temporal.api.nexus.v1.Link}. Returns {@code null} if no variant is set or encoding fails.
@@ -176,6 +233,10 @@ public class LinkConverter {
     }
     if (commonLink.hasNexusOperation()) {
       return nexusOperationToNexusLink(commonLink.getNexusOperation());
+    }
+    // check for workflow link only if a more specific variant is not set
+    if (commonLink.hasWorkflow()) {
+      return workflowLinkToNexusLink(commonLink.getWorkflow());
     }
     return null;
   }
@@ -191,6 +252,9 @@ public class LinkConverter {
     }
     if (nexusOperationLinkType.equals(type)) {
       return nexusLinkToNexusOperation(nexusLink);
+    }
+    if (workflowLinkType.equals(type)) {
+      return nexusLinkToWorkflowLink(nexusLink);
     }
     log.warn("ignoring unsupported nexus link type: {}", type);
     return null;

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
@@ -107,7 +107,7 @@ public class LinkConverter {
           .setUrl(url)
           .setType(workflowLinkType)
           .build();
-    } catch (UnsupportedEncodingException e) {
+    } catch (Exception e) {
       log.error("Failed to encode Nexus link URL", e);
       return null;
     }
@@ -190,6 +190,7 @@ public class LinkConverter {
     Link.Builder link = Link.newBuilder();
     try {
       URI uri = new URI(nexusLink.getUrl());
+      log.debug("Parsing nexus link URL: {}", uri.getRawPath());
       if (!uri.getScheme().equals(temporalUrlScheme)) {
         log.error("Failed to parse Nexus link URL: invalid scheme: {}", uri.getScheme());
         return null;
@@ -234,7 +235,6 @@ public class LinkConverter {
     if (commonLink.hasNexusOperation()) {
       return nexusOperationToNexusLink(commonLink.getNexusOperation());
     }
-    // check for workflow link only if a more specific variant is not set
     if (commonLink.hasWorkflow()) {
       return workflowLinkToNexusLink(commonLink.getWorkflow());
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/common/LinkConverter.java
@@ -108,7 +108,7 @@ public class LinkConverter {
           .setType(workflowLinkType)
           .build();
     } catch (Exception e) {
-      log.error("Failed to encode Nexus link URL", e);
+      log.error("Failed to convert WorkflowLink {} to NexusLink", w, e);
       return null;
     }
   }
@@ -218,7 +218,7 @@ public class LinkConverter {
               .setWorkflowId(workflowID)
               .setRunId(runID));
     } catch (Exception e) {
-      log.error("Failed to parse Nexus link URL", e);
+      log.error("Failed to convert NexusLink {} to WorkflowLink", nexusLink, e);
       return null;
     }
     return link.build();

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/InternalNexusOperationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/InternalNexusOperationContext.java
@@ -38,6 +38,21 @@ public class InternalNexusOperationContext {
   private final Object responseLinksLock = new Object();
   private final List<Link> responseLinks = new ArrayList<>();
 
+  private NexusOperationMetadata nexusOperationMetadata;
+
+  /**
+   * Set the Nexus operation metadata
+   *
+   * @param metadata {@link NexusOperationMetadata} to be set
+   */
+  public void setNexusOperationMetadata(NexusOperationMetadata metadata) {
+    this.nexusOperationMetadata = metadata;
+  }
+
+  public NexusOperationMetadata getNexusOperationMetadata() {
+    return nexusOperationMetadata;
+  }
+
   public InternalNexusOperationContext(
       String namespace,
       String taskQueue,

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusOperationMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusOperationMetadata.java
@@ -1,0 +1,22 @@
+package io.temporal.internal.nexus;
+
+import io.temporal.common.Experimental;
+import java.util.Map;
+
+/** Container for an in-flight Nexus operation metadata. */
+@Experimental
+public final class NexusOperationMetadata {
+  public final String requestId;
+  public final String callbackUrl;
+  public final Map<String, String> callbackHeaders;
+
+  public String operationToken;
+  public boolean operationCompleted;
+
+  public NexusOperationMetadata(
+      String requestId, String callbackUrl, Map<String, String> callbackHeaders) {
+    this.requestId = requestId;
+    this.callbackUrl = callbackUrl;
+    this.callbackHeaders = callbackHeaders;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationToken.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationToken.java
@@ -18,21 +18,48 @@ public class OperationToken {
   @JsonProperty("wid")
   private final String workflowId;
 
+  @JsonProperty("rid")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  // only set for updates and activities
+  private final String runId;
+
+  @JsonProperty("uid")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  // only set for updates
+  private final String updateId;
+
   public OperationToken(
       @JsonProperty("t") Integer type,
       @JsonProperty("ns") String namespace,
       @JsonProperty("wid") String workflowId,
+      @JsonProperty("rid") String runId,
+      @JsonProperty("uid") String updateId,
       @JsonProperty("v") Integer version) {
     this.type = OperationTokenType.fromValue(type);
     this.namespace = namespace;
     this.workflowId = workflowId;
+    this.runId = runId;
+    this.updateId = updateId;
     this.version = version;
   }
 
+  /** Generate a token for a workflow run operation */
   public OperationToken(OperationTokenType type, String namespace, String workflowId) {
     this.type = type;
     this.namespace = namespace;
     this.workflowId = workflowId;
+    this.version = null;
+    this.runId = null;
+    this.updateId = null;
+  }
+
+  /** Generate a token for a workflow update operation */
+  public OperationToken(String namespace, String workflowId, String runId, String updateId) {
+    this.type = OperationTokenType.WORKFLOW_UPDATE;
+    this.namespace = namespace;
+    this.workflowId = workflowId;
+    this.runId = runId;
+    this.updateId = updateId;
     this.version = null;
   }
 
@@ -50,5 +77,13 @@ public class OperationToken {
 
   public String getWorkflowId() {
     return workflowId;
+  }
+
+  public String getUpdateId() {
+    return updateId;
+  }
+
+  public String getRunId() {
+    return runId;
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenType.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenType.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum OperationTokenType {
   UNKNOWN(0),
-  WORKFLOW_RUN(1);
+  WORKFLOW_RUN(1),
+  WORKFLOW_UPDATE(3);
 
   private final int value;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenType.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenType.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum OperationTokenType {
   UNKNOWN(0),
   WORKFLOW_RUN(1),
-  WORKFLOW_UPDATE(3);
+  WORKFLOW_UPDATE(3); // 2 is reserved for Activities
 
   private final int value;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenUtil.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/OperationTokenUtil.java
@@ -31,6 +31,9 @@ public class OperationTokenUtil {
     if (token.getVersion() != null && token.getVersion() != 0) {
       throw new IllegalArgumentException("Invalid operation token: unexpected version field");
     }
+    if (Strings.isNullOrEmpty(token.getNamespace())) {
+      throw new IllegalArgumentException("Invalid operation token: missing namespace(ns)");
+    }
     if (Strings.isNullOrEmpty(token.getWorkflowId())) {
       throw new IllegalArgumentException("Invalid operation token: missing workflow ID (wid)");
     }
@@ -53,6 +56,25 @@ public class OperationTokenUtil {
   }
 
   /**
+   * Load a workflow update operation token, asserting that the token type is {@link
+   * OperationTokenType#WORKFLOW_UPDATE}.
+   *
+   * @throws IllegalArgumentException if the operation token is invalid or not a workflow update
+   *     token
+   */
+  public static OperationToken loadWorkflowUpdateOperationToken(String operationToken) {
+    OperationToken token = loadOperationToken(operationToken);
+    if (!token.getType().equals(OperationTokenType.WORKFLOW_UPDATE)) {
+      throw new IllegalArgumentException(
+          "Invalid workflow update token: incorrect operation token type: " + token.getType());
+    }
+    if (Strings.isNullOrEmpty(token.getUpdateId())) {
+      throw new IllegalArgumentException("Invalid workflow update token: missing update ID (uid)");
+    }
+    return token;
+  }
+
+  /**
    * Extract the workflow ID from a workflow run operation token.
    *
    * @throws IllegalArgumentException if the operation token is invalid
@@ -67,6 +89,25 @@ public class OperationTokenUtil {
     String json =
         ow.writeValueAsString(
             new OperationToken(OperationTokenType.WORKFLOW_RUN, namespace, workflowId));
+    return encoder.encodeToString(json.getBytes());
+  }
+
+  /** Generate a workflow update operation token from namespace, workflowId, runId, updateId */
+  public static String generateWorkflowUpdateOperationToken(
+      String namespace, String workflowId, String runId, String updateId)
+      throws JsonProcessingException {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("Invalid workflow update token: missing namespace(ns)");
+    }
+    if (Strings.isNullOrEmpty(workflowId)) {
+      throw new IllegalArgumentException(
+          "Invalid workflow update token: missing workflow ID (wid)");
+    }
+    if (Strings.isNullOrEmpty(updateId)) {
+      throw new IllegalArgumentException("Invalid workflow update token: missing update ID (uid)");
+    }
+    runId = Strings.emptyToNull(runId); // empty runId is allowed but should not be serialized
+    String json = ow.writeValueAsString(new OperationToken(namespace, workflowId, runId, updateId));
     return encoder.encodeToString(json.getBytes());
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/CancelUpdateWorkflowExecutionInput.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/CancelUpdateWorkflowExecutionInput.java
@@ -1,0 +1,40 @@
+package io.temporal.nexus;
+
+import io.temporal.common.Experimental;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Input to {@link TemporalOperationHandler#cancelUpdateWorkflow} describing the workflow update to
+ * cancel.
+ */
+@Experimental
+public final class CancelUpdateWorkflowExecutionInput {
+
+  private final String workflowId;
+  @Nullable private final String runId;
+  private final String updateId;
+
+  public CancelUpdateWorkflowExecutionInput(
+      String workflowId, @Nullable String runId, String updateId) {
+    this.workflowId = Objects.requireNonNull(workflowId);
+    this.runId = runId;
+    this.updateId = Objects.requireNonNull(updateId);
+  }
+
+  /** Returns the workflow ID extracted from the operation token. */
+  public String getWorkflowId() {
+    return workflowId;
+  }
+
+  /** Returns the run ID extracted from the operation token, or null if not present. */
+  @Nullable
+  public String getRunId() {
+    return runId;
+  }
+
+  /** Returns the update ID extracted from the operation token. */
+  public String getUpdateId() {
+    return updateId;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/nexus/CancelUpdateWorkflowInput.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/CancelUpdateWorkflowInput.java
@@ -1,24 +1,23 @@
 package io.temporal.nexus;
 
+import com.google.common.base.Strings;
 import io.temporal.common.Experimental;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * Input to {@link TemporalOperationHandler#cancelUpdateWorkflow} describing the workflow update to
  * cancel.
  */
 @Experimental
-public final class CancelUpdateWorkflowExecutionInput {
+public final class CancelUpdateWorkflowInput {
 
   private final String workflowId;
-  @Nullable private final String runId;
+  private final String runId;
   private final String updateId;
 
-  public CancelUpdateWorkflowExecutionInput(
-      String workflowId, @Nullable String runId, String updateId) {
+  public CancelUpdateWorkflowInput(String workflowId, String runId, String updateId) {
     this.workflowId = Objects.requireNonNull(workflowId);
-    this.runId = runId;
+    this.runId = Strings.nullToEmpty(runId);
     this.updateId = Objects.requireNonNull(updateId);
   }
 
@@ -27,8 +26,7 @@ public final class CancelUpdateWorkflowExecutionInput {
     return workflowId;
   }
 
-  /** Returns the run ID extracted from the operation token, or null if not present. */
-  @Nullable
+  /** Returns the run ID extracted from the operation token, or empty if not present. */
   public String getRunId() {
     return runId;
   }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/CancelUpdateWorkflowInput.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/CancelUpdateWorkflowInput.java
@@ -1,6 +1,5 @@
 package io.temporal.nexus;
 
-import com.google.common.base.Strings;
 import io.temporal.common.Experimental;
 import java.util.Objects;
 
@@ -17,7 +16,7 @@ public final class CancelUpdateWorkflowInput {
 
   public CancelUpdateWorkflowInput(String workflowId, String runId, String updateId) {
     this.workflowId = Objects.requireNonNull(workflowId);
-    this.runId = Strings.nullToEmpty(runId);
+    this.runId = Objects.requireNonNull(runId);
     this.updateId = Objects.requireNonNull(updateId);
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -1,7 +1,10 @@
 package io.temporal.nexus;
 
+import io.nexusrpc.OperationException;
+import io.temporal.client.UpdateOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
 import io.temporal.common.Experimental;
 import io.temporal.workflow.Functions;
 import java.lang.reflect.Type;
@@ -507,4 +510,369 @@ public interface TemporalNexusClient {
       Type resultType,
       WorkflowOptions options,
       Object... args);
+
+  // draft-review: all these combinations are for 1-1 compatibility - check if they can be trimmed
+  /**
+   * Starts a workflow update on an existing workflow as a Nexus operation. The result is delivered
+   * asynchronously via the Nexus completion callback, unless the update RPC comes back already
+   * completed (e.g. a retried request, or a request that failed validation), in which case the
+   * result (or failure) is returned synchronously.
+   *
+   * <p>{@code updateMethod} must be a method reference on a stub created through {@link
+   * WorkflowClient#newWorkflowStub(Class, WorkflowOptions)} or {@link
+   * WorkflowClient#newWorkflowStub(Class, String)}, targeting the existing workflow to update (as
+   * opposed to {@link #startWorkflow}, which creates a new workflow).
+   *
+   * <p>If set, {@code options}' {@code waitForStage} has to be set to {@code WaitForStage =
+   * ACCEPTED} as Nexus Operations only support async Update requests. If unset, will default to
+   * {@code WaitForStage = ACCEPTED}. If {@code options} does not set an update ID, it defaults to
+   * the Nexus request ID which is consistent with other SDKs usage.
+   *
+   * <p>A Nexus callback URL is required for this operation; if the caller did not provide one, this
+   * method throws a {@code BAD_REQUEST} {@code HandlerException}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * MyWorkflow stub = client.getWorkflowClient().newWorkflowStub(MyWorkflow.class, input.getWorkflowId());
+   * client.startWorkflowUpdate(
+   *     stub::myUpdate, input.getArg(),
+   *     UpdateOptions.newBuilder(String.class).setUpdateName("myUpdate").build())
+   * }</pre>
+   *
+   * @param updateFunc unbound method reference to the update method
+   * @param opts update options (must include the update result class)
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func<R> updateFunc, UpdateOptions<R> opts) throws OperationException;
+
+  /**
+   * Starts a one-argument workflow update on an existing workflow as a Nexus operation. See {@link
+   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   *
+   * @param updateFunc unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param options update options (must include the update result class)
+   * @param <A1> the type of the first update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func1<A1, R> updateFunc, A1 arg1, UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a two-argument workflow update on an existing workflow as a Nexus operation. See {@link
+   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param options update options (must include the update result class)
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func2<A1, A2, R> updateMethod, A1 arg1, A2 arg2, UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a three-argument workflow update on an existing workflow as a Nexus operation. See
+   * {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param options update options (must include the update result class)
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func3<A1, A2, A3, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a four-argument workflow update on an existing workflow as a Nexus operation. See {@link
+   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param options update options (must include the update result class)
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func4<A1, A2, A3, A4, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a five-argument workflow update on an existing workflow as a Nexus operation. See {@link
+   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param options update options (must include the update result class)
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a six-argument workflow update on an existing workflow as a Nexus operation. See {@link
+   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param arg6 sixth update argument
+   * @param options update options (must include the update result class)
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @param <A6> the type of the sixth update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  // draft-review: check if all these are also necessary to preserve 1:1 compatibility
+
+  /**
+   * Starts a zero-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param options update options
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc updateMethod, UpdateOptions<Void> options) throws OperationException;
+
+  /**
+   * Starts a one-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param options update options
+   * @param <A1> the type of the first update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc1<A1> updateMethod, A1 arg1, UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a two-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param options update options
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc2<A1, A2> updateMethod, A1 arg1, A2 arg2, UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a three-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param options update options
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc3<A1, A2, A3> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a four-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param options update options
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc4<A1, A2, A3, A4> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a five-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param options update options
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a six-argument workflow update with no return value on an existing workflow as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param arg6 sixth update argument
+   * @param options update options
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @param <A6> the type of the sixth update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a workflow update using an untyped {@link WorkflowStub}, targeting an existing workflow,
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the
+   * full behavior contract.
+   *
+   * @param stub untyped stub for the existing workflow to update, created through {@link
+   *     WorkflowClient#newUntypedWorkflowStub(String)} or similar
+   * @param options update options (must include update name and result class)
+   * @param args update arguments
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <R> TemporalOperationResult<R> startWorkflowUpdate(
+      WorkflowStub stub, UpdateOptions<R> options, Object... args) throws OperationException;
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -4,7 +4,6 @@ import io.nexusrpc.OperationException;
 import io.temporal.client.UpdateOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.client.WorkflowStub;
 import io.temporal.common.Experimental;
 import io.temporal.workflow.Functions;
 import java.lang.reflect.Type;
@@ -518,15 +517,14 @@ public interface TemporalNexusClient {
    * completed (e.g. a retried request, or a request that failed validation), in which case the
    * result (or failure) is returned synchronously.
    *
-   * <p>{@code updateMethod} must be a method reference on a stub created through {@link
-   * WorkflowClient#newWorkflowStub(Class, WorkflowOptions)} or {@link
-   * WorkflowClient#newWorkflowStub(Class, String)}, targeting the existing workflow to update (as
-   * opposed to {@link #startWorkflow}, which creates a new workflow).
+   * <p>{@code updateMethod} must be an unbound method reference to a method on {@code
+   * workflowClass} (as opposed to {@link #startWorkflow}, which creates a new workflow, this
+   * targets the existing workflow identified by {@code workflowId}).
    *
-   * <p>If set, {@code options}' {@code waitForStage} has to be set to {@code WaitForStage =
-   * ACCEPTED} as Nexus Operations only support async Update requests. If unset, will default to
-   * {@code WaitForStage = ACCEPTED}. If {@code options} does not set an update ID, it defaults to
-   * the Nexus request ID which is consistent with other SDKs usage.
+   * <p>{@code options}' {@code waitForStage} has to be set to {@code WaitForStage = ACCEPTED} as
+   * Nexus Operations only support async Update requests. If not, the operation will be marked as
+   * failed. If {@code options} does not set an update ID, it defaults to the Nexus request ID which
+   * is consistent with other SDKs usage.
    *
    * <p>A Nexus callback URL is required for this operation; if the caller did not provide one, this
    * method throws a {@code BAD_REQUEST} {@code HandlerException}.
@@ -534,64 +532,95 @@ public interface TemporalNexusClient {
    * <p>Example:
    *
    * <pre>{@code
-   * MyWorkflow stub = client.getWorkflowClient().newWorkflowStub(MyWorkflow.class, input.getWorkflowId());
    * client.startWorkflowUpdate(
-   *     stub::myUpdate, input.getArg(),
-   *     UpdateOptions.newBuilder(String.class).setUpdateName("myUpdate").build())
+   *     MyWorkflow.class, input.getWorkflowId(),
+   *     MyWorkflow::myUpdate, input.getArg(),
+   *     UpdateOptions.newBuilder(String.class)
+   *         .setUpdateName("myUpdate")
+   *         .setWaitForStage(WorkflowUpdateStage.ACCEPTED)
+   *         .build())
    * }</pre>
    *
-   * @param updateFunc unbound method reference to the update method
-   * @param opts update options (must include the update result class)
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
+   * @param updateMethod unbound method reference to the update method
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <R> the update return type
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func<R> updateFunc, UpdateOptions<R> opts) throws OperationException;
+  <T, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func1<T, R> updateMethod,
+      UpdateOptions<R> options)
+      throws OperationException;
 
   /**
    * Starts a one-argument workflow update on an existing workflow as a Nexus operation. See {@link
-   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
    *
-   * @param updateFunc unbound method reference to the update method
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
+   * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <R> the update return type
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func1<A1, R> updateFunc, A1 arg1, UpdateOptions<R> options)
+  <T, A1, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func2<T, A1, R> updateMethod,
+      A1 arg1,
+      UpdateOptions<R> options)
       throws OperationException;
 
   /**
    * Starts a two-argument workflow update on an existing workflow as a Nexus operation. See {@link
-   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
    * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <R> the update return type
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func2<A1, A2, R> updateMethod, A1 arg1, A2 arg2, UpdateOptions<R> options)
+  <T, A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func3<T, A1, A2, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<R> options)
       throws OperationException;
 
   /**
    * Starts a three-argument workflow update on an existing workflow as a Nexus operation. See
-   * {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   * {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full
+   * behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
    * @param arg3 third update argument
    * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -599,8 +628,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func3<A1, A2, A3, R> updateMethod,
+  <T, A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func4<T, A1, A2, A3, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -609,14 +640,18 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a four-argument workflow update on an existing workflow as a Nexus operation. See {@link
-   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
    * @param arg3 third update argument
    * @param arg4 fourth update argument
    * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -625,8 +660,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func4<A1, A2, A3, A4, R> updateMethod,
+  <T, A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func5<T, A1, A2, A3, A4, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -636,8 +673,11 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a five-argument workflow update on an existing workflow as a Nexus operation. See {@link
-   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
@@ -645,6 +685,7 @@ public interface TemporalNexusClient {
    * @param arg4 fourth update argument
    * @param arg5 fifth update argument
    * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -654,8 +695,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
+  <T, A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func6<T, A1, A2, A3, A4, A5, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -666,8 +709,11 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a six-argument workflow update on an existing workflow as a Nexus operation. See {@link
-   * #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full behavior contract.
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
@@ -676,6 +722,7 @@ public interface TemporalNexusClient {
    * @param arg5 fifth update argument
    * @param arg6 sixth update argument
    * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -686,8 +733,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
+  <T, A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func7<T, A1, A2, A3, A4, A5, A6, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -701,69 +750,96 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a zero-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param options update options
+   * @param <T> the workflow interface type
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc updateMethod, UpdateOptions<Void> options) throws OperationException;
+  <T> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc1<T> updateMethod,
+      UpdateOptions<Void> options)
+      throws OperationException;
 
   /**
    * Starts a one-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param options update options
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc1<A1> updateMethod, A1 arg1, UpdateOptions<Void> options)
+  <T, A1> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc2<T, A1> updateMethod,
+      A1 arg1,
+      UpdateOptions<Void> options)
       throws OperationException;
 
   /**
    * Starts a two-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
    * @param options update options
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc2<A1, A2> updateMethod, A1 arg1, A2 arg2, UpdateOptions<Void> options)
+  <T, A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc3<T, A1, A2> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<Void> options)
       throws OperationException;
 
   /**
    * Starts a three-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
    * @param arg3 third update argument
    * @param options update options
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc3<A1, A2, A3> updateMethod,
+  <T, A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc4<T, A1, A2, A3> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -772,15 +848,18 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a four-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
    * @param arg3 third update argument
    * @param arg4 fourth update argument
    * @param options update options
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -788,8 +867,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc4<A1, A2, A3, A4> updateMethod,
+  <T, A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc5<T, A1, A2, A3, A4> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -799,9 +880,11 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a five-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
@@ -809,6 +892,7 @@ public interface TemporalNexusClient {
    * @param arg4 fourth update argument
    * @param arg5 fifth update argument
    * @param options update options
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -817,8 +901,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
+  <T, A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc6<T, A1, A2, A3, A4, A5> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -829,9 +915,11 @@ public interface TemporalNexusClient {
 
   /**
    * Starts a six-argument workflow update with no return value on an existing workflow as a Nexus
-   * operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the full
-   * behavior contract.
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
    *
+   * @param workflowClass the workflow interface class
+   * @param workflowId the ID of the existing workflow to update
    * @param updateMethod unbound method reference to the update method
    * @param arg1 first update argument
    * @param arg2 second update argument
@@ -840,6 +928,7 @@ public interface TemporalNexusClient {
    * @param arg5 fifth update argument
    * @param arg6 sixth update argument
    * @param options update options
+   * @param <T> the workflow interface type
    * @param <A1> the type of the first update argument
    * @param <A2> the type of the second update argument
    * @param <A3> the type of the third update argument
@@ -849,8 +938,10 @@ public interface TemporalNexusClient {
    * @return a {@link TemporalOperationResult}; sync if the update already completed, async
    *     (carrying the update-workflow operation token) otherwise
    */
-  <A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
+  <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc7<T, A1, A2, A3, A4, A5, A6> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -859,20 +950,4 @@ public interface TemporalNexusClient {
       A6 arg6,
       UpdateOptions<Void> options)
       throws OperationException;
-
-  /**
-   * Starts a workflow update using an untyped {@link WorkflowStub}, targeting an existing workflow,
-   * as a Nexus operation. See {@link #startWorkflowUpdate(Functions.Func, UpdateOptions)} for the
-   * full behavior contract.
-   *
-   * @param stub untyped stub for the existing workflow to update, created through {@link
-   *     WorkflowClient#newUntypedWorkflowStub(String)} or similar
-   * @param options update options (must include update name and result class)
-   * @param args update arguments
-   * @param <R> the update return type
-   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
-   *     (carrying the update-workflow operation token) otherwise
-   */
-  <R> TemporalOperationResult<R> startWorkflowUpdate(
-      WorkflowStub stub, UpdateOptions<R> options, Object... args) throws OperationException;
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -1,6 +1,7 @@
 package io.temporal.nexus;
 
 import io.nexusrpc.OperationException;
+import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.UpdateOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
@@ -510,7 +511,6 @@ public interface TemporalNexusClient {
       WorkflowOptions options,
       Object... args);
 
-  // draft-review: all these combinations are for 1-1 compatibility - check if they can be trimmed
   /**
    * Starts a workflow update on an existing workflow as a Nexus operation. The result is delivered
    * asynchronously via the Nexus completion callback, unless the update RPC comes back already
@@ -746,8 +746,6 @@ public interface TemporalNexusClient {
       UpdateOptions<R> options)
       throws OperationException;
 
-  // draft-review: check if all these are also necessary to preserve 1:1 compatibility
-
   /**
    * Starts a zero-argument workflow update with no return value on an existing workflow as a Nexus
    * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
@@ -941,6 +939,422 @@ public interface TemporalNexusClient {
   <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
       Class<T> workflowClass,
       String workflowId,
+      Functions.Proc7<T, A1, A2, A3, A4, A5, A6> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  // ---------- Update Workflow overloads for WorkflowExecution. Experimental, may be removed in the
+  // future. ----------
+
+  /**
+   * Starts a workflow update on the provided workflow execution as a Nexus operation. See {@link
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func1<T, R> updateMethod,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a one-argument workflow update on the provided workflow execution as a Nexus operation.
+   * See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func2<T, A1, R> updateMethod,
+      A1 arg1,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a two-argument workflow update on the provided workflow execution as a Nexus operation.
+   * See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func3<T, A1, A2, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a three-argument workflow update on the provided workflow execution as a Nexus
+   * operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for
+   * the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func4<T, A1, A2, A3, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a four-argument workflow update on the provided workflow execution as a Nexus operation.
+   * See {@link #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full
+   * behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func5<T, A1, A2, A3, A4, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a five-argument workflow update on the provided workflow execution. See {@link
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func6<T, A1, A2, A3, A4, A5, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a six-argument workflow update on the provided workflow execution. See {@link
+   * #startWorkflowUpdate(Class, String, Functions.Func1, UpdateOptions)} for the full behavior
+   * contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param arg6 sixth update argument
+   * @param options update options (must include the update result class)
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @param <A6> the type of the sixth update argument
+   * @param <R> the update return type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func7<T, A1, A2, A3, A4, A5, A6, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<R> options)
+      throws OperationException;
+
+  /**
+   * Starts a zero-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc1<T> updateMethod,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a one-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc2<T, A1> updateMethod,
+      A1 arg1,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a two-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc3<T, A1, A2> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a three-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc4<T, A1, A2, A3> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a four-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc5<T, A1, A2, A3, A4> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a five-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc6<T, A1, A2, A3, A4, A5> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<Void> options)
+      throws OperationException;
+
+  /**
+   * Starts a six-argument workflow update with no return value on the provided workflow execution
+   * as a Nexus operation. See {@link #startWorkflowUpdate(Class, String, Functions.Func1,
+   * UpdateOptions)} for the full behavior contract.
+   *
+   * @param workflowClass the workflow interface class
+   * @param execution the workflow execution to update
+   * @param updateMethod unbound method reference to the update method
+   * @param arg1 first update argument
+   * @param arg2 second update argument
+   * @param arg3 third update argument
+   * @param arg4 fourth update argument
+   * @param arg5 fifth update argument
+   * @param arg6 sixth update argument
+   * @param options update options
+   * @param <T> the workflow interface type
+   * @param <A1> the type of the first update argument
+   * @param <A2> the type of the second update argument
+   * @param <A3> the type of the third update argument
+   * @param <A4> the type of the fourth update argument
+   * @param <A5> the type of the fifth update argument
+   * @param <A6> the type of the sixth update argument
+   * @return a {@link TemporalOperationResult}; sync if the update already completed, async
+   *     (carrying the update-workflow operation token) otherwise
+   */
+  <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
       Functions.Proc7<T, A1, A2, A3, A4, A5, A6> updateMethod,
       A1 arg1,
       A2 arg2,

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -1,13 +1,22 @@
 package io.temporal.nexus;
 
+import com.google.common.base.Strings;
+import io.nexusrpc.OperationException;
 import io.nexusrpc.handler.HandlerException;
 import io.nexusrpc.handler.OperationContext;
 import io.nexusrpc.handler.OperationStartDetails;
+import io.temporal.client.UpdateOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
+import io.temporal.client.WorkflowUpdateException;
+import io.temporal.client.WorkflowUpdateHandle;
+import io.temporal.client.WorkflowUpdateStage;
 import io.temporal.common.Experimental;
 import io.temporal.internal.client.NexusStartWorkflowResponse;
+import io.temporal.internal.nexus.CurrentNexusOperationContext;
+import io.temporal.internal.nexus.InternalNexusOperationContext;
+import io.temporal.internal.nexus.NexusOperationMetadata;
 import io.temporal.internal.nexus.NexusStartWorkflowHelper;
 import io.temporal.workflow.Functions;
 import java.lang.reflect.Type;
@@ -244,13 +253,7 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   }
 
   private <R> TemporalOperationResult<R> invokeAndReturn(WorkflowHandle<R> handle) {
-    if (!asyncOperationStarted.compareAndSet(false, true)) {
-      throw new HandlerException(
-          HandlerException.ErrorType.BAD_REQUEST,
-          new IllegalStateException(
-              "Only one async operation can be started per operation handler invocation. "
-                  + "Use getWorkflowClient() for additional workflow interactions."));
-    }
+    markAsyncOperationStarted();
     try {
       NexusStartWorkflowResponse response =
           NexusStartWorkflowHelper.startWorkflowAndAttachLinks(
@@ -263,6 +266,271 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
       // the handler can retry without being blocked by the guard.
       asyncOperationStarted.set(false);
       throw t;
+    }
+  }
+
+  // ---------- Update Workflow overloads ----------
+
+  @Override
+  public <R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func<R> updateMethod, UpdateOptions<R> options) throws OperationException {
+    return executeUpdate(options, effective -> WorkflowClient.startUpdate(updateMethod, effective));
+  }
+
+  @Override
+  public <A1, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func1<A1, R> updateMethod, A1 arg1, UpdateOptions<R> options)
+      throws OperationException {
+    return executeUpdate(
+        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, effective));
+  }
+
+  @Override
+  public <A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func2<A1, A2, R> updateMethod, A1 arg1, A2 arg2, UpdateOptions<R> options)
+      throws OperationException {
+    return executeUpdate(
+        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func3<A1, A2, A3, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<R> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func4<A1, A2, A3, A4, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<R> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<R> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, arg5, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<R> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, effective));
+  }
+
+  @Override
+  public TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc updateMethod, UpdateOptions<Void> options) throws OperationException {
+    return executeUpdate(options, effective -> WorkflowClient.startUpdate(updateMethod, effective));
+  }
+
+  @Override
+  public <A1> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc1<A1> updateMethod, A1 arg1, UpdateOptions<Void> options)
+      throws OperationException {
+    return executeUpdate(
+        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, effective));
+  }
+
+  @Override
+  public <A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc2<A1, A2> updateMethod, A1 arg1, A2 arg2, UpdateOptions<Void> options)
+      throws OperationException {
+    return executeUpdate(
+        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, effective));
+  }
+
+  @Override
+  public <A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc3<A1, A2, A3> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc4<A1, A2, A3, A4> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, arg5, effective));
+  }
+
+  @Override
+  public <A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
+      Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, effective));
+  }
+
+  @Override
+  public <R> TemporalOperationResult<R> startWorkflowUpdate(
+      WorkflowStub stub, UpdateOptions<R> options, Object... args) throws OperationException {
+    return executeUpdate(options, effective -> stub.startUpdate(effective, args));
+  }
+
+  /** Function that will trigger {@code startUpdate} on overloads */
+  @FunctionalInterface
+  private interface UpdateCommand<R> {
+    WorkflowUpdateHandle<R> triggerUpdate(UpdateOptions<R> options);
+  }
+
+  /** Common code for all {@code startWorkflowUpdate} overloads. */
+  private <R> TemporalOperationResult<R> executeUpdate(
+      UpdateOptions<R> options, UpdateCommand<R> updateWrapper) throws OperationException {
+
+    UpdateOptions.Builder<R> effectiveOptsBuilder = UpdateOptions.newBuilder(options);
+    String requestId = operationStartDetails.getRequestId();
+    if (Strings.isNullOrEmpty(options.getUpdateId())) {
+      // if updateId is unset, use requestId - consistent with other SDKs
+      effectiveOptsBuilder.setUpdateId(requestId);
+    }
+    if (options.getWaitForStage() == null) {
+      effectiveOptsBuilder.setWaitForStage(WorkflowUpdateStage.ACCEPTED);
+    }
+    options = effectiveOptsBuilder.build();
+    checkNexusUpdateOptionsValid(options);
+    markAsyncOperationStarted();
+
+    String callbackUrl = operationStartDetails.getCallbackUrl();
+    if (Strings.isNullOrEmpty(callbackUrl)) {
+      asyncOperationStarted.set(false);
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST,
+          new IllegalArgumentException("callback URL is required for a Nexus operation"));
+    }
+
+    InternalNexusOperationContext nexusContext = CurrentNexusOperationContext.get();
+    NexusOperationMetadata nexusOperationMetadata =
+        new NexusOperationMetadata(
+            requestId, callbackUrl, operationStartDetails.getCallbackHeaders());
+    // set the nexusOperationMetadata and capture operationCompleted
+    nexusContext.setNexusOperationMetadata(nexusOperationMetadata);
+    try {
+      WorkflowUpdateHandle<R> handle = updateWrapper.triggerUpdate(options);
+      if (nexusOperationMetadata.operationCompleted) {
+        try {
+          R value = handle.getResult();
+          return TemporalOperationResult.sync(value);
+        } catch (WorkflowUpdateException e) {
+          // Only case where operation is completed but getResult fails is if the update
+          // fails non-retriably - validation failure - so fail the operation immediately
+          throw OperationException.failed(e);
+        }
+      }
+      return TemporalOperationResult.async(nexusOperationMetadata.operationToken);
+    } catch (Throwable t) {
+      // Reset on failure so that if the update RPC throws, the handler can retry without being
+      // blocked by the guard.
+      asyncOperationStarted.set(false);
+      throw t;
+    } finally {
+      nexusContext.setNexusOperationMetadata(null);
+    }
+  }
+
+  /**
+   * @throws HandlerException if the options provided are invalid like missing
+   *     UpdateName/WorkflowID/etc
+   */
+  private <R> void checkNexusUpdateOptionsValid(UpdateOptions<R> options) {
+    if (options.getWaitForStage() != WorkflowUpdateStage.ACCEPTED) {
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST,
+          new IllegalArgumentException(
+              "workflow update Nexus operation only support WaitForStage Accepted"));
+    }
+    // draft-review: TBD, this is still under discussion as we may want to let
+    // handlers trigger invalid updates in some cases and just retry forever
+    try {
+      options.validate();
+    } catch (IllegalStateException e) {
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST, new IllegalArgumentException(e.getMessage()));
+    }
+  }
+
+  private void markAsyncOperationStarted() {
+    if (!asyncOperationStarted.compareAndSet(false, true)) {
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST,
+          new IllegalStateException(
+              "Only one async operation can be started per operation handler invocation. "
+                  + "Use getWorkflowClient() for additional workflow interactions."));
     }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -1,5 +1,6 @@
 package io.temporal.nexus;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Strings;
 import io.nexusrpc.OperationException;
 import io.nexusrpc.handler.HandlerException;
@@ -18,6 +19,8 @@ import io.temporal.internal.nexus.CurrentNexusOperationContext;
 import io.temporal.internal.nexus.InternalNexusOperationContext;
 import io.temporal.internal.nexus.NexusOperationMetadata;
 import io.temporal.internal.nexus.NexusStartWorkflowHelper;
+import io.temporal.internal.nexus.OperationToken;
+import io.temporal.internal.nexus.OperationTokenUtil;
 import io.temporal.workflow.Functions;
 import java.lang.reflect.Type;
 import java.util.Objects;
@@ -272,57 +275,90 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   // ---------- Update Workflow overloads ----------
 
   @Override
-  public <R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func<R> updateMethod, UpdateOptions<R> options) throws OperationException {
-    return executeUpdate(options, effective -> WorkflowClient.startUpdate(updateMethod, effective));
-  }
-
-  @Override
-  public <A1, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func1<A1, R> updateMethod, A1 arg1, UpdateOptions<R> options)
+  public <T, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func1<T, R> updateMethod,
+      UpdateOptions<R> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
-        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, effective));
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub), effective));
   }
 
   @Override
-  public <A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func2<A1, A2, R> updateMethod, A1 arg1, A2 arg2, UpdateOptions<R> options)
+  public <T, A1, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func2<T, A1, R> updateMethod,
+      A1 arg1,
+      UpdateOptions<R> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
-        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, effective));
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1), effective));
   }
 
   @Override
-  public <A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func3<A1, A2, A3, R> updateMethod,
+  public <T, A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func3<T, A1, A2, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1, arg2), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func4<T, A1, A2, A3, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       UpdateOptions<R> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
-        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, effective));
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3), effective));
   }
 
   @Override
-  public <A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func4<A1, A2, A3, A4, R> updateMethod,
+  public <T, A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func5<T, A1, A2, A3, A4, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       A4 arg4,
       UpdateOptions<R> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
-        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, effective));
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4), effective));
   }
 
   @Override
-  public <A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func5<A1, A2, A3, A4, A5, R> updateMethod,
+  public <T, A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func6<T, A1, A2, A3, A4, A5, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -330,15 +366,19 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
       A5 arg5,
       UpdateOptions<R> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
         effective ->
-            WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, arg5, effective));
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5), effective));
   }
 
   @Override
-  public <A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
-      Functions.Func6<A1, A2, A3, A4, A5, A6, R> updateMethod,
+  public <T, A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Func7<T, A1, A2, A3, A4, A5, A6, R> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -347,65 +387,99 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
       A6 arg6,
       UpdateOptions<R> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
         effective ->
             WorkflowClient.startUpdate(
-                updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, effective));
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5, arg6), effective));
   }
 
   @Override
-  public TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc updateMethod, UpdateOptions<Void> options) throws OperationException {
-    return executeUpdate(options, effective -> WorkflowClient.startUpdate(updateMethod, effective));
-  }
-
-  @Override
-  public <A1> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc1<A1> updateMethod, A1 arg1, UpdateOptions<Void> options)
+  public <T> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc1<T> updateMethod,
+      UpdateOptions<Void> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
-        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, effective));
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub), effective));
   }
 
   @Override
-  public <A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc2<A1, A2> updateMethod, A1 arg1, A2 arg2, UpdateOptions<Void> options)
+  public <T, A1> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc2<T, A1> updateMethod,
+      A1 arg1,
+      UpdateOptions<Void> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
-        options, effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, effective));
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1), effective));
   }
 
   @Override
-  public <A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc3<A1, A2, A3> updateMethod,
+  public <T, A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc3<T, A1, A2> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1, arg2), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc4<T, A1, A2, A3> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       UpdateOptions<Void> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
-        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, effective));
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3), effective));
   }
 
   @Override
-  public <A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc4<A1, A2, A3, A4> updateMethod,
+  public <T, A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc5<T, A1, A2, A3, A4> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
       A4 arg4,
       UpdateOptions<Void> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
-        effective -> WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, effective));
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4), effective));
   }
 
   @Override
-  public <A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc5<A1, A2, A3, A4, A5> updateMethod,
+  public <T, A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc6<T, A1, A2, A3, A4, A5> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -413,15 +487,19 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
       A5 arg5,
       UpdateOptions<Void> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
         effective ->
-            WorkflowClient.startUpdate(updateMethod, arg1, arg2, arg3, arg4, arg5, effective));
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5), effective));
   }
 
   @Override
-  public <A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
-      Functions.Proc6<A1, A2, A3, A4, A5, A6> updateMethod,
+  public <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      String workflowId,
+      Functions.Proc7<T, A1, A2, A3, A4, A5, A6> updateMethod,
       A1 arg1,
       A2 arg2,
       A3 arg3,
@@ -430,17 +508,12 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
       A6 arg6,
       UpdateOptions<Void> options)
       throws OperationException {
+    T stub = client.newWorkflowStub(workflowClass, workflowId);
     return executeUpdate(
         options,
         effective ->
             WorkflowClient.startUpdate(
-                updateMethod, arg1, arg2, arg3, arg4, arg5, arg6, effective));
-  }
-
-  @Override
-  public <R> TemporalOperationResult<R> startWorkflowUpdate(
-      WorkflowStub stub, UpdateOptions<R> options, Object... args) throws OperationException {
-    return executeUpdate(options, effective -> stub.startUpdate(effective, args));
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5, arg6), effective));
   }
 
   /** Function that will trigger {@code startUpdate} on overloads */
@@ -459,28 +532,23 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
       // if updateId is unset, use requestId - consistent with other SDKs
       effectiveOptsBuilder.setUpdateId(requestId);
     }
-    if (options.getWaitForStage() == null) {
-      effectiveOptsBuilder.setWaitForStage(WorkflowUpdateStage.ACCEPTED);
-    }
     options = effectiveOptsBuilder.build();
     checkNexusUpdateOptionsValid(options);
     markAsyncOperationStarted();
 
-    String callbackUrl = operationStartDetails.getCallbackUrl();
-    if (Strings.isNullOrEmpty(callbackUrl)) {
-      asyncOperationStarted.set(false);
-      throw new HandlerException(
-          HandlerException.ErrorType.BAD_REQUEST,
-          new IllegalArgumentException("callback URL is required for a Nexus operation"));
-    }
-
     InternalNexusOperationContext nexusContext = CurrentNexusOperationContext.get();
-    NexusOperationMetadata nexusOperationMetadata =
-        new NexusOperationMetadata(
-            requestId, callbackUrl, operationStartDetails.getCallbackHeaders());
-    // set the nexusOperationMetadata and capture operationCompleted
-    nexusContext.setNexusOperationMetadata(nexusOperationMetadata);
     try {
+      String callbackUrl = operationStartDetails.getCallbackUrl();
+      if (Strings.isNullOrEmpty(callbackUrl)) {
+        throw new HandlerException(
+            HandlerException.ErrorType.BAD_REQUEST,
+            new IllegalArgumentException("callback URL is required for a Nexus operation"));
+      }
+      NexusOperationMetadata nexusOperationMetadata =
+          new NexusOperationMetadata(
+              requestId, callbackUrl, operationStartDetails.getCallbackHeaders());
+      // set the nexusOperationMetadata and capture operationCompleted
+      nexusContext.setNexusOperationMetadata(nexusOperationMetadata);
       WorkflowUpdateHandle<R> handle = updateWrapper.triggerUpdate(options);
       if (nexusOperationMetadata.operationCompleted) {
         try {
@@ -492,7 +560,25 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
           throw OperationException.failed(e);
         }
       }
-      return TemporalOperationResult.async(nexusOperationMetadata.operationToken);
+      // regenerate token so it has the actual run ID that update is running on
+      // previous generation is only to handle completion before handle is returned
+      String token = "";
+      try {
+        OperationToken ot =
+            OperationTokenUtil.loadWorkflowUpdateOperationToken(
+                nexusOperationMetadata.operationToken);
+        token =
+            OperationTokenUtil.generateWorkflowUpdateOperationToken(
+                ot.getNamespace(),
+                ot.getWorkflowId(),
+                handle.getExecution().getRunId(),
+                ot.getUpdateId());
+      } catch (IllegalArgumentException | JsonProcessingException e) {
+        // should not happen, this is all in SDK
+        throw new HandlerException(
+            HandlerException.ErrorType.INTERNAL, "unexpected error reconstructing token", e);
+      }
+      return TemporalOperationResult.async(token);
     } catch (Throwable t) {
       // Reset on failure so that if the update RPC throws, the handler can retry without being
       // blocked by the guard.
@@ -504,23 +590,21 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   }
 
   /**
-   * @throws HandlerException if the options provided are invalid like missing
+   * @throws OperationException if the options provided are invalid like missing
    *     UpdateName/WorkflowID/etc
    */
-  private <R> void checkNexusUpdateOptionsValid(UpdateOptions<R> options) {
+  private <R> void checkNexusUpdateOptionsValid(UpdateOptions<R> options)
+      throws OperationException {
     if (options.getWaitForStage() != WorkflowUpdateStage.ACCEPTED) {
-      throw new HandlerException(
-          HandlerException.ErrorType.BAD_REQUEST,
-          new IllegalArgumentException(
-              "workflow update Nexus operation only support WaitForStage Accepted"));
+      throw OperationException.failed(
+          "workflow update Nexus operation only support WaitForStage Accepted");
     }
     // draft-review: TBD, this is still under discussion as we may want to let
     // handlers trigger invalid updates in some cases and just retry forever
     try {
       options.validate();
     } catch (IllegalStateException e) {
-      throw new HandlerException(
-          HandlerException.ErrorType.BAD_REQUEST, new IllegalArgumentException(e.getMessage()));
+      throw OperationException.failed(e);
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClientImpl.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Strings;
 import io.nexusrpc.OperationException;
 import io.nexusrpc.handler.HandlerException;
+import io.nexusrpc.handler.HandlerException.RetryBehavior;
 import io.nexusrpc.handler.OperationContext;
 import io.nexusrpc.handler.OperationStartDetails;
+import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.UpdateOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
+import io.temporal.client.WorkflowTargetOptions;
 import io.temporal.client.WorkflowUpdateException;
 import io.temporal.client.WorkflowUpdateHandle;
 import io.temporal.client.WorkflowUpdateStage;
@@ -596,15 +599,21 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
   private <R> void checkNexusUpdateOptionsValid(UpdateOptions<R> options)
       throws OperationException {
     if (options.getWaitForStage() != WorkflowUpdateStage.ACCEPTED) {
-      throw OperationException.failed(
-          "workflow update Nexus operation only support WaitForStage Accepted");
+      throw new HandlerException(
+          HandlerException.ErrorType.INTERNAL,
+          "invalid update request",
+          new IllegalArgumentException(
+              "nexus op workflow updates only support WorkflowUpdateStageAccepted for async updates"),
+          RetryBehavior.RETRYABLE);
     }
-    // draft-review: TBD, this is still under discussion as we may want to let
-    // handlers trigger invalid updates in some cases and just retry forever
     try {
       options.validate();
     } catch (IllegalStateException e) {
-      throw OperationException.failed(e);
+      throw new HandlerException(
+          HandlerException.ErrorType.INTERNAL,
+          "invalid update request",
+          e,
+          RetryBehavior.RETRYABLE);
     }
   }
 
@@ -616,5 +625,254 @@ final class TemporalNexusClientImpl implements TemporalNexusClient {
               "Only one async operation can be started per operation handler invocation. "
                   + "Use getWorkflowClient() for additional workflow interactions."));
     }
+  }
+
+  // ---------- Update Workflow overloads for WorkflowExecution ----------
+
+  @Override
+  public <T, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func1<T, R> updateMethod,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub), effective));
+  }
+
+  @Override
+  public <T, A1, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func2<T, A1, R> updateMethod,
+      A1 arg1,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1), effective));
+  }
+
+  @Override
+  public <T, A1, A2, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func3<T, A1, A2, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1, arg2), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func4<T, A1, A2, A3, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func5<T, A1, A2, A3, A4, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, A5, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func6<T, A1, A2, A3, A4, A5, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, A5, A6, R> TemporalOperationResult<R> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Func7<T, A1, A2, A3, A4, A5, A6, R> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<R> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5, arg6), effective));
+  }
+
+  @Override
+  public <T> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc1<T> updateMethod,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub), effective));
+  }
+
+  @Override
+  public <T, A1> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc2<T, A1> updateMethod,
+      A1 arg1,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective -> WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1), effective));
+  }
+
+  @Override
+  public <T, A1, A2> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc3<T, A1, A2> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(() -> updateMethod.apply(stub, arg1, arg2), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc4<T, A1, A2, A3> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc5<T, A1, A2, A3, A4> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, A5> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc6<T, A1, A2, A3, A4, A5> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5), effective));
+  }
+
+  @Override
+  public <T, A1, A2, A3, A4, A5, A6> TemporalOperationResult<Void> startWorkflowUpdate(
+      Class<T> workflowClass,
+      WorkflowExecution execution,
+      Functions.Proc7<T, A1, A2, A3, A4, A5, A6> updateMethod,
+      A1 arg1,
+      A2 arg2,
+      A3 arg3,
+      A4 arg4,
+      A5 arg5,
+      A6 arg6,
+      UpdateOptions<Void> options)
+      throws OperationException {
+    T stub = newWorkflowStub(workflowClass, execution);
+    return executeUpdate(
+        options,
+        effective ->
+            WorkflowClient.startUpdate(
+                () -> updateMethod.apply(stub, arg1, arg2, arg3, arg4, arg5, arg6), effective));
+  }
+
+  private <T> T newWorkflowStub(Class<T> workflowClass, WorkflowExecution execution) {
+    return client.newWorkflowStub(
+        workflowClass, WorkflowTargetOptions.newBuilder().setWorkflowExecution(execution).build());
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -1,12 +1,12 @@
 package io.temporal.nexus;
 
+import io.nexusrpc.OperationException;
 import io.nexusrpc.handler.*;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.Experimental;
 import io.temporal.internal.nexus.CurrentNexusOperationContext;
 import io.temporal.internal.nexus.InternalNexusOperationContext;
 import io.temporal.internal.nexus.OperationToken;
-import io.temporal.internal.nexus.OperationTokenType;
 import io.temporal.internal.nexus.OperationTokenUtil;
 
 /**
@@ -48,7 +48,8 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
   @FunctionalInterface
   public interface StartHandler<T, R> {
     TemporalOperationResult<R> apply(
-        TemporalOperationStartContext context, TemporalNexusClient client, T input);
+        TemporalOperationStartContext context, TemporalNexusClient client, T input)
+        throws OperationException;
   }
 
   private final StartHandler<T, R> startHandler;
@@ -70,7 +71,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
 
   @Override
   public final OperationStartResult<R> start(
-      OperationContext ctx, OperationStartDetails details, T input) {
+      OperationContext ctx, OperationStartDetails details, T input) throws OperationException {
     InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
     TemporalNexusClient client =
         new TemporalNexusClientImpl(nexusCtx.getWorkflowClient(), ctx, details);
@@ -100,12 +101,20 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
     }
 
     TemporalOperationCancelContext cancelContext = new TemporalOperationCancelContext(ctx, details);
-    if (token.getType() == OperationTokenType.WORKFLOW_RUN) {
-      cancelWorkflowRun(cancelContext, new CancelWorkflowRunInput(token.getWorkflowId()));
-    } else {
-      throw new HandlerException(
-          HandlerException.ErrorType.BAD_REQUEST,
-          new IllegalArgumentException("unsupported operation token type: " + token.getType()));
+    switch (token.getType()) {
+      case WORKFLOW_RUN:
+        cancelWorkflowRun(cancelContext, new CancelWorkflowRunInput(token.getWorkflowId()));
+        break;
+      case WORKFLOW_UPDATE:
+        cancelUpdateWorkflow(
+            cancelContext,
+            new CancelUpdateWorkflowExecutionInput(
+                token.getWorkflowId(), token.getRunId(), token.getUpdateId()));
+        break;
+      default:
+        throw new HandlerException(
+            HandlerException.ErrorType.BAD_REQUEST,
+            new IllegalArgumentException("unsupported operation token type: " + token.getType()));
     }
   }
 
@@ -122,5 +131,22 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
       TemporalOperationCancelContext context, CancelWorkflowRunInput input) {
     WorkflowClient client = CurrentNexusOperationContext.get().getWorkflowClient();
     client.newUntypedWorkflowStub(input.getWorkflowId()).cancel();
+  }
+
+  /**
+   * Called when a cancel request is received for a workflow update token. Override to customize
+   * cancel behavior.
+   *
+   * <p>Default behavior: not implemented. There is no server primitive to cancel an in-flight
+   * workflow update.
+   *
+   * @param context the cancel context
+   * @param input describes the update to cancel
+   */
+  protected void cancelUpdateWorkflow(
+      TemporalOperationCancelContext context, CancelUpdateWorkflowExecutionInput input) {
+    throw new HandlerException(
+        HandlerException.ErrorType.NOT_IMPLEMENTED,
+        new UnsupportedOperationException("cannot cancel an UpdateWorkflow operation"));
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalOperationHandler.java
@@ -108,7 +108,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
       case WORKFLOW_UPDATE:
         cancelUpdateWorkflow(
             cancelContext,
-            new CancelUpdateWorkflowExecutionInput(
+            new CancelUpdateWorkflowInput(
                 token.getWorkflowId(), token.getRunId(), token.getUpdateId()));
         break;
       default:
@@ -144,7 +144,7 @@ public class TemporalOperationHandler<T, R> implements OperationHandler<T, R> {
    * @param input describes the update to cancel
    */
   protected void cancelUpdateWorkflow(
-      TemporalOperationCancelContext context, CancelUpdateWorkflowExecutionInput input) {
+      TemporalOperationCancelContext context, CancelUpdateWorkflowInput input) {
     throw new HandlerException(
         HandlerException.ErrorType.NOT_IMPLEMENTED,
         new UnsupportedOperationException("cannot cancel an UpdateWorkflow operation"));

--- a/temporal-sdk/src/test/java/io/temporal/internal/client/RootWorkflowClientInvokerLinkPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/client/RootWorkflowClientInvokerLinkPropagationTest.java
@@ -9,25 +9,33 @@ import com.uber.m3.tally.Scope;
 import io.temporal.api.common.v1.Link;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
+import io.temporal.api.enums.v1.UpdateWorkflowExecutionLifecycleStage;
+import io.temporal.api.update.v1.UpdateRef;
 import io.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse;
 import io.temporal.api.workflowservice.v1.SignalWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.SignalWorkflowExecutionResponse;
 import io.temporal.api.workflowservice.v1.StartWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.StartWorkflowExecutionResponse;
+import io.temporal.api.workflowservice.v1.UpdateWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.UpdateWorkflowExecutionResponse;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowUpdateStage;
 import io.temporal.common.interceptors.Header;
+import io.temporal.common.interceptors.WorkflowClientCallsInterceptor.StartUpdateInput;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor.WorkflowSignalInput;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor.WorkflowSignalWithStartInput;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor.WorkflowStartInput;
 import io.temporal.internal.client.external.GenericWorkflowClient;
 import io.temporal.internal.nexus.CurrentNexusOperationContext;
 import io.temporal.internal.nexus.InternalNexusOperationContext;
+import io.temporal.internal.nexus.NexusOperationMetadata;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -265,6 +273,79 @@ public class RootWorkflowClientInvokerLinkPropagationTest {
     Assert.assertTrue(
         "expected no response link captured on the start path",
         nexusCtx.getResponseLinks().isEmpty());
+  }
+
+  /**
+   * Verify startUpdate only adds completion callback if {@link NexusOperationMetadata} is present
+   * on the operation context, i.e. when the update was started via {@code
+   * TemporalNexusClientImpl.startWorkflowUpdate}
+   */
+  @Test
+  public void updateWorkflowSetCallbacksIffNexusMetadataPresent() {
+    nexusCtx.setNexusOperationMetadata(
+        new NexusOperationMetadata("rid", "temporal://dummy", Collections.emptyMap()));
+
+    when(genericClient.update(any(UpdateWorkflowExecutionRequest.class), any()))
+        .thenReturn(acceptedUpdateResponse());
+
+    invoker.startUpdate(newStartUpdateInput());
+
+    ArgumentCaptor<UpdateWorkflowExecutionRequest> captor =
+        ArgumentCaptor.forClass(UpdateWorkflowExecutionRequest.class);
+    org.mockito.Mockito.verify(genericClient).update(captor.capture(), any());
+    Assert.assertEquals(
+        "expect callback to be attached when NexusOperationMetadata is present",
+        1,
+        captor.getValue().getRequest().getCompletionCallbacksCount());
+  }
+
+  /**
+   * Verify plain Nexus operation handlers that don't go through {@code TemporalNexusClient} ie,
+   * missing {@link NexusOperationMetadata} do not have a callback attached
+   */
+  @Test
+  public void updateWorkflowSkipSetCallbacksIfNexusMetadataAbsent() {
+    when(genericClient.update(any(UpdateWorkflowExecutionRequest.class), any()))
+        .thenReturn(acceptedUpdateResponse());
+
+    invoker.startUpdate(newStartUpdateInput());
+
+    ArgumentCaptor<UpdateWorkflowExecutionRequest> captor =
+        ArgumentCaptor.forClass(UpdateWorkflowExecutionRequest.class);
+    org.mockito.Mockito.verify(genericClient).update(captor.capture(), any());
+    Assert.assertEquals(
+        "expect no callback when NexusOperationMetadata is absent",
+        0,
+        captor.getValue().getRequest().getCompletionCallbacksCount());
+  }
+
+  private static UpdateWorkflowExecutionResponse acceptedUpdateResponse() {
+    return UpdateWorkflowExecutionResponse.newBuilder()
+        .setStage(
+            UpdateWorkflowExecutionLifecycleStage
+                .UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED)
+        .setUpdateRef(
+            UpdateRef.newBuilder()
+                .setWorkflowExecution(
+                    WorkflowExecution.newBuilder().setWorkflowId(WORKFLOW_ID).setRunId("rid"))
+                .setUpdateId("uid"))
+        .build();
+  }
+
+  private static StartUpdateInput<String> newStartUpdateInput() {
+    return new StartUpdateInput<>(
+        WorkflowExecution.newBuilder().setWorkflowId(WORKFLOW_ID).setRunId("rid").build(),
+        Optional.of("TestWorkflow"),
+        "un",
+        Header.empty(),
+        "uid",
+        new Object[] {" "},
+        String.class,
+        String.class,
+        "",
+        io.temporal.api.update.v1.WaitPolicy.newBuilder()
+            .setLifecycleStage(WorkflowUpdateStage.ACCEPTED.getProto())
+            .build());
   }
 
   // ── helpers ──────────────────────────────────────────────────────────────────────────────

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/UpdateRunTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/UpdateRunTokenTest.java
@@ -1,0 +1,106 @@
+package io.temporal.internal.nexus;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import java.util.Base64;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UpdateRunTokenTest {
+  private static final ObjectWriter ow =
+      new ObjectMapper().registerModule(new Jdk8Module()).writer();
+  private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+
+  private static final String namespace = "ns";
+  private static final String workflowId = "w";
+  private static final String runId = "r";
+  private static final String updateId = "u";
+
+  @Test
+  public void serializeWorkflowUpdateTokenOmitsEmptyRunId() throws JsonProcessingException {
+    OperationToken token = new OperationToken("ns", "wid", null, "uid");
+    String json = ow.writeValueAsString(token);
+    JsonNode node = new ObjectMapper().readTree(json);
+    Assert.assertFalse(node.has("rid"));
+  }
+
+  @Test
+  public void testEncodeDecode() throws JsonProcessingException {
+    String encoded =
+        OperationTokenUtil.generateWorkflowUpdateOperationToken(
+            namespace, workflowId, runId, updateId);
+
+    OperationToken token = OperationTokenUtil.loadWorkflowUpdateOperationToken(encoded);
+    Assert.assertEquals(OperationTokenType.WORKFLOW_UPDATE, token.getType());
+    Assert.assertEquals(namespace, token.getNamespace());
+    Assert.assertEquals(workflowId, token.getWorkflowId());
+    Assert.assertEquals(runId, token.getRunId());
+    Assert.assertEquals(updateId, token.getUpdateId());
+    Assert.assertNull(token.getVersion());
+  }
+
+  @Test
+  public void generateUpdateTokenRejectInvalid() {
+    // missing ns
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> OperationTokenUtil.generateWorkflowUpdateOperationToken("", "w", "", "u"));
+    // missing workflowId
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> OperationTokenUtil.generateWorkflowUpdateOperationToken("n", "", "", "u"));
+    // missing updateId
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> OperationTokenUtil.generateWorkflowUpdateOperationToken("n", "w", "", ""));
+  }
+
+  @Test
+  public void loadUpdateTokenRejectInvalid() {
+    // missing namespace
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            OperationTokenUtil.loadWorkflowUpdateOperationToken(
+                encoder.encodeToString(
+                    "{\"t\":3,\"ns\":\"\",\"wid\":\"w\",\"uid\":\"u\"}".getBytes())));
+    // missing workflowId
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            OperationTokenUtil.loadWorkflowUpdateOperationToken(
+                encoder.encodeToString(
+                    "{\"t\":3,\"ns\":\"n\",\"wid\":\"\",\"uid\":\"u\"}".getBytes())));
+    // missing updateId
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            OperationTokenUtil.loadWorkflowUpdateOperationToken(
+                encoder.encodeToString(
+                    "{\"t\":3,\"ns\":\"n\",\"wid\":\"w\",\"uid\":\"\"}".getBytes())));
+  }
+
+  @Test
+  public void rejectInvalidUpdateTokenLoads() throws JsonProcessingException {
+    // loading update token from an encoded workflow run token should fail
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            OperationTokenUtil.loadWorkflowUpdateOperationToken(
+                OperationTokenUtil.generateWorkflowRunOperationToken("w", "n")));
+  }
+
+  @Test
+  public void loadWorkflowUpdateOperationTokenFromEncodedToken() {
+    // {"t":3,"ns":"ns","wid":"w","rid":"r","uid":"u"}
+    String encodedToken = "eyJ0IjozLCJucyI6Im5zIiwid2lkIjoidyIsInJpZCI6InIiLCJ1aWQiOiJ1In0";
+
+    OperationToken token = OperationTokenUtil.loadWorkflowUpdateOperationToken(encodedToken);
+    Assert.assertEquals(OperationTokenType.WORKFLOW_UPDATE, token.getType());
+    Assert.assertEquals("ns", token.getNamespace());
+    Assert.assertEquals("w", token.getWorkflowId());
+    Assert.assertEquals("r", token.getRunId());
+    Assert.assertEquals("u", token.getUpdateId());
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
@@ -14,7 +14,6 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.client.WorkflowUpdateStage;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
-import io.temporal.internal.common.env.EnvironmentVariableUtils;
 import io.temporal.internal.nexus.OperationToken;
 import io.temporal.internal.nexus.OperationTokenType;
 import io.temporal.internal.nexus.OperationTokenUtil;
@@ -111,12 +110,10 @@ public class UpdateWorkflowOperationTest extends BaseNexusTest {
 
   @Test
   public void asyncUpdateWorkflowOperationCompletes() {
-    // only run this test if the server supports update completion callbacks
-    // currently only for local server manual checks until the in-memory test
-    // server can support update completion callbacks
+    // Requires history.enableUpdateCallbacks and history.enableCHASMCallbacks
     assumeTrue(
         "server does not support update completion callbacks",
-        EnvironmentVariableUtils.readBooleanFlag("UPDATE_CALLBACKS_SUPPORTED"));
+        SDKTestWorkflowRule.useExternalService);
 
     TestWorkflows.TestWorkflow1 workflowStub =
         testWorkflowRule.newWorkflowStubTimeoutOptions(

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
@@ -228,10 +228,6 @@ public class UpdateWorkflowOperationTest extends BaseNexusTest {
     public OperationHandler<UpdateRequest, String> update() {
       return TemporalOperationHandler.create(
           (context, client, input) -> {
-            HandlerWorkflow stub =
-                client
-                    .getWorkflowClient()
-                    .newWorkflowStub(HandlerWorkflow.class, input.getTargetWorkflowId());
             UpdateOptions.Builder<String> optionsBuilder =
                 UpdateOptions.newBuilder(String.class)
                     .setUpdateName("setValue")
@@ -240,7 +236,11 @@ public class UpdateWorkflowOperationTest extends BaseNexusTest {
               optionsBuilder.setUpdateId(input.getUpdateId());
             }
             return client.startWorkflowUpdate(
-                stub::setValue, input.getValue(), optionsBuilder.build());
+                HandlerWorkflow.class,
+                input.getTargetWorkflowId(),
+                HandlerWorkflow::setValue,
+                input.getValue(),
+                optionsBuilder.build());
           });
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
@@ -1,0 +1,274 @@
+package io.temporal.workflow.nexus;
+
+import static org.junit.Assume.assumeTrue;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.UpdateOptions;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
+import io.temporal.client.WorkflowUpdateStage;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.NexusOperationFailure;
+import io.temporal.internal.common.env.EnvironmentVariableUtils;
+import io.temporal.internal.nexus.OperationToken;
+import io.temporal.internal.nexus.OperationTokenType;
+import io.temporal.internal.nexus.OperationTokenUtil;
+import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class UpdateWorkflowOperationTest extends BaseNexusTest {
+
+  private static final String asyncVal = "async";
+  private static final String doneSignal = "done";
+  private static final String targetWorkflowId = "update-handler-workflow-" + UUID.randomUUID();
+
+  @ClassRule
+  public static SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(CallerWorkflow.class, HandlerWorkflowImpl.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .setUseTimeskipping(false)
+          .build();
+
+  private static WorkflowStub targetStub;
+
+  @BeforeClass
+  public static void startTargetWorkflow() {
+    // start the handler workflow
+    targetStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(
+                "HandlerWorkflow",
+                WorkflowOptions.newBuilder()
+                    .setWorkflowId(targetWorkflowId)
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .build());
+    targetStub.start();
+  }
+
+  @AfterClass
+  public static void completeTargetWorkflow() {
+    // complete the handler workflow
+    targetStub.signal(doneSignal);
+  }
+
+  @Override
+  protected SDKTestWorkflowRule getTestWorkflowRule() {
+    return testWorkflowRule;
+  }
+
+  @Test
+  public void syncValidationFailureFailsOperation() {
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(
+            TestWorkflows.TestWorkflow1.class, "caller-validation-failure");
+
+    // empty value fails setValueValidator -> synchronous operation failure, no token issued
+    WorkflowFailedException e =
+        Assert.assertThrows(
+            WorkflowFailedException.class, () -> workflowStub.execute(targetWorkflowId + "|"));
+
+    Assert.assertTrue(e.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) e.getCause();
+    Assert.assertTrue(nexusFailure.getCause() instanceof ApplicationFailure);
+  }
+
+  @Test
+  public void syncCompletedUpdateReturnsResult() {
+    // NOTE: this test makes no assumptions about whether update callbacks are enabled
+    // If enabled, the first call will resolve asynchronously due to NEXUS-489. If not,
+    // it resolves sync. In either case, the second call dedups and resolves synchronously
+    String fixedUpdateId = "fixed-update-id-" + testWorkflowRule.getTaskQueue();
+
+    TestWorkflows.TestWorkflow1 first =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(
+            TestWorkflows.TestWorkflow1.class, "caller-dedup-completed-first");
+    Assert.assertEquals(
+        "immediate-value", first.execute(targetWorkflowId + "|immediate-value|" + fixedUpdateId));
+
+    TestWorkflows.TestWorkflow1 second =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(
+            TestWorkflows.TestWorkflow1.class, "caller-dedup-completed-second");
+    Assert.assertEquals(
+        "immediate-value",
+        second.execute(targetWorkflowId + "|immediate-value|" + fixedUpdateId + "|dedup"));
+  }
+
+  @Test
+  public void asyncUpdateWorkflowOperationCompletes() {
+    // only run this test if the server supports update completion callbacks
+    // currently only for local server manual checks until the in-memory test
+    // server can support update completion callbacks
+    assumeTrue(
+        "server does not support update completion callbacks",
+        EnvironmentVariableUtils.readBooleanFlag("UPDATE_CALLBACKS_SUPPORTED"));
+
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(
+            TestWorkflows.TestWorkflow1.class, "caller-async-update");
+    String result = workflowStub.execute(targetWorkflowId + "|" + asyncVal);
+    Assert.assertEquals(asyncVal, result);
+  }
+
+  public static class CallerWorkflow implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String input) {
+      String[] parts = input.split("\\|", 4);
+      String targetWorkflowId = parts[0];
+      String value = parts.length > 1 ? parts[1] : "";
+      String updateId = parts.length > 2 ? parts[2] : null;
+      boolean expectDedup = parts.length > 3 && "dedup".equals(parts[3]);
+
+      NexusOperationOptions options =
+          NexusOperationOptions.newBuilder()
+              .setScheduleToCloseTimeout(Duration.ofSeconds(30))
+              .build();
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder()
+              .setEndpoint(getEndpointName())
+              .setOperationOptions(options)
+              .build();
+
+      TestNexusUpdateService serviceStub =
+          Workflow.newNexusServiceStub(TestNexusUpdateService.class, serviceOptions);
+
+      NexusOperationHandle<String> handle =
+          Workflow.startNexusOperation(
+              serviceStub::update, new UpdateRequest(targetWorkflowId, value, updateId));
+
+      NexusOperationExecution execution = handle.getExecution().get();
+      if (asyncVal.equals(value)) {
+        // must be issued with a token
+        Assert.assertTrue(execution.getOperationToken().isPresent());
+        OperationToken token =
+            OperationTokenUtil.loadWorkflowUpdateOperationToken(
+                execution.getOperationToken().get());
+        Assert.assertEquals(OperationTokenType.WORKFLOW_UPDATE, token.getType());
+        Assert.assertEquals(targetWorkflowId, token.getWorkflowId());
+      } else if (expectDedup) {
+        // dedup onto an already-completed update - sync, no token
+        Assert.assertFalse(execution.getOperationToken().isPresent());
+      }
+
+      return handle.getResult().get();
+    }
+  }
+
+  // Handler workflow
+  @WorkflowInterface
+  public interface HandlerWorkflow {
+    @WorkflowMethod
+    void execute();
+
+    @UpdateMethod(name = "setValue")
+    String setValue(String value);
+
+    @UpdateValidatorMethod(updateName = "setValue")
+    void setValueValidator(String value);
+
+    @SignalMethod(name = doneSignal)
+    void done();
+  }
+
+  public static class HandlerWorkflowImpl implements HandlerWorkflow {
+    private boolean completed;
+
+    @Override
+    public void execute() {
+      Workflow.await(() -> completed);
+    }
+
+    @Override
+    public void done() {
+      completed = true;
+    }
+
+    @Override
+    public String setValue(String value) {
+      if (asyncVal.equals(value)) {
+        Workflow.sleep(Duration.ofSeconds(1));
+      }
+      return value;
+    }
+
+    @Override
+    public void setValueValidator(String value) {
+      if (value == null || value.isEmpty()) {
+        throw new IllegalArgumentException("value required");
+      }
+    }
+  }
+
+  // Nexus Service
+  @Service
+  public interface TestNexusUpdateService {
+    @Operation
+    String update(UpdateRequest input);
+  }
+
+  @ServiceImpl(service = TestNexusUpdateService.class)
+  public static class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<UpdateRequest, String> update() {
+      return TemporalOperationHandler.create(
+          (context, client, input) -> {
+            HandlerWorkflow stub =
+                client
+                    .getWorkflowClient()
+                    .newWorkflowStub(HandlerWorkflow.class, input.getTargetWorkflowId());
+            UpdateOptions.Builder<String> optionsBuilder =
+                UpdateOptions.newBuilder(String.class)
+                    .setUpdateName("setValue")
+                    .setWaitForStage(WorkflowUpdateStage.ACCEPTED);
+            if (input.getUpdateId() != null) {
+              optionsBuilder.setUpdateId(input.getUpdateId());
+            }
+            return client.startWorkflowUpdate(
+                stub::setValue, input.getValue(), optionsBuilder.build());
+          });
+    }
+  }
+
+  // container for the update input
+  public static final class UpdateRequest {
+    public String targetWorkflowId;
+    public String value;
+    public String updateId;
+
+    public UpdateRequest() {}
+
+    public UpdateRequest(String targetWorkflowId, String value, String updateId) {
+      this.targetWorkflowId = targetWorkflowId;
+      this.value = value;
+      this.updateId = updateId;
+    }
+
+    public String getTargetWorkflowId() {
+      return targetWorkflowId;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public String getUpdateId() {
+      return updateId;
+    }
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds support for Workflow Update as a Nexus operation


## Why?
<!-- Tell your future self why have you made these changes -->

Part of effort to expose all Temporal primitives via Nexus operations
## Checklist
<!--- add/delete as needed --->

1. Closes NEXUS-485

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- [x] added integration tests 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
- [ ] TBD 
