### PR TITLE
Run integration tests against Temporal Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Run integration tests (Java 11)
         env:
           TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
-        run: ./gradlew --no-daemon --max-workers=1 test -x spotlessCheck -x spotlessApply -x spotlessJava -PtestJavaVersion=11
+        run: ./gradlew --no-daemon --max-workers=1 --continue test -x spotlessCheck -x spotlessApply -x spotlessJava -PtestJavaVersion=11
 
       - name: Run virtual thread integration tests (Java 21)
         if: success() || failure()
@@ -250,6 +250,7 @@ jobs:
         if: success() || failure()
         with:
           report_paths: "**/build/test-results/*/TEST-*.xml"
+          annotate_only: true
 
   code_format:
     name: Code format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,63 @@ jobs:
         with:
           report_paths: "**/build/test-results/test/TEST-*.xml"
 
+  integration_test_cloud:
+    name: Integration test with Temporal Cloud
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login != 'dependabot[bot]'
+      )
+    continue-on-error: true
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 60
+    concurrency:
+      group: temporal-cloud-integration-tests
+      cancel-in-progress: false
+    env:
+      USER: unittest
+      USE_EXTERNAL_SERVICE: true
+      # API-key authentication uses the regional data-plane endpoint; the namespace endpoint requires mTLS.
+      TEMPORAL_SERVICE_ADDRESS: ca-central-1.aws.api.temporal.io:7233
+      TEMPORAL_NAMESPACE: sdk-ci.a2dd6
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: |
+            11
+            23
+          distribution: "temurin"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@ac396bf1a80af16236baf54bd7330ae21dc6ece5 # v6
+
+      - name: Run integration tests (Java 11)
+        env:
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+        run: ./gradlew --no-daemon --max-workers=1 test -x spotlessCheck -x spotlessApply -x spotlessJava -PtestJavaVersion=11
+
+      - name: Run virtual thread integration tests (Java 21)
+        if: success() || failure()
+        env:
+          TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
+        run: ./gradlew --no-daemon --max-workers=1 :temporal-sdk:virtualThreadTests -x spotlessCheck -x spotlessApply -x spotlessJava -PtestJavaVersion=21
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
+        if: success() || failure()
+        with:
+          report_paths: "**/build/test-results/*/TEST-*.xml"
+
   code_format:
     name: Code format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
       TEMPORAL_NAMESPACE: sdk-ci.a2dd6
     steps:
       - name: Checkout repo
-        uses: actions/checkout@9c091bb21b7c1c1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: recursive

--- a/temporal-sdk/src/main/java/io/temporal/client/ActivityClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/ActivityClientImpl.java
@@ -7,6 +7,7 @@ import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
 import io.temporal.common.interceptors.ActivityClientInterceptor;
 import io.temporal.common.interceptors.Header;
 import io.temporal.internal.client.ActivityHandleImpl;
+import io.temporal.internal.client.NamespaceInjectWorkflowServiceStubs;
 import io.temporal.internal.client.RootActivityClientInvoker;
 import io.temporal.internal.client.external.GenericWorkflowClientImpl;
 import io.temporal.internal.client.external.ManualActivityCompletionClientFactory;
