### PR TITLE
💥 Fix exception serialize in update validator

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflow.java
@@ -162,6 +162,9 @@ class SyncWorkflow implements ReplayWorkflow {
               } catch (ReadOnlyException r) {
                 // Rethrow instead on rejecting the update to fail the WFT
                 throw r;
+              } catch (WorkflowExecutionException e) {
+                callbacks.reject(e.getFailure());
+                return;
               } catch (Exception e) {
                 callbacks.reject(
                     workflowContext

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateValidatorFailureSerializationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateValidatorFailureSerializationTest.java
@@ -1,0 +1,121 @@
+package io.temporal.workflow.updateTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowUpdateException;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.internal.SDKTestOptions;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.CompletablePromise;
+import io.temporal.workflow.QueryMethod;
+import io.temporal.workflow.UpdateMethod;
+import io.temporal.workflow.UpdateValidatorMethod;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UpdateValidatorFailureSerializationTest {
+
+  private static final String FAILURE_MESSAGE = "validator rejected";
+  private static final String FAILURE_TYPE = "TestValidatorFailure";
+  private static final String FAILURE_DETAIL = "failure detail";
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestWorkflowImpl.class).build();
+
+  @Test
+  public void validatorPreservesApplicationFailure() {
+    TestWorkflow workflow = startWorkflow();
+
+    WorkflowUpdateException exception =
+        assertThrows(WorkflowUpdateException.class, () -> workflow.update(true));
+
+    assertApplicationFailure(exception);
+    workflow.complete();
+  }
+
+  private TestWorkflow startWorkflow() {
+    WorkflowOptions options =
+        SDKTestOptions.newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue()).toBuilder()
+            .setWorkflowId(UUID.randomUUID().toString())
+            .build();
+    TestWorkflow workflow =
+        testWorkflowRule.getWorkflowClient().newWorkflowStub(TestWorkflow.class, options);
+    WorkflowClient.start(workflow::execute);
+    SDKTestWorkflowRule.waitForOKQuery(workflow);
+    return workflow;
+  }
+
+  private static void assertApplicationFailure(WorkflowUpdateException exception) {
+    assertNotNull(exception.getCause());
+    assertTrue(exception.getCause() instanceof ApplicationFailure);
+
+    ApplicationFailure failure = (ApplicationFailure) exception.getCause();
+    assertEquals(FAILURE_MESSAGE, failure.getOriginalMessage());
+    assertEquals(FAILURE_TYPE, failure.getType());
+    assertTrue(failure.isNonRetryable());
+    assertEquals(1, failure.getDetails().getSize());
+    assertEquals(FAILURE_DETAIL, failure.getDetails().get(0, String.class));
+    assertNull(failure.getCause());
+  }
+
+  @WorkflowInterface
+  public interface TestWorkflow {
+
+    @WorkflowMethod
+    void execute();
+
+    @QueryMethod
+    String getState();
+
+    @UpdateMethod
+    void update(boolean reject);
+
+    @UpdateValidatorMethod(updateName = "update")
+    void validateUpdate(boolean reject);
+
+    @UpdateMethod
+    void complete();
+  }
+
+  public static class TestWorkflowImpl implements TestWorkflow {
+
+    private final CompletablePromise<Void> done = Workflow.newPromise();
+
+    @Override
+    public void execute() {
+      done.get();
+    }
+
+    @Override
+    public String getState() {
+      return "ready";
+    }
+
+    @Override
+    public void update(boolean reject) {}
+
+    @Override
+    public void validateUpdate(boolean reject) {
+      if (reject) {
+        throw ApplicationFailure.newNonRetryableFailure(
+            FAILURE_MESSAGE, FAILURE_TYPE, FAILURE_DETAIL);
+      }
+    }
+
+    @Override
+    public void complete() {
+      done.complete(null);
+    }
+  }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix exception serialize in update validator

## Why?
update validator was effectively double serializing the error. 

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/2875

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes update validator failure handling, which affects how rejection errors are reported to clients. Scope is small and covered by a new regression test.
> 
> **Overview**
> Fixes update validators **double-serializing** rejection failures, which stripped `ApplicationFailure` type, details, and non-retryable flags from the client-visible error.
> 
> When a validator throws `ApplicationFailure`, it is already wrapped as `WorkflowExecutionException` with a serialized `Failure`. The validator catch path now rejects with that failure directly (matching execute-update handling) instead of running `exceptionToFailure` again.
> 
> Adds a regression test that asserts message, type, details, and non-retryable status are preserved on reject.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9248a819410f2e31a1cea71d41236c19d221cc2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->