### PR TITLE
Include WorkflowType in wrapFailure error message

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -607,6 +607,8 @@ final class WorkflowWorker implements SuspendableWorker {
               + execution.getWorkflowId()
               + ", RunId="
               + execution.getRunId()
+              + ", WorkflowType="
+              + task.getResponse().getWorkflowType().getName()
               + ", Attempt="
               + task.getResponse().getAttempt(),
           failure);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -611,6 +611,8 @@ final class WorkflowWorker implements SuspendableWorker {
               + execution.getWorkflowId()
               + ", RunId="
               + execution.getRunId()
+              + ", WorkflowType="
+              + task.getResponse().getWorkflowType().getName()
               + ", Attempt="
               + task.getResponse().getAttempt(),
           failure);


### PR DESCRIPTION
## Summary
- `WorkflowWorker$TaskHandlerImpl.wrapFailure` builds a `RuntimeException` message ("Failure processing workflow task. WorkflowId=..., RunId=..., Attempt=...") when a workflow task fails processing, but omits the workflow type.
- `PollWorkflowTaskQueueResponse` (already available on `task.getResponse()`) carries the workflow type, so this adds `WorkflowType=` to the message using that existing data — no new lookups or API surface required.
- This makes the error immediately actionable: today, debugging one of these failures requires a separate lookup (e.g. `temporal workflow describe`) just to find out which workflow type failed.

## Test plan
- [ ] Existing `WorkflowWorker`/task-handler tests still pass
- [ ] No behavior change other than the added field in the exception message
