### PR TITLE
💥 Report Nexus input deserialization failures as non-retryable BAD_REQUEST

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/PayloadSerializer.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/PayloadSerializer.java
@@ -2,8 +2,11 @@ package io.temporal.internal.nexus;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.nexusrpc.Serializer;
+import io.nexusrpc.handler.HandlerException;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DataConverterException;
+import io.temporal.failure.ApplicationFailure;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -13,9 +16,23 @@ import javax.annotation.Nullable;
  * PayloadSerializer is a serializer that converts objects to and from {@link
  * io.nexusrpc.Serializer.Content} objects by using the {@link DataConverter} to convert objects to
  * and from {@link Payload} objects.
+ *
+ * <p>Nexus propagates serializer failures as-is, so the error type and retry behavior a handler
+ * reports for them is decided here.
+ *
+ * <p>Input that will never decode into the expected type is the caller's fault and is reported as a
+ * non-retryable {@link HandlerException.ErrorType#BAD_REQUEST}. Any other failure on the way to the
+ * value, a {@link io.temporal.payload.codec.PayloadCodec} outage for example, may well succeed on a
+ * retry, so it is left to the handling in {@link NexusTaskHandlerImpl} that a failure from an
+ * operation handler would get.
+ *
+ * <p>Serializing an operation result is not translated at all. Note that this still means a
+ * converter can choose the outcome: a non-retryable {@link ApplicationFailure} raised while
+ * serializing a result becomes a non-retryable {@code INTERNAL} handler error by way of {@link
+ * NexusTaskHandlerImpl}, and anything else keeps the retryable {@code INTERNAL} default.
  */
 class PayloadSerializer implements Serializer {
-  DataConverter dataConverter;
+  private final DataConverter dataConverter;
 
   PayloadSerializer(DataConverter dataConverter) {
     this.dataConverter = dataConverter;
@@ -39,10 +56,22 @@ class PayloadSerializer implements Serializer {
         return dataConverter.fromPayload(
             payload, (Class<?>) ((ParameterizedType) type).getRawType(), type);
       } else {
-        throw new IllegalArgumentException("Unsupported type: " + type);
+        // A problem with the operation definition rather than with the request, but no amount of
+        // retrying will introduce support for the type.
+        throw new HandlerException(
+            HandlerException.ErrorType.INTERNAL,
+            "Unsupported operation input type: " + type,
+            null,
+            HandlerException.RetryBehavior.NON_RETRYABLE);
       }
-    } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException(e);
+    } catch (HandlerException | ApplicationFailure e) {
+      // The data converter already picked an error type and retry behavior, keep them.
+      throw e;
+    } catch (InvalidProtocolBufferException | DataConverterException e) {
+      // These bytes will not become this type on a retry. Everything else propagates, so a
+      // transient failure such as a payload codec outage stays retryable.
+      throw new HandlerException(
+          HandlerException.ErrorType.BAD_REQUEST, "failed to deserialize input", e);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/NexusTaskHandlerImplTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/NexusTaskHandlerImplTest.java
@@ -133,6 +133,36 @@ public class NexusTaskHandlerImplTest {
   }
 
   @Test
+  public void startTaskWithUndeserializableInput() throws TimeoutException {
+    WorkflowClient client = mock(WorkflowClient.class);
+    NexusTaskHandlerImpl nexusTaskHandlerImpl =
+        new NexusTaskHandlerImpl(
+            client, NAMESPACE, TASK_QUEUE, dataConverter, new WorkerInterceptor[] {});
+    nexusTaskHandlerImpl.registerNexusServiceImplementations(
+        new Object[] {new TestNexusServiceImpl2Echo()});
+    nexusTaskHandlerImpl.start();
+
+    PollNexusTaskQueueResponse.Builder task =
+        PollNexusTaskQueueResponse.newBuilder()
+            .setRequest(
+                Request.newBuilder()
+                    .setStartOperation(
+                        StartOperationRequest.newBuilder()
+                            .setOperation("operation")
+                            .setService("TestNexusService2")
+                            // The operation takes an Integer, so this input never deserializes
+                            .setPayload(dataConverter.toPayload("not an integer").get())
+                            .build()));
+
+    NexusTaskHandler.Result result =
+        nexusTaskHandlerImpl.handle(new NexusTask(task, null, null), metricsScope);
+    HandlerException e = result.getHandlerException();
+    Assert.assertNotNull(e);
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, e.getErrorType());
+    Assert.assertFalse(e.isRetryable());
+  }
+
+  @Test
   public void startAsyncSyncOperation() throws TimeoutException {
     WorkflowClient client = mock(WorkflowClient.class);
     NexusTaskHandlerImpl nexusTaskHandlerImpl =
@@ -400,6 +430,14 @@ public class NexusTaskHandlerImplTest {
             }
             return i;
           });
