### PR TITLE
💥 Fix unbounded timeout failure chain in local activity 

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -502,7 +502,8 @@ final class SyncWorkflowContext implements WorkflowContext, WorkflowOutboundCall
                               input,
                               originalScheduledTime,
                               laException.getLastAttempt() + 1,
-                              laException.getFailure(),
+                              // Carry the attempt failure, not the local ActivityFailure wrapper.
+                              laException.getFailure().getCause(),
                               result);
                           return null;
                         });

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
@@ -28,7 +28,7 @@ import org.junit.*;
 
 public class LocalActivityRetryOverLocalBackoffThresholdTest {
 
-  private static final int TIMEOUT_ATTEMPTS = 53;
+  private static final int TIMEOUT_ATTEMPTS = 3;
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -100,12 +100,12 @@ public class LocalActivityRetryOverLocalBackoffThresholdTest {
     controlledActivity.verifyAttempts();
   }
 
-  @Test(timeout = 120_000)
+  @Test
   public void repeatedTimeoutsDoNotBuildAnUnboundedFailureChain() {
     Worker worker = testWorkflowRule.getWorker();
     ControlledActivityImpl activity =
         new ControlledActivityImpl(
-            Collections.singletonList(ControlledActivityImpl.Outcome.SLEEP), TIMEOUT_ATTEMPTS, 100);
+            Collections.singletonList(ControlledActivityImpl.Outcome.SLEEP), TIMEOUT_ATTEMPTS, 1);
     worker.registerActivitiesImplementations(activity);
     worker.registerWorkflowImplementationTypes(TimingOutWorkflowImpl.class);
     testWorkflowRule.getTestEnvironment().start();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityRetryOverLocalBackoffThresholdTest.java
@@ -6,11 +6,13 @@ import io.temporal.activity.LocalActivityOptions;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.enums.v1.RetryState;
+import io.temporal.api.enums.v1.TimeoutType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowException;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ActivityFailure;
+import io.temporal.failure.TimeoutFailure;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.Workflow;
@@ -25,6 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.*;
 
 public class LocalActivityRetryOverLocalBackoffThresholdTest {
+
+  private static final int TIMEOUT_ATTEMPTS = 53;
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -96,6 +100,35 @@ public class LocalActivityRetryOverLocalBackoffThresholdTest {
     controlledActivity.verifyAttempts();
   }
 
+  @Test(timeout = 120_000)
+  public void repeatedTimeoutsDoNotBuildAnUnboundedFailureChain() {
+    Worker worker = testWorkflowRule.getWorker();
+    ControlledActivityImpl activity =
+        new ControlledActivityImpl(
+            Collections.singletonList(ControlledActivityImpl.Outcome.SLEEP), TIMEOUT_ATTEMPTS, 100);
+    worker.registerActivitiesImplementations(activity);
+    worker.registerWorkflowImplementationTypes(TimingOutWorkflowImpl.class);
+    testWorkflowRule.getTestEnvironment().start();
+
+    TestWorkflows.TestWorkflow1 workflowStub =
+        testWorkflowRule.newWorkflowStubTimeoutOptions(TestWorkflows.TestWorkflow1.class);
+
+    WorkflowException e =
+        assertThrows(
+            WorkflowException.class, () -> workflowStub.execute(testWorkflowRule.getTaskQueue()));
+    assertTrue(e.getCause() instanceof ActivityFailure);
+    ActivityFailure activityFailure = (ActivityFailure) e.getCause();
+    assertEquals(RetryState.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED, activityFailure.getRetryState());
+    assertTrue(activityFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure timeoutFailure = (TimeoutFailure) activityFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, timeoutFailure.getTimeoutType());
+    assertTrue(timeoutFailure.getCause() instanceof TimeoutFailure);
+    TimeoutFailure previousTimeoutFailure = (TimeoutFailure) timeoutFailure.getCause();
+    assertEquals(TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE, previousTimeoutFailure.getTimeoutType());
+    assertNull(previousTimeoutFailure.getCause());
+    activity.verifyAttempts();
+  }
+
   public static class TestWorkflowImpl implements TestWorkflows.TestWorkflow1 {
 
     @Override
@@ -142,6 +175,27 @@ public class LocalActivityRetryOverLocalBackoffThresholdTest {
       activities.execute(taskQueue);
 
       return "ignored";
+    }
+  }
+
+  public static class TimingOutWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+
+    @Override
+    public String execute(String taskQueue) {
+      LocalActivityOptions options =
+          LocalActivityOptions.newBuilder()
+              .setStartToCloseTimeout(Duration.ofMillis(10))
+              .setLocalRetryThreshold(Duration.ofMillis(1))
+              .setRetryOptions(
+                  RetryOptions.newBuilder()
+                      .setInitialInterval(Duration.ofMillis(2))
+                      .setBackoffCoefficient(1)
+                      .setMaximumAttempts(TIMEOUT_ATTEMPTS)
+                      .build())
+              .build();
+      TestActivities.NoArgsReturnsStringActivity activity =
+          Workflow.newLocalActivityStub(TestActivities.NoArgsReturnsStringActivity.class, options);
+      return activity.execute();
     }
   }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Local activities retried across the local-retry threshold were carrying the entire ActivityFailure wrapper into each new attempt. Repeated timeouts therefore created an unbounded nested failure chain, cuasing oversized histories or serialization failures.

## Why?

Was causing the failure to grow very large and even fail the workflow it got so large.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-java/issues/3005

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core local-activity retry and failure propagation in the workflow sync path; behavior change is narrow but could affect failure shape seen by workflows and history markers.
> 
> **Overview**
> Fixes local activity retries that cross the **local retry threshold** so they no longer grow an unbounded nested failure chain on repeated failures (e.g. timeouts).
> 
> When scheduling the next attempt after backoff, `SyncWorkflowContext` now passes **`laException.getFailure().getCause()`** as `previousExecutionFailure` instead of the full wrapper failure. That keeps only the underlying attempt failure (e.g. `TimeoutFailure`) linked across attempts, avoiding oversized workflow history and serialization blowups.
> 
> A new integration test **`repeatedTimeoutsDoNotBuildAnUnboundedFailureChain`** asserts that after max attempts the surfaced `ActivityFailure` has at most two chained `TimeoutFailure` nodes, with the oldest having no further cause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1786ea1466d71971431084471367493dbc1684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->