### PR TITLE
Report non-retryable PayloadValidationError as BAD_REQUEST

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/PayloadSerializer.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/PayloadSerializer.java
@@ -21,10 +21,12 @@ import javax.annotation.Nullable;
  * reports for them is decided here.
  *
  * <p>Input that will never decode into the expected type is the caller's fault and is reported as a
- * non-retryable {@link HandlerException.ErrorType#BAD_REQUEST}. Any other failure on the way to the
- * value, a {@link io.temporal.payload.codec.PayloadCodec} outage for example, may well succeed on a
- * retry, so it is left to the handling in {@link NexusTaskHandlerImpl} that a failure from an
- * operation handler would get.
+ * non-retryable {@link HandlerException.ErrorType#BAD_REQUEST}. A data converter can also opt into
+ * that treatment for input it decoded but rejected, by throwing a non-retryable {@link
+ * ApplicationFailure} of type {@value #PAYLOAD_VALIDATION_ERROR_TYPE}. Any other failure on the way
+ * to the value, a {@link io.temporal.payload.codec.PayloadCodec} outage for example, may well
+ * succeed on a retry, so it is left to the handling in {@link NexusTaskHandlerImpl} that a failure
+ * from an operation handler would get.
  *
  * <p>Serializing an operation result is not translated at all. Note that this still means a
  * converter can choose the outcome: a non-retryable {@link ApplicationFailure} raised while
@@ -32,6 +34,13 @@ import javax.annotation.Nullable;
  * NexusTaskHandlerImpl}, and anything else keeps the retryable {@code INTERNAL} default.
  */
 class PayloadSerializer implements Serializer {
+  /**
+   * {@link ApplicationFailure#getType()} a data converter uses to say it understood the input but
+   * considers it invalid. When non-retryable, it is reported as {@link
+   * HandlerException.ErrorType#BAD_REQUEST} rather than as a handler-side {@code INTERNAL} error.
+   */
+  static final String PAYLOAD_VALIDATION_ERROR_TYPE = "PayloadValidationError";
+
   private final DataConverter dataConverter;
 
   PayloadSerializer(DataConverter dataConverter) {
@@ -64,7 +73,16 @@ class PayloadSerializer implements Serializer {
             null,
             HandlerException.RetryBehavior.NON_RETRYABLE);
       }
-    } catch (HandlerException | ApplicationFailure e) {
+    } catch (ApplicationFailure e) {
+      if (e.isNonRetryable() && PAYLOAD_VALIDATION_ERROR_TYPE.equals(e.getType())) {
+        // The data converter decoded the input and rejected it, so this is the caller's fault
+        // rather than a handler-side error.
+        throw new HandlerException(
+            HandlerException.ErrorType.BAD_REQUEST, "invalid operation input", e);
+      }
+      // Otherwise the data converter already picked an error type and retry behavior, keep them.
+      throw e;
+    } catch (HandlerException e) {
       // The data converter already picked an error type and retry behavior, keep them.
       throw e;
     } catch (InvalidProtocolBufferException | DataConverterException e) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
@@ -126,6 +126,59 @@ public class PayloadSerializerTest {
   }
 
   @Test
+  public void testDeserializeNonRetryablePayloadValidationErrorIsNonRetryableBadRequest() {
+    // The converter understood the input and rejected it, which makes this the caller's fault.
+    RuntimeException cause = new RuntimeException("field 'name' must not be empty");
+    ApplicationFailure original =
+        ApplicationFailure.newNonRetryableFailureWithCause(
+            "invalid input", PayloadSerializer.PAYLOAD_VALIDATION_ERROR_TYPE, cause);
+    PayloadSerializer serializer = failingSerializer(null, original);
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+
+    HandlerException e =
+        Assert.assertThrows(
+            HandlerException.class, () -> serializer.deserialize(content, String.class));
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, e.getErrorType());
+    Assert.assertFalse(e.isRetryable());
+    Assert.assertEquals("invalid operation input", e.getMessage());
+    // The converter's own message is not in the wrapper, so it has to survive on the cause.
+    Assert.assertSame(original, e.getCause());
+    Assert.assertEquals("invalid input", original.getOriginalMessage());
+    Assert.assertSame(cause, e.getCause().getCause());
+  }
+
+  @Test
+  public void testDeserializeNonRetryableOtherApplicationFailureTypeIsPropagatedAsIs() {
+    // Only the PayloadValidationError type opts into BAD_REQUEST, everything else keeps the
+    // non-retryable INTERNAL handling NexusTaskHandlerImpl applies.
+    ApplicationFailure original =
+        ApplicationFailure.newNonRetryableFailure("invalid input", "SomeOtherValidationError");
+    PayloadSerializer serializer = failingSerializer(null, original);
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+
+    Assert.assertSame(
+        original,
+        Assert.assertThrows(
+            ApplicationFailure.class, () -> serializer.deserialize(content, String.class)));
+  }
+
+  @Test
+  public void testDeserializeRetryablePayloadValidationErrorIsPropagatedAsIs() {
+    // A retryable failure may succeed on a retry, so the type alone must not make it a
+    // non-retryable BAD_REQUEST.
+    ApplicationFailure original =
+        ApplicationFailure.newFailure(
+            "invalid input", PayloadSerializer.PAYLOAD_VALIDATION_ERROR_TYPE);
+    PayloadSerializer serializer = failingSerializer(null, original);
+    PayloadSerializer.Content content = payloadSerializer.serialize("test");
+
+    Assert.assertSame(
+        original,
+        Assert.assertThrows(
+            ApplicationFailure.class, () -> serializer.deserialize(content, String.class)));
+  }
+
+  @Test
   public void testDeserializeTransientFailureIsNotTranslated() {
     // A payload codec outage is not the caller's fault and may succeed on a retry, so it must not
     // be flattened into a non-retryable BAD_REQUEST.

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
@@ -142,9 +142,15 @@ public class PayloadSerializerTest {
     Assert.assertFalse(e.isRetryable());
     Assert.assertEquals("invalid operation input", e.getMessage());
     // The converter's own message is not in the wrapper, so it has to survive on the cause.
-    Assert.assertSame(original, e.getCause());
-    Assert.assertEquals("invalid input", original.getOriginalMessage());
-    Assert.assertSame(cause, e.getCause().getCause());
+    Assert.assertTrue(
+        "expected an ApplicationFailure cause, got " + e.getCause(),
+        e.getCause() instanceof ApplicationFailure);
+    ApplicationFailure causeFailure = (ApplicationFailure) e.getCause();
+    Assert.assertSame(original, causeFailure);
+    Assert.assertEquals(PayloadSerializer.PAYLOAD_VALIDATION_ERROR_TYPE, causeFailure.getType());
+    Assert.assertTrue(causeFailure.isNonRetryable());
+    Assert.assertEquals("invalid input", causeFailure.getOriginalMessage());
+    Assert.assertSame(cause, causeFailure.getCause());
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
@@ -32,13 +32,20 @@ import org.junit.*;
  * operation input. A {@link HandlerException} keeps the error type and retry behavior the converter
  * chose, and an {@link ApplicationFailure} is wrapped by {@link
  * io.temporal.internal.nexus.NexusTaskHandlerImpl} the same way one thrown from an operation
- * handler is. Neither is rewritten to BAD_REQUEST, which is what happens to every other failure.
+ * handler is. Neither is rewritten to BAD_REQUEST, which is what happens to every other failure,
+ * with one exception: a non-retryable {@code PayloadValidationError} is the converter's way of
+ * saying the input itself was invalid, so it is reported as a non-retryable BAD_REQUEST.
  */
 public class OperationInputDeserializationErrorPropagationTest {
   private static final String HANDLER_EXCEPTION = "handler-exception";
   private static final String NON_RETRYABLE_APPLICATION_FAILURE =
       "non-retryable-application-failure";
   private static final String RETRYABLE_APPLICATION_FAILURE = "retryable-application-failure";
+  private static final String NON_RETRYABLE_PAYLOAD_VALIDATION_ERROR =
+      "non-retryable-payload-validation-error";
+  private static final String RETRYABLE_PAYLOAD_VALIDATION_ERROR =
+      "retryable-payload-validation-error";
+  private static final String PAYLOAD_VALIDATION_ERROR_TYPE = "PayloadValidationError";
   private static final String CODEC_FAILURE = "codec-failure";
 
   private static final AtomicInteger deserializeAttempts = new AtomicInteger();
@@ -116,6 +123,38 @@ public class OperationInputDeserializationErrorPropagationTest {
   @Test(timeout = 30000)
   public void retryableApplicationFailureIsRetried() {
     assertRetriedUntilTimeout(RETRYABLE_APPLICATION_FAILURE);
+  }
+
+  @Test
+  public void nonRetryablePayloadValidationErrorBecomesNonRetryableBadRequest() {
+    HandlerException handlerFailure =
+        executeAndGetHandlerException(NON_RETRYABLE_PAYLOAD_VALIDATION_ERROR);
+
+    // BAD_REQUEST rather than the INTERNAL every other non-retryable ApplicationFailure gets.
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, handlerFailure.getErrorType());
+    Assert.assertFalse(handlerFailure.isRetryable());
+    if (isUsingNewFormat()) {
+      Assert.assertEquals("invalid operation input", handlerFailure.getMessage());
+    }
+    // The wrapper message does not carry the converter's own message, so it has to survive on the
+    // cause for the caller to see why the input was rejected.
+    Throwable cause = handlerFailure.getCause();
+    Assert.assertNotNull(cause);
+    Assert.assertTrue(
+        "expected the converter's message on the cause, got " + cause.getMessage(),
+        cause.getMessage().contains("intentional failure"));
+
+    Assert.assertEquals(1, deserializeAttempts.get());
+    Assert.assertEquals(0, operationInvocations.get());
+  }
+
+  /**
+   * The PayloadValidationError type only opts into BAD_REQUEST when the failure is non-retryable,
+   * so a retryable one keeps being retried.
+   */
+  @Test(timeout = 30000)
+  public void retryablePayloadValidationErrorIsRetried() {
+    assertRetriedUntilTimeout(RETRYABLE_PAYLOAD_VALIDATION_ERROR);
   }
 
   /**
@@ -245,6 +284,12 @@ public class OperationInputDeserializationErrorPropagationTest {
           return ApplicationFailure.newNonRetryableFailure("intentional failure", "TestFailure");
         case RETRYABLE_APPLICATION_FAILURE:
           return ApplicationFailure.newFailure("intentional failure", "TestFailure");
+        case NON_RETRYABLE_PAYLOAD_VALIDATION_ERROR:
+          return ApplicationFailure.newNonRetryableFailure(
+              "intentional failure", PAYLOAD_VALIDATION_ERROR_TYPE);
+        case RETRYABLE_PAYLOAD_VALIDATION_ERROR:
+          return ApplicationFailure.newFailure(
+              "intentional failure", PAYLOAD_VALIDATION_ERROR_TYPE);
         case CODEC_FAILURE:
           return new PayloadCodecException("intentional failure");
         default:

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
@@ -141,6 +141,9 @@ public class OperationInputDeserializationErrorPropagationTest {
     Throwable cause = handlerFailure.getCause();
     Assert.assertNotNull(cause);
     Assert.assertTrue(
+        "expected an ApplicationFailure cause, got " + cause, cause instanceof ApplicationFailure);
+    Assert.assertEquals("PayloadValidationError", ((ApplicationFailure) cause).getType());
+    Assert.assertTrue(
         "expected the converter's message on the cause, got " + cause.getMessage(),
         cause.getMessage().contains("intentional failure"));
 


### PR DESCRIPTION
## What changed

A data converter can now signal that a Nexus operation's input is invalid by throwing a non-retryable `ApplicationFailure` of type `PayloadValidationError` while deserializing the input. `PayloadSerializer` translates such a failure into a `BAD_REQUEST` `HandlerException` with the message `invalid operation input`, retaining the original failure as its cause.

Previously any `ApplicationFailure` from the data converter propagated and was turned into an `INTERNAL` handler error by `NexusTaskHandlerImpl`, which callers retry — so a caller sending invalid input was retried until timeout instead of failing fast.

## Unchanged

- `ApplicationFailure` of any other type → propagated as before (`INTERNAL`)
- A **retryable** `PayloadValidationError` → propagated as before (`INTERNAL`); non-retryable is required
- `HandlerException` from the converter → passed through untouched
- `InvalidProtocolBufferException` / `DataConverterException` → `BAD_REQUEST` as before
- `serialize()` is untouched — `BAD_REQUEST` would be wrong for a result-encoding failure

## Tests

- `PayloadSerializerTest`: positive case asserting `BAD_REQUEST`, non-retryable, the wrapper message and the preserved cause; negative cases for a different error type and for a retryable `PayloadValidationError`.
- `OperationInputDeserializationErrorPropagationTest`: end-to-end through the test server, including a retryable case that proves the non-retryable guard by being retried.

## Cross-SDK

Part of a coordinated change; equivalent PRs exist for Go, TypeScript, Python and .NET. The wrapper message wording is aligned across SDKs, adapted to each SDK's message style.