### PR TITLE
Fix: Propagate WorkflowOptions.priority through signalWithStart

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientRequestFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/WorkflowClientRequestFactory.java
@@ -210,6 +210,9 @@ final class WorkflowClientRequestFactory {
       request.setVersioningOverride(startParameters.getVersioningOverride());
     }
 
+    if (startParameters.hasPriority()) {
+      request.setPriority(startParameters.getPriority());
+    }
     return request;
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/PriorityInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/PriorityInfoTest.java
@@ -6,11 +6,13 @@ import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
 import io.temporal.common.Priority;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
+import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,7 +22,10 @@ public class PriorityInfoTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
-          .setWorkflowTypes(TestPriority.class, TestPriorityChildWorkflow.class)
+          .setWorkflowTypes(
+              TestPriority.class,
+              TestPriorityChildWorkflow.class,
+              TestSignalWithStartPriorityWorkflowImpl.class)
           .setActivityImplementations(new PriorityActivitiesImpl())
           .build();
 
@@ -42,6 +47,24 @@ public class PriorityInfoTest {
                     .build());
     String result = workflowStub.execute(testWorkflowRule.getTaskQueue());
     assertEquals("5:tenant-123:2.5", result);
+  }
+
+  @Test
+  public void testPriorityWithSignalWithStart() {
+    WorkflowStub stub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(
+                "TestSignalWithStartPriorityWorkflow",
+                WorkflowOptions.newBuilder()
+                    .setWorkflowId("test-signal-with-start-priority-" + UUID.randomUUID())
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setPriority(Priority.newBuilder().setPriorityKey(2).build())
+                    .build());
+    stub.signalWithStart(
+        "mySignal", new Object[] {"signalArg"}, new Object[] {testWorkflowRule.getTaskQueue()});
+    String result = stub.getResult(String.class);
+    assertEquals("2:null:0.0", result);
   }
 
   @ActivityInterface
@@ -129,6 +152,34 @@ public class PriorityInfoTest {
           + key
           + ":"
           + workflowPriority.getFairnessWeight();
+    }
+  }
+
+  @WorkflowInterface
+  public interface TestSignalWithStartPriorityWorkflow {
+    @WorkflowMethod
+    String execute(String taskQueue);
+
+    @SignalMethod
+    void mySignal(String arg);
+  }
+
+  public static class TestSignalWithStartPriorityWorkflowImpl
+      implements TestSignalWithStartPriorityWorkflow {
+
+    private boolean received = false;
+
+    @Override
+    public String execute(String taskQueue) {
+      Workflow.await(() -> received);
+      Priority priority = Workflow.getInfo().getPriority();
+      String key = priority.getFairnessKey() != null ? priority.getFairnessKey() : "null";
+      return priority.getPriorityKey() + ":" + key + ":" + priority.getFairnessWeight();
+    }
+
+    @Override
+    public void mySignal(String arg) {
+      received = true;
     }
   }
 }

--- a/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/testservice/TestWorkflowService.java
@@ -1657,6 +1657,9 @@ public final class TestWorkflowService extends WorkflowServiceGrpc.WorkflowServi
       if (!r.getLinksList().isEmpty()) {
         startRequest.addAllLinks(r.getLinksList());
       }
+      if (r.hasPriority()) {
+        startRequest.setPriority(r.getPriority());
+      }
 
       StartWorkflowExecutionResponse startResult =
           startWorkflowExecutionImpl(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added Priority propagation to `WorkflowClientRequestFactory.newSignalWithStartWorkflowExecutionRequest` — one if `(startParameters.hasPriority()) `block, mirroring the existing pattern already used for memo, searchAttributes, header, userMetadata, and versioningOverride in the same method. 
Also added a regression test in `PriorityInfoTest.java (testPriorityWithSignalWithStart)` exercising `WorkflowStub.signalWithStart(...)` with Priority set on WorkflowOptions, asserting the workflow observes the priority via `Workflow.getInfo().getPriority().`

## Why?
signalWithStart never propagated WorkflowOptions.priority onto the wire, despite `SignalWithStartWorkflowExecutionRequest (request_response.proto, field 26)` already supporting it — only the plain start() path (newStartWorkflowExecutionRequest) set it. 
There's a comment directly above that method — // If you add anything new here, keep newSignalWithStartWorkflowExecutionRequest in sync — suggesting this was simply missed when Priority was added. Confirmed via SDK source across every version from 1.31.0 (when Priority was introduced) through the latest release — never fixed. Verified live against a real Temporal cluster: a signalWithStart dispatch with priorityKey set produced a WorkflowExecutionStarted event with no priority field at all.

This silently breaks any caller relying on signalWithStart for priority — including workflows that need "signal if already running, else start" semantics and can't safely switch to plain start() without losing that behavior.

## Checklist
1. Closes: https://github.com/temporalio/sdk-java/issues/2965
2. How was this tested: added testPriorityWithSignalWithStart in PriorityInfoTest.java; fails on main (would report the workflow's default priority instead of the one set on signalWithStart) and passes with this fix.
3. Any docs updates needed: none found referencing this specific gap — docs.temporal.io/develop/task-queue-priority-fairness's existing examples already only show start()-based usage, so no doc correction needed there.

