### PR TITLE
Document server-default schedule catchup window

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/SchedulePolicy.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/SchedulePolicy.java
@@ -38,7 +38,8 @@ public final class SchedulePolicy {
 
     /**
      * Set the amount of time in the past to execute missed actions after a Temporal server is
-     * unavailable.
+     * unavailable. If unset, the request omits this value and the Temporal Server applies its
+     * default (currently one year).
      */
     public Builder setCatchupWindow(Duration catchupWindow) {
       this.catchupWindow = catchupWindow;
@@ -81,7 +82,8 @@ public final class SchedulePolicy {
 
   /**
    * Gets the amount of time in the past to execute missed actions after a Temporal server is
-   * unavailable.
+   * unavailable. A {@code null} value is omitted from requests so the Temporal Server applies its
+   * default (currently one year).
    *
    * @return the schedules catchup window
    */

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -90,6 +90,8 @@ public class ScheduleTest {
     ScheduleHandle handle = client.createSchedule(scheduleId, schedule, options);
     ScheduleDescription description = handle.describe();
     Assert.assertEquals(scheduleId, description.getId());
+    Assert.assertEquals(
+        Duration.ofDays(365), description.getSchedule().getPolicy().getCatchupWindow());
     // Verify the schedule description has the correct (i.e. no) memo
     Assert.assertNull(description.getMemo("memokey1", String.class));
     // Try to create a schedule that already exists

--- a/temporal-sdk/src/test/java/io/temporal/internal/client/ScheduleProtoUtilTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/client/ScheduleProtoUtilTest.java
@@ -1,0 +1,25 @@
+package io.temporal.internal.client;
+
+import io.temporal.client.schedules.SchedulePolicy;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScheduleProtoUtilTest {
+  private final ScheduleProtoUtil util = new ScheduleProtoUtil(null, null);
+
+  @Test
+  public void policyToProtoOmitsDefaultCatchupWindow() {
+    Assert.assertFalse(util.policyToProto(SchedulePolicy.newBuilder().build()).hasCatchupWindow());
+  }
+
+  @Test
+  public void policyToProtoIncludesExplicitCatchupWindow() {
+    Assert.assertEquals(
+        300L,
+        util.policyToProto(
+                SchedulePolicy.newBuilder().setCatchupWindow(Duration.ofMinutes(5)).build())
+            .getCatchupWindow()
+            .getSeconds());
+  }
+}


### PR DESCRIPTION
## What changed
- Document that a null catch-up window is omitted and defaults to one year on the server.
- Add protobuf conversion coverage proving the field is absent unless explicitly configured.
- Add server-backed describe coverage for the one-year default.

## Why
Java already serialized an unspecified value correctly, but the public contract and regression coverage were incomplete.

## Breaking changes
None.