+    }
+  }
+
+  @ServiceImpl(service = TestNexusServices.TestNexusService2.class)
+  public class TestNexusServiceImpl2Echo {
+    @OperationImpl
+    public OperationHandler<Integer, Integer> operation() {
+      return OperationHandler.sync((ctx, details, i) -> i);
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
@@ -1,12 +1,23 @@
 package io.temporal.internal.nexus;
 
 import com.google.common.reflect.TypeToken;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.nexusrpc.handler.HandlerException;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DataConverterException;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.common.converter.EncodedValuesTest;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.payload.codec.PayloadCodecException;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -59,5 +70,148 @@ public class PayloadSerializerTest {
         WorkflowExecution.newBuilder().setWorkflowId("id").setRunId("runId").build();
     PayloadSerializer.Content content = payloadSerializer.serialize(exec);
     Assert.assertEquals(exec, payloadSerializer.deserialize(content, WorkflowExecution.class));
+  }
+
+  @Test
+  public void testDeserializeMalformedPayloadIsNonRetryableBadRequest() {
+    // Truncated varint, so these bytes are not a Payload and never will be.
+    PayloadSerializer.Content content =
+        PayloadSerializer.Content.newBuilder()
+            .setData(new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0xff})
+            .build();
+
+    HandlerException e =
+        Assert.assertThrows(
+            HandlerException.class, () -> payloadSerializer.deserialize(content, String.class));
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, e.getErrorType());
+    Assert.assertFalse(e.isRetryable());
+    Assert.assertTrue(e.getCause() instanceof InvalidProtocolBufferException);
+  }
+
+  @Test
+  public void testDeserializeWrongTypeIsNonRetryableBadRequest() {
+    PayloadSerializer.Content content = payloadSerializer.serialize("not an integer");
+
+    HandlerException e =
+        Assert.assertThrows(
+            HandlerException.class, () -> payloadSerializer.deserialize(content, Integer.class));
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, e.getErrorType());
+    Assert.assertFalse(e.isRetryable());
+    Assert.assertTrue(e.getCause() instanceof DataConverterException);
+  }
+
+  @Test
+  public void testDeserializeHandlerExceptionIsPropagatedAsIs() {
+    HandlerException original =
+        new HandlerException(HandlerException.ErrorType.NOT_FOUND, new RuntimeException("nope"));
+    PayloadSerializer serializer = failingSerializer(null, original);
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+
+    Assert.assertSame(
+        original,
+        Assert.assertThrows(
+            HandlerException.class, () -> serializer.deserialize(content, String.class)));
+  }
+
+  @Test
+  public void testDeserializeApplicationFailureIsPropagatedAsIs() {
+    ApplicationFailure original = ApplicationFailure.newNonRetryableFailure("bad", "TestFailure");
+    PayloadSerializer serializer = failingSerializer(null, original);
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+
+    Assert.assertSame(
+        original,
+        Assert.assertThrows(
+            ApplicationFailure.class, () -> serializer.deserialize(content, String.class)));
+  }
+
+  @Test
+  public void testDeserializeTransientFailureIsNotTranslated() {
+    // A payload codec outage is not the caller's fault and may succeed on a retry, so it must not
+    // be flattened into a non-retryable BAD_REQUEST.
+    PayloadCodecException original = new PayloadCodecException("codec server unavailable");
+    PayloadSerializer serializer = failingSerializer(null, original);
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+
+    Assert.assertSame(
+        original,
+        Assert.assertThrows(
+            PayloadCodecException.class, () -> serializer.deserialize(content, String.class)));
+  }
+
+  @Test
+  public void testDeserializeUnsupportedTypeIsNonRetryableInternal() {
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+    Type unsupported =
+        new GenericArrayType() {
+          @Override
+          public Type getGenericComponentType() {
+            return String.class;
+          }
+        };
+
+    HandlerException e =
+        Assert.assertThrows(
+            HandlerException.class, () -> payloadSerializer.deserialize(content, unsupported));
+    // A handler definition problem, so not reported as the caller's fault, but still permanent.
+    Assert.assertEquals(HandlerException.ErrorType.INTERNAL, e.getErrorType());
+    Assert.assertFalse(e.isRetryable());
+  }
+
+  @Test
+  public void testSerializeFailureIsPropagatedAsIs() {
+    // Result serialization failures are not translated, so they keep the default retryable
+    // INTERNAL handling applied by NexusTaskHandlerImpl.
+    RuntimeException original = new RuntimeException("cannot serialize");
+    PayloadSerializer serializer = failingSerializer(original, null);
+
+    Assert.assertSame(
+        original, Assert.assertThrows(RuntimeException.class, () -> serializer.serialize("test")));
+  }
+
+  @Test
+  public void testSerializeApplicationFailureIsPropagatedAsIs() {
+    // Result serialization is not translated either, which means a converter can still pick the
+    // outcome: NexusTaskHandlerImpl turns this into a non-retryable INTERNAL handler error.
+    ApplicationFailure original = ApplicationFailure.newNonRetryableFailure("bad", "TestFailure");
+    PayloadSerializer serializer = failingSerializer(original, null);
+
+    Assert.assertSame(
+        original,
+        Assert.assertThrows(ApplicationFailure.class, () -> serializer.serialize("test")));
+  }
+
+  /** A serializer whose underlying data converter fails in the requested direction. */
+  private static PayloadSerializer failingSerializer(
+      @Nullable RuntimeException onSerialize, @Nullable RuntimeException onDeserialize) {
+    return new PayloadSerializer(
+        new DataConverter() {
+          @Override
+          public <T> Optional<Payload> toPayload(T value) {
+            if (onSerialize != null) {
+              throw onSerialize;
+            }
+            return dataConverter.toPayload(value);
+          }
+
+          @Override
+          public <T> T fromPayload(Payload payload, Class<T> valueClass, Type valueType) {
+            if (onDeserialize != null) {
+              throw onDeserialize;
+            }
+            return dataConverter.fromPayload(payload, valueClass, valueType);
+          }
+
+          @Override
+          public Optional<Payloads> toPayloads(Object... values) {
+            return dataConverter.toPayloads(values);
+          }
+
+          @Override
+          public <T> T fromPayloads(
+              int index, Optional<Payloads> content, Class<T> valueType, Type valueGenericType) {
+            return dataConverter.fromPayloads(index, content, valueType, valueGenericType);
+          }
+        });
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusFailureOldFormatTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusFailureOldFormatTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 /**
- * Runs the OperationFailMetric suite with the old failure format forced via system property. This
+ * Runs the Nexus failure suites with the old failure format forced via system property. This
  * verifies that the test server correctly handles the old format (UnsuccessfulOperationError and
  * HandlerError) even though it advertises support for the new format.
  *
@@ -14,7 +14,11 @@ import org.junit.runners.Suite;
  * responses regardless of server capabilities.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({OperationFailMetricTest.class})
+@Suite.SuiteClasses({
+  OperationFailMetricTest.class,
+  OperationInputDeserializationFailTest.class,
+  OperationInputDeserializationErrorPropagationTest.class
+})
 public class NexusFailureOldFormatTest {
   private static String originalValue;
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
@@ -1,0 +1,255 @@
+package io.temporal.workflow.nexus;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+import io.nexusrpc.handler.HandlerException;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.common.converter.DataConverter;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.NexusOperationFailure;
+import io.temporal.failure.TimeoutFailure;
+import io.temporal.payload.codec.PayloadCodecException;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import org.junit.*;
+
+/**
+ * Verifies how a caller workflow sees failures a data converter raises while deserializing Nexus
+ * operation input. A {@link HandlerException} keeps the error type and retry behavior the converter
+ * chose, and an {@link ApplicationFailure} is wrapped by {@link
+ * io.temporal.internal.nexus.NexusTaskHandlerImpl} the same way one thrown from an operation
+ * handler is. Neither is rewritten to BAD_REQUEST, which is what happens to every other failure.
+ */
+public class OperationInputDeserializationErrorPropagationTest {
+  private static final String HANDLER_EXCEPTION = "handler-exception";
+  private static final String NON_RETRYABLE_APPLICATION_FAILURE =
+      "non-retryable-application-failure";
+  private static final String RETRYABLE_APPLICATION_FAILURE = "retryable-application-failure";
+  private static final String CODEC_FAILURE = "codec-failure";
+
+  private static final AtomicInteger deserializeAttempts = new AtomicInteger();
+  private static final AtomicInteger operationInvocations = new AtomicInteger();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestNexus.class)
+          .setNexusServiceImplementation(new PoisonInputServiceImpl())
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder()
+                  .setDataConverter(new PoisonInputDataConverter())
+                  .build())
+          .build();
+
+  // Check if we're forcing old format via system property
+  private static boolean isUsingNewFormat() {
+    return !("true".equalsIgnoreCase(System.getProperty("temporal.nexus.forceOldFailureFormat")));
+  }
+
+  @Before
+  public void setUp() {
+    deserializeAttempts.set(0);
+    operationInvocations.set(0);
+  }
+
+  private HandlerException executeAndGetHandlerException(String mode) {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    WorkflowFailedException workflowException =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(mode));
+    Assert.assertTrue(workflowException.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) workflowException.getCause();
+    Assert.assertTrue(
+        "expected a HandlerException, got " + nexusFailure.getCause(),
+        nexusFailure.getCause() instanceof HandlerException);
+    return (HandlerException) nexusFailure.getCause();
+  }
+
+  @Test
+  public void handlerExceptionKeepsItsErrorType() {
+    HandlerException handlerFailure = executeAndGetHandlerException(HANDLER_EXCEPTION);
+
+    // NOT_FOUND rather than the BAD_REQUEST every other deserialization failure is reported as,
+    // so this also proves the converter's choice was not overwritten.
+    Assert.assertEquals(HandlerException.ErrorType.NOT_FOUND, handlerFailure.getErrorType());
+    Assert.assertFalse(handlerFailure.isRetryable());
+
+    Assert.assertEquals(1, deserializeAttempts.get());
+    Assert.assertEquals(0, operationInvocations.get());
+  }
+
+  @Test
+  public void nonRetryableApplicationFailureBecomesNonRetryableInternal() {
+    HandlerException handlerFailure =
+        executeAndGetHandlerException(NON_RETRYABLE_APPLICATION_FAILURE);
+
+    Assert.assertEquals(HandlerException.ErrorType.INTERNAL, handlerFailure.getErrorType());
+    Assert.assertEquals(
+        HandlerException.RetryBehavior.NON_RETRYABLE, handlerFailure.getRetryBehavior());
+    Assert.assertFalse(handlerFailure.isRetryable());
+    if (isUsingNewFormat()) {
+      Assert.assertEquals(
+          "Handler failed with non-retryable application error", handlerFailure.getMessage());
+    }
+    Throwable cause = handlerFailure.getCause();
+    Assert.assertNotNull(cause);
+    Assert.assertTrue(cause.getMessage().contains("intentional failure"));
+
+    Assert.assertEquals(1, deserializeAttempts.get());
+    Assert.assertEquals(0, operationInvocations.get());
+  }
+
+  @Test(timeout = 30000)
+  public void retryableApplicationFailureIsRetried() {
+    assertRetriedUntilTimeout(RETRYABLE_APPLICATION_FAILURE);
+  }
+
+  /**
+   * A payload codec outage is not the caller's fault and may resolve on its own, so it must not be
+   * reported as a non-retryable BAD_REQUEST the way undeserializable input is.
+   */
+  @Test(timeout = 30000)
+  public void codecFailureIsRetried() {
+    assertRetriedUntilTimeout(CODEC_FAILURE);
+  }
+
+  private void assertRetriedUntilTimeout(String mode) {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+    WorkflowFailedException workflowException =
+        Assert.assertThrows(WorkflowFailedException.class, () -> workflowStub.execute(mode));
+
+    // Retried until the operation's schedule-to-close timeout, so the caller sees a timeout
+    // rather than the handler error itself.
+    Assert.assertTrue(workflowException.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) workflowException.getCause();
+    Assert.assertTrue(
+        "expected a TimeoutFailure, got " + nexusFailure.getCause(),
+        nexusFailure.getCause() instanceof TimeoutFailure);
+
+    Assert.assertTrue(
+        "expected more than one attempt, got " + deserializeAttempts.get(),
+        deserializeAttempts.get() > 1);
+    Assert.assertEquals(0, operationInvocations.get());
+  }
+
+  public static class TestNexus implements TestWorkflow1 {
+    @Override
+    public String execute(String mode) {
+      PoisonInputService service =
+          Workflow.newNexusServiceStub(
+              PoisonInputService.class,
+              NexusServiceOptions.newBuilder()
+                  .setOperationOptions(
+                      NexusOperationOptions.newBuilder()
+                          .setScheduleToCloseTimeout(Duration.ofSeconds(5))
+                          .build())
+                  .build());
+      return service.operation(new FailureMode(mode));
+    }
+  }
+
+  /** Operation input type the data converter refuses to deserialize. */
+  public static class FailureMode {
+    public String mode;
+
+    public FailureMode() {}
+
+    FailureMode(String mode) {
+      this.mode = mode;
+    }
+  }
+
+  @Service
+  public interface PoisonInputService {
+    @Operation
+    String operation(FailureMode input);
+  }
+
+  @ServiceImpl(service = PoisonInputService.class)
+  public static class PoisonInputServiceImpl {
+    @OperationImpl
+    public OperationHandler<FailureMode, String> operation() {
+      return OperationHandler.sync(
+          (ctx, details, input) -> {
+            operationInvocations.incrementAndGet();
+            return input.mode;
+          });
+    }
+  }
+
+  /**
+   * Delegates everything to the standard converter except deserializing a {@link FailureMode},
+   * which fails with the exception that value names.
+   */
+  private static class PoisonInputDataConverter implements DataConverter {
+    private final DataConverter delegate = DefaultDataConverter.STANDARD_INSTANCE;
+
+    @Override
+    public <T> Optional<Payload> toPayload(T value) {
+      return delegate.toPayload(value);
+    }
+
+    @Override
+    public Optional<Payloads> toPayloads(Object... values) {
+      return delegate.toPayloads(values);
+    }
+
+    @Override
+    public <T> T fromPayload(Payload payload, Class<T> valueClass, Type valueType) {
+      if (valueClass == FailureMode.class) {
+        deserializeAttempts.incrementAndGet();
+        throw failureFor(delegate.fromPayload(payload, FailureMode.class, FailureMode.class).mode);
+      }
+      return delegate.fromPayload(payload, valueClass, valueType);
+    }
+
+    @Override
+    public <T> T fromPayloads(
+        int index, Optional<Payloads> content, Class<T> valueType, Type valueGenericType) {
+      return delegate.fromPayloads(index, content, valueType, valueGenericType);
+    }
+
+    @Nonnull
+    @Override
+    public RuntimeException failureToException(@Nonnull Failure failure) {
+      return delegate.failureToException(failure);
+    }
+
+    @Nonnull
+    @Override
+    public Failure exceptionToFailure(@Nonnull Throwable throwable) {
+      return delegate.exceptionToFailure(throwable);
+    }
+
+    private static RuntimeException failureFor(String mode) {
+      switch (mode) {
+        case HANDLER_EXCEPTION:
+          return new HandlerException(
+              HandlerException.ErrorType.NOT_FOUND, new RuntimeException("intentional failure"));
+        case NON_RETRYABLE_APPLICATION_FAILURE:
+          return ApplicationFailure.newNonRetryableFailure("intentional failure", "TestFailure");
+        case RETRYABLE_APPLICATION_FAILURE:
+          return ApplicationFailure.newFailure("intentional failure", "TestFailure");
+        case CODEC_FAILURE:
+          return new PayloadCodecException("intentional failure");
+        default:
+          throw new IllegalStateException("unknown failure mode: " + mode);
+      }
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationFailTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationFailTest.java
@@ -1,0 +1,136 @@
+package io.temporal.workflow.nexus;
+
+import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
+
+import com.google.common.collect.ImmutableMap;
+import com.uber.m3.tally.RootScopeBuilder;
+import io.nexusrpc.handler.HandlerException;
+import io.nexusrpc.handler.OperationHandler;
+import io.nexusrpc.handler.OperationImpl;
+import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.common.reporter.TestStatsReporter;
+import io.temporal.failure.NexusOperationFailure;
+import io.temporal.serviceclient.MetricsTag;
+import io.temporal.testUtils.Eventually;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.MetricsType;
+import io.temporal.worker.WorkerMetricsTag;
+import io.temporal.workflow.*;
+import io.temporal.workflow.shared.TestNexusServices;
+import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.*;
+
+/**
+ * Verifies that a caller workflow sees input a handler cannot deserialize as a non-retryable {@link
+ * HandlerException.ErrorType#BAD_REQUEST} rather than as a retryable internal error that is retried
+ * until the operation's schedule-to-close timeout.
+ */
+public class OperationInputDeserializationFailTest {
+  private static final AtomicInteger operationInvocations = new AtomicInteger();
+
+  private final TestStatsReporter reporter = new TestStatsReporter();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestNexus.class)
+          .setNexusServiceImplementation(new TestNexusServiceImpl())
+          .setMetricsScope(
+              new RootScopeBuilder()
+                  .reporter(reporter)
+                  .reportEvery(com.uber.m3.util.Duration.ofMillis(10)))
+          .build();
+
+  // Check if we're forcing old format via system property
+  private static boolean isUsingNewFormat() {
+    return !("true".equalsIgnoreCase(System.getProperty("temporal.nexus.forceOldFailureFormat")));
+  }
+
+  @Before
+  public void setUp() {
+    operationInvocations.set(0);
+  }
+
+  @Test
+  public void inputDeserializationFailureIsNonRetryableBadRequest() {
+    TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflow1.class);
+
+    WorkflowFailedException workflowException =
+        Assert.assertThrows(
+            WorkflowFailedException.class,
+            () -> workflowStub.execute(testWorkflowRule.getNexusEndpoint().getSpec().getName()));
+
+    Assert.assertTrue(workflowException.getCause() instanceof NexusOperationFailure);
+    NexusOperationFailure nexusFailure = (NexusOperationFailure) workflowException.getCause();
+    Assert.assertEquals("TestNexusService2", nexusFailure.getService());
+    Assert.assertEquals("operation", nexusFailure.getOperation());
+
+    // The caller sees the handler error itself. Had it stayed retryable, the operation would have
+    // been retried until the schedule-to-close timeout and surfaced as a timeout instead.
+    Assert.assertTrue(nexusFailure.getCause() instanceof HandlerException);
+    HandlerException handlerFailure = (HandlerException) nexusFailure.getCause();
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, handlerFailure.getErrorType());
+    Assert.assertFalse(handlerFailure.isRetryable());
+    if (isUsingNewFormat()) {
+      Assert.assertTrue(handlerFailure.getMessage().contains("failed to deserialize input"));
+    }
+
+    // Input is deserialized before the operation handler runs, so user code is never reached.
+    Assert.assertEquals(0, operationInvocations.get());
+
+    // Reported under the BAD_REQUEST failure type. The no-retry guarantee is the assertion above
+    // that the caller got the handler error rather than a timeout, since assertEventually returns
+    // on the first successful evaluation and would not see a later attempt.
+    Map<String, String> execFailedTags =
+        ImmutableMap.<String, String>builder()
+            .putAll(MetricsTag.defaultTags(NAMESPACE))
+            .put(MetricsTag.WORKER_TYPE, WorkerMetricsTag.WorkerType.NEXUS_WORKER.getValue())
+            .put(MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue())
+            .put(MetricsTag.NEXUS_SERVICE, "TestNexusService2")
+            .put(MetricsTag.NEXUS_OPERATION, "operation")
+            .put(
+                MetricsTag.TASK_FAILURE_TYPE,
+                MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_BAD_REQUEST)
+            .buildKeepingLast();
+    Eventually.assertEventually(
+        Duration.ofSeconds(3),
+        () -> reporter.assertCounter(MetricsType.NEXUS_EXEC_FAILED_COUNTER, execFailedTags, 1));
+  }
+
+  public static class TestNexus implements TestWorkflow1 {
+    @Override
+    public String execute(String endpoint) {
+      NexusServiceOptions serviceOptions =
+          NexusServiceOptions.newBuilder()
+              .setEndpoint(endpoint)
+              .setOperationOptions(
+                  NexusOperationOptions.newBuilder()
+                      .setScheduleToCloseTimeout(Duration.ofSeconds(10))
+                      .build())
+              .build();
+      // An untyped stub lets the caller send an input the handler cannot deserialize, the way a
+      // caller built against an incompatible version of the service would.
+      NexusServiceStub serviceStub =
+          Workflow.newUntypedNexusServiceStub("TestNexusService2", serviceOptions);
+      // The operation takes an Integer.
+      return serviceStub.execute("operation", String.class, "not an integer");
+    }
+  }
+
+  @ServiceImpl(service = TestNexusServices.TestNexusService2.class)
+  public static class TestNexusServiceImpl {
+    @OperationImpl
+    public OperationHandler<Integer, Integer> operation() {
+      return OperationHandler.sync(
+          (ctx, details, i) -> {
+            operationInvocations.incrementAndGet();
+            return i;
+          });
+    }
+  }
+}


### PR DESCRIPTION
io.nexusrpc:nexus-sdk 0.6.0-alpha no longer wraps serializer errors in a generic RuntimeException (nexus-rpc/sdk-java#47), so PayloadSerializer is now the place that decides the error type and retry behavior for them.

Failures deserializing Nexus operation input are reported as a non-retryable HandlerException with error type BAD_REQUEST. A HandlerException or ApplicationFailure raised by the data converter is propagated as-is, so a converter can pick its own error type and retry behavior. Result serialization is deliberately left alone and keeps the retryable INTERNAL default applied by NexusTaskHandlerImpl.

BREAKING CHANGE: input a handler cannot deserialize previously failed with a retryable INTERNAL handler error and was retried until the operation's schedule-to-close timeout. It now fails immediately with a non-retryable BAD_REQUEST.
