### PR TITLE
Fix ScheduleRange validation

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleRange.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/schedules/ScheduleRange.java
@@ -22,7 +22,9 @@ public final class ScheduleRange {
    * Create a inclusive range for a schedule match value.
    *
    * @param start The inclusive start of the range
-   * @param end The inclusive end of the range. Default if unset or less than start is start.
+   * @param end The inclusive end of the range. Must be non-negative. Default if unset or less than
+   *     start is start.
+   * @throws IllegalStateException if start or end is negative
    */
   public ScheduleRange(int start, int end) {
     this(start, end, 0);
@@ -32,11 +34,13 @@ public final class ScheduleRange {
    * Create a inclusive range for a schedule match value.
    *
    * @param start The inclusive start of the range
-   * @param end The inclusive end of the range. Default if unset or less than start is start.
+   * @param end The inclusive end of the range. Must be non-negative. Default if unset or less than
+   *     start is start.
    * @param step The step to take between each value. Default if unset or 0, is 1.
+   * @throws IllegalStateException if start, end, or step is negative
    */
   public ScheduleRange(int start, int end, int step) {
-    Preconditions.checkState(start >= 0 && step >= 0 && step >= 0);
+    Preconditions.checkState(start >= 0 && end >= 0 && step >= 0);
     this.start = start;
     this.end = end;
     this.step = step;

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleRangeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleRangeTest.java
@@ -1,0 +1,12 @@
+package io.temporal.client.schedules;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScheduleRangeTest {
+  @Test
+  public void rejectsNegativeEnd() {
+    Assert.assertThrows(IllegalStateException.class, () -> new ScheduleRange(0, -1));
+    Assert.assertThrows(IllegalStateException.class, () -> new ScheduleRange(0, -1, 0));
+  }
+}


### PR DESCRIPTION
## What was changed
The three-argument constructor accidentally checked `step` twice, so negative `end` values were accepted. `end` should follow the same non-negative constraint as `start` and `step`.

## Why?

`ScheduleRange(int start, int end, int step)` checked `step >= 0` twice and did not validate `end`.

As a result, negative `end` values were accepted even though schedule range values are expected to be non-negative. This change corrects the validation while preserving the existing constructor signatures and exception behavior.

## Checklist

1. Closes #2728

2. How was this tested:

- Added `ScheduleRangeTest` covering negative `end` values in both constructors. The test fails on `main` and passes with this change.