### PR TITLE
Remove experimental markers from user metadata fields

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/ActivityOptions.java
@@ -238,7 +238,6 @@ public final class ActivityOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setSummary(String summary) {
       this.summary = summary;
       return this;
@@ -452,7 +451,6 @@ public final class ActivityOptions {
     return versioningIntent;
   }
 
-  @Experimental
   public String getSummary() {
     return summary;
   }

--- a/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/activity/LocalActivityOptions.java
@@ -1,7 +1,6 @@
 package io.temporal.activity;
 
 import com.google.common.base.Objects;
-import io.temporal.common.Experimental;
 import io.temporal.common.MethodRetry;
 import io.temporal.common.RetryOptions;
 import java.time.Duration;
@@ -167,7 +166,6 @@ public final class LocalActivityOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setSummary(String summary) {
       this.summary = summary;
       return this;
@@ -279,7 +277,6 @@ public final class LocalActivityOptions {
     return doNotIncludeArgumentsIntoMarker != null && doNotIncludeArgumentsIntoMarker;
   }
 
-  @Experimental
   public String getSummary() {
     return summary;
   }

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowExecutionDescription.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowExecutionDescription.java
@@ -1,7 +1,6 @@
 package io.temporal.client;
 
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
-import io.temporal.common.Experimental;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.payload.context.WorkflowSerializationContext;
 import javax.annotation.Nonnull;
@@ -25,7 +24,6 @@ public class WorkflowExecutionDescription extends WorkflowExecutionMetadata {
    * <p>Note: Will be decoded on each invocation, so it is recommended to cache the result if it is
    * used multiple times.
    */
-  @Experimental
   @Nullable
   public String getStaticSummary() {
     if (!response.getExecutionConfig().getUserMetadata().hasSummary()) {
@@ -48,7 +46,6 @@ public class WorkflowExecutionDescription extends WorkflowExecutionMetadata {
    * <p>Note: Will be decoded on each invocation, so it is recommended to cache the result if it is
    * used multiple times.
    */
-  @Experimental
   @Nullable
   public String getStaticDetails() {
     if (!response.getExecutionConfig().getUserMetadata().hasDetails()) {

--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
@@ -400,7 +400,6 @@ public final class WorkflowOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setStaticSummary(String staticSummary) {
       this.staticSummary = staticSummary;
       return this;
@@ -413,7 +412,6 @@ public final class WorkflowOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setStaticDetails(String staticDetails) {
       this.staticDetails = staticDetails;
       return this;
@@ -716,12 +714,10 @@ public final class WorkflowOptions {
     return links;
   }
 
-  @Experimental
   public String getStaticSummary() {
     return staticSummary;
   }
 
-  @Experimental
   public String getStaticDetails() {
     return staticDetails;
   }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/ChildWorkflowOptions.java
@@ -309,7 +309,6 @@ public final class ChildWorkflowOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setStaticSummary(String staticSummary) {
       this.staticSummary = staticSummary;
       return this;
@@ -322,7 +321,6 @@ public final class ChildWorkflowOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setStaticDetails(String staticDetails) {
       this.staticDetails = staticDetails;
       return this;
@@ -534,12 +532,10 @@ public final class ChildWorkflowOptions {
     return versioningIntent;
   }
 
-  @Experimental
   public String getStaticSummary() {
     return staticSummary;
   }
 
-  @Experimental
   public String getStaticDetails() {
     return staticDetails;
   }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/TimerOptions.java
@@ -1,6 +1,5 @@
 package io.temporal.workflow;
 
-import io.temporal.common.Experimental;
 import java.util.Objects;
 
 /** TimerOptions is used to specify options for a timer. */
@@ -42,7 +41,6 @@ public final class TimerOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public Builder setSummary(String summary) {
       this.summary = summary;
       return this;

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -1538,7 +1538,6 @@ public final class Workflow {
    *
    * @param details details to set
    */
-  @Experimental
   public static void setCurrentDetails(String details) {
     WorkflowInternal.setCurrentDetails(details);
   }
@@ -1548,7 +1547,6 @@ public final class Workflow {
    *
    * @return details of the current workflow
    */
-  @Experimental
   @Nullable
   public static String getCurrentDetails() {
     return WorkflowInternal.getCurrentDetails();


### PR DESCRIPTION
## Summary
- Remove `@Experimental` from user metadata methods: StaticSummary, StaticDetails, CurrentDetails, Activity Summary, Timer Summary
- Clean up unused `import io.temporal.common.Experimental` where no other experimental annotations remain
- These features are stable and shipping across all SDKs - graduating to GA API surface
- 7 files changed, 20 deletions

## Test plan
- [ ] Verify no compilation errors
- [ ] Confirm NexusOperationOptions, SideEffectOptions, MutableSideEffectOptions, ActivityExecutionDescription experimental markers are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)