### PR TITLE
Bump auto-enroll autoscaling minimum to the fixed poller default

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/PollerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/PollerOptions.java
@@ -42,7 +42,7 @@ public final class PollerOptions {
         && namespaceCapabilities.isPollerAutoscalingAutoEnroll()
         && !(options.getPollerBehavior() instanceof PollerBehaviorAutoscaling)) {
       return PollerOptions.newBuilder(options)
-          .setPollerBehavior(new PollerBehaviorAutoscaling())
+          .setPollerBehavior(new PollerBehaviorAutoscaling(5, 100, 5))
           .build();
     }
     return options;

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/PollerAutoscalingAutoEnrollTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/PollerAutoscalingAutoEnrollTest.java
@@ -66,8 +66,8 @@ public class PollerAutoscalingAutoEnrollTest {
     assertTrue(
         "defaulted poller type should switch to autoscaling",
         resolved.getPollerBehavior() instanceof PollerBehaviorAutoscaling);
-    // The enrolled behavior uses the PollerBehaviorAutoscaling defaults.
-    assertEquals(new PollerBehaviorAutoscaling(), resolved.getPollerBehavior());
+    // The enrolled behavior uses the explicit auto-enroll min/max/initial values.
+    assertEquals(new PollerBehaviorAutoscaling(5, 100, 5), resolved.getPollerBehavior());
   }
 
   @Test


### PR DESCRIPTION
## Why

When a worker auto-enrolls into poller autoscaling (via the `PollerAutoscalingAutoEnroll` namespace capability), it previously started with a minimum of **1** poller. That's fewer than the fixed default (**5**) a worker would otherwise run, so auto-enrolling could cause a throughput regression from too few pollers.

This sets the autoscaling **minimum equal to the fixed default poller count**, so auto-enrolling never starts below what a non-autoscaling worker would use.

## What

Auto-enroll now uses explicit values:

| min | max | initial |
|-----|-----|---------|
| **5** (fixed default) | 100 | 5 |

Applies to workflow, activity, and nexus pollers.

**Tested:** `./gradlew :temporal-sdk:test --tests "*PollerAutoscalingAutoEnroll*" --tests "*WorkerPollerAutoEnroll*"` passes. Updated one assertion to expect `PollerBehaviorAutoscaling(5, 100, 5)`.