### PR TITLE
Temporary: test Temporal Cloud API key permissions

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,69 +1,39 @@
-name: Publish snapshot
-defaults:
-  run:
-    shell: bash -euo pipefail -O nullglob {0}
+name: Temporal Cloud API key smoke test
+
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run'
+        description: 'Compatibility input for manual dispatch'
         required: true
         default: true
         type: boolean
-  push:
-    branches:
-      - 'main'
-    paths-ignore:
-      - 'releases/**'
-      - 'docker/buildkite/**'
-      - '.buildkite/**'
-      - '.github/**'
-    tags-ignore:
-      - 'v*'
 
 permissions:
   contents: read
 
 jobs:
-  publish-snapshot:
-    if: github.repository == 'temporalio/sdk-java' || github.event_name == 'workflow_dispatch'
+  smoke:
+    name: Run one Workflow and Activity
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          java-version: '23'
-          distribution: 'temurin'
-          
+          java-version: "23"
+          distribution: "temurin"
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@ac396bf1a80af16236baf54bd7330ae21dc6ece5 # v6
 
-      # Prefer env variables here rather than inline ${{ secrets.FOO }} to
-      # decrease the likelihood that secrets end up printed to stdout.
-      - name: Set up publishing secrets
-        run: |
-          base64 -d > "$HOME/secring.gpg" <<<"$KEY"
-          printf "signing.keyId = %s\n" "$KEY_ID" >> gradle.properties
-          printf "signing.password = %s\n" "$KEY_PASSWORD" >> gradle.properties
-          printf "signing.secretKeyRingFile = %s\n" "$HOME/secring.gpg" >> gradle.properties
-          printf "ossrhUsername = %s\n" "$RH_USER" >> gradle.properties
-          printf "ossrhPassword = %s\n" "$RH_PASSWORD" >> gradle.properties
+      - name: Run Temporal Cloud API key smoke test
+        run: >-
+          ./gradlew --no-daemon
+          :temporal-sdk:test
+          --tests io.temporal.client.CloudNamespaceAccessSmokeTest
         env:
-          KEY: ${{ secrets.JAR_SIGNING_KEY }}
-          KEY_PASSWORD: ${{ secrets.JAR_SIGNING_KEY_PASSWORD }}
-          KEY_ID: ${{ secrets.JAR_SIGNING_KEY_ID }}
-          RH_USER: ${{ secrets.RH_USER }}
-          RH_PASSWORD: ${{ secrets.RH_PASSWORD }}
-
-      - name: Dry run
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
-        run: ./gradlew --dry-run publishToSonatype
-
-      - name: Publish
-        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
-        run: ./gradlew publishToSonatype
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}

--- a/temporal-sdk/src/test/java/io/temporal/client/CloudNamespaceAccessSmokeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/CloudNamespaceAccessSmokeTest.java
@@ -1,0 +1,97 @@
+package io.temporal.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.worker.Worker;
+import io.temporal.worker.WorkerFactory;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class CloudNamespaceAccessSmokeTest {
+  private static final String NAMESPACE = "sdk-ci.a2dd6";
+  private static final String TARGET = "sdk-ci.a2dd6.tmprl.cloud:7233";
+
+  @WorkflowInterface
+  public interface SmokeWorkflow {
+    @WorkflowMethod
+    String run(String input);
+  }
+
+  @ActivityInterface
+  public interface SmokeActivity {
+    @ActivityMethod
+    String echo(String input);
+  }
+
+  public static class SmokeWorkflowImpl implements SmokeWorkflow {
+    private final SmokeActivity activity =
+        Workflow.newActivityStub(
+            SmokeActivity.class,
+            ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(10)).build());
+
+    @Override
+    public String run(String input) {
+      return activity.echo(input);
+    }
+  }
+
+  public static class SmokeActivityImpl implements SmokeActivity {
+    @Override
+    public String echo(String input) {
+      return input;
+    }
+  }
+
+  @Test
+  public void apiKeyCanRunWorkflowAndActivity() throws InterruptedException {
+    String apiKey = System.getenv("TEMPORAL_CLIENT_CLOUD_API_KEY");
+    assertNotNull("TEMPORAL_CLIENT_CLOUD_API_KEY must be set", apiKey);
+
+    String resourceName = "sdk-java-cloud-auth-smoke-" + UUID.randomUUID();
+    WorkflowServiceStubs service =
+        WorkflowServiceStubs.newServiceStubs(
+            WorkflowServiceStubsOptions.newBuilder()
+                .setTarget(TARGET)
+                .setEnableHttps(true)
+                .addApiKey(() -> apiKey)
+                .build());
+    WorkflowClient client =
+        WorkflowClient.newInstance(
+            service, WorkflowClientOptions.newBuilder().setNamespace(NAMESPACE).build());
+    WorkerFactory factory = WorkerFactory.newInstance(client);
+
+    try {
+      Worker worker = factory.newWorker(resourceName);
+      worker.registerWorkflowImplementationTypes(SmokeWorkflowImpl.class);
+      worker.registerActivitiesImplementations(new SmokeActivityImpl());
+      factory.start();
+
+      SmokeWorkflow workflow =
+          client.newWorkflowStub(
+              SmokeWorkflow.class,
+              WorkflowOptions.newBuilder()
+                  .setWorkflowId(resourceName)
+                  .setTaskQueue(resourceName)
+                  .setWorkflowExecutionTimeout(Duration.ofMinutes(2))
+                  .build());
+
+      assertEquals("smoke-ok", workflow.run("smoke-ok"));
+    } finally {
+      factory.shutdownNow();
+      factory.awaitTermination(5, TimeUnit.SECONDS);
+      service.shutdownNow();
+      service.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+}


### PR DESCRIPTION
Temporary draft PR used only to verify that the existing GitHub API-key secret can run one Workflow and one Activity in sdk-ci.a2dd6. Ordinary push and pull-request CI is skipped. This PR and its branch will be deleted after the smoke run.