@@ -36,6 +37,7 @@ class ActivityClientImpl implements ActivityClient {
   private final Scope metricsScope;
 
   ActivityClientImpl(WorkflowServiceStubs stubs, ActivityClientOptions options) {
+    stubs = new NamespaceInjectWorkflowServiceStubs(stubs, options.getNamespace());
     this.stubs = stubs;
     this.options = options;
     this.metricsScope =

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityNextRetryDelayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityNextRetryDelayTest.java
@@ -19,6 +19,7 @@ public class ActivityNextRetryDelayTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
+          .setTestTimeoutSeconds(30)
           .setWorkflowTypes(TestWorkflowImpl.class)
           .setActivityImplementations(new NextRetryDelayActivityImpl())
           .build();

--- a/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.*;
 
 import io.grpc.*;
 import io.temporal.api.nexus.v1.Endpoint;
+import io.temporal.client.ActivityClient;
+import io.temporal.client.ActivityClientOptions;
+import io.temporal.client.StartActivityOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
@@ -137,6 +140,34 @@ public class AuthorizationTokenTest {
     } finally {
       testEnvironment.deleteNexusEndpoint(endpoint);
     }
+  }
+
+  @Test
+  public void activityClientRequestsShouldHaveNamespaceHeader() {
+    ActivityClient client =
+        ActivityClient.newInstance(
+            testEnvironment.getWorkflowServiceStubs(),
+            ActivityClientOptions.newBuilder()
+                .setNamespace(testEnvironment.getNamespace())
+                .build());
+    try {
+      client.start(
+          "TestActivity",
+          StartActivityOptions.newBuilder()
+              .setId("test-activity")
+              .setTaskQueue(TASK_QUEUE)
+              .setScheduleToCloseTimeout(Duration.ofMinutes(1))
+              .build());
+    } catch (StatusRuntimeException e) {
+      assertEquals(Status.Code.UNIMPLEMENTED, e.getStatus().getCode());
+    }
+
+    GrpcRequest request =
+        loggedRequests.stream()
+            .filter(r -> "StartActivityExecution".equals(r.methodName))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("StartActivityExecution request was not sent"));
+    assertEquals(testEnvironment.getNamespace(), request.namespace);
   }
 
   public static class EmptyWorkflowImpl implements TestWorkflows.TestWorkflow1 {

--- a/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
@@ -3,6 +3,7 @@ package io.temporal.authorization;
 import static org.junit.Assert.*;
 
 import io.grpc.*;
+import io.temporal.api.nexus.v1.Endpoint;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,6 +32,7 @@ public class AuthorizationTokenTest {
   private static final String AUTH_TOKEN = "Bearer <token>";
 
   private TestWorkflowEnvironment testEnvironment;
+  private final AtomicInteger authTokenSupplyCount = new AtomicInteger();
 
   @Rule
   public TestWatcher watchman =
@@ -45,6 +48,7 @@ public class AuthorizationTokenTest {
   @Before
   public void setUp() {
     loggedRequests.clear();
+    authTokenSupplyCount.set(0);
     WorkflowServiceStubsOptions stubOptions =
         WorkflowServiceStubsOptions.newBuilder()
             .addGrpcClientInterceptor(
@@ -78,7 +82,12 @@ public class AuthorizationTokenTest {
                     }
                   }
                 })
-            .addGrpcMetadataProvider(new AuthorizationGrpcMetadataProvider(() -> AUTH_TOKEN))
+            .addGrpcMetadataProvider(
+                new AuthorizationGrpcMetadataProvider(
+                    () -> {
+                      authTokenSupplyCount.incrementAndGet();
+                      return AUTH_TOKEN;
+                    }))
             .build();
 
     TestEnvironmentOptions options =
@@ -117,6 +126,16 @@ public class AuthorizationTokenTest {
             testEnvironment.getNamespace(),
             grpcRequest.namespace);
       }
+    }
+  }
+
+  @Test
+  public void operatorServiceRequestsShouldHaveAnAuthToken() {
+    Endpoint endpoint = testEnvironment.createNexusEndpoint("authorization-token-test", TASK_QUEUE);
+    try {
+      assertTrue(authTokenSupplyCount.get() > 0);
+    } finally {
+      testEnvironment.deleteNexusEndpoint(endpoint);
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -32,6 +32,7 @@ public class ScheduleTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
+          .setTestTimeoutSeconds(30)
           .setWorkflowTypes(ScheduleTest.QuickWorkflowImpl.class)
           .build();
 

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
@@ -132,6 +132,7 @@ public class ScheduleWithTypedSearchAttributesTest {
 
   @Test
   public void updateExternalSchedule() {
+    String namespace = testWorkflowRule.getWorkflowClient().getOptions().getNamespace();
     // Create schedule using raw GRPC api to simulate one created from a different SDK
     io.temporal.api.common.v1.SearchAttributes searchAttributes =
         io.temporal.api.common.v1.SearchAttributes.newBuilder()
@@ -159,7 +160,7 @@ public class ScheduleWithTypedSearchAttributesTest {
             .build();
     CreateScheduleRequest request =
         CreateScheduleRequest.newBuilder()
-            .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+            .setNamespace(namespace)
             .setIdentity(testWorkflowRule.getWorkflowClient().getOptions().getIdentity())
             .setRequestId(UUID.randomUUID().toString())
             .setScheduleId(scheduleId)
@@ -224,7 +225,7 @@ public class ScheduleWithTypedSearchAttributesTest {
         .blockingStub()
         .deleteSchedule(
             DeleteScheduleRequest.newBuilder()
-                .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+                .setNamespace(namespace)
                 .setIdentity(testWorkflowRule.getWorkflowClient().getOptions().getIdentity())
                 .setScheduleId(scheduleId)
                 .build());

--- a/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
@@ -58,6 +58,7 @@ public class WorkflowIdSignedPayloadsTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
+          .setTestTimeoutSeconds(30)
           .setWorkflowTypes(
               SimpleWorkflowWithAnActivity.class,
               TestWorkflowWithCronScheduleImpl.class,

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest.java
@@ -78,7 +78,7 @@ public class OutdatedDirectQueryReplayWorkflowRunTaskHandlerTest {
 
     ReplayWorkflowRunTaskHandler handler =
         new ReplayWorkflowRunTaskHandler(
-            "UnitTest",
+            testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
             createReplayWorkflow(workflowExecutionHistory),
             wft,
             SingleWorkerOptions.newBuilder().build(),

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
@@ -134,7 +134,7 @@ public class ActivityFailedMetricsTests {
       String workerType, String workflowType) {
     Map<String, String> tags = new HashMap<>();
     tags.put("task_queue", testWorkflowRule.getTaskQueue());
-    tags.put("namespace", "UnitTest");
+    tags.put("namespace", testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
     tags.put("activity_type", "Execute");
     tags.put("exception", "ApplicationFailure");
     tags.put("worker_type", workerType);

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowFailedMetricsTests.java
@@ -125,7 +125,7 @@ public class WorkflowFailedMetricsTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest",
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
         "workflow_type",
         workflowType);
   }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotGrpcInterceptedTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotGrpcInterceptedTests.java
@@ -186,7 +186,7 @@ public class WorkflowSlotGrpcInterceptedTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest");
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
   }
 
   private static class MaybeFailWFTResponseInterceptor implements ClientInterceptor {

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotTests.java
@@ -233,7 +233,7 @@ public class WorkflowSlotTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest");
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/worker/ResourceBasedTunerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/ResourceBasedTunerTests.java
@@ -190,6 +190,6 @@ public class ResourceBasedTunerTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest");
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -21,6 +21,7 @@ import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.testing.internal.ExternalServiceTestConfigurator;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Async;
 import io.temporal.workflow.CompletablePromise;
@@ -52,8 +53,9 @@ import org.slf4j.LoggerFactory;
 public class StickyWorkerTest {
 
   private static final boolean useExternalService =
-      Boolean.parseBoolean(System.getenv("USE_EXTERNAL_SERVICE"));
-  private static final String serviceAddress = System.getenv("TEMPORAL_SERVICE_ADDRESS");
+      ExternalServiceTestConfigurator.isUseExternalService();
+  private static final String serviceAddress =
+      ExternalServiceTestConfigurator.getTemporalServiceAddress();
 
   @Rule public TestName testName = new TestName();
 
@@ -519,6 +521,8 @@ public class StickyWorkerTest {
               .setMetricsScope(metricsScope)
               .setWorkflowClientOptions(clientOptions)
               .setWorkerFactoryOptions(options)
+              .setWorkflowServiceStubsOptions(
+                  ExternalServiceTestConfigurator.getWorkflowServiceStubsOptions())
               .setUseExternalService(useExternalService)
               .setTarget(serviceAddress)
               .build();

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -10,7 +10,6 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
@@ -152,9 +151,7 @@ public class WorkerStressTests {
       if (ExternalServiceTestConfigurator.isUseExternalService()) {
         service =
             WorkflowServiceStubs.newServiceStubs(
-                WorkflowServiceStubsOptions.newBuilder()
-                    .setTarget(ExternalServiceTestConfigurator.getTemporalServiceAddress())
-                    .build());
+                ExternalServiceTestConfigurator.getWorkflowServiceStubsOptions());
         WorkflowClient client = WorkflowClient.newInstance(service, clientOptions);
         factory = WorkerFactory.newInstance(client, options);
       } else {

--- a/temporal-sdk/src/test/java/io/temporal/worker/tuning/ResourceBasedSlotSupplierNonRecursiveTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/tuning/ResourceBasedSlotSupplierNonRecursiveTest.java
@@ -12,7 +12,6 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.internal.worker.SlotReservationData;
 import io.temporal.internal.worker.TrackingSlotSupplier;
 import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.Worker;
@@ -192,12 +191,13 @@ public class ResourceBasedSlotSupplierNonRecursiveTest {
     // Create connections to real Temporal server
     WorkflowServiceStubs service =
         WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder()
-                .setTarget(ExternalServiceTestConfigurator.getTemporalServiceAddress())
-                .build());
+            ExternalServiceTestConfigurator.getWorkflowServiceStubsOptions());
     WorkflowClient client =
         WorkflowClient.newInstance(
-            service, WorkflowClientOptions.newBuilder().setNamespace("default").build());
+            service,
+            WorkflowClientOptions.newBuilder()
+                .setNamespace(ExternalServiceTestConfigurator.getNamespace())
+                .build());
     WorkerFactory workerFactory = WorkerFactory.newInstance(client);
 
     // Create our own resource controller that we can control

--- a/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java
@@ -10,7 +10,7 @@ import io.grpc.StatusRuntimeException;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.internal.ExternalServiceTestConfigurator;
 import io.temporal.worker.WorkerFactory;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -22,8 +22,7 @@ import org.junit.Test;
 public class WorkerFactoryTests {
 
   private static final boolean useExternalService =
-      Boolean.parseBoolean(System.getenv("USE_EXTERNAL_SERVICE"));
-  private static final String serviceAddress = System.getenv("TEMPORAL_SERVICE_ADDRESS");
+      ExternalServiceTestConfigurator.isUseExternalService();
 
   @BeforeClass
   public static void beforeClass() {
@@ -37,8 +36,13 @@ public class WorkerFactoryTests {
   public void setUp() {
     service =
         WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder().setTarget(serviceAddress).build());
-    WorkflowClient client = WorkflowClient.newInstance(service);
+            ExternalServiceTestConfigurator.getWorkflowServiceStubsOptions());
+    WorkflowClient client =
+        WorkflowClient.newInstance(
+            service,
+            WorkflowClientOptions.newBuilder()
+                .setNamespace(ExternalServiceTestConfigurator.getNamespace())
+                .build());
     factory = WorkerFactory.newInstance(client);
   }
 
@@ -138,7 +142,7 @@ public class WorkerFactoryTests {
   public void startFailsOnNonexistentNamespace() {
     WorkflowServiceStubs serviceLocal =
         WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder().setTarget(serviceAddress).build());
+            ExternalServiceTestConfigurator.getWorkflowServiceStubsOptions());
     WorkflowClient clientLocal =
         WorkflowClient.newInstance(
             serviceLocal, WorkflowClientOptions.newBuilder().setNamespace("i_dont_exist").build());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyBlockWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyBlockWorkflowTest.java
@@ -87,7 +87,7 @@ public class NonDeterministicWorkflowPolicyBlockWorkflowTest {
             "task_queue",
             testWorkflowRule.getTaskQueue(),
             "namespace",
-            "UnitTest",
+            testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
             "workflow_type",
             "TestWorkflowStringArg",
             "worker_type",

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationInfoTest.java
@@ -27,7 +27,11 @@ public class NexusOperationInfoTest {
         testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
     String expectedEndpoint = testWorkflowRule.getNexusEndpoint().getSpec().getName();
     Assert.assertEquals(
-        "UnitTest:" + testWorkflowRule.getTaskQueue() + ":" + expectedEndpoint,
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace()
+            + ":"
+            + testWorkflowRule.getTaskQueue()
+            + ":"
+            + expectedEndpoint,
         workflowStub.execute(testWorkflowRule.getTaskQueue()));
   }
 

--- a/temporal-sdk/src/virtualThreadTests/java/io/temporal/worker/WorkerWithVirtualThreadsStressTests.java
+++ b/temporal-sdk/src/virtualThreadTests/java/io/temporal/worker/WorkerWithVirtualThreadsStressTests.java
@@ -10,7 +10,6 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
@@ -139,9 +138,7 @@ public class WorkerWithVirtualThreadsStressTests {
       if (ExternalServiceTestConfigurator.isUseExternalService()) {
         service =
             WorkflowServiceStubs.newServiceStubs(
-                WorkflowServiceStubsOptions.newBuilder()
-                    .setTarget(ExternalServiceTestConfigurator.getTemporalServiceAddress())
-                    .build());
+                ExternalServiceTestConfigurator.getWorkflowServiceStubsOptions());
         WorkflowClient client = WorkflowClient.newInstance(service, clientOptions);
         factory = WorkerFactory.newInstance(client, options);
       } else {

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -230,9 +230,10 @@ spring:
     activate:
       on-profile: worker-versioning
   temporal:
-    namespace: UnitTest
+    namespace: ${TEMPORAL_NAMESPACE:UnitTest}
     connection:
-      target: 127.0.0.1:7233
+      target: ${TEMPORAL_SERVICE_ADDRESS:127.0.0.1:7233}
+      api-key: ${TEMPORAL_CLIENT_CLOUD_API_KEY:}
     test-server:
       enabled: false
     workers-auto-discovery:

--- a/temporal-test-server/src/test/java/io/temporal/testserver/functional/DescribeNamespaceTest.java
+++ b/temporal-test-server/src/test/java/io/temporal/testserver/functional/DescribeNamespaceTest.java
@@ -8,7 +8,6 @@ import io.grpc.StatusRuntimeException;
 import io.temporal.api.enums.v1.NamespaceState;
 import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
 import io.temporal.api.workflowservice.v1.DescribeNamespaceResponse;
-import io.temporal.internal.docker.RegisterTestNamespace;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,13 +23,13 @@ public class DescribeNamespaceTest {
             .blockingStub()
             .describeNamespace(
                 DescribeNamespaceRequest.newBuilder()
-                    .setNamespace(RegisterTestNamespace.NAMESPACE)
+                    .setNamespace(SDKTestWorkflowRule.NAMESPACE)
                     .build());
     assertEquals(
         NamespaceState.NAMESPACE_STATE_REGISTERED,
         describeNamespaceResponse.getNamespaceInfo().getState());
     assertEquals(
-        RegisterTestNamespace.NAMESPACE, describeNamespaceResponse.getNamespaceInfo().getName());
+        SDKTestWorkflowRule.NAMESPACE, describeNamespaceResponse.getNamespaceInfo().getName());
     assertTrue(describeNamespaceResponse.getNamespaceInfo().getId().length() > 0);
   }
 
@@ -46,7 +45,7 @@ public class DescribeNamespaceTest {
             .blockingStub()
             .describeNamespace(
                 DescribeNamespaceRequest.newBuilder()
-                    .setNamespace(RegisterTestNamespace.NAMESPACE)
+                    .setNamespace(SDKTestWorkflowRule.NAMESPACE)
                     .build());
 
     assertTrue(

--- a/temporal-testing/src/main/java/io/temporal/internal/docker/RegisterTestNamespace.java
+++ b/temporal-testing/src/main/java/io/temporal/internal/docker/RegisterTestNamespace.java
@@ -16,9 +16,14 @@ public class RegisterTestNamespace {
   private static final boolean useExternalService =
       Boolean.parseBoolean(System.getenv("USE_EXTERNAL_SERVICE"));
   private static final String serviceAddress = System.getenv("TEMPORAL_SERVICE_ADDRESS");
+  private static final String existingNamespace = System.getenv("TEMPORAL_NAMESPACE");
 
   public static void main(String[] args) throws InterruptedException {
     if (!useExternalService) {
+      return;
+    }
+    if (existingNamespace != null) {
+      System.out.println("Using pre-registered namespace " + existingNamespace);
       return;
     }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowEnvironmentInternal.java
@@ -112,6 +112,10 @@ public final class TestWorkflowEnvironmentInternal implements TestWorkflowEnviro
         OperatorServiceStubs.newServiceStubs(
             OperatorServiceStubsOptions.newBuilder()
                 .setChannel(workflowServiceStubs.getRawChannel())
+                .setGrpcMetadataProviders(
+                    testEnvironmentOptions
+                        .getWorkflowServiceStubsOptions()
+                        .getGrpcMetadataProviders())
                 .validateAndBuildWithDefaults());
 
     WorkflowClient client =

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowExtension.java
@@ -255,8 +255,10 @@ public class TestWorkflowExtension
 
   @Override
   public void testFailed(ExtensionContext context, Throwable cause) {
-    TestWorkflowEnvironment testEnvironment = getTestEnvironment(context);
-    System.err.println("Workflow execution histories:\n" + testEnvironment.getDiagnostics());
+    if (!useExternalService) {
+      TestWorkflowEnvironment testEnvironment = getTestEnvironment(context);
+      System.err.println("Workflow execution histories:\n" + testEnvironment.getDiagnostics());
+    }
   }
 
   private TestWorkflowEnvironment getTestEnvironment(ExtensionContext context) {

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -93,7 +93,10 @@ public class TestWorkflowRule implements TestRule {
       new TestWatcher() {
         @Override
         protected void failed(Throwable e, Description description) {
-          System.err.println("WORKFLOW EXECUTION HISTORIES:\n" + testEnvironment.getDiagnostics());
+          if (!useExternalService) {
+            System.err.println(
+                "WORKFLOW EXECUTION HISTORIES:\n" + testEnvironment.getDiagnostics());
+          }
         }
       };
 
@@ -403,9 +406,12 @@ public class TestWorkflowRule implements TestRule {
         new Statement() {
           @Override
           public void evaluate() throws Throwable {
-            start();
-            base.evaluate();
-            shutdown();
+            try {
+              start();
+              base.evaluate();
+            } finally {
+              shutdown();
+            }
           }
         };
 

--- a/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/TestWorkflowRule.java
@@ -513,7 +513,7 @@ public class TestWorkflowRule implements TestRule {
    * @return stubs connected to the test server (in-memory or external)
    */
   public WorkflowServiceStubs getWorkflowServiceStubs() {
-    return testEnvironment.getWorkflowServiceStubs();
+    return getWorkflowClient().getWorkflowServiceStubs();
   }
 
   /**

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/ExternalServiceTestConfigurator.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/ExternalServiceTestConfigurator.java
@@ -1,14 +1,22 @@
 package io.temporal.testing.internal;
 
+import io.temporal.client.WorkflowClientOptions;
 import io.temporal.internal.common.env.EnvironmentVariableUtils;
+import io.temporal.internal.docker.RegisterTestNamespace;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowRule;
+import javax.annotation.Nullable;
 
 public class ExternalServiceTestConfigurator {
   private static boolean USE_EXTERNAL_SERVICE =
       EnvironmentVariableUtils.readBooleanFlag("USE_EXTERNAL_SERVICE");
   private static String TEMPORAL_SERVICE_ADDRESS =
       EnvironmentVariableUtils.readString("TEMPORAL_SERVICE_ADDRESS");
+  private static String TEMPORAL_NAMESPACE =
+      EnvironmentVariableUtils.readString("TEMPORAL_NAMESPACE");
+  private static String TEMPORAL_CLIENT_CLOUD_API_KEY =
+      EnvironmentVariableUtils.readString("TEMPORAL_CLIENT_CLOUD_API_KEY");
   private static boolean USE_VIRTUAL_THREADS =
       EnvironmentVariableUtils.readBooleanFlag("USE_VIRTUAL_THREADS");
 
@@ -26,11 +34,32 @@ public class ExternalServiceTestConfigurator {
         : null;
   }
 
+  public static String getNamespace() {
+    return TEMPORAL_NAMESPACE != null ? TEMPORAL_NAMESPACE : RegisterTestNamespace.NAMESPACE;
+  }
+
+  public static WorkflowServiceStubsOptions getWorkflowServiceStubsOptions() {
+    return configureWorkflowServiceStubsOptions(null);
+  }
+
   public static TestWorkflowRule.Builder configure(TestWorkflowRule.Builder testWorkflowRule) {
+    return configure(testWorkflowRule, null);
+  }
+
+  public static TestWorkflowRule.Builder configure(
+      TestWorkflowRule.Builder testWorkflowRule,
+      @Nullable WorkflowServiceStubsOptions workflowServiceStubsOptions) {
     if (USE_EXTERNAL_SERVICE) {
       testWorkflowRule.setUseExternalService(true);
       if (TEMPORAL_SERVICE_ADDRESS != null) {
         testWorkflowRule.setTarget(TEMPORAL_SERVICE_ADDRESS);
+      }
+      if (TEMPORAL_NAMESPACE != null) {
+        testWorkflowRule.setNamespace(TEMPORAL_NAMESPACE);
+      }
+      if (hasApiKey()) {
+        testWorkflowRule.setWorkflowServiceStubsOptions(
+            configureWorkflowServiceStubsOptions(workflowServiceStubsOptions));
       }
     }
     return testWorkflowRule;
@@ -39,9 +68,23 @@ public class ExternalServiceTestConfigurator {
   public static TestEnvironmentOptions.Builder configure(
       TestEnvironmentOptions.Builder testEnvironmentOptions) {
     if (USE_EXTERNAL_SERVICE) {
+      TestEnvironmentOptions existingOptions = testEnvironmentOptions.build();
       testEnvironmentOptions.setUseExternalService(true);
       if (TEMPORAL_SERVICE_ADDRESS != null) {
         testEnvironmentOptions.setTarget(TEMPORAL_SERVICE_ADDRESS);
+      }
+      if (TEMPORAL_NAMESPACE != null) {
+        WorkflowClientOptions workflowClientOptions = existingOptions.getWorkflowClientOptions();
+        testEnvironmentOptions.setWorkflowClientOptions(
+            (workflowClientOptions == null
+                    ? WorkflowClientOptions.newBuilder()
+                    : WorkflowClientOptions.newBuilder(workflowClientOptions))
+                .setNamespace(TEMPORAL_NAMESPACE)
+                .build());
+      }
+      if (hasApiKey()) {
+        testEnvironmentOptions.setWorkflowServiceStubsOptions(
+            configureWorkflowServiceStubsOptions(existingOptions.getWorkflowServiceStubsOptions()));
       }
     }
     return testEnvironmentOptions;
@@ -49,5 +92,24 @@ public class ExternalServiceTestConfigurator {
 
   public static TestEnvironmentOptions.Builder configuredTestEnvironmentOptions() {
     return configure(TestEnvironmentOptions.newBuilder());
+  }
+
+  private static WorkflowServiceStubsOptions configureWorkflowServiceStubsOptions(
+      @Nullable WorkflowServiceStubsOptions workflowServiceStubsOptions) {
+    WorkflowServiceStubsOptions.Builder builder =
+        workflowServiceStubsOptions == null
+            ? WorkflowServiceStubsOptions.newBuilder()
+            : WorkflowServiceStubsOptions.newBuilder(workflowServiceStubsOptions);
+    if (USE_EXTERNAL_SERVICE && TEMPORAL_SERVICE_ADDRESS != null) {
+      builder.setTarget(TEMPORAL_SERVICE_ADDRESS);
+    }
+    if (USE_EXTERNAL_SERVICE && hasApiKey()) {
+      builder.addApiKey(() -> TEMPORAL_CLIENT_CLOUD_API_KEY);
+    }
+    return builder.build();
+  }
+
+  private static boolean hasApiKey() {
+    return TEMPORAL_CLIENT_CLOUD_API_KEY != null && !TEMPORAL_CLIENT_CLOUD_API_KEY.isEmpty();
   }
 }

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestWorkflowRule.java
@@ -63,7 +63,7 @@ public class SDKTestWorkflowRule implements TestRule {
 
   private static final long BUSY_WAIT_SLEEP_MS = 100;
 
-  public static final String NAMESPACE = "UnitTest";
+  public static final String NAMESPACE = ExternalServiceTestConfigurator.getNamespace();
   public static final String UUID_REGEXP =
       "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
   // Enable to regenerate JsonFiles used for replay testing.
@@ -91,7 +91,9 @@ public class SDKTestWorkflowRule implements TestRule {
             : null;
 
     testWorkflowRule =
-        ExternalServiceTestConfigurator.configure(builder.testWorkflowRuleBuilder).build();
+        ExternalServiceTestConfigurator.configure(
+                builder.testWorkflowRuleBuilder, builder.workflowServiceStubsOptions)
+            .build();
   }
 
   public static Builder newBuilder() {
@@ -104,6 +106,7 @@ public class SDKTestWorkflowRule implements TestRule {
     private boolean workerFactoryOptionsAreSet = false;
     private boolean workerOptionsAreSet = false;
     private final TestWorkflowRule.Builder testWorkflowRuleBuilder;
+    private WorkflowServiceStubsOptions workflowServiceStubsOptions;
 
     public Builder() {
       testWorkflowRuleBuilder = TestWorkflowRule.newBuilder();
@@ -111,6 +114,7 @@ public class SDKTestWorkflowRule implements TestRule {
 
     public Builder setWorkflowServiceStubsOptions(
         WorkflowServiceStubsOptions workflowServiceStubsOptions) {
+      this.workflowServiceStubsOptions = workflowServiceStubsOptions;
       testWorkflowRuleBuilder.setWorkflowServiceStubsOptions(workflowServiceStubsOptions);
       return this;
     }

--- a/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentActivityClientTest.java
+++ b/temporal-testing/src/test/java/io/temporal/testing/TestWorkflowEnvironmentActivityClientTest.java
@@ -2,11 +2,13 @@ package io.temporal.testing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.temporal.client.ActivityClient;
 import io.temporal.client.ActivityClientOptions;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.interceptors.ActivityClientInterceptor;
+import io.temporal.internal.client.NamespaceInjectWorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -31,7 +33,10 @@ public class TestWorkflowEnvironmentActivityClientTest {
 
       assertEquals("workflow-client-namespace", activityClientOptions.getNamespace());
       assertEquals("workflow-client-identity", activityClientOptions.getIdentity());
-      assertSame(testEnv.getWorkflowServiceStubs(), getWorkflowServiceStubs(activityClient));
+      WorkflowServiceStubs activityClientStubs = getWorkflowServiceStubs(activityClient);
+      assertTrue(activityClientStubs instanceof NamespaceInjectWorkflowServiceStubs);
+      assertSame(
+          testEnv.getWorkflowServiceStubs().getRawChannel(), activityClientStubs.getRawChannel());
     }
   }
 


### PR DESCRIPTION
## What was changed

Run SDK integration tests against `sdk-ci.a2dd6` in a separate, serialized, non-gating job for trusted branches and PRs.

## Why?

Exercise the suite against Temporal Cloud without exposing secrets or blocking merges.

## Checklist

1. Closes: N/A

2. How was this tested: Targeted local tests and a [Cloud API-key smoke run](https://github.com/temporalio/sdk-java/actions/runs/30408835112).

3. Any docs updates needed? No.