### PR TITLE
Fix setRetryOptions merging initialInterval into congestionInitialInterval

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -272,7 +272,8 @@ public final class RpcRetryOptions {
       setInitialInterval(
           OptionsUtils.merge(initialInterval, o.getInitialInterval(), Duration.class));
       setCongestionInitialInterval(
-          OptionsUtils.merge(congestionInitialInterval, o.getInitialInterval(), Duration.class));
+          OptionsUtils.merge(
+              congestionInitialInterval, o.getCongestionInitialInterval(), Duration.class));
       setExpiration(OptionsUtils.merge(expiration, o.getExpiration(), Duration.class));
       setMaximumInterval(
           OptionsUtils.merge(maximumInterval, o.getMaximumInterval(), Duration.class));

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/RpcRetryOptionsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/RpcRetryOptionsTest.java
@@ -1,0 +1,30 @@
+package io.temporal.serviceclient;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class RpcRetryOptionsTest {
+
+  /**
+   * congestionInitialInterval is the backoff used for RESOURCE_EXHAUSTED and is deliberately set
+   * much higher than initialInterval. Builder.setRetryOptions must merge it from the source's
+   * congestionInitialInterval, not from its initialInterval, otherwise that margin is silently
+   * collapsed.
+   */
+  @Test
+  public void setRetryOptionsMergesCongestionInitialInterval() {
+    RpcRetryOptions source =
+        RpcRetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofMillis(200))
+            .setCongestionInitialInterval(Duration.ofSeconds(7))
+            .validateBuildWithDefaults();
+
+    RpcRetryOptions merged =
+        RpcRetryOptions.newBuilder().setRetryOptions(source).validateBuildWithDefaults();
+
+    assertEquals(Duration.ofMillis(200), merged.getInitialInterval());
+    assertEquals(Duration.ofSeconds(7), merged.getCongestionInitialInterval());
+  }
+}


### PR DESCRIPTION
## Problem

`RpcRetryOptions.Builder.setRetryOptions` merges every field from its own counterpart — except `congestionInitialInterval`, which reads the source's **`initialInterval`**:

```java
setInitialInterval(
    OptionsUtils.merge(initialInterval, o.getInitialInterval(), Duration.class));
setCongestionInitialInterval(
    OptionsUtils.merge(congestionInitialInterval, o.getInitialInterval(), Duration.class));  // <-- wrong getter
setExpiration(OptionsUtils.merge(expiration, o.getExpiration(), Duration.class));
setMaximumInterval(
    OptionsUtils.merge(maximumInterval, o.getMaximumInterval(), Duration.class));
```

Two consequences: the source's `congestionInitialInterval` is never read, and the value is silently overwritten by the regular initial interval.

## Why it matters

`congestionInitialInterval` is the backoff applied to gRPC `RESOURCE_EXHAUSTED` (via `BackoffThrottler`, used by `GrpcSyncRetryer` / `GrpcAsyncRetryer`), and it is deliberately defaulted **10x higher** than the regular interval — `DefaultStubServiceOperationRpcRetryOptions` sets `INITIAL_INTERVAL=100ms` vs `CONGESTION_INITIAL_INTERVAL=1000ms`.

Merging collapses that margin, so a client ends up retrying an already-congested server *faster* than intended — the opposite of the field's purpose. #1465, which introduced it, states the rationale directly: *"Aggressive retry will worsen the situation and could lead to more serious outage."*

## Fix

Read `o.getCongestionInitialInterval()`.

## Test

Adds `RpcRetryOptionsTest.setRetryOptionsMergesCongestionInitialInterval`: builds a source with a 200ms initial / 7s congestion interval, merges it via `setRetryOptions`, and asserts both survive.

Against unmodified source it fails with:
```
java.lang.AssertionError: expected:<PT7S> but was:<PT0.2S>
```
and passes with the fix. `temporal-serviceclient` is pure logic — the test needs no server or docker (`./gradlew :temporal-serviceclient:test --tests "io.temporal.serviceclient.RpcRetryOptionsTest"`). Spotless check clean.
