### PR TITLE
Auto-enroll pollers into autoscaling on PollerAutoscalingAutoEnroll (Java SDK)

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -43,7 +43,7 @@ final class ActivityWorker implements SuspendableWorker {
   private final String taskQueue;
   private final SingleWorkerOptions options;
   private final double taskQueueActivitiesPerSecond;
-  private final PollerOptions pollerOptions;
+  private PollerOptions pollerOptions;
   private final Scope workerMetricsScope;
   private final GrpcRetryer grpcRetryer;
   private final GrpcRetryer.GrpcRetryerOptions replyGrpcRetryerOptions;
@@ -83,6 +83,11 @@ final class ActivityWorker implements SuspendableWorker {
   @Override
   public boolean start() {
     if (handler.isAnyTypeSupported()) {
+      // Auto-enroll into poller autoscaling if the namespace advertises the capability and this
+      // poller type was left at its default. Resolved here (after namespace capabilities are known)
+      // so the poller built below reflects the effective behavior.
+      this.pollerOptions =
+          PollerOptions.maybeEnrollInPollerAutoscaling(pollerOptions, namespaceCapabilities);
       this.pollTaskExecutor =
           new PollTaskExecutor<>(
               namespace,

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NamespaceCapabilities.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NamespaceCapabilities.java
@@ -19,8 +19,10 @@ public final class NamespaceCapabilities {
     if (capabilities.getPollerAutoscalingAutoEnroll()) {
       pollerAutoscalingAutoEnroll.set(true);
     }
-    // Auto-enroll implies full poller autoscaling support, including scaling down, so it also
-    // enables pollerAutoscaling (which drives serverSupportsAutoscaling in PollScaleReportHandle).
+    // The auto-enroll capability implies the server speaks the full poller-scaling protocol, so
+    // also enable pollerAutoscaling: it is the flag AsyncPoller passes to PollScaleReportHandle as
+    // serverSupportsAutoscaling, which lets the poller count follow the server's scaling
+    // suggestions.
     if (capabilities.getPollerAutoscaling() || capabilities.getPollerAutoscalingAutoEnroll()) {
       pollerAutoscaling.set(true);
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NamespaceCapabilities.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NamespaceCapabilities.java
@@ -19,11 +19,7 @@ public final class NamespaceCapabilities {
     if (capabilities.getPollerAutoscalingAutoEnroll()) {
       pollerAutoscalingAutoEnroll.set(true);
     }
-    // The auto-enroll capability implies the server speaks the full poller-scaling protocol, so
-    // also enable pollerAutoscaling: it is the flag AsyncPoller passes to PollScaleReportHandle as
-    // serverSupportsAutoscaling, which lets the poller count follow the server's scaling
-    // suggestions.
-    if (capabilities.getPollerAutoscaling() || capabilities.getPollerAutoscalingAutoEnroll()) {
+    if (capabilities.getPollerAutoscaling()) {
       pollerAutoscaling.set(true);
     }
     if (capabilities.getWorkerPollCompleteOnShutdown()) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NamespaceCapabilities.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NamespaceCapabilities.java
@@ -10,12 +10,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class NamespaceCapabilities {
   private final AtomicBoolean pollerAutoscaling = new AtomicBoolean(false);
+  private final AtomicBoolean pollerAutoscalingAutoEnroll = new AtomicBoolean(false);
   private final AtomicBoolean gracefulPollShutdown = new AtomicBoolean(false);
   private final AtomicBoolean workerHeartbeats = new AtomicBoolean(false);
   private final AtomicBoolean workerCommands = new AtomicBoolean(false);
 
   public void setFromCapabilities(Capabilities capabilities) {
-    if (capabilities.getPollerAutoscaling()) {
+    if (capabilities.getPollerAutoscalingAutoEnroll()) {
+      pollerAutoscalingAutoEnroll.set(true);
+    }
+    // Auto-enroll implies full poller autoscaling support, including scaling down, so it also
+    // enables pollerAutoscaling (which drives serverSupportsAutoscaling in PollScaleReportHandle).
+    if (capabilities.getPollerAutoscaling() || capabilities.getPollerAutoscalingAutoEnroll()) {
       pollerAutoscaling.set(true);
     }
     if (capabilities.getWorkerPollCompleteOnShutdown()) {
@@ -31,6 +37,10 @@ public final class NamespaceCapabilities {
 
   public boolean isPollerAutoscaling() {
     return pollerAutoscaling.get();
+  }
+
+  public boolean isPollerAutoscalingAutoEnroll() {
+    return pollerAutoscalingAutoEnroll.get();
   }
 
   public boolean isGracefulPollShutdown() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -46,7 +46,7 @@ final class NexusWorker implements SuspendableWorker {
   private final String namespace;
   private final String taskQueue;
   private final SingleWorkerOptions options;
-  private final PollerOptions pollerOptions;
+  private PollerOptions pollerOptions;
   private final Scope workerMetricsScope;
   private final DataConverter dataConverter;
   private final GrpcRetryer grpcRetryer;
@@ -114,6 +114,11 @@ final class NexusWorker implements SuspendableWorker {
   @Override
   public boolean start() {
     if (handler.start()) {
+      // Auto-enroll into poller autoscaling if the namespace advertises the capability and this
+      // poller type was left at its default. Resolved here (after namespace capabilities are known)
+      // so the poller built below reflects the effective behavior.
+      this.pollerOptions =
+          PollerOptions.maybeEnrollInPollerAutoscaling(pollerOptions, namespaceCapabilities);
       this.pollTaskExecutor =
           new PollTaskExecutor<>(
               namespace,

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollerOptions.java
@@ -3,6 +3,7 @@ package io.temporal.internal.worker;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.worker.tuning.PollerBehavior;
+import io.temporal.worker.tuning.PollerBehaviorAutoscaling;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -26,6 +27,27 @@ public final class PollerOptions {
     return DEFAULT_INSTANCE;
   }
 
+  /**
+   * If the given options are eligible for poller-autoscaling auto-enrollment (the user left this
+   * poller type at its default) and the namespace advertises the auto-enroll capability, returns a
+   * copy of the options with a default {@link PollerBehaviorAutoscaling} behavior. Otherwise
+   * returns the options unchanged.
+   *
+   * <p>Must only be called before the worker's poller is created (i.e. at worker start), so the
+   * resolved behavior is picked up when the poller is built.
+   */
+  public static PollerOptions maybeEnrollInPollerAutoscaling(
+      PollerOptions options, NamespaceCapabilities namespaceCapabilities) {
+    if (options.isAutoscalingAutoEnrollEligible()
+        && namespaceCapabilities.isPollerAutoscalingAutoEnroll()
+        && !(options.getPollerBehavior() instanceof PollerBehaviorAutoscaling)) {
+      return PollerOptions.newBuilder(options)
+          .setPollerBehavior(new PollerBehaviorAutoscaling())
+          .build();
+    }
+    return options;
+  }
+
   private static final PollerOptions DEFAULT_INSTANCE;
 
   static {
@@ -46,6 +68,7 @@ public final class PollerOptions {
     private Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
     private boolean usingVirtualThreads;
     private ExecutorService pollerTaskExecutorOverride;
+    private boolean autoscalingAutoEnrollEligible;
 
     private Builder() {}
 
@@ -65,6 +88,7 @@ public final class PollerOptions {
       this.uncaughtExceptionHandler = options.getUncaughtExceptionHandler();
       this.usingVirtualThreads = options.isUsingVirtualThreads();
       this.pollerTaskExecutorOverride = options.getPollerTaskExecutorOverride();
+      this.autoscalingAutoEnrollEligible = options.isAutoscalingAutoEnrollEligible();
     }
 
     /** Defines interval for measuring poll rate. Larger the interval more spiky can be the load. */
@@ -152,6 +176,16 @@ public final class PollerOptions {
       return this;
     }
 
+    /**
+     * Marks whether this poller type was left at its default (the user set neither a fixed poller
+     * count nor a poller behavior) and is therefore eligible for poller-autoscaling auto-enrollment
+     * when the namespace advertises the capability.
+     */
+    public Builder setAutoscalingAutoEnrollEligible(boolean autoscalingAutoEnrollEligible) {
+      this.autoscalingAutoEnrollEligible = autoscalingAutoEnrollEligible;
+      return this;
+    }
+
     public PollerOptions build() {
       if (uncaughtExceptionHandler == null) {
         uncaughtExceptionHandler =
@@ -180,7 +214,8 @@ public final class PollerOptions {
           uncaughtExceptionHandler,
           pollThreadNamePrefix,
           usingVirtualThreads,
-          pollerTaskExecutorOverride);
+          pollerTaskExecutorOverride,
+          autoscalingAutoEnrollEligible);
     }
   }
 
@@ -198,6 +233,7 @@ public final class PollerOptions {
   private final boolean usingVirtualThreads;
   private final ExecutorService pollerTaskExecutorOverride;
   private final PollerBehavior pollerBehavior;
+  private final boolean autoscalingAutoEnrollEligible;
 
   private PollerOptions(
       int maximumPollRateIntervalMilliseconds,
@@ -211,7 +247,8 @@ public final class PollerOptions {
       Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
       String pollThreadNamePrefix,
       boolean usingVirtualThreads,
-      ExecutorService pollerTaskExecutorOverride) {
+      ExecutorService pollerTaskExecutorOverride,
+      boolean autoscalingAutoEnrollEligible) {
     this.maximumPollRateIntervalMilliseconds = maximumPollRateIntervalMilliseconds;
     this.maximumPollRatePerSecond = maximumPollRatePerSecond;
     this.backoffCoefficient = backoffCoefficient;
@@ -224,6 +261,7 @@ public final class PollerOptions {
     this.pollThreadNamePrefix = pollThreadNamePrefix;
     this.usingVirtualThreads = usingVirtualThreads;
     this.pollerTaskExecutorOverride = pollerTaskExecutorOverride;
+    this.autoscalingAutoEnrollEligible = autoscalingAutoEnrollEligible;
   }
 
   public int getMaximumPollRateIntervalMilliseconds() {
@@ -272,6 +310,10 @@ public final class PollerOptions {
 
   public ExecutorService getPollerTaskExecutorOverride() {
     return pollerTaskExecutorOverride;
+  }
+
+  public boolean isAutoscalingAutoEnrollEligible() {
+    return autoscalingAutoEnrollEligible;
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -48,7 +48,7 @@ final class WorkflowWorker implements SuspendableWorker {
   private final WorkflowExecutorCache cache;
   private final WorkflowTaskHandler handler;
   private final String stickyTaskQueueName;
-  private final PollerOptions pollerOptions;
+  private PollerOptions pollerOptions;
   private final Scope workerMetricsScope;
   private final GrpcRetryer grpcRetryer;
   private final EagerActivityDispatcher eagerActivityDispatcher;
@@ -99,6 +99,11 @@ final class WorkflowWorker implements SuspendableWorker {
   @Override
   public boolean start() {
     if (handler.isAnyTypeSupported()) {
+      // Auto-enroll into poller autoscaling if the namespace advertises the capability and this
+      // poller type was left at its default. Resolved here (after namespace capabilities are known)
+      // so the poller built below reflects the effective behavior.
+      this.pollerOptions =
+          PollerOptions.maybeEnrollInPollerAutoscaling(pollerOptions, namespaceCapabilities);
       pollTaskExecutor =
           new PollTaskExecutor<>(
               namespace,

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -132,6 +132,27 @@ public final class Worker {
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(1).put(MetricsTag.TASK_QUEUE, taskQueue).build();
     Scope taggedScope = metricsScope.tagged(tags);
+
+    // Determine, per poller type, whether the user left it at its default (set neither a fixed
+    // poller count nor a poller behavior). Eligible types are auto-enrolled into poller autoscaling
+    // at start() when the namespace advertises the PollerAutoscalingAutoEnroll capability. This
+    // must
+    // be read from the raw (pre-defaulting) options, since validateAndBuildWithDefaults() fills in
+    // a
+    // fixed default poller count that would otherwise look like an explicit choice.
+    boolean workflowTaskAutoEnrollEligible =
+        options == null
+            || (options.getWorkflowTaskPollersBehavior() == null
+                && options.getMaxConcurrentWorkflowTaskPollers() == 0);
+    boolean activityTaskAutoEnrollEligible =
+        options == null
+            || (options.getActivityTaskPollersBehavior() == null
+                && options.getMaxConcurrentActivityTaskPollers() == 0);
+    boolean nexusTaskAutoEnrollEligible =
+        options == null
+            || (options.getNexusTaskPollersBehavior() == null
+                && options.getMaxConcurrentNexusTaskPollers() == 0);
+
     SingleWorkerOptions activityOptions =
         toActivityOptions(
             factoryOptions,
@@ -140,7 +161,8 @@ public final class Worker {
             contextPropagators,
             taggedScope,
             workerInstanceKey,
-            workerControlTaskQueue);
+            workerControlTaskQueue,
+            activityTaskAutoEnrollEligible);
     if (this.options.isLocalActivityWorkerOnly()) {
       activityWorker = null;
     } else {
@@ -174,7 +196,8 @@ public final class Worker {
             contextPropagators,
             taggedScope,
             workerInstanceKey,
-            workerControlTaskQueue);
+            workerControlTaskQueue,
+            nexusTaskAutoEnrollEligible);
     SlotSupplier<NexusSlotInfo> nexusSlotSupplier =
         this.options.getWorkerTuner() == null
             ? new FixedSizeSlotSupplier<>(this.options.getMaxConcurrentNexusExecutionSize())
@@ -194,7 +217,8 @@ public final class Worker {
             contextPropagators,
             taggedScope,
             workerInstanceKey,
-            workerControlTaskQueue);
+            workerControlTaskQueue,
+            workflowTaskAutoEnrollEligible);
     SingleWorkerOptions localActivityOptions =
         toLocalActivityOptions(
             factoryOptions,
@@ -901,7 +925,8 @@ public final class Worker {
       List<ContextPropagator> contextPropagators,
       Scope metricsScope,
       String workerInstanceKey,
-      String workerControlTaskQueue) {
+      String workerControlTaskQueue,
+      boolean autoEnrollEligible) {
     return toSingleWorkerOptions(
             factoryOptions,
             options,
@@ -920,6 +945,7 @@ public final class Worker {
                         : new PollerBehaviorSimpleMaximum(
                             options.getMaxConcurrentActivityTaskPollers()))
                 .setUsingVirtualThreads(options.isUsingVirtualThreadsOnActivityWorker())
+                .setAutoscalingAutoEnrollEligible(autoEnrollEligible)
                 .build())
         .setMetricsScope(metricsScope)
         .build();
@@ -932,7 +958,8 @@ public final class Worker {
       List<ContextPropagator> contextPropagators,
       Scope metricsScope,
       String workerInstanceKey,
-      String workerControlTaskQueue) {
+      String workerControlTaskQueue,
+      boolean autoEnrollEligible) {
     return toSingleWorkerOptions(
             factoryOptions,
             options,
@@ -948,6 +975,7 @@ public final class Worker {
                         : new PollerBehaviorSimpleMaximum(
                             options.getMaxConcurrentNexusTaskPollers()))
                 .setUsingVirtualThreads(options.isUsingVirtualThreadsOnNexusWorker())
+                .setAutoscalingAutoEnrollEligible(autoEnrollEligible)
                 .build())
         .setMetricsScope(metricsScope)
         .setUsingVirtualThreads(options.isUsingVirtualThreadsOnNexusWorker())
@@ -962,7 +990,8 @@ public final class Worker {
       List<ContextPropagator> contextPropagators,
       Scope metricsScope,
       String workerInstanceKey,
-      String workerControlTaskQueue) {
+      String workerControlTaskQueue,
+      boolean autoEnrollEligible) {
     Map<String, String> tags =
         new ImmutableMap.Builder<String, String>(1).put(MetricsTag.TASK_QUEUE, taskQueue).build();
 
@@ -1005,6 +1034,7 @@ public final class Worker {
                         ? pollerBehavior
                         : new PollerBehaviorSimpleMaximum(maxConcurrentWorkflowTaskPollers))
                 .setUsingVirtualThreads(options.isUsingVirtualThreadsOnWorkflowWorker())
+                .setAutoscalingAutoEnrollEligible(autoEnrollEligible)
                 .build())
         .setStickyQueueScheduleToStartTimeout(stickyQueueScheduleToStartTimeout)
         .setStickyTaskQueueDrainTimeout(options.getStickyTaskQueueDrainTimeout())

--- a/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/Worker.java
@@ -133,25 +133,13 @@ public final class Worker {
         new ImmutableMap.Builder<String, String>(1).put(MetricsTag.TASK_QUEUE, taskQueue).build();
     Scope taggedScope = metricsScope.tagged(tags);
 
-    // Determine, per poller type, whether the user left it at its default (set neither a fixed
-    // poller count nor a poller behavior). Eligible types are auto-enrolled into poller autoscaling
-    // at start() when the namespace advertises the PollerAutoscalingAutoEnroll capability. This
-    // must
-    // be read from the raw (pre-defaulting) options, since validateAndBuildWithDefaults() fills in
-    // a
-    // fixed default poller count that would otherwise look like an explicit choice.
-    boolean workflowTaskAutoEnrollEligible =
-        options == null
-            || (options.getWorkflowTaskPollersBehavior() == null
-                && options.getMaxConcurrentWorkflowTaskPollers() == 0);
-    boolean activityTaskAutoEnrollEligible =
-        options == null
-            || (options.getActivityTaskPollersBehavior() == null
-                && options.getMaxConcurrentActivityTaskPollers() == 0);
-    boolean nexusTaskAutoEnrollEligible =
-        options == null
-            || (options.getNexusTaskPollersBehavior() == null
-                && options.getMaxConcurrentNexusTaskPollers() == 0);
+    // Poller types the user left at their default are auto-enrolled into poller autoscaling at
+    // start() when the namespace advertises the PollerAutoscalingAutoEnroll capability. Eligibility
+    // tracks whether the user called a poller setter (recorded on WorkerOptions.Builder), not the
+    // resolved value, so a defaulted count of 5 is not mistaken for an explicit choice.
+    boolean workflowTaskAutoEnrollEligible = this.options.isWorkflowTaskPollerAutoEnrollEligible();
+    boolean activityTaskAutoEnrollEligible = this.options.isActivityTaskPollerAutoEnrollEligible();
+    boolean nexusTaskAutoEnrollEligible = this.options.isNexusTaskPollerAutoEnrollEligible();
 
     SingleWorkerOptions activityOptions =
         toActivityOptions(

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -229,6 +229,10 @@ public final class WorkerOptions {
      * value cannot be 1 and will be adjusted to 2 if set to that value.
      *
      * <p>Default is 5, which is chosen if set to zero.
+     *
+     * <p>NOTE: If neither this nor {@link #setWorkflowTaskPollersBehavior} is set and the worker's
+     * namespace is configured to auto-enroll workers into poller autoscaling, the worker will
+     * automatically use poller autoscaling for workflow tasks instead of a fixed number of pollers.
      */
     public Builder setMaxConcurrentWorkflowTaskPollers(int maxConcurrentWorkflowTaskPollers) {
       this.maxConcurrentWorkflowTaskPollers = maxConcurrentWorkflowTaskPollers;
@@ -241,6 +245,10 @@ public final class WorkerOptions {
      * tasks from a task queue.
      *
      * <p>Default is 5, which is chosen if set to zero.
+     *
+     * <p>NOTE: If neither this nor {@link #setNexusTaskPollersBehavior} is set and the worker's
+     * namespace is configured to auto-enroll workers into poller autoscaling, the worker will
+     * automatically use poller autoscaling for nexus tasks instead of a fixed number of pollers.
      */
     @Experimental
     public Builder setMaxConcurrentNexusTaskPollers(int maxConcurrentNexusTaskPollers) {
@@ -268,6 +276,10 @@ public final class WorkerOptions {
      * `MaxConcurrentActivityExecutionSize` options and still cannot keep up with the request rate.
      *
      * <p>Default is 5, which is chosen if set to zero.
+     *
+     * <p>NOTE: If neither this nor {@link #setActivityTaskPollersBehavior} is set and the worker's
+     * namespace is configured to auto-enroll workers into poller autoscaling, the worker will
+     * automatically use poller autoscaling for activity tasks instead of a fixed number of pollers.
      */
     public Builder setMaxConcurrentActivityTaskPollers(int maxConcurrentActivityTaskPollers) {
       this.maxConcurrentActivityTaskPollers = maxConcurrentActivityTaskPollers;
@@ -505,19 +517,38 @@ public final class WorkerOptions {
      *
      * <p>If the sticky queue is enabled, the poller behavior will be used for the sticky queue as
      * well.
+     *
+     * <p>NOTE: If neither this nor {@link #setMaxConcurrentWorkflowTaskPollers} is set and the
+     * worker's namespace is configured to auto-enroll workers into poller autoscaling, the worker
+     * will automatically use poller autoscaling for workflow tasks instead of a fixed number of
+     * pollers.
      */
     public Builder setWorkflowTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.workflowTaskPollersBehavior = pollerBehavior;
       return this;
     }
 
-    /** Set the poller behavior for activity task pollers. */
+    /**
+     * Set the poller behavior for activity task pollers.
+     *
+     * <p>NOTE: If neither this nor {@link #setMaxConcurrentActivityTaskPollers} is set and the
+     * worker's namespace is configured to auto-enroll workers into poller autoscaling, the worker
+     * will automatically use poller autoscaling for activity tasks instead of a fixed number of
+     * pollers.
+     */
     public Builder setActivityTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.activityTaskPollersBehavior = pollerBehavior;
       return this;
     }
 
-    /** Set the poller behavior for nexus task pollers. */
+    /**
+     * Set the poller behavior for nexus task pollers.
+     *
+     * <p>NOTE: If neither this nor {@link #setMaxConcurrentNexusTaskPollers} is set and the
+     * worker's namespace is configured to auto-enroll workers into poller autoscaling, the worker
+     * will automatically use poller autoscaling for nexus tasks instead of a fixed number of
+     * pollers.
+     */
     public Builder setNexusTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.nexusTaskPollersBehavior = pollerBehavior;
       return this;

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -79,6 +79,13 @@ public final class WorkerOptions {
     private PollerBehavior nexusTaskPollersBehavior;
     private boolean allowActivityHeartbeatDuringShutdown;
     private PreferredVersionProvider preferredVersionProvider;
+    // Track whether the user explicitly configured the pollers for a task type (called either the
+    // max-concurrent-pollers or the poller-behavior setter). A type left unconfigured is eligible
+    // for poller-autoscaling auto-enrollment. This must reflect the user's intent, not the resolved
+    // value, since defaulting fills in a non-zero count that would otherwise look explicit.
+    private boolean workflowTaskPollersConfigured;
+    private boolean activityTaskPollersConfigured;
+    private boolean nexusTaskPollersConfigured;
 
     private Builder() {}
 
@@ -116,6 +123,9 @@ public final class WorkerOptions {
       this.nexusTaskPollersBehavior = o.nexusTaskPollersBehavior;
       this.allowActivityHeartbeatDuringShutdown = o.allowActivityHeartbeatDuringShutdown;
       this.preferredVersionProvider = o.preferredVersionProvider;
+      this.workflowTaskPollersConfigured = o.workflowTaskPollersConfigured;
+      this.activityTaskPollersConfigured = o.activityTaskPollersConfigured;
+      this.nexusTaskPollersConfigured = o.nexusTaskPollersConfigured;
     }
 
     /**
@@ -236,6 +246,7 @@ public final class WorkerOptions {
      */
     public Builder setMaxConcurrentWorkflowTaskPollers(int maxConcurrentWorkflowTaskPollers) {
       this.maxConcurrentWorkflowTaskPollers = maxConcurrentWorkflowTaskPollers;
+      this.workflowTaskPollersConfigured = true;
       return this;
     }
 
@@ -253,6 +264,7 @@ public final class WorkerOptions {
     @Experimental
     public Builder setMaxConcurrentNexusTaskPollers(int maxConcurrentNexusTaskPollers) {
       this.maxConcurrentNexusTaskPollers = maxConcurrentNexusTaskPollers;
+      this.nexusTaskPollersConfigured = true;
       return this;
     }
 
@@ -283,6 +295,7 @@ public final class WorkerOptions {
      */
     public Builder setMaxConcurrentActivityTaskPollers(int maxConcurrentActivityTaskPollers) {
       this.maxConcurrentActivityTaskPollers = maxConcurrentActivityTaskPollers;
+      this.activityTaskPollersConfigured = true;
       return this;
     }
 
@@ -525,6 +538,7 @@ public final class WorkerOptions {
      */
     public Builder setWorkflowTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.workflowTaskPollersBehavior = pollerBehavior;
+      this.workflowTaskPollersConfigured = true;
       return this;
     }
 
@@ -538,6 +552,7 @@ public final class WorkerOptions {
      */
     public Builder setActivityTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.activityTaskPollersBehavior = pollerBehavior;
+      this.activityTaskPollersConfigured = true;
       return this;
     }
 
@@ -551,6 +566,7 @@ public final class WorkerOptions {
      */
     public Builder setNexusTaskPollersBehavior(PollerBehavior pollerBehavior) {
       this.nexusTaskPollersBehavior = pollerBehavior;
+      this.nexusTaskPollersConfigured = true;
       return this;
     }
 
@@ -620,7 +636,10 @@ public final class WorkerOptions {
           activityTaskPollersBehavior,
           nexusTaskPollersBehavior,
           allowActivityHeartbeatDuringShutdown,
-          preferredVersionProvider);
+          preferredVersionProvider,
+          workflowTaskPollersConfigured,
+          activityTaskPollersConfigured,
+          nexusTaskPollersConfigured);
     }
 
     public WorkerOptions validateAndBuildWithDefaults() {
@@ -754,7 +773,10 @@ public final class WorkerOptions {
           activityTaskPollersBehavior,
           nexusTaskPollersBehavior,
           allowActivityHeartbeatDuringShutdown,
-          preferredVersionProvider);
+          preferredVersionProvider,
+          workflowTaskPollersConfigured,
+          activityTaskPollersConfigured,
+          nexusTaskPollersConfigured);
     }
   }
 
@@ -788,6 +810,9 @@ public final class WorkerOptions {
   private final PollerBehavior nexusTaskPollersBehavior;
   private final boolean allowActivityHeartbeatDuringShutdown;
   private final PreferredVersionProvider preferredVersionProvider;
+  private final boolean workflowTaskPollersConfigured;
+  private final boolean activityTaskPollersConfigured;
+  private final boolean nexusTaskPollersConfigured;
 
   private WorkerOptions(
       double maxWorkerActivitiesPerSecond,
@@ -819,7 +844,10 @@ public final class WorkerOptions {
       PollerBehavior activityTaskPollersBehavior,
       PollerBehavior nexusTaskPollersBehavior,
       boolean allowActivityHeartbeatDuringShutdown,
-      PreferredVersionProvider preferredVersionProvider) {
+      PreferredVersionProvider preferredVersionProvider,
+      boolean workflowTaskPollersConfigured,
+      boolean activityTaskPollersConfigured,
+      boolean nexusTaskPollersConfigured) {
     this.maxWorkerActivitiesPerSecond = maxWorkerActivitiesPerSecond;
     this.maxConcurrentActivityExecutionSize = maxConcurrentActivityExecutionSize;
     this.maxConcurrentWorkflowTaskExecutionSize = maxConcurrentWorkflowTaskExecutionSize;
@@ -850,6 +878,38 @@ public final class WorkerOptions {
     this.nexusTaskPollersBehavior = nexusTaskPollersBehavior;
     this.allowActivityHeartbeatDuringShutdown = allowActivityHeartbeatDuringShutdown;
     this.preferredVersionProvider = preferredVersionProvider;
+    this.workflowTaskPollersConfigured = workflowTaskPollersConfigured;
+    this.activityTaskPollersConfigured = activityTaskPollersConfigured;
+    this.nexusTaskPollersConfigured = nexusTaskPollersConfigured;
+  }
+
+  /**
+   * Whether the workflow task pollers were left at their default (the user called neither {@link
+   * Builder#setMaxConcurrentWorkflowTaskPollers} nor {@link
+   * Builder#setWorkflowTaskPollersBehavior}), which makes them eligible for poller-autoscaling
+   * auto-enrollment.
+   */
+  boolean isWorkflowTaskPollerAutoEnrollEligible() {
+    return !workflowTaskPollersConfigured;
+  }
+
+  /**
+   * Whether the activity task pollers were left at their default (the user called neither {@link
+   * Builder#setMaxConcurrentActivityTaskPollers} nor {@link
+   * Builder#setActivityTaskPollersBehavior}), which makes them eligible for poller-autoscaling
+   * auto-enrollment.
+   */
+  boolean isActivityTaskPollerAutoEnrollEligible() {
+    return !activityTaskPollersConfigured;
+  }
+
+  /**
+   * Whether the nexus task pollers were left at their default (the user called neither {@link
+   * Builder#setMaxConcurrentNexusTaskPollers} nor {@link Builder#setNexusTaskPollersBehavior}),
+   * which makes them eligible for poller-autoscaling auto-enrollment.
+   */
+  boolean isNexusTaskPollerAutoEnrollEligible() {
+    return !nexusTaskPollersConfigured;
   }
 
   public double getMaxWorkerActivitiesPerSecond() {

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/PollerAutoscalingAutoEnrollTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/PollerAutoscalingAutoEnrollTest.java
@@ -1,0 +1,113 @@
+package io.temporal.internal.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.api.namespace.v1.NamespaceInfo.Capabilities;
+import io.temporal.worker.tuning.PollerBehaviorAutoscaling;
+import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
+import org.junit.Test;
+
+/**
+ * Tests for poller-autoscaling auto-enrollment: when a namespace advertises the
+ * PollerAutoscalingAutoEnroll capability, poller types left at their default are switched to poller
+ * autoscaling, while explicitly-configured poller types are left untouched.
+ */
+public class PollerAutoscalingAutoEnrollTest {
+
+  private static NamespaceCapabilities capabilities(boolean autoEnroll, boolean pollerAutoscaling) {
+    NamespaceCapabilities caps = new NamespaceCapabilities();
+    caps.setFromCapabilities(
+        Capabilities.newBuilder()
+            .setPollerAutoscalingAutoEnroll(autoEnroll)
+            .setPollerAutoscaling(pollerAutoscaling)
+            .build());
+    return caps;
+  }
+
+  private static PollerOptions eligibleFixedPollerOptions() {
+    return PollerOptions.newBuilder()
+        .setPollerBehavior(new PollerBehaviorSimpleMaximum(5))
+        .setAutoscalingAutoEnrollEligible(true)
+        .build();
+  }
+
+  @Test
+  public void autoEnrollCapabilityImpliesPollerAutoscaling() {
+    // Auto-enroll implies full autoscaling support (including scale-down), so it also enables the
+    // pollerAutoscaling flag that PollScaleReportHandle reads as serverSupportsAutoscaling.
+    NamespaceCapabilities caps = capabilities(true, false);
+    assertTrue(caps.isPollerAutoscalingAutoEnroll());
+    assertTrue(caps.isPollerAutoscaling());
+  }
+
+  @Test
+  public void pollerAutoscalingWithoutAutoEnrollDoesNotImplyAutoEnroll() {
+    NamespaceCapabilities caps = capabilities(false, true);
+    assertFalse(caps.isPollerAutoscalingAutoEnroll());
+    assertTrue(caps.isPollerAutoscaling());
+  }
+
+  @Test
+  public void noCapabilitiesLeavesEverythingDisabled() {
+    NamespaceCapabilities caps = capabilities(false, false);
+    assertFalse(caps.isPollerAutoscalingAutoEnroll());
+    assertFalse(caps.isPollerAutoscaling());
+  }
+
+  @Test
+  public void eligibleDefaultIsEnrolledWhenCapabilityAdvertised() {
+    PollerOptions resolved =
+        PollerOptions.maybeEnrollInPollerAutoscaling(
+            eligibleFixedPollerOptions(), capabilities(true, false));
+    assertTrue(
+        "defaulted poller type should switch to autoscaling",
+        resolved.getPollerBehavior() instanceof PollerBehaviorAutoscaling);
+    // The enrolled behavior uses the PollerBehaviorAutoscaling defaults.
+    assertEquals(new PollerBehaviorAutoscaling(), resolved.getPollerBehavior());
+  }
+
+  @Test
+  public void eligibleDefaultIsNotEnrolledWhenCapabilityAbsent() {
+    PollerOptions options = eligibleFixedPollerOptions();
+    PollerOptions resolved =
+        PollerOptions.maybeEnrollInPollerAutoscaling(options, capabilities(false, false));
+    assertSame("without the capability the options are unchanged", options, resolved);
+    assertTrue(resolved.getPollerBehavior() instanceof PollerBehaviorSimpleMaximum);
+  }
+
+  @Test
+  public void explicitlyConfiguredPollerIsNotEnrolled() {
+    // A poller type the user configured explicitly is not eligible and must not be switched, even
+    // when the namespace advertises auto-enroll.
+    PollerOptions options =
+        PollerOptions.newBuilder()
+            .setPollerBehavior(new PollerBehaviorSimpleMaximum(3))
+            .setAutoscalingAutoEnrollEligible(false)
+            .build();
+    PollerOptions resolved =
+        PollerOptions.maybeEnrollInPollerAutoscaling(options, capabilities(true, false));
+    assertSame("explicitly configured poller is untouched", options, resolved);
+    assertEquals(
+        3,
+        ((PollerBehaviorSimpleMaximum) resolved.getPollerBehavior()).getMaxConcurrentTaskPollers());
+  }
+
+  @Test
+  public void alreadyAutoscalingPollerIsLeftUnchanged() {
+    // An eligible poller that already uses autoscaling (e.g. a user-set autoscaling behavior on a
+    // type otherwise treated as eligible) is returned unchanged rather than rebuilt.
+    PollerBehaviorAutoscaling behavior = new PollerBehaviorAutoscaling(2, 20, 4);
+    PollerOptions options =
+        PollerOptions.newBuilder()
+            .setPollerBehavior(behavior)
+            .setAutoscalingAutoEnrollEligible(true)
+            .build();
+    PollerOptions resolved =
+        PollerOptions.maybeEnrollInPollerAutoscaling(options, capabilities(true, false));
+    assertSame(options, resolved);
+    assertSame(behavior, resolved.getPollerBehavior());
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/PollerAutoscalingAutoEnrollTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/PollerAutoscalingAutoEnrollTest.java
@@ -35,12 +35,13 @@ public class PollerAutoscalingAutoEnrollTest {
   }
 
   @Test
-  public void autoEnrollCapabilityImpliesPollerAutoscaling() {
-    // Auto-enroll implies full autoscaling support (including scale-down), so it also enables the
-    // pollerAutoscaling flag that PollScaleReportHandle reads as serverSupportsAutoscaling.
+  public void autoEnrollAndPollerAutoscalingAreIndependent() {
+    // Auto-enroll drives only the enrollment decision; it does not by itself enable the separate
+    // pollerAutoscaling (scale-down) capability. The server advertises pollerAutoscaling on its
+    // own.
     NamespaceCapabilities caps = capabilities(true, false);
     assertTrue(caps.isPollerAutoscalingAutoEnroll());
-    assertTrue(caps.isPollerAutoscaling());
+    assertFalse(caps.isPollerAutoscaling());
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollEligibilityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollEligibilityTest.java
@@ -126,9 +126,8 @@ public class WorkerPollerAutoEnrollEligibilityTest {
 
   @Test
   public void defaultInstanceMakesEveryPollerTypeEligible() {
-    // getDefaultInstance() carries the numeric default poller count (5), but the user never called
-    // a
-    // setter, so all types remain eligible.
+    // getDefaultInstance() carries the numeric default poller count (5) but no setter was called,
+    // so all types remain eligible.
     Worker worker = buildWorker(WorkerOptions.getDefaultInstance());
     assertTrue(workflowEligible(worker));
     assertTrue(activityEligible(worker));

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollEligibilityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollEligibilityTest.java
@@ -22,13 +22,14 @@ import java.util.Collections;
 import org.junit.Test;
 
 /**
- * Verifies that {@link Worker} derives per-poller-type auto-enroll eligibility from the raw
- * (pre-defaulting) {@link WorkerOptions} and threads it into each internal worker's poller options.
+ * Verifies that {@link Worker} derives per-poller-type auto-enroll eligibility from whether the
+ * user called a poller setter (tracked on {@link WorkerOptions.Builder}) and threads it into each
+ * internal worker's poller options.
  *
- * <p>This guards the subtlest part of poller-autoscaling auto-enrollment: eligibility must be read
- * before {@code validateAndBuildWithDefaults()} fills in a fixed default poller count. If it were
- * read from the already-defaulted options, every default worker would look explicitly configured
- * and auto-enroll would silently never happen.
+ * <p>This guards the subtlest part of poller-autoscaling auto-enrollment: eligibility must reflect
+ * the user's intent, not the resolved value. Options from {@code getDefaultInstance()} or {@code
+ * validateAndBuildWithDefaults()} carry the numeric default poller count (5) yet must stay
+ * eligible, while an explicit count of 5 must not. Value-based inference cannot tell these apart.
  */
 public class WorkerPollerAutoEnrollEligibilityTest {
 
@@ -118,6 +119,53 @@ public class WorkerPollerAutoEnrollEligibilityTest {
   public void explicitMaxConcurrentPollersOnOneTypeLeavesOthersEligible() {
     Worker worker =
         buildWorker(WorkerOptions.newBuilder().setMaxConcurrentWorkflowTaskPollers(4).build());
+    assertFalse(workflowEligible(worker));
+    assertTrue(activityEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+
+  @Test
+  public void defaultInstanceMakesEveryPollerTypeEligible() {
+    // getDefaultInstance() carries the numeric default poller count (5), but the user never called
+    // a
+    // setter, so all types remain eligible.
+    Worker worker = buildWorker(WorkerOptions.getDefaultInstance());
+    assertTrue(workflowEligible(worker));
+    assertTrue(activityEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+
+  @Test
+  public void validateAndBuildWithDefaultsMakesEveryPollerTypeEligible() {
+    Worker worker = buildWorker(WorkerOptions.newBuilder().validateAndBuildWithDefaults());
+    assertTrue(workflowEligible(worker));
+    assertTrue(activityEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+
+  @Test
+  public void copyOfDefaultInstanceIsEligible() {
+    // Provenance must survive newBuilder(options), for both build paths.
+    Worker fromBuild =
+        buildWorker(WorkerOptions.newBuilder(WorkerOptions.getDefaultInstance()).build());
+    assertTrue(workflowEligible(fromBuild));
+    assertTrue(activityEligible(fromBuild));
+    assertTrue(nexusEligible(fromBuild));
+
+    Worker fromValidate =
+        buildWorker(
+            WorkerOptions.newBuilder(WorkerOptions.getDefaultInstance())
+                .validateAndBuildWithDefaults());
+    assertTrue(workflowEligible(fromValidate));
+    assertTrue(activityEligible(fromValidate));
+    assertTrue(nexusEligible(fromValidate));
+  }
+
+  @Test
+  public void explicitCountEqualToNumericDefaultIsIneligible() {
+    // Explicitly setting the count to its numeric default (5) still counts as "configured".
+    Worker worker =
+        buildWorker(WorkerOptions.newBuilder().setMaxConcurrentWorkflowTaskPollers(5).build());
     assertFalse(workflowEligible(worker));
     assertTrue(activityEligible(worker));
     assertTrue(nexusEligible(worker));

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollEligibilityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollEligibilityTest.java
@@ -1,0 +1,138 @@
+package io.temporal.worker;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.uber.m3.tally.NoopScope;
+import com.uber.m3.tally.Scope;
+import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.internal.sync.WorkflowThreadExecutor;
+import io.temporal.internal.worker.NamespaceCapabilities;
+import io.temporal.internal.worker.WorkflowExecutorCache;
+import io.temporal.internal.worker.WorkflowRunLockManager;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link Worker} derives per-poller-type auto-enroll eligibility from the raw
+ * (pre-defaulting) {@link WorkerOptions} and threads it into each internal worker's poller options.
+ *
+ * <p>This guards the subtlest part of poller-autoscaling auto-enrollment: eligibility must be read
+ * before {@code validateAndBuildWithDefaults()} fills in a fixed default poller count. If it were
+ * read from the already-defaulted options, every default worker would look explicitly configured
+ * and auto-enroll would silently never happen.
+ */
+public class WorkerPollerAutoEnrollEligibilityTest {
+
+  private Worker buildWorker(WorkerOptions options) {
+    WorkflowServiceStubs service = mock(WorkflowServiceStubs.class);
+    when(service.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+    WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+    when(service.blockingStub()).thenReturn(blockingStub);
+    when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+
+    WorkflowClient client = mock(WorkflowClient.class);
+    when(client.getWorkflowServiceStubs()).thenReturn(service);
+    when(client.getOptions())
+        .thenReturn(
+            WorkflowClientOptions.newBuilder()
+                .setNamespace("test-ns")
+                .setIdentity("test-worker")
+                .validateAndBuildWithDefaults());
+
+    Scope metricsScope = new NoopScope();
+    WorkflowRunLockManager runLocks = new WorkflowRunLockManager();
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, runLocks, metricsScope);
+    WorkflowThreadExecutor wfThreadExecutor = mock(WorkflowThreadExecutor.class);
+
+    return new Worker(
+        client,
+        "test-task-queue",
+        WorkerFactoryOptions.newBuilder().build(),
+        options,
+        metricsScope,
+        runLocks,
+        cache,
+        true,
+        wfThreadExecutor,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        "test-worker-group",
+        new NamespaceCapabilities());
+  }
+
+  private boolean workflowEligible(Worker worker) {
+    return worker.workflowWorker.getWorkflowPollerOptions().isAutoscalingAutoEnrollEligible();
+  }
+
+  private boolean activityEligible(Worker worker) {
+    return worker.activityWorker.getPollerOptions().isAutoscalingAutoEnrollEligible();
+  }
+
+  private boolean nexusEligible(Worker worker) {
+    return worker.nexusWorker.getPollerOptions().isAutoscalingAutoEnrollEligible();
+  }
+
+  @Test
+  public void defaultOptionsMakeEveryPollerTypeEligible() {
+    Worker worker = buildWorker(WorkerOptions.newBuilder().build());
+    assertTrue(workflowEligible(worker));
+    assertTrue(activityEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+
+  @Test
+  public void nullOptionsMakeEveryPollerTypeEligible() {
+    // WorkerFactory.newWorker(taskQueue) passes null options through to the Worker constructor.
+    Worker worker = buildWorker(null);
+    assertTrue(workflowEligible(worker));
+    assertTrue(activityEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+
+  @Test
+  public void explicitMaxConcurrentPollersMakeAllTypesIneligible() {
+    Worker worker =
+        buildWorker(
+            WorkerOptions.newBuilder()
+                .setMaxConcurrentWorkflowTaskPollers(4)
+                .setMaxConcurrentActivityTaskPollers(3)
+                .setMaxConcurrentNexusTaskPollers(2)
+                .build());
+    assertFalse(workflowEligible(worker));
+    assertFalse(activityEligible(worker));
+    assertFalse(nexusEligible(worker));
+  }
+
+  @Test
+  public void explicitMaxConcurrentPollersOnOneTypeLeavesOthersEligible() {
+    Worker worker =
+        buildWorker(WorkerOptions.newBuilder().setMaxConcurrentWorkflowTaskPollers(4).build());
+    assertFalse(workflowEligible(worker));
+    assertTrue(activityEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+
+  @Test
+  public void explicitPollerBehaviorMakesOnlyThatTypeIneligible() {
+    Worker worker =
+        buildWorker(
+            WorkerOptions.newBuilder()
+                .setActivityTaskPollersBehavior(new PollerBehaviorSimpleMaximum(3))
+                .build());
+    // Only the activity poller was configured explicitly; workflow and nexus stay eligible.
+    assertFalse(activityEligible(worker));
+    assertTrue(workflowEligible(worker));
+    assertTrue(nexusEligible(worker));
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollStartupTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerAutoEnrollStartupTest.java
@@ -1,0 +1,157 @@
+package io.temporal.worker;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.uber.m3.tally.NoopScope;
+import com.uber.m3.tally.Scope;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.api.namespace.v1.NamespaceInfo.Capabilities;
+import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.api.workflowservice.v1.ShutdownWorkerRequest;
+import io.temporal.api.workflowservice.v1.ShutdownWorkerResponse;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.internal.sync.WorkflowThreadExecutor;
+import io.temporal.internal.worker.NamespaceCapabilities;
+import io.temporal.internal.worker.ShutdownManager;
+import io.temporal.internal.worker.WorkflowExecutorCache;
+import io.temporal.internal.worker.WorkflowRunLockManager;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.tuning.PollerBehaviorAutoscaling;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.shared.TestNexusServices;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+/**
+ * Full start-path wiring test for poller-autoscaling auto-enrollment: when the namespace advertises
+ * the capability, starting a worker with default options switches the workflow, activity, and nexus
+ * pollers' effective behavior to {@link PollerBehaviorAutoscaling}.
+ */
+public class WorkerPollerAutoEnrollStartupTest {
+
+  @WorkflowInterface
+  public interface DemoWorkflow {
+    @WorkflowMethod
+    void run();
+  }
+
+  public static class DemoWorkflowImpl implements DemoWorkflow {
+    @Override
+    public void run() {}
+  }
+
+  @ActivityInterface
+  public interface DemoActivity {
+    @ActivityMethod
+    void doThing();
+  }
+
+  public static class DemoActivityImpl implements DemoActivity {
+    @Override
+    public void doThing() {}
+  }
+
+  @ServiceImpl(service = TestNexusServices.TestNexusService1.class)
+  public static class DemoNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, String> operation() {
+      return OperationHandler.sync((ctx, details, name) -> "Hello " + name);
+    }
+  }
+
+  @Test
+  public void autoEnrollAtStartupSwitchesPollersToAutoscaling() throws Exception {
+    WorkflowServiceStubs service = mock(WorkflowServiceStubs.class);
+    when(service.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+
+    // Async pollers poll via futureStub().withOption(...).pollXxxTaskQueue(...). Return futures
+    // that
+    // never complete so the started poller threads park harmlessly until shutdown cancels them.
+    WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
+    when(service.futureStub()).thenReturn(futureStub);
+    when(futureStub.withOption(any(), any())).thenReturn(futureStub);
+    when(futureStub.pollWorkflowTaskQueue(any())).thenReturn(SettableFuture.create());
+    when(futureStub.pollActivityTaskQueue(any())).thenReturn(SettableFuture.create());
+    when(futureStub.pollNexusTaskQueue(any())).thenReturn(SettableFuture.create());
+    when(futureStub.shutdownWorker(any(ShutdownWorkerRequest.class)))
+        .thenReturn(Futures.immediateFuture(ShutdownWorkerResponse.newBuilder().build()));
+
+    WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+    when(service.blockingStub()).thenReturn(blockingStub);
+    when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+
+    WorkflowClient client = mock(WorkflowClient.class);
+    when(client.getWorkflowServiceStubs()).thenReturn(service);
+    when(client.getOptions())
+        .thenReturn(
+            WorkflowClientOptions.newBuilder()
+                .setNamespace("test-ns")
+                .setIdentity("test-worker")
+                .validateAndBuildWithDefaults());
+
+    // Namespace advertises the auto-enroll capability.
+    NamespaceCapabilities capabilities = new NamespaceCapabilities();
+    capabilities.setFromCapabilities(
+        Capabilities.newBuilder().setPollerAutoscalingAutoEnroll(true).build());
+
+    Scope metricsScope = new NoopScope();
+    WorkflowRunLockManager runLocks = new WorkflowRunLockManager();
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, runLocks, metricsScope);
+    WorkflowThreadExecutor wfThreadExecutor = mock(WorkflowThreadExecutor.class);
+
+    Worker worker =
+        new Worker(
+            client,
+            "test-task-queue",
+            WorkerFactoryOptions.newBuilder().build(),
+            WorkerOptions.newBuilder().build(),
+            metricsScope,
+            runLocks,
+            cache,
+            true,
+            wfThreadExecutor,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            "test-worker-group",
+            capabilities);
+
+    // Register all three task types so each worker starts its poller.
+    worker.registerWorkflowImplementationTypes(DemoWorkflowImpl.class);
+    worker.registerActivitiesImplementations(new DemoActivityImpl());
+    worker.registerNexusServiceImplementation(new DemoNexusServiceImpl());
+
+    worker.start();
+    try {
+      assertTrue(
+          "workflow pollers should be autoscaling",
+          worker.workflowWorker.getWorkflowPollerOptions().getPollerBehavior()
+              instanceof PollerBehaviorAutoscaling);
+      assertTrue(
+          "activity pollers should be autoscaling",
+          worker.activityWorker.getPollerOptions().getPollerBehavior()
+              instanceof PollerBehaviorAutoscaling);
+      assertTrue(
+          "nexus pollers should be autoscaling",
+          worker.nexusWorker.getPollerOptions().getPollerBehavior()
+              instanceof PollerBehaviorAutoscaling);
+    } finally {
+      worker.shutdown(new ShutdownManager(), true).get(5, TimeUnit.SECONDS);
+    }
+  }
+}


### PR DESCRIPTION
Mirrors the Go SDK ([temporalio/sdk-go#2442](https://github.com/temporalio/sdk-go/pull/2442)).

## What

When a namespace advertises the `PollerAutoscalingAutoEnroll` capability, workers automatically use **poller autoscaling** for any poller type left at its default — i.e. where the user set neither `MaxConcurrent<Type>TaskPollers` nor a `<Type>TaskPollerBehavior`. Explicitly configured pollers are left alone. Applies to workflow, activity, and nexus pollers.

## How

- `Worker` records, per poller type, whether it was left at its default (read from the raw `WorkerOptions`, before defaults are applied).
- At `start()` — once namespace capabilities are known — each eligible poller's behavior is swapped to autoscaling before its poller is created.
- Auto-enroll also implies scale-down support, so `NamespaceCapabilities` treats it as enabling `pollerAutoscaling` too.

## Proto

Bumps the `temporal/api` submodule to pick up the `poller_autoscaling_auto_enroll` capability (api #803).

## Testing

- `PollerAutoscalingAutoEnrollTest` — the enroll decision (default + capability → autoscaling; capability off, explicit count, or explicit behavior → unchanged).
- `WorkerPollerAutoEnrollEligibilityTest` — `Worker` marks defaults eligible and explicit config ineligible, per type.
- Existing poller/worker tests still pass.