### PR TITLE
Report Activity result when the Activity leaves the interrupt flag set

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityWorker.java
@@ -353,6 +353,13 @@ final class ActivityWorker implements SuspendableWorker {
         sw.stop();
       }
 
+      // An Activity may return with the thread's interrupt flag raised, either because it caught an
+      // InterruptedException and restored the flag or because it never noticed the flag at all.
+      // gRPC's blocking stubs abort when Thread.interrupted() is set (see
+      // io.grpc.stub.ClientCalls#blockingUnaryCall), so leaving the flag raised here would make the
+      // call below fail and the Activity result would never be reported. Clear it for the duration
+      // of the reporting call and restore it afterwards, so the flag still reaches the thread pool.
+      boolean interrupted = Thread.interrupted();
       try {
         sendReply(taskToken, result, metricsScope);
       } catch (Exception e) {
@@ -362,6 +369,10 @@ final class ActivityWorker implements SuspendableWorker {
         //  so we can increment a failure counter instead of success if send result failed.
         //  This will also align the behavior of ActivityWorker with WorkflowWorker.
         throw e;
+      } finally {
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
       }
 
       if (result.getTaskCompleted() != null) {

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityInterruptedFlagTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityInterruptedFlagTest.java
@@ -1,0 +1,88 @@
+package io.temporal.activity;
+
+import io.temporal.common.RetryOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * An Activity that returns with the thread's interrupt flag raised must still have its result
+ * reported to the server. gRPC's blocking stubs abort when {@code Thread.interrupted()} is set (see
+ * {@code io.grpc.stub.ClientCalls#blockingUnaryCall}), so a raised flag would otherwise make the
+ * completion call fail and the result would be lost.
+ */
+public class ActivityInterruptedFlagTest {
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestWorkflowImpl.class)
+          .setActivityImplementations(new InterruptingActivityImpl())
+          .build();
+
+  /** The Activity never noticed the flag and returned normally. */
+  @Test
+  public void activityReturningWithInterruptedFlagIsReportedAsCompleted() {
+    TestWorkflow workflow = testWorkflowRule.newWorkflowStub(TestWorkflow.class);
+    Assert.assertEquals("done", workflow.execute(false));
+  }
+
+  /** The Activity caught an InterruptedException, restored the flag, and returned a result. */
+  @Test
+  public void activityRestoringInterruptedFlagIsReportedAsCompleted() {
+    TestWorkflow workflow = testWorkflowRule.newWorkflowStub(TestWorkflow.class);
+    Assert.assertEquals("done", workflow.execute(true));
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+    @WorkflowMethod
+    String execute(boolean viaInterruptedException);
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflow {
+    @Override
+    public String execute(boolean viaInterruptedException) {
+      InterruptingActivity activity =
+          Workflow.newActivityStub(
+              InterruptingActivity.class,
+              ActivityOptions.newBuilder()
+                  .setStartToCloseTimeout(Duration.ofSeconds(5))
+                  .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+                  .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
+                  .build());
+      return activity.execute(viaInterruptedException);
+    }
+  }
+
+  @ActivityInterface
+  public interface InterruptingActivity {
+    String execute(boolean viaInterruptedException);
+  }
+
+  public static class InterruptingActivityImpl implements InterruptingActivity {
+    @Override
+    public String execute(boolean viaInterruptedException) {
+      if (viaInterruptedException) {
+        // Interrupt ourselves, observe the resulting InterruptedException, restore the flag and
+        // carry on, which is the documented way for blocking code to propagate an interrupt.
+        Thread.currentThread().interrupt();
+        try {
+          Thread.sleep(Long.MAX_VALUE);
+          Assert.fail("expected an InterruptedException");
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      } else {
+        // The Activity never noticed the flag.
+        Thread.currentThread().interrupt();
+      }
+      return "done";
+    }
+  }
+}


### PR DESCRIPTION
## What was changed

`ActivityWorker` now clears the thread's interrupt flag around the call that reports an Activity result, and restores it afterwards.

## Why

An Activity can return with the interrupt flag raised, either because it caught an `InterruptedException`, restored the flag and carried on, or because it never noticed the flag at all. gRPC's blocking stubs abort when `Thread.interrupted()` is set (`io.grpc.stub.ClientCalls#blockingUnaryCall`), which the SDK already notes in `MultiThreadedPoller.PollTask`. So the `RespondActivityTaskCompleted` call issued immediately after the Activity returns fails, and the result is never reported. The Activity then times out and the Workflow observes a failure even though the Activity completed successfully.

Reproduced on `main` (v1.38.0) with an Activity that raises the flag and returns `"done"`:

```
WARN  i.t.internal.worker.ActivityWorker - Failure during reporting of activity result
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.sendReply(ActivityWorker.java:406)
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handleActivity(ActivityWorker.java:357)
...
io.temporal.failure.ActivityFailure: Activity with activityType='Execute' failed: 'Activity task timed out'
```

This is the general case of the problem fixed for one specific caller in #722; that PR removed an interrupt the SDK itself was raising, while this makes the reporting path resilient to a flag raised by user code.

The flag is restored in a `finally` once reporting is done, so it still reaches the thread pool and continues to work for shutdown, per the approach suggested in the issue.

## Checklist

1. Closes #731

2. How was this tested:

Added `io.temporal.activity.ActivityInterruptedFlagTest` with two cases matching the two scenarios described in the issue: an Activity that never noticed the flag, and one that caught an `InterruptedException`, restored the flag and returned a result. Both assert the Workflow receives the Activity's return value.

Both fail on unmodified `main` (the Workflow fails with `Activity task timed out` as above) and pass with this change. `./gradlew :temporal-sdk:test --tests "io.temporal.activity.ActivityInterruptedFlagTest"` reports `tests="2" failures="0" errors="0"`, and `:temporal-sdk:spotlessCheck` passes.

3. Any docs updates needed?

No.
