### PR TITLE
Bump jacoco and simplify code coverage CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,14 +25,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@ac396bf1a80af16236baf54bd7330ae21dc6ece5 # v6
 
-      - name: Run Tests
-        run: ./gradlew test -x spotlessCheck -x spotlessApply -Pjacoco -PtestJavaVersion=23
-        continue-on-error: true
-
-      - name: Run Test Coverage
-        run: ./gradlew testCodeCoverageReport -Pjacoco
-
-      - name: Publish Coverage
+      - name: Run and Publish Test Coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: ./gradlew coverallsJacoco -Pjacoco
+        run: ./gradlew coverallsJacoco -x spotlessCheck -x spotlessApply -Pjacoco -PtestJavaVersion=23

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,12 +3,16 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 jobs:
   code-coverage:
+    if: github.event_name == 'push' || github.head_ref == 'fix-temporal-sdk-java-main-code-coverage'
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,16 +3,12 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
 
 jobs:
   code-coverage:
-    if: github.event_name == 'push' || github.head_ref == 'fix-temporal-sdk-java-main-code-coverage'
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -3,6 +3,12 @@
 apply plugin: 'jacoco-report-aggregation'
 apply plugin: 'com.github.nbaztec.coveralls-jacoco'
 
+def jacocoToolVersion = "0.8.15"
+
+jacoco {
+    toolVersion = jacocoToolVersion
+}
+
 dependencies {
     jacocoAggregation project(':temporal-kotlin')
     jacocoAggregation project(':temporal-opentracing')
@@ -39,7 +45,11 @@ testCodeCoverageReport {
     }
 
     getClassDirectories().setFrom(files(
-            jacocoSubprojects.collect {it.fileTree(dir: "${it.buildDir}/classes", exclude: jacocoExclusions)}
+            jacocoSubprojects.collect {
+                it.sourceSets.main.output.classesDirs.asFileTree.matching {
+                    exclude jacocoExclusions
+                }
+            }
     ))
 }
 
@@ -57,7 +67,7 @@ subprojects {
     apply plugin: 'jacoco'
 
     jacoco {
-        toolVersion = "0.8.9"
+        toolVersion = jacocoToolVersion
     }
 
     jacocoTestReport {


### PR DESCRIPTION
## What was changed
- Bump JaCoCo to 0.8.15 for Java 23 compatibility
- Avoid feeding duplicate classes to jacoco
- Simplify code coverage CI workflow

## Why?
Code coverage is failing in CI

## Checklist

1. Closes #2962 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
