### PR TITLE
Fix WorkerOptions.Builder.isUsingVirtualThreadsOnWorkflowWorker

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java
@@ -920,7 +920,7 @@ public final class WorkerOptions {
   }
 
   public boolean isUsingVirtualThreadsOnWorkflowWorker() {
-    return usingVirtualThreadsOnActivityWorker;
+    return usingVirtualThreadsOnWorkflowWorker;
   }
 
   public boolean isUsingVirtualThreadsOnActivityWorker() {

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerOptionsTest.java
@@ -182,6 +182,46 @@ public class WorkerOptionsTest {
   }
 
   @Test
+  public void setUsingVirtualThreadsEnablesAllWorkers() {
+    WorkerOptions options = WorkerOptions.newBuilder().setUsingVirtualThreads(true).build();
+    assertTrue(options.isUsingVirtualThreadsOnWorkflowWorker());
+    assertTrue(options.isUsingVirtualThreadsOnActivityWorker());
+    assertTrue(options.isUsingVirtualThreadsOnLocalActivityWorker());
+    assertTrue(options.isUsingVirtualThreadsOnNexusWorker());
+  }
+
+  @Test
+  public void perWorkerVirtualThreadOptionsAreIndependent() {
+    WorkerOptions workflowOnly =
+        WorkerOptions.newBuilder().setUsingVirtualThreadsOnWorkflowWorker(true).build();
+    assertTrue(workflowOnly.isUsingVirtualThreadsOnWorkflowWorker());
+    assertFalse(workflowOnly.isUsingVirtualThreadsOnActivityWorker());
+    assertFalse(workflowOnly.isUsingVirtualThreadsOnLocalActivityWorker());
+    assertFalse(workflowOnly.isUsingVirtualThreadsOnNexusWorker());
+
+    WorkerOptions activityOnly =
+        WorkerOptions.newBuilder().setUsingVirtualThreadsOnActivityWorker(true).build();
+    assertFalse(activityOnly.isUsingVirtualThreadsOnWorkflowWorker());
+    assertTrue(activityOnly.isUsingVirtualThreadsOnActivityWorker());
+    assertFalse(activityOnly.isUsingVirtualThreadsOnLocalActivityWorker());
+    assertFalse(activityOnly.isUsingVirtualThreadsOnNexusWorker());
+
+    WorkerOptions localActivityOnly =
+        WorkerOptions.newBuilder().setUsingVirtualThreadsOnLocalActivityWorker(true).build();
+    assertFalse(localActivityOnly.isUsingVirtualThreadsOnWorkflowWorker());
+    assertFalse(localActivityOnly.isUsingVirtualThreadsOnActivityWorker());
+    assertTrue(localActivityOnly.isUsingVirtualThreadsOnLocalActivityWorker());
+    assertFalse(localActivityOnly.isUsingVirtualThreadsOnNexusWorker());
+
+    WorkerOptions nexusOnly =
+        WorkerOptions.newBuilder().setUsingVirtualThreadsOnNexusWorker(true).build();
+    assertFalse(nexusOnly.isUsingVirtualThreadsOnWorkflowWorker());
+    assertFalse(nexusOnly.isUsingVirtualThreadsOnActivityWorker());
+    assertFalse(nexusOnly.isUsingVirtualThreadsOnLocalActivityWorker());
+    assertTrue(nexusOnly.isUsingVirtualThreadsOnNexusWorker());
+  }
+
+  @Test
   public void verifyMaxTaskQueuePerSecondsDisablesEagerExecution() {
     // Verify that by default eager execution is enabled
     WorkerOptions w1 = WorkerOptions.newBuilder().build();


### PR DESCRIPTION
## What was changed

WorkerOptions.Builder.isUsingVirtualThreadsOnWorkflowWorker was returning the value of WorkerOptions.Builder.usingVirtualThreadsOnActivityWorker instead of WorkerOptions.Builder.usingVirtualThreadsOnWorkflowWorker. This change corrects it to use the correct field.

## Checklist

1. Closes #2745

2. How was this tested:
New testcases were added to WorkerflowOptionsTest and tests were verified as passing.

3. Any docs updates needed?
No