### PR TITLE
Support Spring property placeholders in @WorkflowImpl workers attribute

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -306,6 +306,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
       WorkflowImpl annotation = AnnotationUtils.findAnnotation(clazz, WorkflowImpl.class);
 
       for (String workerName : annotation.workers()) {
+        workerName = environment.resolvePlaceholders(workerName);
         Worker worker = workers.getByName(workerName);
         if (worker == null) {
           throw new BeanDefinitionValidationException(
@@ -328,6 +329,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
           ActivityImpl annotation = AnnotationUtils.findAnnotation(targetClass, ActivityImpl.class);
           if (annotation != null) {
             for (String workerName : annotation.workers()) {
+              workerName = environment.resolvePlaceholders(workerName);
               Worker worker = workers.getByName(workerName);
               if (worker == null) {
                 throw new BeanDefinitionValidationException(
@@ -353,6 +355,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
               AnnotationUtils.findAnnotation(targetClass, NexusServiceImpl.class);
           if (annotation != null) {
             for (String workerName : annotation.workers()) {
+              workerName = environment.resolvePlaceholders(workerName);
               Worker worker = workers.getByName(workerName);
               if (worker == null) {
                 throw new BeanDefinitionValidationException(

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByWorkerNameResolverTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryByWorkerNameResolverTest.java
@@ -1,0 +1,49 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.byworkernameresolver.TestWorkflow;
+import io.temporal.testing.TestWorkflowEnvironment;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = AutoDiscoveryByWorkerNameResolverTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-by-worker-name-resolver")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryByWorkerNameResolverTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired TestWorkflowEnvironment testWorkflowEnvironment;
+
+  @Autowired WorkflowClient workflowClient;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testWorkerNamePropertyResolution() {
+    TestWorkflow testWorkflow =
+        workflowClient.newWorkflowStub(
+            TestWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue("UnitTest").build());
+    String result = testWorkflow.execute("done");
+    Assertions.assertEquals("done", result);
+  }
+
+  @ComponentScan(
+      excludeFilters = {
+        @ComponentScan.Filter(
+            pattern =
+                "io\\.temporal\\.spring\\.boot\\.autoconfigure"
+                    + "\\.(bytaskqueue|byworkername|workerversioning)\\..*",
+            type = FilterType.REGEX)
+      })
+  public static class Configuration {}
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestActivity.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestActivity.java
@@ -1,0 +1,8 @@
+package io.temporal.spring.boot.autoconfigure.byworkernameresolver;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface TestActivity {
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestActivityImpl.java
@@ -1,0 +1,13 @@
+package io.temporal.spring.boot.autoconfigure.byworkernameresolver;
+
+import io.temporal.spring.boot.ActivityImpl;
+import org.springframework.stereotype.Component;
+
+@Component("ResolverTestActivityImpl")
+@ActivityImpl(workers = "${worker.name}")
+public class TestActivityImpl implements TestActivity {
+  @Override
+  public String execute(String input) {
+    return input;
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestActivityImpl.java
@@ -1,10 +1,12 @@
 package io.temporal.spring.boot.autoconfigure.byworkernameresolver;
 
 import io.temporal.spring.boot.ActivityImpl;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component("ResolverTestActivityImpl")
 @ActivityImpl(workers = "${worker.name}")
+@Profile("auto-discovery-by-worker-name-resolver")
 public class TestActivityImpl implements TestActivity {
   @Override
   public String execute(String input) {

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestWorkflow.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestWorkflow.java
@@ -1,0 +1,11 @@
+package io.temporal.spring.boot.autoconfigure.byworkernameresolver;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface TestWorkflow {
+
+  @WorkflowMethod
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestWorkflowImpl.java
@@ -4,8 +4,10 @@ import io.temporal.activity.ActivityOptions;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
+import org.springframework.context.annotation.Profile;
 
 @WorkflowImpl(workers = "${worker.name}")
+@Profile("auto-discovery-by-worker-name-resolver")
 public class TestWorkflowImpl implements TestWorkflow {
 
   @Override

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/byworkernameresolver/TestWorkflowImpl.java
@@ -1,0 +1,20 @@
+package io.temporal.spring.boot.autoconfigure.byworkernameresolver;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.spring.boot.WorkflowImpl;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+
+@WorkflowImpl(workers = "${worker.name}")
+public class TestWorkflowImpl implements TestWorkflow {
+
+  @Override
+  public String execute(String input) {
+    return Workflow.newActivityStub(
+            TestActivity.class,
+            ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(1))
+                .validateAndBuildWithDefaults())
+        .execute(input);
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -125,6 +125,22 @@ spring:
 spring:
   config:
     activate:
+      on-profile: auto-discovery-by-worker-name-resolver
+  temporal:
+    workers:
+      - task-queue: UnitTest
+        name: mainWorker
+    workers-auto-discovery:
+      workflow-packages:
+        - io.temporal.spring.boot.autoconfigure.byworkernameresolver
+      register-activity-beans: true
+worker:
+  name: mainWorker
+
+---
+spring:
+  config:
+    activate:
       on-profile: auto-discovery-with-profile
   temporal:
     workers:


### PR DESCRIPTION
## What was changed

Added `environment.resolvePlaceholders(workerName)` in three methods in `WorkersTemplate.java`:
- `configureWorkflowImplementationsByWorkerName`
- `configureActivityBeansByWorkerName`
- `configureNexusServiceBeansByWorkerName`

## Why?

Issue #2747: the `workers` attribute in `@WorkflowImpl`, `@ActivityImpl`, and `@NexusServiceImpl` did not resolve Spring property placeholders like `${my.worker.name}`. The `taskQueues` attribute already resolves placeholders, so this makes `workers` consistent.

## Checklist

- [x] Added `resolvePlaceholders` call in all three methods
- [x] Consistent with existing `taskQueues` placeholder resolution pattern

Fixes #2747