### PR TITLE
External Storage Integration: WorkflowWorker, replay, history

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandler.java
@@ -175,7 +175,9 @@ class ReplayWorkflowRunTaskHandler implements WorkflowRunTaskHandler {
               .setForceWorkflowTask(
                   localActivityTaskCount > 0 && !context.isWorkflowMethodCompleted())
               .setNonfirstLocalActivityAttempts(localActivityMeteringHelper.getNonfirstAttempts())
-              .setSdkFlags(newSdkFlags);
+              .setSdkFlags(newSdkFlags)
+              .setParentWorkflowExecution(context.getParentWorkflowExecution())
+              .setContinuedAsNew(context.getContinuedExecutionRunId().isPresent());
       if (workflowStateMachines.sdkNameToWrite() != null) {
         result.setWriteSdkName(workflowStateMachines.sdkNameToWrite());
       }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -23,6 +23,7 @@ import io.temporal.api.workflowservice.v1.*;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.common.WorkflowExecutionUtils;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.worker.*;
 import io.temporal.payload.context.WorkflowSerializationContext;
 import io.temporal.serviceclient.MetricsTag;
@@ -77,6 +78,12 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     String workflowType = workflowTask.getWorkflowType().getName();
     Scope metricsScope =
         options.getMetricsScope().tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, workflowType));
+    ExternalStorageRunner externalStorage = options.getExternalStorage();
+    if (externalStorage == null) {
+      ExternalStorageRunner.throwIfContainsReference(workflowTask);
+    } else {
+      workflowTask = externalStorage.retrieve(workflowTask);
+    }
     return handleWorkflowTaskWithQuery(workflowTask.toBuilder(), metricsScope);
   }
 
@@ -94,7 +101,8 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       logWorkflowTaskToBeProcessed(workflowTask, createdNew);
 
       ServiceWorkflowHistoryIterator historyIterator =
-          new ServiceWorkflowHistoryIterator(service, namespace, workflowTask, metricsScope);
+          new ServiceWorkflowHistoryIterator(
+              service, namespace, workflowTask, metricsScope, options.getExternalStorage());
       boolean finalCommand;
       Result result;
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -166,7 +166,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       }
 
       return result;
-    } catch (InterruptedException e) {
+    } catch (InterruptedException | CancellationException e) {
       throw e;
     } catch (Throwable e) {
       // Note here that the executor might not be in the cache, even when the caching is on. In that

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -20,6 +20,7 @@ import io.temporal.api.sdk.v1.WorkflowTaskCompletedMetadata;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.common.CancellationToken;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.common.WorkflowExecutionUtils;
@@ -82,7 +83,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     if (externalStorage == null) {
       ExternalStorageRunner.throwIfContainsReference(workflowTask);
     } else {
-      workflowTask = externalStorage.retrieve(workflowTask);
+      workflowTask = externalStorage.retrieve(workflowTask, CancellationToken.none());
     }
     return handleWorkflowTaskWithQuery(workflowTask.toBuilder(), metricsScope);
   }
@@ -407,7 +408,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       if (externalStorage == null) {
         ExternalStorageRunner.throwIfContainsReference(getHistoryResponse);
       } else {
-        getHistoryResponse = externalStorage.retrieve(getHistoryResponse);
+        getHistoryResponse = externalStorage.retrieve(getHistoryResponse, CancellationToken.none());
       }
       workflowTask
           .setHistory(getHistoryResponse.getHistory())

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -403,6 +403,12 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
               .blockingStub()
               .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
               .getWorkflowExecutionHistory(getHistoryRequest);
+      ExternalStorageRunner externalStorage = options.getExternalStorage();
+      if (externalStorage == null) {
+        ExternalStorageRunner.throwIfContainsReference(getHistoryResponse);
+      } else {
+        getHistoryResponse = externalStorage.retrieve(getHistoryResponse);
+      }
       workflowTask
           .setHistory(getHistoryResponse.getHistory())
           .setNextPageToken(getHistoryResponse.getNextPageToken());

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -104,11 +104,11 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     String workflowType = workflowTask.getWorkflowType().getName();
     Scope metricsScope =
         options.getMetricsScope().tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, workflowType));
-    ExternalStorageRunner externalStorage = options.getExternalStorage();
-    if (externalStorage == null) {
+    ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
+    if (externalStorageRunner == null) {
       ExternalStorageRunner.throwIfContainsReference(workflowTask);
     } else {
-      workflowTask = externalStorage.retrieve(workflowTask, storageCancellation);
+      workflowTask = externalStorageRunner.retrieve(workflowTask, storageCancellation);
     }
     return handleWorkflowTaskWithQuery(workflowTask.toBuilder(), metricsScope);
   }
@@ -132,7 +132,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
               namespace,
               workflowTask,
               metricsScope,
-              options.getExternalStorage(),
+              options.getExternalStorageRunner(),
               storageCancellation);
       boolean finalCommand;
       Result result;
@@ -434,11 +434,12 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
               .blockingStub()
               .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
               .getWorkflowExecutionHistory(getHistoryRequest);
-      ExternalStorageRunner externalStorage = options.getExternalStorage();
-      if (externalStorage == null) {
+      ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
+      if (externalStorageRunner == null) {
         ExternalStorageRunner.throwIfContainsReference(getHistoryResponse);
       } else {
-        getHistoryResponse = externalStorage.retrieve(getHistoryResponse, storageCancellation);
+        getHistoryResponse =
+            externalStorageRunner.retrieve(getHistoryResponse, storageCancellation);
       }
       workflowTask
           .setHistory(getHistoryResponse.getHistory())

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -292,7 +292,8 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
         null,
         result.isFinalCommand(),
         eventIdSetHandle,
-        result.getApplyPostCompletionMetrics());
+        result.getApplyPostCompletionMetrics(),
+        result.isContinuedAsNew() ? null : result.getParentWorkflowExecution());
   }
 
   private Result failureToWFTResult(

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -104,12 +104,6 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     String workflowType = workflowTask.getWorkflowType().getName();
     Scope metricsScope =
         options.getMetricsScope().tagged(ImmutableMap.of(MetricsTag.WORKFLOW_TYPE, workflowType));
-    ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
-    if (externalStorageRunner == null) {
-      ExternalStorageRunner.throwIfContainsReference(workflowTask);
-    } else {
-      workflowTask = externalStorageRunner.retrieve(workflowTask, storageCancellation);
-    }
     return handleWorkflowTaskWithQuery(workflowTask.toBuilder(), metricsScope);
   }
 
@@ -122,6 +116,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     boolean useCache = stickyTaskQueue != null;
 
     try {
+      workflowTask = retrieveStoredPayloads(workflowTask);
       workflowRunTaskHandler =
           getOrCreateWorkflowExecutor(useCache, workflowTask, metricsScope, createdNew);
       logWorkflowTaskToBeProcessed(workflowTask, createdNew);
@@ -207,6 +202,16 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
         workflowRunTaskHandler.close();
       }
     }
+  }
+
+  private PollWorkflowTaskQueueResponse.Builder retrieveStoredPayloads(
+      PollWorkflowTaskQueueResponse.Builder workflowTask) {
+    ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
+    if (externalStorageRunner == null) {
+      ExternalStorageRunner.throwIfContainsReference(workflowTask.build());
+      return workflowTask;
+    }
+    return externalStorageRunner.retrieve(workflowTask.build(), storageCancellation).toBuilder();
   }
 
   private Result createCompletedWFTRequest(

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -20,7 +20,6 @@ import io.temporal.api.sdk.v1.WorkflowTaskCompletedMetadata;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.taskqueue.v1.TaskQueue;
 import io.temporal.api.workflowservice.v1.*;
-import io.temporal.common.CancellationToken;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.common.WorkflowExecutionUtils;
@@ -54,7 +53,6 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
   private final WorkflowServiceStubs service;
   private final TaskQueue stickyTaskQueue;
   private final LocalActivityDispatcher localActivityDispatcher;
-  private final CancellationToken<CancellationException> storageCancellation;
 
   public ReplayWorkflowTaskHandler(
       String namespace,
@@ -65,29 +63,6 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       Duration stickyTaskQueueScheduleToStartTimeout,
       WorkflowServiceStubs service,
       LocalActivityDispatcher localActivityDispatcher) {
-    this(
-        namespace,
-        asyncWorkflowFactory,
-        cache,
-        options,
-        stickyTaskQueue,
-        stickyTaskQueueScheduleToStartTimeout,
-        service,
-        localActivityDispatcher,
-        CancellationToken.none());
-  }
-
-  public ReplayWorkflowTaskHandler(
-      String namespace,
-      ReplayWorkflowFactory asyncWorkflowFactory,
-      WorkflowExecutorCache cache,
-      SingleWorkerOptions options,
-      TaskQueue stickyTaskQueue,
-      Duration stickyTaskQueueScheduleToStartTimeout,
-      WorkflowServiceStubs service,
-      LocalActivityDispatcher localActivityDispatcher,
-      CancellationToken<CancellationException> storageCancellation) {
-    this.storageCancellation = storageCancellation;
     this.namespace = namespace;
     this.workflowFactory = asyncWorkflowFactory;
     this.cache = cache;
@@ -128,7 +103,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
               workflowTask,
               metricsScope,
               options.getExternalStorageRunner(),
-              storageCancellation);
+              options.getStorageCancellation());
       boolean finalCommand;
       Result result;
 
@@ -211,7 +186,9 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       ExternalStorageRunner.throwIfContainsReference(workflowTask.build());
       return workflowTask;
     }
-    return externalStorageRunner.retrieve(workflowTask.build(), storageCancellation).toBuilder();
+    return externalStorageRunner
+        .retrieve(workflowTask.build(), options.getStorageCancellation())
+        .toBuilder();
   }
 
   private Result createCompletedWFTRequest(
@@ -445,7 +422,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
         ExternalStorageRunner.throwIfContainsReference(getHistoryResponse);
       } else {
         getHistoryResponse =
-            externalStorageRunner.retrieve(getHistoryResponse, storageCancellation);
+            externalStorageRunner.retrieve(getHistoryResponse, options.getStorageCancellation());
       }
       workflowTask
           .setHistory(getHistoryResponse.getHistory())

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java
@@ -36,6 +36,7 @@ import java.io.StringWriter;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -53,6 +54,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
   private final WorkflowServiceStubs service;
   private final TaskQueue stickyTaskQueue;
   private final LocalActivityDispatcher localActivityDispatcher;
+  private final CancellationToken<CancellationException> storageCancellation;
 
   public ReplayWorkflowTaskHandler(
       String namespace,
@@ -63,6 +65,29 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       Duration stickyTaskQueueScheduleToStartTimeout,
       WorkflowServiceStubs service,
       LocalActivityDispatcher localActivityDispatcher) {
+    this(
+        namespace,
+        asyncWorkflowFactory,
+        cache,
+        options,
+        stickyTaskQueue,
+        stickyTaskQueueScheduleToStartTimeout,
+        service,
+        localActivityDispatcher,
+        CancellationToken.none());
+  }
+
+  public ReplayWorkflowTaskHandler(
+      String namespace,
+      ReplayWorkflowFactory asyncWorkflowFactory,
+      WorkflowExecutorCache cache,
+      SingleWorkerOptions options,
+      TaskQueue stickyTaskQueue,
+      Duration stickyTaskQueueScheduleToStartTimeout,
+      WorkflowServiceStubs service,
+      LocalActivityDispatcher localActivityDispatcher,
+      CancellationToken<CancellationException> storageCancellation) {
+    this.storageCancellation = storageCancellation;
     this.namespace = namespace;
     this.workflowFactory = asyncWorkflowFactory;
     this.cache = cache;
@@ -83,7 +108,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
     if (externalStorage == null) {
       ExternalStorageRunner.throwIfContainsReference(workflowTask);
     } else {
-      workflowTask = externalStorage.retrieve(workflowTask, CancellationToken.none());
+      workflowTask = externalStorage.retrieve(workflowTask, storageCancellation);
     }
     return handleWorkflowTaskWithQuery(workflowTask.toBuilder(), metricsScope);
   }
@@ -103,7 +128,12 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
 
       ServiceWorkflowHistoryIterator historyIterator =
           new ServiceWorkflowHistoryIterator(
-              service, namespace, workflowTask, metricsScope, options.getExternalStorage());
+              service,
+              namespace,
+              workflowTask,
+              metricsScope,
+              options.getExternalStorage(),
+              storageCancellation);
       boolean finalCommand;
       Result result;
 
@@ -408,7 +438,7 @@ public final class ReplayWorkflowTaskHandler implements WorkflowTaskHandler {
       if (externalStorage == null) {
         ExternalStorageRunner.throwIfContainsReference(getHistoryResponse);
       } else {
-        getHistoryResponse = externalStorage.retrieve(getHistoryResponse, CancellationToken.none());
+        getHistoryResponse = externalStorage.retrieve(getHistoryResponse, storageCancellation);
       }
       workflowTask
           .setHistory(getHistoryResponse.getHistory())

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
@@ -20,6 +20,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CancellationException;
 import javax.annotation.Nullable;
 
 /** Supports iteration over history while loading new pages through calls to the service. */
@@ -33,6 +34,7 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
   private final PollWorkflowTaskQueueResponseOrBuilder task;
   private final GrpcRetryer grpcRetryer;
   private final @Nullable ExternalStorageRunner externalStorage;
+  private final CancellationToken<CancellationException> storageCancellation;
   private Deadline deadline;
   private Iterator<HistoryEvent> current;
   ByteString nextPageToken;
@@ -42,7 +44,7 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       String namespace,
       PollWorkflowTaskQueueResponseOrBuilder task,
       Scope metricsScope) {
-    this(service, namespace, task, metricsScope, null);
+    this(service, namespace, task, metricsScope, null, CancellationToken.none());
   }
 
   ServiceWorkflowHistoryIterator(
@@ -50,7 +52,9 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       String namespace,
       PollWorkflowTaskQueueResponseOrBuilder task,
       Scope metricsScope,
-      @Nullable ExternalStorageRunner externalStorage) {
+      @Nullable ExternalStorageRunner externalStorage,
+      CancellationToken<CancellationException> storageCancellation) {
+    this.storageCancellation = storageCancellation;
     this.service = service;
     this.namespace = namespace;
     this.task = task;
@@ -82,7 +86,7 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       if (externalStorage == null) {
         ExternalStorageRunner.throwIfContainsReference(history);
       } else {
-        history = externalStorage.retrieve(history, CancellationToken.none());
+        history = externalStorage.retrieve(history, storageCancellation);
       }
       current = history.getEventsList().iterator();
       nextPageToken = response.getNextPageToken();

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
@@ -33,7 +33,7 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
   private final Scope metricsScope;
   private final PollWorkflowTaskQueueResponseOrBuilder task;
   private final GrpcRetryer grpcRetryer;
-  private final @Nullable ExternalStorageRunner externalStorage;
+  private final @Nullable ExternalStorageRunner externalStorageRunner;
   private final CancellationToken<CancellationException> storageCancellation;
   private Deadline deadline;
   private Iterator<HistoryEvent> current;
@@ -52,14 +52,14 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       String namespace,
       PollWorkflowTaskQueueResponseOrBuilder task,
       Scope metricsScope,
-      @Nullable ExternalStorageRunner externalStorage,
+      @Nullable ExternalStorageRunner externalStorageRunner,
       CancellationToken<CancellationException> storageCancellation) {
     this.storageCancellation = storageCancellation;
     this.service = service;
     this.namespace = namespace;
     this.task = task;
     this.metricsScope = metricsScope;
-    this.externalStorage = externalStorage;
+    this.externalStorageRunner = externalStorageRunner;
     // TODO Refactor WorkflowHistoryIteratorTest or WorkflowHistoryIterator to remove this check.
     //  `service == null` shouldn't be allowed as it's needed for a normal functioning of this
     // class.
@@ -83,10 +83,10 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       GetWorkflowExecutionHistoryResponse response = queryWorkflowExecutionHistory();
 
       History history = response.getHistory();
-      if (externalStorage == null) {
+      if (externalStorageRunner == null) {
         ExternalStorageRunner.throwIfContainsReference(history);
       } else {
-        history = externalStorage.retrieve(history, storageCancellation);
+        history = externalStorageRunner.retrieve(history, storageCancellation);
       }
       current = history.getEventsList().iterator();
       nextPageToken = response.getNextPageToken();

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
@@ -12,6 +12,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
+import io.temporal.common.CancellationToken;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.serviceclient.RpcRetryOptions;
@@ -81,7 +82,7 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       if (externalStorage == null) {
         ExternalStorageRunner.throwIfContainsReference(history);
       } else {
-        history = externalStorage.retrieve(history);
+        history = externalStorage.retrieve(history, CancellationToken.none());
       }
       current = history.getEventsList().iterator();
       nextPageToken = response.getNextPageToken();

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ServiceWorkflowHistoryIterator.java
@@ -12,12 +12,14 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponseOrBuilder;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.serviceclient.RpcRetryOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import javax.annotation.Nullable;
 
 /** Supports iteration over history while loading new pages through calls to the service. */
 class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
@@ -29,6 +31,7 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
   private final Scope metricsScope;
   private final PollWorkflowTaskQueueResponseOrBuilder task;
   private final GrpcRetryer grpcRetryer;
+  private final @Nullable ExternalStorageRunner externalStorage;
   private Deadline deadline;
   private Iterator<HistoryEvent> current;
   ByteString nextPageToken;
@@ -38,10 +41,20 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       String namespace,
       PollWorkflowTaskQueueResponseOrBuilder task,
       Scope metricsScope) {
+    this(service, namespace, task, metricsScope, null);
+  }
+
+  ServiceWorkflowHistoryIterator(
+      WorkflowServiceStubs service,
+      String namespace,
+      PollWorkflowTaskQueueResponseOrBuilder task,
+      Scope metricsScope,
+      @Nullable ExternalStorageRunner externalStorage) {
     this.service = service;
     this.namespace = namespace;
     this.task = task;
     this.metricsScope = metricsScope;
+    this.externalStorage = externalStorage;
     // TODO Refactor WorkflowHistoryIteratorTest or WorkflowHistoryIterator to remove this check.
     //  `service == null` shouldn't be allowed as it's needed for a normal functioning of this
     // class.
@@ -64,7 +77,13 @@ class ServiceWorkflowHistoryIterator implements WorkflowHistoryIterator {
       // true.
       GetWorkflowExecutionHistoryResponse response = queryWorkflowExecutionHistory();
 
-      current = response.getHistory().getEventsList().iterator();
+      History history = response.getHistory();
+      if (externalStorage == null) {
+        ExternalStorageRunner.throwIfContainsReference(history);
+      } else {
+        history = externalStorage.retrieve(history);
+      }
+      current = history.getEventsList().iterator();
       nextPageToken = response.getNextPageToken();
       // Server can return an empty page, but a valid nextPageToken that contains
       // more events.

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowTaskResult.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowTaskResult.java
@@ -1,12 +1,14 @@
 package io.temporal.internal.replay;
 
 import io.temporal.api.command.v1.Command;
+import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.protocol.v1.Message;
 import io.temporal.api.query.v1.WorkflowQueryResult;
 import io.temporal.common.VersioningBehavior;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 public final class WorkflowTaskResult {
 
@@ -26,6 +28,8 @@ public final class WorkflowTaskResult {
     private String writeSdkVersion;
     private VersioningBehavior versioningBehavior;
     private Runnable applyPostCompletionMetrics;
+    private @Nullable WorkflowExecution parentWorkflowExecution;
+    private boolean continuedAsNew;
 
     public Builder setCommands(List<Command> commands) {
       this.commands = commands;
@@ -77,6 +81,16 @@ public final class WorkflowTaskResult {
       return this;
     }
 
+    public Builder setParentWorkflowExecution(@Nullable WorkflowExecution parentWorkflowExecution) {
+      this.parentWorkflowExecution = parentWorkflowExecution;
+      return this;
+    }
+
+    public Builder setContinuedAsNew(boolean continuedAsNew) {
+      this.continuedAsNew = continuedAsNew;
+      return this;
+    }
+
     public Builder setApplyPostCompletionMetrics(Runnable applyPostCompletionMetrics) {
       this.applyPostCompletionMetrics = applyPostCompletionMetrics;
       return this;
@@ -94,7 +108,9 @@ public final class WorkflowTaskResult {
           writeSdkName,
           writeSdkVersion,
           versioningBehavior == null ? VersioningBehavior.UNSPECIFIED : versioningBehavior,
-          applyPostCompletionMetrics);
+          applyPostCompletionMetrics,
+          parentWorkflowExecution,
+          continuedAsNew);
     }
   }
 
@@ -109,6 +125,8 @@ public final class WorkflowTaskResult {
   private final String writeSdkVersion;
   private final VersioningBehavior versioningBehavior;
   private final Runnable applyPostCompletionMetrics;
+  private final @Nullable WorkflowExecution parentWorkflowExecution;
+  private final boolean continuedAsNew;
 
   private WorkflowTaskResult(
       List<Command> commands,
@@ -121,7 +139,9 @@ public final class WorkflowTaskResult {
       String writeSdkName,
       String writeSdkVersion,
       VersioningBehavior versioningBehavior,
-      Runnable applyPostCompletionMetrics) {
+      Runnable applyPostCompletionMetrics,
+      @Nullable WorkflowExecution parentWorkflowExecution,
+      boolean continuedAsNew) {
     this.commands = commands;
     this.messages = messages;
     this.nonfirstLocalActivityAttempts = nonfirstLocalActivityAttempts;
@@ -136,6 +156,19 @@ public final class WorkflowTaskResult {
     this.writeSdkVersion = writeSdkVersion;
     this.versioningBehavior = versioningBehavior;
     this.applyPostCompletionMetrics = applyPostCompletionMetrics;
+    this.parentWorkflowExecution = parentWorkflowExecution;
+    this.continuedAsNew = continuedAsNew;
+  }
+
+  /** The workflow that started this one as a child, or {@code null} if it has no parent. */
+  @Nullable
+  public WorkflowExecution getParentWorkflowExecution() {
+    return parentWorkflowExecution;
+  }
+
+  /** Whether this run was created by a continue-as-new rather than started directly. */
+  public boolean isContinuedAsNew() {
+    return continuedAsNew;
   }
 
   public List<Command> getCommands() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/BasePoller.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/BasePoller.java
@@ -9,6 +9,7 @@ import io.temporal.worker.tuning.SlotSupplierFuture;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.*;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,6 +177,8 @@ abstract class BasePoller<T> implements SuspendableWorker {
     ex instanceof RejectedExecutionException
         // if the worker thread gets InterruptedException - it's normal during shutdown
         || ex instanceof InterruptedException
+        || ex instanceof CancellationException
+        || ex.getCause() instanceof CancellationException
         // if we get wrapped InterruptedException like what PollTask or GRPC clients do with
         // setting Thread.interrupted() on - it's normal during shutdown too. See PollTask
         // javadoc.

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SingleWorkerOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SingleWorkerOptions.java
@@ -3,6 +3,7 @@ package io.temporal.internal.worker;
 import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.Scope;
 import io.temporal.api.common.v1.WorkerVersionStamp;
+import io.temporal.common.CancellationToken;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.GlobalDataConverter;
@@ -12,6 +13,7 @@ import io.temporal.worker.PreferredVersionProvider;
 import io.temporal.worker.WorkerDeploymentOptions;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import javax.annotation.Nullable;
 
 public final class SingleWorkerOptions {
@@ -48,6 +50,7 @@ public final class SingleWorkerOptions {
     private String workerControlTaskQueue;
     private PreferredVersionProvider preferredVersionProvider;
     private @Nullable ExternalStorageRunner externalStorageRunner;
+    private CancellationToken<CancellationException> storageCancellation = CancellationToken.none();
 
     private Builder() {}
 
@@ -77,6 +80,7 @@ public final class SingleWorkerOptions {
       this.workerControlTaskQueue = options.getWorkerControlTaskQueue();
       this.preferredVersionProvider = options.getPreferredVersionProvider();
       this.externalStorageRunner = options.getExternalStorageRunner();
+      this.storageCancellation = options.getStorageCancellation();
     }
 
     public Builder setIdentity(String identity) {
@@ -189,6 +193,13 @@ public final class SingleWorkerOptions {
       return this;
     }
 
+    /** Cancelled when this worker stops, to abandon its in-flight external storage work. */
+    public Builder setStorageCancellation(
+        CancellationToken<CancellationException> storageCancellation) {
+      this.storageCancellation = storageCancellation;
+      return this;
+    }
+
     public Builder setExternalStorageRunner(@Nullable ExternalStorageRunner externalStorageRunner) {
       this.externalStorageRunner = externalStorageRunner;
       return this;
@@ -237,7 +248,8 @@ public final class SingleWorkerOptions {
           this.allowActivityHeartbeatDuringShutdown,
           this.workerControlTaskQueue,
           this.preferredVersionProvider,
-          this.externalStorageRunner);
+          this.externalStorageRunner,
+          this.storageCancellation);
     }
   }
 
@@ -263,6 +275,7 @@ public final class SingleWorkerOptions {
   private final String workerControlTaskQueue;
   private final PreferredVersionProvider preferredVersionProvider;
   private final @Nullable ExternalStorageRunner externalStorageRunner;
+  private final CancellationToken<CancellationException> storageCancellation;
 
   private SingleWorkerOptions(
       String identity,
@@ -286,7 +299,8 @@ public final class SingleWorkerOptions {
       boolean allowActivityHeartbeatDuringShutdown,
       String workerControlTaskQueue,
       PreferredVersionProvider preferredVersionProvider,
-      @Nullable ExternalStorageRunner externalStorageRunner) {
+      @Nullable ExternalStorageRunner externalStorageRunner,
+      CancellationToken<CancellationException> storageCancellation) {
     this.identity = identity;
     this.binaryChecksum = binaryChecksum;
     this.buildId = buildId;
@@ -309,6 +323,7 @@ public final class SingleWorkerOptions {
     this.workerControlTaskQueue = workerControlTaskQueue;
     this.preferredVersionProvider = preferredVersionProvider;
     this.externalStorageRunner = externalStorageRunner;
+    this.storageCancellation = storageCancellation;
   }
 
   public String getIdentity() {
@@ -412,6 +427,10 @@ public final class SingleWorkerOptions {
   @Nullable
   public ExternalStorageRunner getExternalStorageRunner() {
     return externalStorageRunner;
+  }
+
+  public CancellationToken<CancellationException> getStorageCancellation() {
+    return storageCancellation;
   }
 
   public WorkerVersioningOptions getWorkerVersioningOptions() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -181,11 +181,12 @@ public class SyncWorkflowWorker implements SuspendableWorker {
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
+    CompletableFuture<Void> workflowWorkerShutdown =
+        workflowWorker.shutdown(shutdownManager, interruptTasks);
     if (interruptTasks) {
       storageCancellation.cancel();
     }
-    return workflowWorker
-        .shutdown(shutdownManager, interruptTasks)
+    return workflowWorkerShutdown
         .thenCompose(ignore -> laWorker.shutdown(shutdownManager, interruptTasks))
         .exceptionally(
             e -> {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -74,6 +74,10 @@ public class SyncWorkflowWorker implements SuspendableWorker {
       @Nonnull SlotSupplier<WorkflowSlotInfo> slotSupplier,
       @Nonnull SlotSupplier<LocalActivitySlotInfo> laSlotSupplier,
       @Nonnull NamespaceCapabilities namespaceCapabilities) {
+    singleWorkerOptions =
+        SingleWorkerOptions.newBuilder(singleWorkerOptions)
+            .setStorageCancellation(storageCancellation.token())
+            .build();
     this.identity = singleWorkerOptions.getIdentity();
     this.namespace = namespace;
     this.taskQueue = taskQueue;
@@ -114,8 +118,7 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             stickyTaskQueue,
             singleWorkerOptions.getStickyQueueScheduleToStartTimeout(),
             client.getWorkflowServiceStubs(),
-            laWorker.getLocalActivityScheduler(),
-            storageCancellation.token());
+            laWorker.getLocalActivityScheduler());
 
     workflowWorker =
         new WorkflowWorker(
@@ -130,8 +133,7 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             eagerActivityDispatcher,
             maxEagerActivityReservationsPerWorkflowTask,
             slotSupplier,
-            namespaceCapabilities,
-            storageCancellation.token());
+            namespaceCapabilities);
 
     // Exists to support Worker#replayWorkflowExecution functionality.
     // This handler has to be non-sticky to avoid evicting actual executions from the cache
@@ -144,8 +146,7 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             null,
             Duration.ZERO,
             client.getWorkflowServiceStubs(),
-            laWorker.getLocalActivityScheduler(),
-            storageCancellation.token());
+            laWorker.getLocalActivityScheduler());
 
     queryReplayHelper = new QueryReplayHelper(nonStickyReplayTaskHandler);
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/SyncWorkflowWorker.java
@@ -10,6 +10,7 @@ import io.temporal.common.converter.EncodedValues;
 import io.temporal.internal.activity.ActivityExecutionContextFactory;
 import io.temporal.internal.activity.ActivityTaskHandlerImpl;
 import io.temporal.internal.activity.LocalActivityExecutionContextFactoryImpl;
+import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.replay.ReplayWorkflowTaskHandler;
 import io.temporal.internal.sync.POJOWorkflowImplementationFactory;
 import io.temporal.internal.sync.WorkflowThreadExecutor;
@@ -54,6 +55,8 @@ public class SyncWorkflowWorker implements SuspendableWorker {
   private final POJOWorkflowImplementationFactory factory;
   private final DataConverter dataConverter;
   private final ActivityTaskHandlerImpl laTaskHandler;
+  private final CancelSource<CancellationException> storageCancellation =
+      new CancelSource<>(() -> new CancellationException("Worker shutdown"));
   private boolean runningLocalActivityWorker;
 
   public SyncWorkflowWorker(
@@ -111,7 +114,8 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             stickyTaskQueue,
             singleWorkerOptions.getStickyQueueScheduleToStartTimeout(),
             client.getWorkflowServiceStubs(),
-            laWorker.getLocalActivityScheduler());
+            laWorker.getLocalActivityScheduler(),
+            storageCancellation.token());
 
     workflowWorker =
         new WorkflowWorker(
@@ -126,7 +130,8 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             eagerActivityDispatcher,
             maxEagerActivityReservationsPerWorkflowTask,
             slotSupplier,
-            namespaceCapabilities);
+            namespaceCapabilities,
+            storageCancellation.token());
 
     // Exists to support Worker#replayWorkflowExecution functionality.
     // This handler has to be non-sticky to avoid evicting actual executions from the cache
@@ -139,7 +144,8 @@ public class SyncWorkflowWorker implements SuspendableWorker {
             null,
             Duration.ZERO,
             client.getWorkflowServiceStubs(),
-            laWorker.getLocalActivityScheduler());
+            laWorker.getLocalActivityScheduler(),
+            storageCancellation.token());
 
     queryReplayHelper = new QueryReplayHelper(nonStickyReplayTaskHandler);
   }
@@ -175,6 +181,9 @@ public class SyncWorkflowWorker implements SuspendableWorker {
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
+    if (interruptTasks) {
+      storageCancellation.cancel();
+    }
     return workflowWorker
         .shutdown(shutdownManager, interruptTasks)
         .thenCompose(ignore -> laWorker.shutdown(shutdownManager, interruptTasks))

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowTaskHandler.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowTaskHandler.java
@@ -1,11 +1,13 @@
 package io.temporal.internal.worker;
 
+import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
 import io.temporal.serviceclient.RpcRetryOptions;
 import io.temporal.workflow.Functions;
+import javax.annotation.Nullable;
 
 /**
  * Interface of workflow task handlers.
@@ -23,6 +25,7 @@ public interface WorkflowTaskHandler {
     private final boolean completionCommand;
     private final Functions.Proc1<Long> resetEventIdHandle;
     private final Runnable applyPostCompletionMetrics;
+    private final @Nullable WorkflowExecution completionParentExecution;
 
     public Result(
         String workflowType,
@@ -33,6 +36,29 @@ public interface WorkflowTaskHandler {
         boolean completionCommand,
         Functions.Proc1<Long> resetEventIdHandle,
         Runnable applyPostCompletionMetrics) {
+      this(
+          workflowType,
+          taskCompleted,
+          taskFailed,
+          queryCompleted,
+          requestRetryOptions,
+          completionCommand,
+          resetEventIdHandle,
+          applyPostCompletionMetrics,
+          null);
+    }
+
+    public Result(
+        String workflowType,
+        RespondWorkflowTaskCompletedRequest taskCompleted,
+        RespondWorkflowTaskFailedRequest taskFailed,
+        RespondQueryTaskCompletedRequest queryCompleted,
+        RpcRetryOptions requestRetryOptions,
+        boolean completionCommand,
+        Functions.Proc1<Long> resetEventIdHandle,
+        Runnable applyPostCompletionMetrics,
+        @Nullable WorkflowExecution completionParentExecution) {
+      this.completionParentExecution = completionParentExecution;
       this.workflowType = workflowType;
       this.taskCompleted = taskCompleted;
       this.taskFailed = taskFailed;
@@ -41,6 +67,15 @@ public interface WorkflowTaskHandler {
       this.completionCommand = completionCommand;
       this.resetEventIdHandle = resetEventIdHandle;
       this.applyPostCompletionMetrics = applyPostCompletionMetrics;
+    }
+
+    /**
+     * The workflow to attribute this workflow's own result to, or {@code null} to attribute it to
+     * the workflow itself.
+     */
+    @Nullable
+    public WorkflowExecution getCompletionParentExecution() {
+      return completionParentExecution;
     }
 
     public RespondWorkflowTaskCompletedRequest getTaskCompleted() {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -28,7 +28,6 @@ import io.temporal.internal.payload.visitor.MessageVisitor;
 import io.temporal.internal.retryer.GrpcMessageTooLargeException;
 import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.payload.context.WorkflowSerializationContext;
-import io.temporal.payload.storage.StorageDriverActivityInfo;
 import io.temporal.payload.storage.StorageDriverTargetInfo;
 import io.temporal.payload.storage.StorageDriverWorkflowInfo;
 import io.temporal.serviceclient.MetricsTag;
@@ -456,11 +455,6 @@ final class WorkflowWorker implements SuspendableWorker {
     CommandOrBuilder command = (CommandOrBuilder) message;
     // Keep this exhaustive so new command attributes require an explicit target decision.
     switch (command.getAttributesCase()) {
-      case SCHEDULE_ACTIVITY_TASK_COMMAND_ATTRIBUTES:
-        ScheduleActivityTaskCommandAttributesOrBuilder activity =
-            command.getScheduleActivityTaskCommandAttributesOrBuilder();
-        return new StorageDriverActivityInfo(
-            namespace, activity.getActivityId(), null, activity.getActivityType().getName());
       case START_CHILD_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
         StartChildWorkflowExecutionCommandAttributesOrBuilder child =
             command.getStartChildWorkflowExecutionCommandAttributesOrBuilder();
@@ -484,6 +478,7 @@ final class WorkflowWorker implements SuspendableWorker {
               Strings.isNullOrEmpty(workflowType) ? currentWorkflow.getType() : workflowType);
         }
         return current;
+      case SCHEDULE_ACTIVITY_TASK_COMMAND_ATTRIBUTES:
       case ATTRIBUTES_NOT_SET:
       case START_TIMER_COMMAND_ATTRIBUTES:
       case COMPLETE_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -581,7 +581,15 @@ final class WorkflowWorker implements SuspendableWorker {
           nextWFTResponse = Optional.empty();
           boolean iterationFailed = false;
           try {
-            WorkflowTaskHandler.Result result = handleTask(currentTask, workflowTypeScope);
+            WorkflowTaskHandler.Result result;
+            try {
+              result = handleTask(currentTask, workflowTypeScope);
+            } catch (CancellationException e) {
+              if (isShutdown()) {
+                return;
+              }
+              throw e;
+            }
             WorkflowTaskFailedCause taskFailedCause = null;
             try {
               RespondWorkflowTaskCompletedRequest taskCompleted = result.getTaskCompleted();

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -707,10 +707,6 @@ final class WorkflowWorker implements SuspendableWorker {
                       workflowTypeScope,
                       workflowStorageTarget(workflowExecution, workflowType));
                 } catch (ExternalStorageTaskFailure e) {
-                  if (currentTask.getAttempt() > 1) {
-                    throw e;
-                  }
-
                   releaseReason = SlotReleaseReason.error(e);
                   handleReportingFailure(
                       e, currentTask, result, workflowExecution, workflowTypeScope);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -401,16 +401,13 @@ final class WorkflowWorker implements SuspendableWorker {
 
   private void storeOutboundPayloads(
       com.google.protobuf.Message.Builder builder, @Nullable StorageDriverTargetInfo target) {
-    ExternalStorageRunner externalStorage = options.getExternalStorage();
-    if (externalStorage != null) {
-      externalStorage.store(builder, target);
-    }
+    storeOutboundPayloads(builder, target, null);
   }
 
   private void storeOutboundPayloads(
       com.google.protobuf.Message.Builder builder,
       @Nullable StorageDriverTargetInfo target,
-      MessageVisitor<StorageDriverTargetInfo> targetVisitor) {
+      @Nullable MessageVisitor<StorageDriverTargetInfo> targetVisitor) {
     ExternalStorageRunner externalStorage = options.getExternalStorage();
     if (externalStorage != null) {
       externalStorage.store(builder, target, targetVisitor, CancellationToken.none());

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -20,7 +20,6 @@ import io.temporal.api.enums.v1.WorkflowTaskFailedCause;
 import io.temporal.api.errordetails.v1.WorkflowTaskCompletionBufferLostFailure;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.workflowservice.v1.*;
-import io.temporal.common.CancellationToken;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.internal.logging.LoggerTag;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
@@ -77,7 +76,6 @@ final class WorkflowWorker implements SuspendableWorker {
   private final PollerTracker pollerTracker = new PollerTracker();
   private final PollerTracker stickyPollerTracker = new PollerTracker();
   private final NamespaceCapabilities namespaceCapabilities;
-  private final CancellationToken<CancellationException> storageCancellation;
 
   private PollTaskExecutor<WorkflowTask> pollTaskExecutor;
 
@@ -99,8 +97,7 @@ final class WorkflowWorker implements SuspendableWorker {
       @Nonnull EagerActivityDispatcher eagerActivityDispatcher,
       int maxEagerActivityReservationsPerWorkflowTask,
       @Nonnull SlotSupplier<WorkflowSlotInfo> slotSupplier,
-      @Nonnull NamespaceCapabilities namespaceCapabilities,
-      CancellationToken<CancellationException> storageCancellation) {
+      @Nonnull NamespaceCapabilities namespaceCapabilities) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
@@ -117,7 +114,6 @@ final class WorkflowWorker implements SuspendableWorker {
     this.maxEagerActivityReservationsPerWorkflowTask = maxEagerActivityReservationsPerWorkflowTask;
     this.slotSupplier = new TrackingSlotSupplier<>(slotSupplier, this.workerMetricsScope);
     this.namespaceCapabilities = namespaceCapabilities;
-    this.storageCancellation = storageCancellation;
   }
 
   @Override
@@ -416,7 +412,7 @@ final class WorkflowWorker implements SuspendableWorker {
       return;
     }
     try {
-      externalStorageRunner.store(builder, target, targetVisitor, storageCancellation);
+      externalStorageRunner.store(builder, target, targetVisitor, options.getStorageCancellation());
     } catch (Throwable e) {
       if (isShutdown()) {
         throw new WorkerShuttingDown();

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -412,16 +412,16 @@ final class WorkflowWorker implements SuspendableWorker {
       com.google.protobuf.Message.Builder builder,
       @Nullable StorageDriverTargetInfo target,
       @Nullable MessageVisitor<StorageDriverTargetInfo> targetVisitor) {
-    ExternalStorageRunner externalStorage = options.getExternalStorage();
-    if (externalStorage != null) {
-      externalStorage.store(builder, target, targetVisitor, storageCancellation);
+    ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
+    if (externalStorageRunner != null) {
+      externalStorageRunner.store(builder, target, targetVisitor, storageCancellation);
     }
   }
 
   @Nullable
   private StorageDriverTargetInfo workflowStorageTarget(
       WorkflowExecution execution, String workflowType) {
-    if (options.getExternalStorage() == null) {
+    if (options.getExternalStorageRunner() == null) {
       return null;
     }
     return new StorageDriverWorkflowInfo(

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -413,17 +413,12 @@ final class WorkflowWorker implements SuspendableWorker {
     }
     try {
       externalStorageRunner.store(builder, target, targetVisitor, options.getStorageCancellation());
-    } catch (Throwable e) {
-      if (isShutdown()) {
-        throw new WorkerShuttingDown();
-      }
+    } catch (CancellationException e) {
+      // if the worker is shutting down, extstore will throw a CancellationException and we need to
+      // rethrow it here so the handle() method can decide what to do.
+      throw e;
+    } catch (Exception e) {
       throw new ExternalStorageTaskFailure("External storage store failed", e);
-    }
-  }
-
-  private static final class WorkerShuttingDown extends RuntimeException {
-    WorkerShuttingDown() {
-      super(null, null, false, false);
     }
   }
 
@@ -577,15 +572,7 @@ final class WorkflowWorker implements SuspendableWorker {
           nextWFTResponse = Optional.empty();
           boolean iterationFailed = false;
           try {
-            WorkflowTaskHandler.Result result;
-            try {
-              result = handleTask(currentTask, workflowTypeScope);
-            } catch (CancellationException e) {
-              if (isShutdown()) {
-                return;
-              }
-              throw e;
-            }
+            WorkflowTaskHandler.Result result = handleTask(currentTask, workflowTypeScope);
             WorkflowTaskFailedCause taskFailedCause = null;
             try {
               RespondWorkflowTaskCompletedRequest taskCompleted = result.getTaskCompleted();
@@ -763,7 +750,11 @@ final class WorkflowWorker implements SuspendableWorker {
                       workflowStorageTarget(workflowExecution, workflowType));
                 }
               }
-            } catch (WorkerShuttingDown e) {
+            } catch (CancellationException e) {
+              if (!options.getStorageCancellation().isCancellationRequested()) {
+                throw e;
+              }
+              log.trace("Abandoned a workflow task while the worker was shutting down", e);
               return;
             } catch (Exception e) {
               iterationFailed = true;
@@ -800,6 +791,11 @@ final class WorkflowWorker implements SuspendableWorker {
               workflowTypeScope.counter(MetricsType.WORKFLOW_TASK_HEARTBEAT_COUNTER).inc(1);
             }
           } catch (Exception e) {
+            if (e instanceof CancellationException
+                && options.getStorageCancellation().isCancellationRequested()) {
+              log.trace("Abandoned a workflow task while the worker was shutting down", e);
+              return;
+            }
             iterationFailed = true;
             throw e;
           } finally {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -38,6 +38,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.*;
 import io.temporal.worker.tuning.*;
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -77,6 +78,7 @@ final class WorkflowWorker implements SuspendableWorker {
   private final PollerTracker pollerTracker = new PollerTracker();
   private final PollerTracker stickyPollerTracker = new PollerTracker();
   private final NamespaceCapabilities namespaceCapabilities;
+  private final CancellationToken<CancellationException> storageCancellation;
 
   private PollTaskExecutor<WorkflowTask> pollTaskExecutor;
 
@@ -98,7 +100,8 @@ final class WorkflowWorker implements SuspendableWorker {
       @Nonnull EagerActivityDispatcher eagerActivityDispatcher,
       int maxEagerActivityReservationsPerWorkflowTask,
       @Nonnull SlotSupplier<WorkflowSlotInfo> slotSupplier,
-      @Nonnull NamespaceCapabilities namespaceCapabilities) {
+      @Nonnull NamespaceCapabilities namespaceCapabilities,
+      CancellationToken<CancellationException> storageCancellation) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
@@ -115,6 +118,7 @@ final class WorkflowWorker implements SuspendableWorker {
     this.maxEagerActivityReservationsPerWorkflowTask = maxEagerActivityReservationsPerWorkflowTask;
     this.slotSupplier = new TrackingSlotSupplier<>(slotSupplier, this.workerMetricsScope);
     this.namespaceCapabilities = namespaceCapabilities;
+    this.storageCancellation = storageCancellation;
   }
 
   @Override
@@ -410,7 +414,7 @@ final class WorkflowWorker implements SuspendableWorker {
       @Nullable MessageVisitor<StorageDriverTargetInfo> targetVisitor) {
     ExternalStorageRunner externalStorage = options.getExternalStorage();
     if (externalStorage != null) {
-      externalStorage.store(builder, target, targetVisitor, CancellationToken.none());
+      externalStorage.store(builder, target, targetVisitor, storageCancellation);
     }
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -12,10 +12,7 @@ import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.temporal.api.command.v1.Command;
-import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributesOrBuilder;
-import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributesOrBuilder;
-import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributesOrBuilder;
+import io.temporal.api.command.v1.*;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.QueryResultType;
 import io.temporal.api.enums.v1.TaskQueueKind;
@@ -430,27 +427,59 @@ final class WorkflowWorker implements SuspendableWorker {
         namespace, execution.getWorkflowId(), execution.getRunId(), workflowType);
   }
 
-  static StorageDriverTargetInfo refineStorageTarget(
+  static StorageDriverTargetInfo deriveStorageTarget(
       String namespace, StorageDriverTargetInfo current, MessageOrBuilder message) {
-    if (message instanceof ScheduleActivityTaskCommandAttributesOrBuilder) {
-      ScheduleActivityTaskCommandAttributesOrBuilder attrs =
-          (ScheduleActivityTaskCommandAttributesOrBuilder) message;
-      return new StorageDriverActivityInfo(
-          namespace, attrs.getActivityId(), null, attrs.getActivityType().getName());
+    if (!(message instanceof CommandOrBuilder)) {
+      return current;
     }
-    if (message instanceof StartChildWorkflowExecutionCommandAttributesOrBuilder) {
-      StartChildWorkflowExecutionCommandAttributesOrBuilder attrs =
-          (StartChildWorkflowExecutionCommandAttributesOrBuilder) message;
-      return new StorageDriverWorkflowInfo(
-          namespace, attrs.getWorkflowId(), null, attrs.getWorkflowType().getName());
+    CommandOrBuilder command = (CommandOrBuilder) message;
+    // Keep this exhaustive so new command attributes require an explicit target decision.
+    switch (command.getAttributesCase()) {
+      case SCHEDULE_ACTIVITY_TASK_COMMAND_ATTRIBUTES:
+        ScheduleActivityTaskCommandAttributesOrBuilder activity =
+            command.getScheduleActivityTaskCommandAttributesOrBuilder();
+        return new StorageDriverActivityInfo(
+            namespace, activity.getActivityId(), null, activity.getActivityType().getName());
+      case START_CHILD_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+        StartChildWorkflowExecutionCommandAttributesOrBuilder child =
+            command.getStartChildWorkflowExecutionCommandAttributesOrBuilder();
+        return new StorageDriverWorkflowInfo(
+            namespace, child.getWorkflowId(), null, child.getWorkflowType().getName());
+      case SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+        WorkflowExecution execution =
+            command.getSignalExternalWorkflowExecutionCommandAttributes().getExecution();
+        return new StorageDriverWorkflowInfo(
+            namespace, execution.getWorkflowId(), execution.getRunId(), null);
+      case CONTINUE_AS_NEW_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+        if (current instanceof StorageDriverWorkflowInfo) {
+          ContinueAsNewWorkflowExecutionCommandAttributesOrBuilder continueAsNew =
+              command.getContinueAsNewWorkflowExecutionCommandAttributesOrBuilder();
+          StorageDriverWorkflowInfo currentWorkflow = (StorageDriverWorkflowInfo) current;
+          String workflowType = continueAsNew.getWorkflowType().getName();
+          return new StorageDriverWorkflowInfo(
+              namespace,
+              currentWorkflow.getId(),
+              null,
+              Strings.isNullOrEmpty(workflowType) ? currentWorkflow.getType() : workflowType);
+        }
+        return current;
+      case ATTRIBUTES_NOT_SET:
+      case START_TIMER_COMMAND_ATTRIBUTES:
+      case COMPLETE_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+      case FAIL_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+      case REQUEST_CANCEL_ACTIVITY_TASK_COMMAND_ATTRIBUTES:
+      case CANCEL_TIMER_COMMAND_ATTRIBUTES:
+      case CANCEL_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+      case REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+      case RECORD_MARKER_COMMAND_ATTRIBUTES:
+      case UPSERT_WORKFLOW_SEARCH_ATTRIBUTES_COMMAND_ATTRIBUTES:
+      case PROTOCOL_MESSAGE_COMMAND_ATTRIBUTES:
+      case MODIFY_WORKFLOW_PROPERTIES_COMMAND_ATTRIBUTES:
+      case SCHEDULE_NEXUS_OPERATION_COMMAND_ATTRIBUTES:
+      case REQUEST_CANCEL_NEXUS_OPERATION_COMMAND_ATTRIBUTES:
+        return current;
     }
-    if (message instanceof SignalExternalWorkflowExecutionCommandAttributesOrBuilder) {
-      WorkflowExecution execution =
-          ((SignalExternalWorkflowExecutionCommandAttributesOrBuilder) message).getExecution();
-      return new StorageDriverWorkflowInfo(
-          namespace, execution.getWorkflowId(), execution.getRunId(), null);
-    }
-    return current;
+    throw new IllegalStateException("Unhandled command attributes: " + command.getAttributesCase());
   }
 
   private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<WorkflowTask> {
@@ -781,7 +810,7 @@ final class WorkflowWorker implements SuspendableWorker {
       // Offloading shrinks the request, so it has to happen before the request is sized for
       // pagination.
       MessageVisitor<StorageDriverTargetInfo> storageTargetVisitor =
-          (current, message) -> refineStorageTarget(namespace, current, message);
+          (current, message) -> deriveStorageTarget(namespace, current, message);
       storeOutboundPayloads(taskCompleted, storageTarget, storageTargetVisitor);
       RespondWorkflowTaskCompletedRequest request = taskCompleted.build();
       GrpcRetryer.GrpcRetryerOptions grpcRetryOptions =

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -413,8 +413,19 @@ final class WorkflowWorker implements SuspendableWorker {
       @Nullable StorageDriverTargetInfo target,
       @Nullable MessageVisitor<StorageDriverTargetInfo> targetVisitor) {
     ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
-    if (externalStorageRunner != null) {
+    if (externalStorageRunner == null) {
+      return;
+    }
+    try {
       externalStorageRunner.store(builder, target, targetVisitor, storageCancellation);
+    } catch (Throwable e) {
+      throw new ExternalStorageTaskFailure("External storage store failed", e);
+    }
+  }
+
+  private static final class ExternalStorageTaskFailure extends RuntimeException {
+    ExternalStorageTaskFailure(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 
@@ -559,6 +570,22 @@ final class WorkflowWorker implements SuspendableWorker {
                       queryCompleted.toBuilder(),
                       workflowTypeScope,
                       workflowStorageTarget(workflowExecution, workflowType));
+                } catch (ExternalStorageTaskFailure e) {
+                  Failure failure =
+                      storageFailure(
+                          workflowExecution.getWorkflowId(), e, "Failed to send query response");
+                  RespondQueryTaskCompletedRequest.Builder queryFailedBuilder =
+                      RespondQueryTaskCompletedRequest.newBuilder()
+                          .setTaskToken(currentTask.getTaskToken())
+                          .setNamespace(namespace)
+                          .setCompletedType(QueryResultType.QUERY_RESULT_TYPE_FAILED)
+                          .setErrorMessage(failure.getMessage())
+                          .setFailure(failure);
+                  sendDirectQueryCompletedResponse(
+                      currentTask.getTaskToken(),
+                      queryFailedBuilder,
+                      workflowTypeScope,
+                      workflowStorageTarget(workflowExecution, workflowType));
                 } catch (StatusRuntimeException e) {
                   GrpcMessageTooLargeException tooLargeException =
                       GrpcMessageTooLargeException.tryWrap(e);
@@ -676,6 +703,35 @@ final class WorkflowWorker implements SuspendableWorker {
                   sendTaskFailed(
                       currentTask.getTaskToken(),
                       taskFailedBuilder,
+                      result.getRequestRetryOptions(),
+                      workflowTypeScope,
+                      workflowStorageTarget(workflowExecution, workflowType));
+                } catch (ExternalStorageTaskFailure e) {
+                  if (currentTask.getAttempt() > 1) {
+                    throw e;
+                  }
+
+                  releaseReason = SlotReleaseReason.error(e);
+                  handleReportingFailure(
+                      e, currentTask, result, workflowExecution, workflowTypeScope);
+                  taskFailedCause =
+                      WorkflowTaskFailedCause
+                          .WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE;
+
+                  String messagePrefix =
+                      String.format(
+                          "Failed to send workflow task %s",
+                          taskFailed == null ? "completion" : "failure");
+                  RespondWorkflowTaskFailedRequest.Builder storageFailedBuilder =
+                      RespondWorkflowTaskFailedRequest.newBuilder()
+                          .setFailure(
+                              storageFailure(workflowExecution.getWorkflowId(), e, messagePrefix))
+                          .setCause(
+                              WorkflowTaskFailedCause
+                                  .WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE);
+                  sendTaskFailed(
+                      currentTask.getTaskToken(),
+                      storageFailedBuilder,
                       result.getRequestRetryOptions(),
                       workflowTypeScope,
                       workflowStorageTarget(workflowExecution, workflowType));
@@ -1015,6 +1071,20 @@ final class WorkflowWorker implements SuspendableWorker {
               .setType("WorkflowTaskCompletionRequestTooLarge")
               .build();
       applicationFailure.setStackTrace(new StackTraceElement[0]); // don't serialize stack trace
+      return options
+          .getDataConverter()
+          .withContext(new WorkflowSerializationContext(namespace, workflowId))
+          .exceptionToFailure(applicationFailure);
+    }
+
+    private Failure storageFailure(
+        String workflowId, ExternalStorageTaskFailure e, String messagePrefix) {
+      ApplicationFailure applicationFailure =
+          ApplicationFailure.newBuilder()
+              .setMessage(messagePrefix + ": " + e.getMessage())
+              .setType(ExternalStorageTaskFailure.class.getSimpleName())
+              .build();
+      applicationFailure.setStackTrace(new StackTraceElement[0]);
       return options
           .getDataConverter()
           .withContext(new WorkflowSerializationContext(namespace, workflowId))

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -628,54 +628,55 @@ final class WorkflowWorker implements SuspendableWorker {
                 }
               } else {
                 try {
-                  WorkflowTaskFailedCause requestTooLargeCause =
-                      taskCompleted == null
-                          ? null
-                          : completionExceedingSizeLimitCause(taskCompleted);
-                  if (requestTooLargeCause != null) {
-                    // A completion whose recombined command bytes exceed the namespace limit would
-                    // be
-                    // rejected and the workflow terminated by the server, so fail it proactively
-                    // rather than sending doomed pages.
-                    taskFailedCause = requestTooLargeCause;
-                    RespondWorkflowTaskFailedRequest.Builder taskFailedBuilder =
-                        RespondWorkflowTaskFailedRequest.newBuilder()
-                            .setFailure(
-                                requestTooLargeFailure(
-                                    workflowExecution.getWorkflowId(), taskCompleted))
-                            .setCause(requestTooLargeCause);
-                    sendTaskFailed(
-                        currentTask.getTaskToken(),
-                        taskFailedBuilder,
-                        result.getRequestRetryOptions(),
-                        workflowTypeScope);
-                  } else if (taskCompleted != null) {
+                  if (taskCompleted != null) {
                     RespondWorkflowTaskCompletedRequest.Builder requestBuilder =
                         taskCompleted.toBuilder();
                     try (EagerActivitySlotsReservation activitySlotsReservation =
                         new EagerActivitySlotsReservation(
                             eagerActivityDispatcher, maxEagerActivityReservationsPerWorkflowTask)) {
                       activitySlotsReservation.applyToRequest(requestBuilder);
-                      RespondWorkflowTaskCompletedResponse response =
-                          sendTaskCompleted(
+                      RespondWorkflowTaskCompletedRequest request =
+                          prepareTaskCompleted(
                               currentTask.getTaskToken(),
                               requestBuilder,
-                              result.getRequestRetryOptions(),
-                              workflowTypeScope,
                               workflowStorageTarget(workflowExecution, workflowType),
                               parentStorageTarget(result.getCompletionParentExecution()));
-                      // If we were processing a speculative WFT the server may instruct us that the
-                      // task was dropped by resting out event ID.
-                      long resetEventId = response.getResetHistoryEventId();
-                      if (resetEventId != 0) {
-                        result.getResetEventIdHandle().apply(resetEventId);
+                      WorkflowTaskFailedCause requestTooLargeCause =
+                          completionExceedingSizeLimitCause(request);
+                      if (requestTooLargeCause != null) {
+                        // A completion whose recombined command bytes exceed the namespace limit
+                        // would be rejected and the workflow terminated by the server, so fail it
+                        // proactively rather than sending doomed pages.
+                        taskFailedCause = requestTooLargeCause;
+                        RespondWorkflowTaskFailedRequest.Builder taskFailedBuilder =
+                            RespondWorkflowTaskFailedRequest.newBuilder()
+                                .setFailure(
+                                    requestTooLargeFailure(
+                                        workflowExecution.getWorkflowId(), request))
+                                .setCause(requestTooLargeCause);
+                        sendTaskFailed(
+                            currentTask.getTaskToken(),
+                            taskFailedBuilder,
+                            result.getRequestRetryOptions(),
+                            workflowTypeScope,
+                            workflowStorageTarget(workflowExecution, workflowType));
+                      } else {
+                        RespondWorkflowTaskCompletedResponse response =
+                            sendTaskCompleted(
+                                request, result.getRequestRetryOptions(), workflowTypeScope);
+                        // If we were processing a speculative WFT the server may instruct us that
+                        // the task was dropped by resting out event ID.
+                        long resetEventId = response.getResetHistoryEventId();
+                        if (resetEventId != 0) {
+                          result.getResetEventIdHandle().apply(resetEventId);
+                        }
+                        nextWFTResponse =
+                            response.hasWorkflowTask()
+                                ? Optional.of(response.getWorkflowTask())
+                                : Optional.empty();
+                        // TODO we don't have to do this under the runId lock
+                        activitySlotsReservation.handleResponse(response);
                       }
-                      nextWFTResponse =
-                          response.hasWorkflowTask()
-                              ? Optional.of(response.getWorkflowTask())
-                              : Optional.empty();
-                      // TODO we don't have to do this under the runId lock
-                      activitySlotsReservation.handleResponse(response);
                     }
                   } else if (taskFailed != null) {
                     taskFailedCause = taskFailed.getCause();
@@ -864,11 +865,9 @@ final class WorkflowWorker implements SuspendableWorker {
     }
 
     @SuppressWarnings("deprecation")
-    private RespondWorkflowTaskCompletedResponse sendTaskCompleted(
+    private RespondWorkflowTaskCompletedRequest prepareTaskCompleted(
         ByteString taskToken,
         RespondWorkflowTaskCompletedRequest.Builder taskCompleted,
-        RpcRetryOptions retryOptions,
-        Scope workflowTypeMetricsScope,
         @Nullable StorageDriverTargetInfo storageTarget,
         @Nullable StorageDriverTargetInfo completionTarget) {
       taskCompleted
@@ -889,12 +888,16 @@ final class WorkflowWorker implements SuspendableWorker {
         taskCompleted.setBinaryChecksum(options.getBuildId());
       }
 
-      // Offloading shrinks the request, so it has to happen before the request is sized for
-      // pagination.
       MessageVisitor<StorageDriverTargetInfo> storageTargetVisitor =
           (current, message) -> deriveStorageTarget(namespace, current, message, completionTarget);
       storeOutboundPayloads(taskCompleted, storageTarget, storageTargetVisitor);
-      RespondWorkflowTaskCompletedRequest request = taskCompleted.build();
+      return taskCompleted.build();
+    }
+
+    private RespondWorkflowTaskCompletedResponse sendTaskCompleted(
+        RespondWorkflowTaskCompletedRequest request,
+        RpcRetryOptions retryOptions,
+        Scope workflowTypeMetricsScope) {
       GrpcRetryer.GrpcRetryerOptions grpcRetryOptions =
           new GrpcRetryer.GrpcRetryerOptions(
               RpcRetryOptions.newBuilder().buildWithDefaultsFrom(retryOptions), null);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -438,6 +438,18 @@ final class WorkflowWorker implements SuspendableWorker {
   }
 
   @Nullable
+  private StorageDriverTargetInfo parentStorageTarget(@Nullable WorkflowExecution parent) {
+    if (parent == null || options.getExternalStorageRunner() == null) {
+      return null;
+    }
+    return new StorageDriverWorkflowInfo(
+        namespace,
+        Strings.emptyToNull(parent.getWorkflowId()),
+        Strings.emptyToNull(parent.getRunId()),
+        null);
+  }
+
+  @Nullable
   private StorageDriverTargetInfo workflowStorageTarget(
       WorkflowExecution execution, String workflowType) {
     if (options.getExternalStorageRunner() == null) {
@@ -449,6 +461,14 @@ final class WorkflowWorker implements SuspendableWorker {
 
   static StorageDriverTargetInfo deriveStorageTarget(
       String namespace, StorageDriverTargetInfo current, MessageOrBuilder message) {
+    return deriveStorageTarget(namespace, current, message, null);
+  }
+
+  static StorageDriverTargetInfo deriveStorageTarget(
+      String namespace,
+      StorageDriverTargetInfo current,
+      MessageOrBuilder message,
+      @Nullable StorageDriverTargetInfo completionTarget) {
     if (!(message instanceof CommandOrBuilder)) {
       return current;
     }
@@ -478,10 +498,11 @@ final class WorkflowWorker implements SuspendableWorker {
               Strings.isNullOrEmpty(workflowType) ? currentWorkflow.getType() : workflowType);
         }
         return current;
+      case COMPLETE_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
+        return completionTarget != null ? completionTarget : current;
       case SCHEDULE_ACTIVITY_TASK_COMMAND_ATTRIBUTES:
       case ATTRIBUTES_NOT_SET:
       case START_TIMER_COMMAND_ATTRIBUTES:
-      case COMPLETE_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
       case FAIL_WORKFLOW_EXECUTION_COMMAND_ATTRIBUTES:
       case REQUEST_CANCEL_ACTIVITY_TASK_COMMAND_ATTRIBUTES:
       case CANCEL_TIMER_COMMAND_ATTRIBUTES:
@@ -650,7 +671,8 @@ final class WorkflowWorker implements SuspendableWorker {
                               requestBuilder,
                               result.getRequestRetryOptions(),
                               workflowTypeScope,
-                              workflowStorageTarget(workflowExecution, workflowType));
+                              workflowStorageTarget(workflowExecution, workflowType),
+                              parentStorageTarget(result.getCompletionParentExecution()));
                       // If we were processing a speculative WFT the server may instruct us that the
                       // task was dropped by resting out event ID.
                       long resetEventId = response.getResetHistoryEventId();
@@ -847,7 +869,8 @@ final class WorkflowWorker implements SuspendableWorker {
         RespondWorkflowTaskCompletedRequest.Builder taskCompleted,
         RpcRetryOptions retryOptions,
         Scope workflowTypeMetricsScope,
-        @Nullable StorageDriverTargetInfo storageTarget) {
+        @Nullable StorageDriverTargetInfo storageTarget,
+        @Nullable StorageDriverTargetInfo completionTarget) {
       taskCompleted
           .setIdentity(options.getIdentity())
           .setNamespace(namespace)
@@ -869,7 +892,7 @@ final class WorkflowWorker implements SuspendableWorker {
       // Offloading shrinks the request, so it has to happen before the request is sized for
       // pagination.
       MessageVisitor<StorageDriverTargetInfo> storageTargetVisitor =
-          (current, message) -> deriveStorageTarget(namespace, current, message);
+          (current, message) -> deriveStorageTarget(namespace, current, message, completionTarget);
       storeOutboundPayloads(taskCompleted, storageTarget, storageTargetVisitor);
       RespondWorkflowTaskCompletedRequest request = taskCompleted.build();
       GrpcRetryer.GrpcRetryerOptions grpcRetryOptions =

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -419,7 +419,16 @@ final class WorkflowWorker implements SuspendableWorker {
     try {
       externalStorageRunner.store(builder, target, targetVisitor, storageCancellation);
     } catch (Throwable e) {
+      if (isShutdown()) {
+        throw new WorkerShuttingDown();
+      }
       throw new ExternalStorageTaskFailure("External storage store failed", e);
+    }
+  }
+
+  private static final class WorkerShuttingDown extends RuntimeException {
+    WorkerShuttingDown() {
+      super(null, null, false, false);
     }
   }
 
@@ -733,6 +742,8 @@ final class WorkflowWorker implements SuspendableWorker {
                       workflowStorageTarget(workflowExecution, workflowType));
                 }
               }
+            } catch (WorkerShuttingDown e) {
+              return;
             } catch (Exception e) {
               iterationFailed = true;
               releaseReason = SlotReleaseReason.error(e);
@@ -1077,7 +1088,7 @@ final class WorkflowWorker implements SuspendableWorker {
         String workflowId, ExternalStorageTaskFailure e, String messagePrefix) {
       ApplicationFailure applicationFailure =
           ApplicationFailure.newBuilder()
-              .setMessage(messagePrefix + ": " + e.getMessage())
+              .setMessage(messagePrefix + ": " + (e.getCause() != null ? e.getCause() : e))
               .setType(ExternalStorageTaskFailure.class.getSimpleName())
               .build();
       applicationFailure.setStackTrace(new StackTraceElement[0]);

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowWorker.java
@@ -6,12 +6,16 @@ import static io.temporal.serviceclient.MetricsTag.TASK_FAILURE_TYPE;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.MessageOrBuilder;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.ImmutableMap;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.api.command.v1.Command;
+import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributesOrBuilder;
+import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributesOrBuilder;
+import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributesOrBuilder;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.QueryResultType;
 import io.temporal.api.enums.v1.TaskQueueKind;
@@ -19,11 +23,17 @@ import io.temporal.api.enums.v1.WorkflowTaskFailedCause;
 import io.temporal.api.errordetails.v1.WorkflowTaskCompletionBufferLostFailure;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.common.CancellationToken;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.internal.logging.LoggerTag;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.internal.payload.visitor.MessageVisitor;
 import io.temporal.internal.retryer.GrpcMessageTooLargeException;
 import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.payload.context.WorkflowSerializationContext;
+import io.temporal.payload.storage.StorageDriverActivityInfo;
+import io.temporal.payload.storage.StorageDriverTargetInfo;
+import io.temporal.payload.storage.StorageDriverWorkflowInfo;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.RpcRetryOptions;
 import io.temporal.serviceclient.StatusUtils;
@@ -392,6 +402,57 @@ final class WorkflowWorker implements SuspendableWorker {
         options.getIdentity(), namespace, taskQueue);
   }
 
+  private void storeOutboundPayloads(
+      com.google.protobuf.Message.Builder builder, @Nullable StorageDriverTargetInfo target) {
+    ExternalStorageRunner externalStorage = options.getExternalStorage();
+    if (externalStorage != null) {
+      externalStorage.store(builder, target);
+    }
+  }
+
+  private void storeOutboundPayloads(
+      com.google.protobuf.Message.Builder builder,
+      @Nullable StorageDriverTargetInfo target,
+      MessageVisitor<StorageDriverTargetInfo> targetVisitor) {
+    ExternalStorageRunner externalStorage = options.getExternalStorage();
+    if (externalStorage != null) {
+      externalStorage.store(builder, target, targetVisitor, CancellationToken.none());
+    }
+  }
+
+  @Nullable
+  private StorageDriverTargetInfo workflowStorageTarget(
+      WorkflowExecution execution, String workflowType) {
+    if (options.getExternalStorage() == null) {
+      return null;
+    }
+    return new StorageDriverWorkflowInfo(
+        namespace, execution.getWorkflowId(), execution.getRunId(), workflowType);
+  }
+
+  static StorageDriverTargetInfo refineStorageTarget(
+      String namespace, StorageDriverTargetInfo current, MessageOrBuilder message) {
+    if (message instanceof ScheduleActivityTaskCommandAttributesOrBuilder) {
+      ScheduleActivityTaskCommandAttributesOrBuilder attrs =
+          (ScheduleActivityTaskCommandAttributesOrBuilder) message;
+      return new StorageDriverActivityInfo(
+          namespace, attrs.getActivityId(), null, attrs.getActivityType().getName());
+    }
+    if (message instanceof StartChildWorkflowExecutionCommandAttributesOrBuilder) {
+      StartChildWorkflowExecutionCommandAttributesOrBuilder attrs =
+          (StartChildWorkflowExecutionCommandAttributesOrBuilder) message;
+      return new StorageDriverWorkflowInfo(
+          namespace, attrs.getWorkflowId(), null, attrs.getWorkflowType().getName());
+    }
+    if (message instanceof SignalExternalWorkflowExecutionCommandAttributesOrBuilder) {
+      WorkflowExecution execution =
+          ((SignalExternalWorkflowExecutionCommandAttributesOrBuilder) message).getExecution();
+      return new StorageDriverWorkflowInfo(
+          namespace, execution.getWorkflowId(), execution.getRunId(), null);
+    }
+    return current;
+  }
+
   private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<WorkflowTask> {
 
     final WorkflowTaskHandler handler;
@@ -464,7 +525,10 @@ final class WorkflowWorker implements SuspendableWorker {
               if (queryCompleted != null) {
                 try {
                   sendDirectQueryCompletedResponse(
-                      currentTask.getTaskToken(), queryCompleted.toBuilder(), workflowTypeScope);
+                      currentTask.getTaskToken(),
+                      queryCompleted.toBuilder(),
+                      workflowTypeScope,
+                      workflowStorageTarget(workflowExecution, workflowType));
                 } catch (StatusRuntimeException e) {
                   GrpcMessageTooLargeException tooLargeException =
                       GrpcMessageTooLargeException.tryWrap(e);
@@ -484,7 +548,10 @@ final class WorkflowWorker implements SuspendableWorker {
                           .setErrorMessage(failure.getMessage())
                           .setFailure(failure);
                   sendDirectQueryCompletedResponse(
-                      currentTask.getTaskToken(), queryFailedBuilder, workflowTypeScope);
+                      currentTask.getTaskToken(),
+                      queryFailedBuilder,
+                      workflowTypeScope,
+                      workflowStorageTarget(workflowExecution, workflowType));
                 }
               } else {
                 try {
@@ -521,7 +588,8 @@ final class WorkflowWorker implements SuspendableWorker {
                               currentTask.getTaskToken(),
                               requestBuilder,
                               result.getRequestRetryOptions(),
-                              workflowTypeScope);
+                              workflowTypeScope,
+                              workflowStorageTarget(workflowExecution, workflowType));
                       // If we were processing a speculative WFT the server may instruct us that the
                       // task was dropped by resting out event ID.
                       long resetEventId = response.getResetHistoryEventId();
@@ -541,7 +609,8 @@ final class WorkflowWorker implements SuspendableWorker {
                         currentTask.getTaskToken(),
                         taskFailed.toBuilder(),
                         result.getRequestRetryOptions(),
-                        workflowTypeScope);
+                        workflowTypeScope,
+                        workflowStorageTarget(workflowExecution, workflowType));
                   }
 
                   // Apply post-completion metrics only if runnable present and the above succeeded
@@ -578,7 +647,8 @@ final class WorkflowWorker implements SuspendableWorker {
                       currentTask.getTaskToken(),
                       taskFailedBuilder,
                       result.getRequestRetryOptions(),
-                      workflowTypeScope);
+                      workflowTypeScope,
+                      workflowStorageTarget(workflowExecution, workflowType));
                 }
               }
             } catch (Exception e) {
@@ -688,7 +758,8 @@ final class WorkflowWorker implements SuspendableWorker {
         ByteString taskToken,
         RespondWorkflowTaskCompletedRequest.Builder taskCompleted,
         RpcRetryOptions retryOptions,
-        Scope workflowTypeMetricsScope) {
+        Scope workflowTypeMetricsScope,
+        @Nullable StorageDriverTargetInfo storageTarget) {
       taskCompleted
           .setIdentity(options.getIdentity())
           .setNamespace(namespace)
@@ -707,6 +778,11 @@ final class WorkflowWorker implements SuspendableWorker {
         taskCompleted.setBinaryChecksum(options.getBuildId());
       }
 
+      // Offloading shrinks the request, so it has to happen before the request is sized for
+      // pagination.
+      MessageVisitor<StorageDriverTargetInfo> storageTargetVisitor =
+          (current, message) -> refineStorageTarget(namespace, current, message);
+      storeOutboundPayloads(taskCompleted, storageTarget, storageTargetVisitor);
       RespondWorkflowTaskCompletedRequest request = taskCompleted.build();
       GrpcRetryer.GrpcRetryerOptions grpcRetryOptions =
           new GrpcRetryer.GrpcRetryerOptions(
@@ -789,7 +865,8 @@ final class WorkflowWorker implements SuspendableWorker {
         ByteString taskToken,
         RespondWorkflowTaskFailedRequest.Builder taskFailed,
         RpcRetryOptions retryOptions,
-        Scope workflowTypeMetricsScope) {
+        Scope workflowTypeMetricsScope,
+        @Nullable StorageDriverTargetInfo storageTarget) {
       GrpcRetryer.GrpcRetryerOptions grpcRetryOptions =
           new GrpcRetryer.GrpcRetryerOptions(
               RpcRetryOptions.newBuilder().buildWithDefaultsFrom(retryOptions), null);
@@ -803,25 +880,30 @@ final class WorkflowWorker implements SuspendableWorker {
         taskFailed.setWorkerVersion(options.workerVersionStamp());
       }
 
+      storeOutboundPayloads(taskFailed, storageTarget);
+      RespondWorkflowTaskFailedRequest request = taskFailed.build();
       grpcRetryer.retry(
           () ->
               service
                   .blockingStub()
                   .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, workflowTypeMetricsScope)
-                  .respondWorkflowTaskFailed(taskFailed.build()),
+                  .respondWorkflowTaskFailed(request),
           grpcRetryOptions);
     }
 
     private void sendDirectQueryCompletedResponse(
         ByteString taskToken,
         RespondQueryTaskCompletedRequest.Builder queryCompleted,
-        Scope workflowTypeMetricsScope) {
+        Scope workflowTypeMetricsScope,
+        @Nullable StorageDriverTargetInfo storageTarget) {
       queryCompleted.setTaskToken(taskToken).setNamespace(namespace);
+      storeOutboundPayloads(queryCompleted, storageTarget);
+      RespondQueryTaskCompletedRequest request = queryCompleted.build();
       // Do not retry query response
       service
           .blockingStub()
           .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, workflowTypeMetricsScope)
-          .respondQueryTaskCompleted(queryCompleted.build());
+          .respondQueryTaskCompleted(request);
     }
 
     private void logExceptionDuringResultReporting(

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/StartDelayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/StartDelayTest.java
@@ -1,6 +1,7 @@
 package io.temporal.client.functional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.history.v1.HistoryEvent;
@@ -40,8 +41,9 @@ public class StartDelayTest {
     long start = System.currentTimeMillis();
     stubF.func();
     long end = System.currentTimeMillis();
-    // Assert that the workflow took at least 5 seconds to start
-    assertEquals(1000, end - start, 500);
+    long elapsed = end - start;
+    assertTrue("start delay was not honored, took " + elapsed + "ms", elapsed >= 1000);
+    assertTrue("start delay took far longer than 1s, took " + elapsed + "ms", elapsed < 3000);
     WorkflowExecution workflowExecution = WorkflowStub.fromTyped(stubF).getExecution();
     WorkflowExecutionHistory workflowExecutionHistory =
         testWorkflowRule.getWorkflowClient().fetchHistory(workflowExecution.getWorkflowId());

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStorageDataConverterTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStorageDataConverterTest.java
@@ -17,19 +17,12 @@ import io.temporal.failure.ApplicationFailure;
 import io.temporal.payload.codec.PayloadCodec;
 import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.payload.storage.StorageDriver;
-import io.temporal.payload.storage.StorageDriverClaim;
-import io.temporal.payload.storage.StorageDriverRetrieveContext;
-import io.temporal.payload.storage.StorageDriverStoreContext;
-import io.temporal.payload.storage.StorageDriverTargetInfo;
 import io.temporal.payload.storage.StorageDriverWorkflowInfo;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
@@ -39,7 +32,7 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void payloadsRoundTripThroughStorage() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     DataConverter converter = resolving(driver, 0);
 
     Optional<Payloads> stored = converter.toPayloads("a", "b");
@@ -53,19 +46,19 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void payloadsBelowThresholdStayInline() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     DataConverter converter = resolving(driver, 1024);
 
     Optional<Payloads> stored = converter.toPayloads("small");
 
     assertFalse(ExternalStorageReferences.isReference(stored.get().getPayloads(0)));
-    assertTrue(driver.objects.isEmpty());
+    assertTrue(driver.storedPayloads().isEmpty());
     assertEquals("small", converter.fromPayloads(0, stored, String.class, String.class));
   }
 
   @Test
   public void readingOneArgumentDoesNotFetchTheRest() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     DataConverter converter = resolving(driver, 0);
 
     Optional<Payloads> stored = converter.toPayloads("first", "second", "third");
@@ -78,7 +71,7 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void singlePayloadRoundTrips() {
-    DataConverter converter = resolving(new RecordingDriver(), 0);
+    DataConverter converter = resolving(TestStorageDriver.create(), 0);
 
     Optional<Payload> stored = converter.toPayload("value");
 
@@ -88,7 +81,7 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void failureDetailsRoundTrip() {
-    DataConverter converter = resolving(new RecordingDriver(), 0);
+    DataConverter converter = resolving(TestStorageDriver.create(), 0);
 
     Failure failure =
         converter.exceptionToFailure(
@@ -104,27 +97,27 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void storageTargetReachesTheDriver() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     StorageDriverWorkflowInfo target = new StorageDriverWorkflowInfo("ns", "wf-1", null, null);
 
     ExternalStorageDataConverter converter =
         new ExternalStorageDataConverter(plain, runner(driver, 0)).withStorageTarget(target);
     converter.toPayloads("x");
 
-    assertEquals(target, driver.lastTarget);
+    assertEquals(target, driver.lastTarget());
   }
 
   @Test
   public void withoutATargetTheDriverSeesNone() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     resolving(driver, 0).toPayloads("x");
 
-    assertNull(driver.lastTarget);
+    assertNull(driver.lastTarget());
   }
 
   @Test
   public void arrayFromPayloadsRoundTrips() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     DataConverter converter = resolving(driver, 0);
 
     Optional<Payloads> stored = converter.toPayloads("a", 42);
@@ -141,7 +134,7 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void arrayFromPayloadsWithAbsentContentUsesDefaults() {
-    DataConverter converter = resolving(new RecordingDriver(), 0);
+    DataConverter converter = resolving(TestStorageDriver.create(), 0);
 
     Object[] values =
         converter.fromPayloads(
@@ -152,7 +145,7 @@ public class ExternalStorageDataConverterTest {
 
   @Test
   public void arrayFromPayloadsDecodesThroughTheCodecInOneBatch() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     CountingCodec codec = new CountingCodec();
     DataConverter converter = codecBacked(driver, codec);
 
@@ -175,14 +168,14 @@ public class ExternalStorageDataConverterTest {
    */
   @Test
   public void driversOnlyEverSeeCodecEncodedPayloads() {
-    RecordingDriver driver = new RecordingDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     CountingCodec codec = new CountingCodec();
     DataConverter converter = codecBacked(driver, codec);
 
     Optional<Payloads> stored = converter.toPayloads("a", "b", "c");
 
-    assertEquals(3, driver.objects.size());
-    for (Payload payload : driver.objects.values()) {
+    assertEquals(3, driver.storedCount());
+    for (Payload payload : driver.storedPayloads()) {
       String data = payload.getData().toStringUtf8();
       assertFalse(data.contains("\"a\""));
       assertFalse(data.contains("\"b\""));
@@ -240,48 +233,6 @@ public class ExternalStorageDataConverterTest {
         out.add(payload.toBuilder().setData(ByteString.copyFrom(bytes)).build());
       }
       return out;
-    }
-  }
-
-  private static final class RecordingDriver implements StorageDriver {
-    final Map<String, Payload> objects = new HashMap<>();
-    final List<String> retrievedKeys = new ArrayList<>();
-    volatile StorageDriverTargetInfo lastTarget;
-    private int counter = 0;
-
-    @Override
-    public String getName() {
-      return "test";
-    }
-
-    @Override
-    public String getType() {
-      return "test.inmemory";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      lastTarget = context.getTarget();
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = "k-" + (counter++);
-        objects.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      List<Payload> payloads = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        String key = claim.getClaimData().get("key");
-        retrievedKeys.add(key);
-        payloads.add(objects.get(key));
-      }
-      return CompletableFuture.completedFuture(payloads);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStoragePayloadTransformerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStoragePayloadTransformerTest.java
@@ -120,16 +120,7 @@ public class ExternalStoragePayloadTransformerTest {
   @Test
   public void selectorReceivesSelectContextCarryingTheTarget() throws Exception {
     AtomicReference<StorageDriverSelectContext> seen = new AtomicReference<>();
-    AtomicReference<StorageDriverStoreContext> storeSeen = new AtomicReference<>();
-    InMemoryDriver driver =
-        new InMemoryDriver("d1") {
-          @Override
-          public CompletableFuture<List<StorageDriverClaim>> store(
-              StorageDriverStoreContext context, List<Payload> payloads) {
-            storeSeen.set(context);
-            return super.store(context, payloads);
-          }
-        };
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     StorageDriverSelector selector =
         (context, payload) -> {
           seen.set(context);
@@ -151,8 +142,7 @@ public class ExternalStoragePayloadTransformerTest {
 
     assertNotNull(seen.get());
     assertSame(target, seen.get().getTarget());
-    assertNotNull(storeSeen.get());
-    assertSame(target, storeSeen.get().getTarget());
+    assertEquals(Collections.singletonList(target), driver.targets);
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStoragePayloadTransformerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStoragePayloadTransformerTest.java
@@ -21,7 +21,6 @@ import io.temporal.payload.storage.StorageDriverSelector;
 import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.payload.storage.StorageDriverTargetInfo;
 import io.temporal.payload.storage.StorageDriverWorkflowInfo;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +38,7 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void storesAndRetrievesRoundTrip() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStoragePayloadTransformer transformer = transformer(driver, 0);
     List<Payload> input = Arrays.asList(payload("a"), payload("b"));
 
@@ -59,7 +58,7 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void payloadBelowThresholdStaysInline() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStoragePayloadTransformer transformer = transformer(driver, 100);
     Payload small = payload("x");
     Payload large = payload(repeat("y", 200));
@@ -75,7 +74,7 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void selectorReturningNullKeepsInline() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStoragePayloadTransformer transformer =
         ExternalStoragePayloadTransformer.fromOptions(
             ExternalStorage.newBuilder()
@@ -95,8 +94,8 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void multipleDriversBatchPerDriverAndPreserveOrder() throws Exception {
-    InMemoryDriver d1 = new InMemoryDriver("d1");
-    InMemoryDriver d2 = new InMemoryDriver("d2");
+    TestStorageDriver d1 = TestStorageDriver.named("d1");
+    TestStorageDriver d2 = TestStorageDriver.named("d2");
     Map<String, StorageDriver> byPrefix = new HashMap<>();
     byPrefix.put("1", d1);
     byPrefix.put("2", d2);
@@ -220,7 +219,7 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void unknownDriverOnRetrieveFails() {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStoragePayloadTransformer transformer = transformer(driver, 0);
     Payload reference =
         ExternalStorageReferences.toReferencePayload(
@@ -235,8 +234,8 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void selectorReturningUnregisteredDriverFails() {
-    InMemoryDriver registered = new InMemoryDriver("d1");
-    InMemoryDriver stranger = new InMemoryDriver("d2");
+    TestStorageDriver registered = TestStorageDriver.named("d1");
+    TestStorageDriver stranger = TestStorageDriver.named("d2");
     ExternalStoragePayloadTransformer transformer =
         ExternalStoragePayloadTransformer.fromOptions(
             ExternalStorage.newBuilder()
@@ -350,7 +349,7 @@ public class ExternalStoragePayloadTransformerTest {
 
   @Test
   public void selectorObservesCallerCancellationToken() {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     CancelSource<CancellationException> caller = new CancelSource<>(CancellationException::new);
     AtomicReference<CancellationToken<CancellationException>> observed = new AtomicReference<>();
     ExternalStoragePayloadTransformer transformer =
@@ -439,41 +438,6 @@ public class ExternalStoragePayloadTransformerTest {
     public CompletableFuture<List<Payload>> retrieve(
         StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
       throw new UnsupportedOperationException();
-    }
-  }
-
-  private static class InMemoryDriver extends FakeDriver {
-    final Map<String, Payload> objects = new HashMap<>();
-    final List<Integer> storeBatchSizes = new ArrayList<>();
-    final List<Integer> retrieveBatchSizes = new ArrayList<>();
-    private int counter = 0;
-
-    InMemoryDriver(String name) {
-      super(name);
-    }
-
-    @Override
-    public CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      storeBatchSizes.add(payloads.size());
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = getName() + "-" + (counter++);
-        objects.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      retrieveBatchSizes.add(claims.size());
-      List<Payload> payloads = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        payloads.add(objects.get(claim.getClaimData().get("key")));
-      }
-      return CompletableFuture.completedFuture(payloads);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStorageRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStorageRunnerTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.ByteString;
 import io.temporal.api.command.v1.Command;
+import io.temporal.api.command.v1.CommandOrBuilder;
 import io.temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes;
 import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributes;
 import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributesOrBuilder;
@@ -16,6 +17,7 @@ import io.temporal.api.common.v1.ActivityType;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.SearchAttributes;
+import io.temporal.api.sdk.v1.UserMetadata;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskCompletedRequest;
 import io.temporal.common.CancellationToken;
 import io.temporal.internal.concurrent.structured.CancelSource;
@@ -160,7 +162,7 @@ public class ExternalStorageRunnerTest {
   }
 
   @Test
-  public void storeAppliesPerCommandTargetFromMessageVisitor() {
+  public void storeScopesCommandTargetOverAttributesAndMetadata() {
     TargetCapturingDriver driver = new TargetCapturingDriver("d1");
     ExternalStorageRunner storage = transformer(driver, 0);
 
@@ -168,6 +170,8 @@ public class ExternalStorageRunnerTest {
         RespondWorkflowTaskCompletedRequest.newBuilder()
             .addCommands(
                 Command.newBuilder()
+                    .setUserMetadata(
+                        UserMetadata.newBuilder().setSummary(payload("activity-summary")))
                     .setScheduleActivityTaskCommandAttributes(
                         ScheduleActivityTaskCommandAttributes.newBuilder()
                             .setActivityId("act-1")
@@ -184,11 +188,15 @@ public class ExternalStorageRunnerTest {
         new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
     MessageVisitor<StorageDriverTargetInfo> visitor =
         (current, message) -> {
-          if (message instanceof ScheduleActivityTaskCommandAttributesOrBuilder) {
-            ScheduleActivityTaskCommandAttributesOrBuilder attrs =
-                (ScheduleActivityTaskCommandAttributesOrBuilder) message;
-            return new StorageDriverActivityInfo(
-                "ns", attrs.getActivityId(), null, attrs.getActivityType().getName());
+          if (message instanceof CommandOrBuilder) {
+            CommandOrBuilder command = (CommandOrBuilder) message;
+            if (command.getAttributesCase()
+                == Command.AttributesCase.SCHEDULE_ACTIVITY_TASK_COMMAND_ATTRIBUTES) {
+              ScheduleActivityTaskCommandAttributesOrBuilder attrs =
+                  command.getScheduleActivityTaskCommandAttributesOrBuilder();
+              return new StorageDriverActivityInfo(
+                  "ns", attrs.getActivityId(), null, attrs.getActivityType().getName());
+            }
           }
           return current;
         };
@@ -198,6 +206,9 @@ public class ExternalStorageRunnerTest {
     assertEquals(
         new StorageDriverActivityInfo("ns", "act-1", null, "MyActivity"),
         driver.targetFor("activity-input"));
+    assertEquals(
+        new StorageDriverActivityInfo("ns", "act-1", null, "MyActivity"),
+        driver.targetFor("activity-summary"));
     assertEquals(workflowTarget, driver.targetFor("wf-result"));
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStorageRunnerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/ExternalStorageRunnerTest.java
@@ -25,18 +25,9 @@ import io.temporal.internal.payload.visitor.MessageVisitor;
 import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.payload.storage.StorageDriver;
 import io.temporal.payload.storage.StorageDriverActivityInfo;
-import io.temporal.payload.storage.StorageDriverClaim;
-import io.temporal.payload.storage.StorageDriverRetrieveContext;
-import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.payload.storage.StorageDriverTargetInfo;
 import io.temporal.payload.storage.StorageDriverWorkflowInfo;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
@@ -45,7 +36,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void storeAndRetrieveRoundTripsOverAMessage() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStorageRunner transformer = transformer(driver, 0);
     Payloads message =
         Payloads.newBuilder().addPayloads(payload("a")).addPayloads(payload("b")).build();
@@ -63,7 +54,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void walksNestedPayloads() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStorageRunner transformer = transformer(driver, 0);
     Command command =
         Command.newBuilder()
@@ -83,7 +74,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void payloadBelowThresholdLeavesMessageUnchanged() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStorageRunner transformer = transformer(driver, 1024);
     Payloads message = Payloads.newBuilder().addPayloads(payload("small")).build();
 
@@ -98,7 +89,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void searchAttributesAreNotOffloaded() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStorageRunner transformer = transformer(driver, 0);
     Command command =
         Command.newBuilder()
@@ -124,7 +115,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void throwIfContainsReferenceThrowsOnANestedReference() throws Exception {
-    ExternalStorageRunner transformer = transformer(new InMemoryDriver("d1"), 0);
+    ExternalStorageRunner transformer = transformer(TestStorageDriver.named("d1"), 0);
     RespondWorkflowTaskCompletedRequest.Builder request =
         RespondWorkflowTaskCompletedRequest.newBuilder()
             .addCommands(
@@ -144,7 +135,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void throwIfContainsReferenceThrowsOnReference() throws Exception {
-    InMemoryDriver driver = new InMemoryDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStorageRunner transformer = transformer(driver, 0);
     Payloads.Builder builder = Payloads.newBuilder().addPayloads(payload("a"));
     transformer.store(builder, null, null, CancellationToken.none());
@@ -163,7 +154,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void storeScopesCommandTargetOverAttributesAndMetadata() {
-    TargetCapturingDriver driver = new TargetCapturingDriver("d1");
+    TestStorageDriver driver = TestStorageDriver.named("d1");
     ExternalStorageRunner storage = transformer(driver, 0);
 
     RespondWorkflowTaskCompletedRequest.Builder request =
@@ -214,7 +205,7 @@ public class ExternalStorageRunnerTest {
 
   @Test
   public void callerCancellationAbortsStore() {
-    ExternalStorageRunner storage = transformer(new HangingDriver("d1"), 0);
+    ExternalStorageRunner storage = transformer(TestStorageDriver.named("d1").neverAnswers(), 0);
     CancelSource<CancellationException> caller = new CancelSource<>(CancellationException::new);
     caller.cancel();
     Payloads message = Payloads.newBuilder().addPayloads(payload("big")).build();
@@ -227,7 +218,7 @@ public class ExternalStorageRunnerTest {
   @Test
   public void completedOperationsReleaseTheirCancellationRegistrations() {
     RegistrationCountingToken token = new RegistrationCountingToken();
-    ExternalStorageRunner storage = transformer(new InMemoryDriver("d1"), 0);
+    ExternalStorageRunner storage = transformer(TestStorageDriver.named("d1"), 0);
 
     for (int i = 0; i < 5; i++) {
       Payloads.Builder builder = Payloads.newBuilder().addPayloads(payload("a"));
@@ -272,123 +263,6 @@ public class ExternalStorageRunnerTest {
     public Registration onCancel(Runnable callback) {
       open.incrementAndGet();
       return open::decrementAndGet;
-    }
-  }
-
-  private static final class InMemoryDriver implements StorageDriver {
-    private final String name;
-    private final Map<String, Payload> objects = new HashMap<>();
-    final List<Integer> storeBatchSizes = new ArrayList<>();
-    private int counter = 0;
-
-    InMemoryDriver(String name) {
-      this.name = name;
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public String getType() {
-      return "test.inmemory";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      storeBatchSizes.add(payloads.size());
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = name + "-" + (counter++);
-        objects.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      List<Payload> payloads = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        payloads.add(objects.get(claim.getClaimData().get("key")));
-      }
-      return CompletableFuture.completedFuture(payloads);
-    }
-  }
-
-  private static final class TargetCapturingDriver implements StorageDriver {
-    private final String name;
-    private final Map<String, StorageDriverTargetInfo> targetByData = new HashMap<>();
-    private int counter = 0;
-
-    TargetCapturingDriver(String name) {
-      this.name = name;
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public String getType() {
-      return "test.capture";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        targetByData.put(payload.getData().toStringUtf8(), context.getTarget());
-        claims.add(
-            new StorageDriverClaim(Collections.singletonMap("key", name + "-" + (counter++))));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    synchronized StorageDriverTargetInfo targetFor(String data) {
-      return targetByData.get(data);
-    }
-
-    @Override
-    public CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      throw new UnsupportedOperationException();
-    }
-  }
-
-  /** Driver whose operations never settle, so only cancellation can end a blocking call. */
-  private static final class HangingDriver implements StorageDriver {
-    private final String name;
-
-    HangingDriver(String name) {
-      this.name = name;
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public String getType() {
-      return "test.hanging";
-    }
-
-    @Override
-    public CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      return new CompletableFuture<>();
-    }
-
-    @Override
-    public CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      return new CompletableFuture<>();
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/TestStorageDriver.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/TestStorageDriver.java
@@ -1,0 +1,229 @@
+package io.temporal.internal.payload.storage;
+
+import io.temporal.api.common.v1.Payload;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
+import io.temporal.payload.storage.StorageDriverTargetInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+/**
+ * In-memory storage driver for tests. Records what it was asked to do, and can be told to fail,
+ * block or never answer so that one driver covers the cases the tests need.
+ */
+public final class TestStorageDriver implements StorageDriver {
+
+  private final String name;
+  private final Map<String, Payload> objects = new HashMap<>();
+  private final Map<String, StorageDriverTargetInfo> targetByData = new HashMap<>();
+  private int counter;
+
+  public final List<Integer> storeBatchSizes = new CopyOnWriteArrayList<>();
+  public final List<Integer> retrieveBatchSizes = new CopyOnWriteArrayList<>();
+  public final List<String> retrievedKeys = new CopyOnWriteArrayList<>();
+  public final List<StorageDriverTargetInfo> targets = new CopyOnWriteArrayList<>();
+  public final List<String> storedData = new CopyOnWriteArrayList<>();
+  public final AtomicInteger stores = new AtomicInteger();
+  public final AtomicInteger retrieves = new AtomicInteger();
+  public final AtomicInteger injectedFailures = new AtomicInteger();
+
+  private volatile boolean neverAnswers;
+  private final AtomicInteger storeFailures = new AtomicInteger();
+  private final AtomicInteger retrieveFailures = new AtomicInteger();
+  private volatile @Nullable String failStoresContaining;
+  private volatile @Nullable CountDownLatch storeEntered;
+  private volatile @Nullable CountDownLatch releaseStore;
+
+  private TestStorageDriver(String name) {
+    this.name = name;
+  }
+
+  public static TestStorageDriver create() {
+    return new TestStorageDriver("test");
+  }
+
+  public static TestStorageDriver named(String name) {
+    return new TestStorageDriver(name);
+  }
+
+  /** Neither storing nor retrieving ever finishes, so only cancellation can end the call. */
+  public TestStorageDriver neverAnswers() {
+    this.neverAnswers = true;
+    return this;
+  }
+
+  public TestStorageDriver failStores(int times) {
+    this.storeFailures.set(times);
+    return this;
+  }
+
+  /** Fails the next {@code times} stores that carry a payload containing {@code marker}. */
+  public TestStorageDriver failStoresContaining(String marker, int times) {
+    this.failStoresContaining = marker;
+    this.storeFailures.set(times);
+    return this;
+  }
+
+  public TestStorageDriver failRetrieves(int times) {
+    this.retrieveFailures.set(times);
+    return this;
+  }
+
+  /** Holds each store until {@code release}, counting down {@code entered} on the way in. */
+  public TestStorageDriver blockStores(CountDownLatch entered, CountDownLatch release) {
+    this.storeEntered = entered;
+    this.releaseStore = release;
+    return this;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getType() {
+    return "test.in-memory";
+  }
+
+  @Override
+  public synchronized CompletableFuture<List<StorageDriverClaim>> store(
+      StorageDriverStoreContext context, List<Payload> payloads) {
+    stores.incrementAndGet();
+    storeBatchSizes.add(payloads.size());
+    targets.add(context.getTarget());
+
+    CountDownLatch entered = storeEntered;
+    if (entered != null) {
+      entered.countDown();
+    }
+    CountDownLatch release = releaseStore;
+    if (release != null) {
+      try {
+        release.await(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (neverAnswers) {
+      return new CompletableFuture<>();
+    }
+    if (shouldFailStore(payloads)) {
+      injectedFailures.incrementAndGet();
+      return failed("storage unavailable");
+    }
+
+    List<StorageDriverClaim> claims = new ArrayList<>();
+    for (Payload payload : payloads) {
+      String data = payload.getData().toStringUtf8();
+      storedData.add(data);
+      targetByData.put(data, context.getTarget());
+      String key = name + "-" + (counter++);
+      objects.put(key, payload);
+      claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+    }
+    return CompletableFuture.completedFuture(claims);
+  }
+
+  @Override
+  public synchronized CompletableFuture<List<Payload>> retrieve(
+      StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+    retrieves.incrementAndGet();
+    retrieveBatchSizes.add(claims.size());
+    for (StorageDriverClaim claim : claims) {
+      retrievedKeys.add(claim.getClaimData().get("key"));
+    }
+    if (neverAnswers) {
+      return new CompletableFuture<>();
+    }
+    if (retrieveFailures.get() > 0) {
+      retrieveFailures.decrementAndGet();
+      injectedFailures.incrementAndGet();
+      return failed("storage unavailable");
+    }
+    List<Payload> payloads = new ArrayList<>();
+    for (StorageDriverClaim claim : claims) {
+      payloads.add(objects.get(claim.getClaimData().get("key")));
+    }
+    return CompletableFuture.completedFuture(payloads);
+  }
+
+  /** Forgets everything stored and recorded, and clears any injected behaviour. */
+  public synchronized void reset() {
+    objects.clear();
+    targetByData.clear();
+    counter = 0;
+    storeBatchSizes.clear();
+    retrieveBatchSizes.clear();
+    retrievedKeys.clear();
+    targets.clear();
+    storedData.clear();
+    stores.set(0);
+    retrieves.set(0);
+    injectedFailures.set(0);
+    storeFailures.set(0);
+    retrieveFailures.set(0);
+    failStoresContaining = null;
+    storeEntered = null;
+    releaseStore = null;
+    neverAnswers = false;
+  }
+
+  /** The target supplied when the payload with this data was stored. */
+  public synchronized StorageDriverTargetInfo targetFor(String data) {
+    return targetByData.get(data);
+  }
+
+  public synchronized int storedCount() {
+    return objects.size();
+  }
+
+  public synchronized Collection<Payload> storedPayloads() {
+    return new ArrayList<>(objects.values());
+  }
+
+  /** The target supplied with the most recent store, or {@code null} if nothing was stored. */
+  public StorageDriverTargetInfo lastTarget() {
+    return targets.isEmpty() ? null : targets.get(targets.size() - 1);
+  }
+
+  public boolean stored(String substring) {
+    return storedData.stream().anyMatch(data -> data.contains(substring));
+  }
+
+  private boolean shouldFailStore(List<Payload> payloads) {
+    if (storeFailures.get() <= 0) {
+      return false;
+    }
+    String marker = failStoresContaining;
+    if (marker == null) {
+      storeFailures.decrementAndGet();
+      return true;
+    }
+    for (Payload payload : payloads) {
+      if (payload.getData().toStringUtf8().contains(marker)) {
+        storeFailures.decrementAndGet();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static <T> CompletableFuture<T> failed(String message) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(new IllegalStateException(message));
+    return future;
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/TestStorageDriver.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/payload/storage/TestStorageDriver.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -40,6 +41,7 @@ public final class TestStorageDriver implements StorageDriver {
   public final AtomicInteger injectedFailures = new AtomicInteger();
 
   private volatile boolean neverAnswers;
+  private volatile boolean cancelInsteadOfFailing;
   private final AtomicInteger storeFailures = new AtomicInteger();
   private final AtomicInteger retrieveFailures = new AtomicInteger();
   private volatile @Nullable String failStoresContaining;
@@ -66,6 +68,13 @@ public final class TestStorageDriver implements StorageDriver {
 
   public TestStorageDriver failStores(int times) {
     this.storeFailures.set(times);
+    return this;
+  }
+
+  /** Fails the next {@code times} stores the way an abandoned call does. */
+  public TestStorageDriver cancelStores(int times) {
+    this.storeFailures.set(times);
+    this.cancelInsteadOfFailing = true;
     return this;
   }
 
@@ -122,7 +131,9 @@ public final class TestStorageDriver implements StorageDriver {
     }
     if (shouldFailStore(payloads)) {
       injectedFailures.incrementAndGet();
-      return failed("storage unavailable");
+      return cancelInsteadOfFailing
+          ? cancelled("external storage stopped")
+          : failed("storage unavailable");
     }
 
     List<StorageDriverClaim> claims = new ArrayList<>();
@@ -179,6 +190,7 @@ public final class TestStorageDriver implements StorageDriver {
     storeEntered = null;
     releaseStore = null;
     neverAnswers = false;
+    cancelInsteadOfFailing = false;
   }
 
   /** The target supplied when the payload with this data was stored. */
@@ -219,6 +231,12 @@ public final class TestStorageDriver implements StorageDriver {
       }
     }
     return false;
+  }
+
+  private static <T> CompletableFuture<T> cancelled(String message) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(new CancellationException(message));
+    return future;
   }
 
   private static <T> CompletableFuture<T> failed(String message) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -230,12 +230,14 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
             "namespace",
             setUpMockWorkflowFactory(),
             new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope()),
-            SingleWorkerOptions.newBuilder().setExternalStorageRunner(externalStorage).build(),
+            SingleWorkerOptions.newBuilder()
+                .setExternalStorageRunner(externalStorage)
+                .setStorageCancellation(stopping.token())
+                .build(),
             null,
             Duration.ofSeconds(5),
             client,
-            null,
-            stopping.token());
+            null);
 
     assertThrows(
         "stopping storage must not be turned into a workflow task failure",

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -20,6 +20,7 @@ import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.common.CancellationToken;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
@@ -154,7 +155,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
                     .setWorkflowExecutionStartedEventAttributes(
                         startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
                             .setInput(Payloads.newBuilder().addPayloads(input))));
-    externalStorage.store(storedHistory, null);
+    externalStorage.store(storedHistory, null, null, CancellationToken.none());
 
     WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
     when(client.getServerCapabilities())

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -3,6 +3,7 @@ package io.temporal.internal.replay;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -137,6 +138,70 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
   }
 
   @Test
+  public void resolvesExternalStorageReferencesInTheWorkflowTaskItself() throws Throwable {
+    InMemoryStorageDriver driver = new InMemoryStorageDriver();
+    ExternalStorageRunner externalStorage =
+        ExternalStorageRunner.create(
+            ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build());
+    PollWorkflowTaskQueueResponse fullTask = HistoryUtils.generateWorkflowTaskWithInitialHistory();
+    HistoryEvent startedEvent = fullTask.getHistory().getEvents(0);
+    Payload input = Payload.newBuilder().setData(ByteString.copyFromUtf8("input")).build();
+    History.Builder storedHistory =
+        fullTask.getHistory().toBuilder()
+            .setEvents(
+                0,
+                startedEvent.toBuilder()
+                    .setWorkflowExecutionStartedEventAttributes(
+                        startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
+                            .setInput(Payloads.newBuilder().addPayloads(input))));
+    externalStorage.store(storedHistory, null, null, CancellationToken.none());
+    assertNotEquals(
+        "the payload must be replaced by a reference, otherwise this test proves nothing",
+        input,
+        storedInput(storedHistory));
+
+    WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+    when(client.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+
+    ReplayWorkflow workflow = mock(ReplayWorkflow.class);
+    when(workflow.eventLoop()).thenReturn(true);
+    when(workflow.getOutput()).thenReturn(Optional.empty());
+    WorkflowContext workflowContext = mock(WorkflowContext.class);
+    when(workflowContext.getRunningUpdateHandlers()).thenReturn(new HashMap<>());
+    when(workflow.getWorkflowContext()).thenReturn(workflowContext);
+    ReplayWorkflowFactory workflowFactory = mock(ReplayWorkflowFactory.class);
+    when(workflowFactory.getWorkflow(any(), any())).thenReturn(workflow);
+
+    WorkflowTaskHandler taskHandler =
+        new ReplayWorkflowTaskHandler(
+            "namespace",
+            workflowFactory,
+            new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope()),
+            SingleWorkerOptions.newBuilder().setExternalStorageRunner(externalStorage).build(),
+            null,
+            Duration.ofSeconds(5),
+            client,
+            null);
+
+    taskHandler.handleWorkflowTask(fullTask.toBuilder().setHistory(storedHistory).build());
+
+    ArgumentCaptor<HistoryEvent> event = ArgumentCaptor.forClass(HistoryEvent.class);
+    verify(workflow).start(event.capture(), any());
+    assertEquals(
+        input,
+        event.getValue().getWorkflowExecutionStartedEventAttributes().getInput().getPayloads(0));
+  }
+
+  private static Payload storedInput(History.Builder history) {
+    return history
+        .getEvents(0)
+        .getWorkflowExecutionStartedEventAttributes()
+        .getInput()
+        .getPayloads(0);
+  }
+
+  @Test
   public void aFailedDownloadIsReportedAsAWorkflowTaskFailure() throws Throwable {
     InMemoryStorageDriver driver = new InMemoryStorageDriver();
     ExternalStorageRunner externalStorage =
@@ -203,6 +268,10 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
                         startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
                             .setInput(Payloads.newBuilder().addPayloads(input))));
     externalStorage.store(storedHistory, null, null, CancellationToken.none());
+    assertNotEquals(
+        "the payload must be replaced by a reference, otherwise this test proves nothing",
+        input,
+        storedInput(storedHistory));
 
     WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
     when(client.getServerCapabilities())

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -181,7 +181,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
             "namespace",
             workflowFactory,
             new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope()),
-            SingleWorkerOptions.newBuilder().setExternalStorage(externalStorage).build(),
+            SingleWorkerOptions.newBuilder().setExternalStorageRunner(externalStorage).build(),
             null,
             Duration.ofSeconds(5),
             client,

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -24,28 +24,21 @@ import io.temporal.api.workflowservice.v1.*;
 import io.temporal.common.CancellationToken;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.internal.payload.storage.TestStorageDriver;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
 import io.temporal.internal.worker.SingleWorkerOptions;
 import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.internal.worker.WorkflowRunLockManager;
 import io.temporal.internal.worker.WorkflowTaskHandler;
 import io.temporal.payload.storage.ExternalStorage;
-import io.temporal.payload.storage.StorageDriver;
-import io.temporal.payload.storage.StorageDriverClaim;
-import io.temporal.payload.storage.StorageDriverRetrieveContext;
-import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.serviceclient.Version;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testUtils.HistoryUtils;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -139,7 +132,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
 
   @Test
   public void resolvesExternalStorageReferencesInTheWorkflowTaskItself() throws Throwable {
-    InMemoryStorageDriver driver = new InMemoryStorageDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     ExternalStorageRunner externalStorage =
         ExternalStorageRunner.create(
             ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build());
@@ -203,7 +196,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
 
   @Test
   public void aFailedDownloadIsReportedAsAWorkflowTaskFailure() throws Throwable {
-    InMemoryStorageDriver driver = new InMemoryStorageDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     ExternalStorageRunner externalStorage =
         ExternalStorageRunner.create(
             ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build());
@@ -219,7 +212,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
                         startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
                             .setInput(Payloads.newBuilder().addPayloads(input))));
     externalStorage.store(storedHistory, null, null, CancellationToken.none());
-    driver.failRetrieve = true;
+    driver.failRetrieves(1);
 
     WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
     when(client.getServerCapabilities())
@@ -253,7 +246,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     ExternalStorageRunner externalStorage =
         ExternalStorageRunner.create(
             ExternalStorage.newBuilder()
-                .setDriver(new InMemoryStorageDriver())
+                .setDriver(TestStorageDriver.create())
                 .setPayloadSizeThreshold(0)
                 .build());
     PollWorkflowTaskQueueResponse fullTask = HistoryUtils.generateWorkflowTaskWithInitialHistory();
@@ -422,48 +415,5 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     when(mockWorkflowContext.getRunningUpdateHandlers()).thenReturn(new HashMap<>());
     when(mockWorkflow.getWorkflowContext()).thenReturn(mockWorkflowContext);
     return mockFactory;
-  }
-
-  private static final class InMemoryStorageDriver implements StorageDriver {
-    private final Map<String, Payload> payloads = new HashMap<>();
-    private int nextKey;
-    boolean failRetrieve;
-
-    @Override
-    public String getName() {
-      return "test";
-    }
-
-    @Override
-    public String getType() {
-      return "test.in-memory";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = Integer.toString(nextKey++);
-        this.payloads.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      if (failRetrieve) {
-        CompletableFuture<List<Payload>> failed = new CompletableFuture<>();
-        failed.completeExceptionally(new RuntimeException("storage unavailable"));
-        return failed;
-      }
-      List<Payload> retrieved = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        retrieved.add(payloads.get(claim.getClaimData().get("key")));
-      }
-      return CompletableFuture.completedFuture(retrieved);
-    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -137,6 +137,53 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
   }
 
   @Test
+  public void aFailedDownloadIsReportedAsAWorkflowTaskFailure() throws Throwable {
+    InMemoryStorageDriver driver = new InMemoryStorageDriver();
+    ExternalStorageRunner externalStorage =
+        ExternalStorageRunner.create(
+            ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build());
+    PollWorkflowTaskQueueResponse fullTask = HistoryUtils.generateWorkflowTaskWithInitialHistory();
+    HistoryEvent startedEvent = fullTask.getHistory().getEvents(0);
+    Payload input = Payload.newBuilder().setData(ByteString.copyFromUtf8("input")).build();
+    History.Builder storedHistory =
+        fullTask.getHistory().toBuilder()
+            .setEvents(
+                0,
+                startedEvent.toBuilder()
+                    .setWorkflowExecutionStartedEventAttributes(
+                        startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
+                            .setInput(Payloads.newBuilder().addPayloads(input))));
+    externalStorage.store(storedHistory, null, null, CancellationToken.none());
+    driver.failRetrieve = true;
+
+    WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+    when(client.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+
+    WorkflowTaskHandler taskHandler =
+        new ReplayWorkflowTaskHandler(
+            "namespace",
+            setUpMockWorkflowFactory(),
+            new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope()),
+            SingleWorkerOptions.newBuilder().setExternalStorageRunner(externalStorage).build(),
+            null,
+            Duration.ofSeconds(5),
+            client,
+            null);
+
+    WorkflowTaskHandler.Result result =
+        taskHandler.handleWorkflowTask(fullTask.toBuilder().setHistory(storedHistory).build());
+
+    assertNotNull(
+        "a failed download must be reported rather than ending the task", result.getTaskFailed());
+    assertTrue(result.getTaskFailed().hasFailure());
+    assertTrue(
+        "the reported failure must say what went wrong, got: "
+            + result.getTaskFailed().getFailure().getMessage(),
+        result.getTaskFailed().getFailure().getMessage().contains("storage unavailable"));
+  }
+
+  @Test
   public void resolvesExternalStorageReferencesInFetchedFullHistory() throws Throwable {
     ExternalStorageRunner externalStorage =
         ExternalStorageRunner.create(
@@ -311,6 +358,7 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
   private static final class InMemoryStorageDriver implements StorageDriver {
     private final Map<String, Payload> payloads = new HashMap<>();
     private int nextKey;
+    boolean failRetrieve;
 
     @Override
     public String getName() {
@@ -337,6 +385,11 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     @Override
     public synchronized CompletableFuture<List<Payload>> retrieve(
         StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      if (failRetrieve) {
+        CompletableFuture<List<Payload>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("storage unavailable"));
+        return failed;
+      }
       List<Payload> retrieved = new ArrayList<>();
       for (StorageDriverClaim claim : claims) {
         retrieved.add(payloads.get(claim.getClaimData().get("key")));

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -4,6 +4,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +24,7 @@ import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.common.CancellationToken;
 import io.temporal.internal.common.InternalUtils;
+import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.payload.storage.TestStorageDriver;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
@@ -39,6 +41,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -192,6 +195,53 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
         .getWorkflowExecutionStartedEventAttributes()
         .getInput()
         .getPayloads(0);
+  }
+
+  @Test
+  public void aCancelledDownloadIsNotReportedAsAWorkflowTaskFailure() throws Throwable {
+    TestStorageDriver driver = TestStorageDriver.create();
+    ExternalStorageRunner externalStorage =
+        ExternalStorageRunner.create(
+            ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build());
+    PollWorkflowTaskQueueResponse fullTask = HistoryUtils.generateWorkflowTaskWithInitialHistory();
+    HistoryEvent startedEvent = fullTask.getHistory().getEvents(0);
+    Payload input = Payload.newBuilder().setData(ByteString.copyFromUtf8("input")).build();
+    History.Builder storedHistory =
+        fullTask.getHistory().toBuilder()
+            .setEvents(
+                0,
+                startedEvent.toBuilder()
+                    .setWorkflowExecutionStartedEventAttributes(
+                        startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
+                            .setInput(Payloads.newBuilder().addPayloads(input))));
+    externalStorage.store(storedHistory, null, null, CancellationToken.none());
+    driver.neverAnswers();
+
+    CancelSource<CancellationException> stopping =
+        new CancelSource<>(() -> new CancellationException("Worker shutdown"));
+    stopping.cancel();
+
+    WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+    when(client.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+
+    WorkflowTaskHandler taskHandler =
+        new ReplayWorkflowTaskHandler(
+            "namespace",
+            setUpMockWorkflowFactory(),
+            new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope()),
+            SingleWorkerOptions.newBuilder().setExternalStorageRunner(externalStorage).build(),
+            null,
+            Duration.ofSeconds(5),
+            client,
+            null,
+            stopping.token());
+
+    assertThrows(
+        "stopping storage must not be turned into a workflow task failure",
+        CancellationException.class,
+        () ->
+            taskHandler.handleWorkflowTask(fullTask.toBuilder().setHistory(storedHistory).build()));
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -7,32 +7,46 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
 import com.uber.m3.tally.NoopScope;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.History;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.taskqueue.v1.StickyExecutionAttributes;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.internal.common.InternalUtils;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.statemachines.ExecuteLocalActivityParameters;
 import io.temporal.internal.worker.SingleWorkerOptions;
 import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.internal.worker.WorkflowRunLockManager;
 import io.temporal.internal.worker.WorkflowTaskHandler;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.serviceclient.Version;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testUtils.HistoryUtils;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
 
@@ -119,6 +133,67 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     assertEquals(
         "Premature end of stream, expectedLastEventID=3 but no more events after eventID=2",
         result.getTaskFailed().getFailure().getMessage());
+  }
+
+  @Test
+  public void resolvesExternalStorageReferencesInFetchedFullHistory() throws Throwable {
+    ExternalStorageRunner externalStorage =
+        ExternalStorageRunner.create(
+            ExternalStorage.newBuilder()
+                .setDriver(new InMemoryStorageDriver())
+                .setPayloadSizeThreshold(0)
+                .build());
+    PollWorkflowTaskQueueResponse fullTask = HistoryUtils.generateWorkflowTaskWithInitialHistory();
+    HistoryEvent startedEvent = fullTask.getHistory().getEvents(0);
+    Payload input = Payload.newBuilder().setData(ByteString.copyFromUtf8("input")).build();
+    History.Builder storedHistory =
+        fullTask.getHistory().toBuilder()
+            .setEvents(
+                0,
+                startedEvent.toBuilder()
+                    .setWorkflowExecutionStartedEventAttributes(
+                        startedEvent.getWorkflowExecutionStartedEventAttributes().toBuilder()
+                            .setInput(Payloads.newBuilder().addPayloads(input))));
+    externalStorage.store(storedHistory, null);
+
+    WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+    when(client.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+    WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+    when(client.blockingStub()).thenReturn(blockingStub);
+    when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+    when(blockingStub.getWorkflowExecutionHistory(any()))
+        .thenReturn(
+            GetWorkflowExecutionHistoryResponse.newBuilder().setHistory(storedHistory).build());
+
+    ReplayWorkflow workflow = mock(ReplayWorkflow.class);
+    when(workflow.eventLoop()).thenReturn(true);
+    when(workflow.getOutput()).thenReturn(Optional.empty());
+    WorkflowContext workflowContext = mock(WorkflowContext.class);
+    when(workflowContext.getRunningUpdateHandlers()).thenReturn(new HashMap<>());
+    when(workflow.getWorkflowContext()).thenReturn(workflowContext);
+    ReplayWorkflowFactory workflowFactory = mock(ReplayWorkflowFactory.class);
+    when(workflowFactory.getWorkflow(any(), any())).thenReturn(workflow);
+    WorkflowTaskHandler taskHandler =
+        new ReplayWorkflowTaskHandler(
+            "namespace",
+            workflowFactory,
+            new WorkflowExecutorCache(10, new WorkflowRunLockManager(), new NoopScope()),
+            SingleWorkerOptions.newBuilder().setExternalStorage(externalStorage).build(),
+            null,
+            Duration.ofSeconds(5),
+            client,
+            null);
+
+    taskHandler.handleWorkflowTask(
+        fullTask.toBuilder().setHistory(History.getDefaultInstance()).build());
+
+    ArgumentCaptor<HistoryEvent> event = ArgumentCaptor.forClass(HistoryEvent.class);
+    verify(workflow).start(event.capture(), any());
+    assertEquals(
+        input,
+        event.getValue().getWorkflowExecutionStartedEventAttributes().getInput().getPayloads(0));
   }
 
   @Test
@@ -230,5 +305,42 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     when(mockWorkflowContext.getRunningUpdateHandlers()).thenReturn(new HashMap<>());
     when(mockWorkflow.getWorkflowContext()).thenReturn(mockWorkflowContext);
     return mockFactory;
+  }
+
+  private static final class InMemoryStorageDriver implements StorageDriver {
+    private final Map<String, Payload> payloads = new HashMap<>();
+    private int nextKey;
+
+    @Override
+    public String getName() {
+      return "test";
+    }
+
+    @Override
+    public String getType() {
+      return "test.in-memory";
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
+        StorageDriverStoreContext context, List<Payload> payloads) {
+      List<StorageDriverClaim> claims = new ArrayList<>();
+      for (Payload payload : payloads) {
+        String key = Integer.toString(nextKey++);
+        this.payloads.put(key, payload);
+        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+      }
+      return CompletableFuture.completedFuture(claims);
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<Payload>> retrieve(
+        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      List<Payload> retrieved = new ArrayList<>();
+      for (StorageDriverClaim claim : claims) {
+        retrieved.add(payloads.get(claim.getClaimData().get("key")));
+      }
+      return CompletableFuture.completedFuture(retrieved);
+    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
@@ -1,12 +1,29 @@
 package io.temporal.internal.replay;
 
 import com.google.protobuf.ByteString;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.history.v1.History;
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.internal.payload.storage.ExternalStorageNotConfiguredException;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.testUtils.HistoryUtils;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
@@ -83,5 +100,105 @@ public class ServiceWorkflowHistoryIteratorTest {
     Assert.assertFalse(iterator.hasNext());
     Assert.assertThrows(NoSuchElementException.class, iterator::next);
     Assert.assertEquals(4, timesCalledServer.get());
+  }
+
+  @Test
+  public void resolvesExternalStorageReferencesInFetchedPages() {
+    ExternalStorageRunner storage = inMemoryStorage();
+    History inline = historyWithInput(payload("big-input"));
+    History.Builder builder = inline.toBuilder();
+    storage.store(builder, null);
+    History stored = builder.build();
+    Assert.assertNotEquals(
+        "stored history should hold a reference, not the inline payload", inline, stored);
+
+    ServiceWorkflowHistoryIterator iterator = fetchingIterator(stored, storage);
+
+    HistoryEvent event = iterator.next();
+    Assert.assertEquals(
+        payload("big-input"),
+        event.getWorkflowExecutionStartedEventAttributes().getInput().getPayloads(0));
+  }
+
+  @Test
+  public void failsLoudWhenAFetchedPageHasAReferenceAndStorageIsNotConfigured() {
+    History.Builder builder = historyWithInput(payload("big-input")).toBuilder();
+    inMemoryStorage().store(builder, null);
+    History stored = builder.build();
+
+    ServiceWorkflowHistoryIterator iterator = fetchingIterator(stored, null);
+
+    Assert.assertThrows(ExternalStorageNotConfiguredException.class, iterator::hasNext);
+  }
+
+  private static ServiceWorkflowHistoryIterator fetchingIterator(
+      History page, ExternalStorageRunner storage) {
+    PollWorkflowTaskQueueResponse workflowTask =
+        PollWorkflowTaskQueueResponse.newBuilder().setNextPageToken(NEXT_PAGE_TOKEN).build();
+    return new ServiceWorkflowHistoryIterator(null, "default", workflowTask, null, storage) {
+      @Override
+      GetWorkflowExecutionHistoryResponse queryWorkflowExecutionHistory() {
+        return GetWorkflowExecutionHistoryResponse.newBuilder().setHistory(page).build();
+      }
+    };
+  }
+
+  private static ExternalStorageRunner inMemoryStorage() {
+    return ExternalStorageRunner.create(
+        ExternalStorage.newBuilder()
+            .setDriver(new InMemoryDriver())
+            .setPayloadSizeThreshold(0)
+            .build());
+  }
+
+  private static History historyWithInput(Payload payload) {
+    return History.newBuilder()
+        .addEvents(
+            HistoryEvent.newBuilder()
+                .setWorkflowExecutionStartedEventAttributes(
+                    WorkflowExecutionStartedEventAttributes.newBuilder()
+                        .setInput(Payloads.newBuilder().addPayloads(payload))))
+        .build();
+  }
+
+  private static Payload payload(String data) {
+    return Payload.newBuilder().setData(ByteString.copyFromUtf8(data)).build();
+  }
+
+  private static final class InMemoryDriver implements StorageDriver {
+    private final Map<String, Payload> objects = new HashMap<>();
+    private int counter = 0;
+
+    @Override
+    public String getName() {
+      return "test";
+    }
+
+    @Override
+    public String getType() {
+      return "test.inmemory";
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
+        StorageDriverStoreContext context, List<Payload> payloads) {
+      List<StorageDriverClaim> claims = new ArrayList<>();
+      for (Payload payload : payloads) {
+        String key = "k-" + (counter++);
+        objects.put(key, payload);
+        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+      }
+      return CompletableFuture.completedFuture(claims);
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<Payload>> retrieve(
+        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      List<Payload> payloads = new ArrayList<>();
+      for (StorageDriverClaim claim : claims) {
+        payloads.add(objects.get(claim.getClaimData().get("key")));
+      }
+      return CompletableFuture.completedFuture(payloads);
+    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
@@ -8,6 +8,7 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.common.CancellationToken;
 import io.temporal.internal.payload.storage.ExternalStorageNotConfiguredException;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.payload.storage.ExternalStorage;
@@ -107,7 +108,7 @@ public class ServiceWorkflowHistoryIteratorTest {
     ExternalStorageRunner storage = inMemoryStorage();
     History inline = historyWithInput(payload("big-input"));
     History.Builder builder = inline.toBuilder();
-    storage.store(builder, null);
+    storage.store(builder, null, null, CancellationToken.none());
     History stored = builder.build();
     Assert.assertNotEquals(
         "stored history should hold a reference, not the inline payload", inline, stored);
@@ -123,7 +124,7 @@ public class ServiceWorkflowHistoryIteratorTest {
   @Test
   public void failsLoudWhenAFetchedPageHasAReferenceAndStorageIsNotConfigured() {
     History.Builder builder = historyWithInput(payload("big-input")).toBuilder();
-    inMemoryStorage().store(builder, null);
+    inMemoryStorage().store(builder, null, null, CancellationToken.none());
     History stored = builder.build();
 
     ServiceWorkflowHistoryIterator iterator = fetchingIterator(stored, null);

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
@@ -12,21 +12,12 @@ import io.temporal.common.CancellationToken;
 import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.payload.storage.ExternalStorageNotConfiguredException;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.internal.payload.storage.TestStorageDriver;
 import io.temporal.payload.storage.ExternalStorage;
-import io.temporal.payload.storage.StorageDriver;
-import io.temporal.payload.storage.StorageDriverClaim;
-import io.temporal.payload.storage.StorageDriverRetrieveContext;
-import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.testUtils.HistoryUtils;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
@@ -173,7 +164,7 @@ public class ServiceWorkflowHistoryIteratorTest {
   private static ExternalStorageRunner inMemoryStorage() {
     return ExternalStorageRunner.create(
         ExternalStorage.newBuilder()
-            .setDriver(new InMemoryDriver())
+            .setDriver(TestStorageDriver.create())
             .setPayloadSizeThreshold(0)
             .build());
   }
@@ -190,42 +181,5 @@ public class ServiceWorkflowHistoryIteratorTest {
 
   private static Payload payload(String data) {
     return Payload.newBuilder().setData(ByteString.copyFromUtf8(data)).build();
-  }
-
-  private static final class InMemoryDriver implements StorageDriver {
-    private final Map<String, Payload> objects = new HashMap<>();
-    private int counter = 0;
-
-    @Override
-    public String getName() {
-      return "test";
-    }
-
-    @Override
-    public String getType() {
-      return "test.inmemory";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = "k-" + (counter++);
-        objects.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      List<Payload> payloads = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        payloads.add(objects.get(claim.getClaimData().get("key")));
-      }
-      return CompletableFuture.completedFuture(payloads);
-    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ServiceWorkflowHistoryIteratorTest.java
@@ -9,6 +9,7 @@ import io.temporal.api.history.v1.WorkflowExecutionStartedEventAttributes;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
 import io.temporal.common.CancellationToken;
+import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.payload.storage.ExternalStorageNotConfiguredException;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.payload.storage.ExternalStorage;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
@@ -132,11 +134,35 @@ public class ServiceWorkflowHistoryIteratorTest {
     Assert.assertThrows(ExternalStorageNotConfiguredException.class, iterator::hasNext);
   }
 
+  @Test
+  public void aCancelledTokenAbortsRetrievalOfAFetchedPage() {
+    ExternalStorageRunner storage = inMemoryStorage();
+    History.Builder builder = historyWithInput(payload("big-input")).toBuilder();
+    storage.store(builder, null, null, CancellationToken.none());
+    History stored = builder.build();
+
+    CancelSource<CancellationException> source =
+        new CancelSource<>(() -> new CancellationException("Worker shutdown"));
+    source.cancel();
+
+    ServiceWorkflowHistoryIterator iterator = fetchingIterator(stored, storage, source.token());
+
+    Assert.assertThrows(CancellationException.class, iterator::hasNext);
+  }
+
   private static ServiceWorkflowHistoryIterator fetchingIterator(
       History page, ExternalStorageRunner storage) {
+    return fetchingIterator(page, storage, CancellationToken.none());
+  }
+
+  private static ServiceWorkflowHistoryIterator fetchingIterator(
+      History page,
+      ExternalStorageRunner storage,
+      CancellationToken<CancellationException> storageCancellation) {
     PollWorkflowTaskQueueResponse workflowTask =
         PollWorkflowTaskQueueResponse.newBuilder().setNextPageToken(NEXT_PAGE_TOKEN).build();
-    return new ServiceWorkflowHistoryIterator(null, "default", workflowTask, null, storage) {
+    return new ServiceWorkflowHistoryIterator(
+        null, "default", workflowTask, null, storage, storageCancellation) {
       @Override
       GetWorkflowExecutionHistoryResponse queryWorkflowExecutionHistory() {
         return GetWorkflowExecutionHistoryResponse.newBuilder().setHistory(page).build();

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/AsyncPollerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/AsyncPollerTest.java
@@ -202,7 +202,7 @@ public class AsyncPollerTest {
     pollLatch.await();
 
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(5, slotSupplierInner.reservedCount.get());
           assertEquals(0, slotSupplier.getUsedSlots().size());
@@ -212,7 +212,7 @@ public class AsyncPollerTest {
     future.complete(new TestScalingTask(null, slotSupplier));
 
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(5, executor.processed.get());
         });
@@ -371,7 +371,7 @@ public class AsyncPollerTest {
     assertFalse(poller.isSuspended());
     pollLatch.await();
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(0, executor.processed.get());
           assertEquals(1, slotSupplierInner.reservedCount.get());
@@ -381,7 +381,7 @@ public class AsyncPollerTest {
     poller.suspendPolling();
     completePoll.get().apply();
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(1, executor.processed.get());
           assertEquals(2, slotSupplierInner.reservedCount.get());

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
@@ -76,6 +76,35 @@ public class WorkflowWorkerExternalStorageFailureTest {
             .isEmpty());
   }
 
+  @Test
+  public void aStorageFailureIsReportedOnEveryAttemptNotJustTheFirst() throws Exception {
+    String workflowId = "extstore-wft-retry-" + UUID.randomUUID();
+    String input = "wft-retry-" + UUID.randomUUID();
+    driver.failStoresContaining.set("echo: " + input);
+    driver.failuresToInject.set(2);
+
+    TestWorkflows.TestWorkflow1 workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflows.TestWorkflow1.class,
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setWorkflowId(workflowId)
+                    .build());
+    WorkflowClient.start(workflow::execute, input);
+
+    awaitEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED);
+
+    Assert.assertEquals(
+        "expected two injected store failures", 2, driver.injectedStoreFailures.get());
+    Assert.assertTrue(
+        "a reported failure must not leave a workflow task timeout in history",
+        testWorkflowRule
+            .getHistoryEvents(workflowId, EventType.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT)
+            .isEmpty());
+  }
+
   private void awaitEvent(String workflowId, EventType eventType) throws InterruptedException {
     long deadline = System.nanoTime() + Duration.ofSeconds(8).toNanos();
     while (System.nanoTime() < deadline) {
@@ -98,6 +127,7 @@ public class WorkflowWorkerExternalStorageFailureTest {
     private final String name;
     private final Map<String, Payload> objects = new HashMap<>();
     final AtomicReference<String> failStoresContaining = new AtomicReference<>();
+    final AtomicInteger failuresToInject = new AtomicInteger(1);
     final AtomicInteger injectedStoreFailures = new AtomicInteger();
     private int counter = 0;
 
@@ -108,6 +138,7 @@ public class WorkflowWorkerExternalStorageFailureTest {
     synchronized void reset() {
       objects.clear();
       failStoresContaining.set(null);
+      failuresToInject.set(1);
       injectedStoreFailures.set(0);
     }
 
@@ -128,7 +159,9 @@ public class WorkflowWorkerExternalStorageFailureTest {
       if (marker != null) {
         for (Payload payload : payloads) {
           if (payload.getData().toStringUtf8().contains(marker)) {
-            failStoresContaining.set(null);
+            if (failuresToInject.decrementAndGet() <= 0) {
+              failStoresContaining.set(null);
+            }
             injectedStoreFailures.incrementAndGet();
             CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
             failed.completeExceptionally(new IllegalStateException("storage unavailable"));

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
@@ -1,27 +1,15 @@
 package io.temporal.internal.worker;
 
-import io.temporal.api.common.v1.Payload;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.internal.payload.storage.TestStorageDriver;
 import io.temporal.payload.storage.ExternalStorage;
-import io.temporal.payload.storage.StorageDriver;
-import io.temporal.payload.storage.StorageDriverClaim;
-import io.temporal.payload.storage.StorageDriverRetrieveContext;
-import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,7 +17,7 @@ import org.junit.Test;
 
 public class WorkflowWorkerExternalStorageFailureTest {
 
-  private static final FlakyDriver driver = new FlakyDriver("wf-flaky");
+  private static final TestStorageDriver driver = TestStorageDriver.named("wf-flaky");
 
   private static final ExternalStorage storage =
       ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build();
@@ -51,7 +39,7 @@ public class WorkflowWorkerExternalStorageFailureTest {
   public void aFailedOutboundStoreFailsTheWorkflowTaskInsteadOfTimingOut() throws Exception {
     String workflowId = "extstore-wft-" + UUID.randomUUID();
     String input = "wft-store-" + UUID.randomUUID();
-    driver.failStoresContaining.set("echo: " + input);
+    driver.failStoresContaining("echo: " + input, 1);
 
     TestWorkflows.TestWorkflow1 workflow =
         testWorkflowRule
@@ -67,7 +55,7 @@ public class WorkflowWorkerExternalStorageFailureTest {
     awaitEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED);
 
     Assert.assertEquals(
-        "expected exactly one injected store failure", 1, driver.injectedStoreFailures.get());
+        "expected exactly one injected store failure", 1, driver.injectedFailures.get());
     testWorkflowRule.assertHistoryEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
     String reported =
         testWorkflowRule
@@ -89,8 +77,7 @@ public class WorkflowWorkerExternalStorageFailureTest {
   public void aStorageFailureIsReportedOnEveryAttemptNotJustTheFirst() throws Exception {
     String workflowId = "extstore-wft-retry-" + UUID.randomUUID();
     String input = "wft-retry-" + UUID.randomUUID();
-    driver.failStoresContaining.set("echo: " + input);
-    driver.failuresToInject.set(2);
+    driver.failStoresContaining("echo: " + input, 2);
 
     TestWorkflows.TestWorkflow1 workflow =
         testWorkflowRule
@@ -105,8 +92,7 @@ public class WorkflowWorkerExternalStorageFailureTest {
 
     awaitEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED);
 
-    Assert.assertEquals(
-        "expected two injected store failures", 2, driver.injectedStoreFailures.get());
+    Assert.assertEquals("expected two injected store failures", 2, driver.injectedFailures.get());
     Assert.assertTrue(
         "a reported failure must not leave a workflow task timeout in history",
         testWorkflowRule
@@ -129,72 +115,6 @@ public class WorkflowWorkerExternalStorageFailureTest {
     @Override
     public String execute(String input) {
       return "echo: " + input;
-    }
-  }
-
-  private static final class FlakyDriver implements StorageDriver {
-    private final String name;
-    private final Map<String, Payload> objects = new HashMap<>();
-    final AtomicReference<String> failStoresContaining = new AtomicReference<>();
-    final AtomicInteger failuresToInject = new AtomicInteger(1);
-    final AtomicInteger injectedStoreFailures = new AtomicInteger();
-    private int counter = 0;
-
-    FlakyDriver(String name) {
-      this.name = name;
-    }
-
-    synchronized void reset() {
-      objects.clear();
-      failStoresContaining.set(null);
-      failuresToInject.set(1);
-      injectedStoreFailures.set(0);
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public String getType() {
-      return "test.wf.flaky";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      String marker = failStoresContaining.get();
-      if (marker != null) {
-        for (Payload payload : payloads) {
-          if (payload.getData().toStringUtf8().contains(marker)) {
-            if (failuresToInject.decrementAndGet() <= 0) {
-              failStoresContaining.set(null);
-            }
-            injectedStoreFailures.incrementAndGet();
-            CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
-            failed.completeExceptionally(new IllegalStateException("storage unavailable"));
-            return failed;
-          }
-        }
-      }
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = name + "-" + (counter++);
-        objects.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      List<Payload> payloads = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        payloads.add(objects.get(claim.getClaimData().get("key")));
-      }
-      return CompletableFuture.completedFuture(payloads);
     }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
@@ -69,6 +69,15 @@ public class WorkflowWorkerExternalStorageFailureTest {
     Assert.assertEquals(
         "expected exactly one injected store failure", 1, driver.injectedStoreFailures.get());
     testWorkflowRule.assertHistoryEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
+    String reported =
+        testWorkflowRule
+            .getHistoryEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED)
+            .getWorkflowTaskFailedEventAttributes()
+            .getFailure()
+            .getMessage();
+    Assert.assertTrue(
+        "the reported failure must say what went wrong, got: " + reported,
+        reported.contains("storage unavailable"));
     Assert.assertTrue(
         "a reported failure must not leave a workflow task timeout in history",
         testWorkflowRule

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageFailureTest.java
@@ -1,0 +1,158 @@
+package io.temporal.internal.worker;
+
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.enums.v1.EventType;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WorkflowWorkerExternalStorageFailureTest {
+
+  private static final FlakyDriver driver = new FlakyDriver("wf-flaky");
+
+  private static final ExternalStorage storage =
+      ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(EchoWorkflowImpl.class)
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder().setExternalStorage(storage).build())
+          .build();
+
+  @Before
+  public void resetDriver() {
+    driver.reset();
+  }
+
+  @Test
+  public void aFailedOutboundStoreFailsTheWorkflowTaskInsteadOfTimingOut() throws Exception {
+    String workflowId = "extstore-wft-" + UUID.randomUUID();
+    String input = "wft-store-" + UUID.randomUUID();
+    driver.failStoresContaining.set("echo: " + input);
+
+    TestWorkflows.TestWorkflow1 workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflows.TestWorkflow1.class,
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setWorkflowId(workflowId)
+                    .build());
+    WorkflowClient.start(workflow::execute, input);
+
+    awaitEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED);
+
+    Assert.assertEquals(
+        "expected exactly one injected store failure", 1, driver.injectedStoreFailures.get());
+    testWorkflowRule.assertHistoryEvent(workflowId, EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED);
+    Assert.assertTrue(
+        "a reported failure must not leave a workflow task timeout in history",
+        testWorkflowRule
+            .getHistoryEvents(workflowId, EventType.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT)
+            .isEmpty());
+  }
+
+  private void awaitEvent(String workflowId, EventType eventType) throws InterruptedException {
+    long deadline = System.nanoTime() + Duration.ofSeconds(8).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (!testWorkflowRule.getHistoryEvents(workflowId, eventType).isEmpty()) {
+        return;
+      }
+      Thread.sleep(100);
+    }
+    Assert.fail("timed out waiting for " + eventType + " on " + workflowId);
+  }
+
+  public static class EchoWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      return "echo: " + input;
+    }
+  }
+
+  private static final class FlakyDriver implements StorageDriver {
+    private final String name;
+    private final Map<String, Payload> objects = new HashMap<>();
+    final AtomicReference<String> failStoresContaining = new AtomicReference<>();
+    final AtomicInteger injectedStoreFailures = new AtomicInteger();
+    private int counter = 0;
+
+    FlakyDriver(String name) {
+      this.name = name;
+    }
+
+    synchronized void reset() {
+      objects.clear();
+      failStoresContaining.set(null);
+      injectedStoreFailures.set(0);
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getType() {
+      return "test.wf.flaky";
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
+        StorageDriverStoreContext context, List<Payload> payloads) {
+      String marker = failStoresContaining.get();
+      if (marker != null) {
+        for (Payload payload : payloads) {
+          if (payload.getData().toStringUtf8().contains(marker)) {
+            failStoresContaining.set(null);
+            injectedStoreFailures.incrementAndGet();
+            CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IllegalStateException("storage unavailable"));
+            return failed;
+          }
+        }
+      }
+      List<StorageDriverClaim> claims = new ArrayList<>();
+      for (Payload payload : payloads) {
+        String key = name + "-" + (counter++);
+        objects.put(key, payload);
+        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+      }
+      return CompletableFuture.completedFuture(claims);
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<Payload>> retrieve(
+        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      List<Payload> payloads = new ArrayList<>();
+      for (StorageDriverClaim claim : claims) {
+        payloads.add(objects.get(claim.getClaimData().get("key")));
+      }
+      return CompletableFuture.completedFuture(payloads);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerExternalStorageTest.java
@@ -1,0 +1,113 @@
+package io.temporal.internal.worker;
+
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.internal.payload.storage.TestStorageDriver;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.Workflow;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** e2e tests */
+public class WorkflowWorkerExternalStorageTest {
+
+  private static final int THRESHOLD = 4096;
+  private static final String CONTINUED_MARKER = "continued:";
+
+  private static final TestStorageDriver driver = TestStorageDriver.named("wf-happy");
+
+  private static final ExternalStorage storage =
+      ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(THRESHOLD).build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ContinueAsNewWorkflowImpl.class, EchoWorkflowImpl.class)
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder().setExternalStorage(storage).build())
+          .build();
+
+  @Before
+  public void resetDriver() {
+    driver.reset();
+  }
+
+  @Test
+  public void aLargeContinueAsNewInputIsStoredThenRestoredOnTheContinuedRun() {
+    TestWorkflows.TestWorkflow1 workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflows.TestWorkflow1.class,
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setWorkflowId("extstore-can-" + UUID.randomUUID())
+                    .build());
+
+    // Blocking call follows the continue-as-new and returns the continued run's result.
+    String result = workflow.execute("start");
+
+    int expectedInputLength = CONTINUED_MARKER.length() + THRESHOLD * 2;
+    Assert.assertEquals(
+        "the continued run must observe the full restored input, not a storage reference",
+        "len:" + expectedInputLength,
+        result);
+    Assert.assertTrue("the worker must have offloaded a payload", driver.stores.get() > 0);
+    Assert.assertTrue("the continued run must have retrieved it", driver.retrieves.get() > 0);
+    Assert.assertTrue(
+        "the large continue-as-new input must be what was stored", driver.stored(CONTINUED_MARKER));
+  }
+
+  @Test
+  public void aResultUnderTheThresholdIsLeftInlineAndReadableByTheClient() {
+    EchoWorkflow workflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                EchoWorkflow.class,
+                WorkflowOptions.newBuilder()
+                    .setTaskQueue(testWorkflowRule.getTaskQueue())
+                    .setWorkflowId("extstore-inline-" + UUID.randomUUID())
+                    .build());
+
+    String result = workflow.echo("small");
+
+    Assert.assertEquals("echo: small", result);
+    Assert.assertEquals("nothing under the threshold should be offloaded", 0, driver.stores.get());
+  }
+
+  public static class ContinueAsNewWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      if (input.startsWith(CONTINUED_MARKER)) {
+        return "len:" + input.length();
+      }
+      StringBuilder large = new StringBuilder(CONTINUED_MARKER);
+      for (int i = 0; i < THRESHOLD * 2; i++) {
+        large.append('x');
+      }
+      Workflow.newContinueAsNewStub(TestWorkflows.TestWorkflow1.class).execute(large.toString());
+      throw new IllegalStateException("unreachable: continue-as-new ends the run");
+    }
+  }
+
+  @WorkflowInterface
+  public interface EchoWorkflow {
+    @WorkflowMethod
+    String echo(String input);
+  }
+
+  public static class EchoWorkflowImpl implements EchoWorkflow {
+    @Override
+    public String echo(String input) {
+      return "echo: " + input;
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -3,9 +3,16 @@ package io.temporal.internal.worker;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.google.common.util.concurrent.Futures;
 import com.google.protobuf.ByteString;
 import com.uber.m3.tally.NoopScope;
@@ -19,16 +26,25 @@ import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributes;
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
 import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes;
 import io.temporal.api.common.v1.ActivityType;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
 import io.temporal.common.CancellationToken;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.common.InternalUtils;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.replay.ReplayWorkflow;
 import io.temporal.internal.replay.ReplayWorkflowFactory;
 import io.temporal.internal.replay.ReplayWorkflowTaskHandler;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
 import io.temporal.payload.storage.StorageDriverActivityInfo;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.payload.storage.StorageDriverTargetInfo;
 import io.temporal.payload.storage.StorageDriverWorkflowInfo;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -40,8 +56,11 @@ import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
 import io.temporal.worker.tuning.SlotSupplier;
 import io.temporal.worker.tuning.WorkflowSlotInfo;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -461,6 +480,192 @@ public class WorkflowWorkerTest {
     when(mockFactory.isAnyTypeSupported()).thenReturn(true);
     when(mockWorkflow.eventLoop()).thenReturn(false);
     return mockFactory;
+  }
+
+  @Test
+  public void aStoreThatFailsWhileShuttingDownIsNotTreatedAsAProblem() throws Exception {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ListAppender<ILoggingEvent> logs = new ListAppender<>();
+    logs.setContext(loggerContext);
+    logs.start();
+    ch.qos.logback.classic.Logger workerLog =
+        loggerContext.getLogger(WorkflowWorker.class.getName());
+    workerLog.addAppender(logs);
+    try {
+      WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+      when(client.getServerCapabilities())
+          .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+
+      WorkflowRunLockManager runLockManager = new WorkflowRunLockManager();
+      Scope metricsScope =
+          new RootScopeBuilder()
+              .reporter(reporter)
+              .reportEvery(com.uber.m3.util.Duration.ofMillis(1));
+      WorkflowExecutorCache cache = new WorkflowExecutorCache(10, runLockManager, metricsScope);
+      SlotSupplier<WorkflowSlotInfo> slotSupplier = new FixedSizeSlotSupplier<>(10);
+
+      WorkflowTaskHandler taskHandler = mock(WorkflowTaskHandler.class);
+      when(taskHandler.isAnyTypeSupported()).thenReturn(true);
+
+      CountDownLatch storeEntered = new CountDownLatch(1);
+      CountDownLatch releaseStore = new CountDownLatch(1);
+      BlockingDriver driver = new BlockingDriver(storeEntered, releaseStore);
+      CountDownLatch escaped = new CountDownLatch(1);
+
+      WorkflowWorker worker =
+          new WorkflowWorker(
+              client,
+              "default",
+              "task_queue",
+              "sticky_task_queue",
+              SingleWorkerOptions.newBuilder()
+                  .setIdentity("test_identity")
+                  .setBuildId(UUID.randomUUID().toString())
+                  .setWorkerInstanceKey(UUID.randomUUID().toString())
+                  .setPollerOptions(
+                      PollerOptions.newBuilder()
+                          .setPollerBehavior(new PollerBehaviorSimpleMaximum(1))
+                          .setUncaughtExceptionHandler((thread, error) -> escaped.countDown())
+                          .build())
+                  .setMetricsScope(metricsScope)
+                  .setExternalStorageRunner(
+                      ExternalStorageRunner.create(
+                          ExternalStorage.newBuilder()
+                              .setDriver(driver)
+                              .setPayloadSizeThreshold(0)
+                              .build()))
+                  .build(),
+              runLockManager,
+              cache,
+              taskHandler,
+              mock(EagerActivityDispatcher.class),
+              3,
+              slotSupplier,
+              new NamespaceCapabilities(),
+              CancellationToken.none());
+
+      WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
+          mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
+      when(futureStub.shutdownWorker(any(ShutdownWorkerRequest.class)))
+          .thenReturn(Futures.immediateFuture(ShutdownWorkerResponse.newBuilder().build()));
+      WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
+          mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+      when(client.blockingStub()).thenReturn(blockingStub);
+      when(client.futureStub()).thenReturn(futureStub);
+      when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+
+      PollWorkflowTaskQueueResponse pollResponse =
+          PollWorkflowTaskQueueResponse.newBuilder()
+              .setTaskToken(ByteString.copyFrom("token", UTF_8))
+              .setWorkflowExecution(
+                  WorkflowExecution.newBuilder()
+                      .setWorkflowId(WORKFLOW_ID)
+                      .setRunId(RUN_ID)
+                      .build())
+              .setWorkflowType(WorkflowType.newBuilder().setName(WORKFLOW_TYPE).build())
+              .build();
+      CountDownLatch pollTaskQueueLatch = new CountDownLatch(1);
+      CountDownLatch blockPollTaskQueueLatch = new CountDownLatch(1);
+      when(blockingStub.pollWorkflowTaskQueue(any(PollWorkflowTaskQueueRequest.class)))
+          .thenReturn(pollResponse)
+          .thenAnswer(
+              (Answer<PollWorkflowTaskQueueResponse>)
+                  invocation -> {
+                    pollTaskQueueLatch.countDown();
+                    blockPollTaskQueueLatch.await();
+                    return null;
+                  });
+
+      when(taskHandler.handleWorkflowTask(any(PollWorkflowTaskQueueResponse.class)))
+          .thenAnswer(
+              (Answer<WorkflowTaskHandler.Result>)
+                  invocation ->
+                      new WorkflowTaskHandler.Result(
+                          WORKFLOW_TYPE,
+                          RespondWorkflowTaskCompletedRequest.newBuilder()
+                              .addCommands(
+                                  Command.newBuilder()
+                                      .setCompleteWorkflowExecutionCommandAttributes(
+                                          CompleteWorkflowExecutionCommandAttributes.newBuilder()
+                                              .setResult(
+                                                  Payloads.newBuilder()
+                                                      .addPayloads(
+                                                          Payload.newBuilder()
+                                                              .setData(
+                                                                  ByteString.copyFrom(
+                                                                      "result", UTF_8))))))
+                              .build(),
+                          null,
+                          null,
+                          null,
+                          false,
+                          null,
+                          null));
+
+      assertTrue(worker.start());
+      assertTrue(storeEntered.await(10, TimeUnit.SECONDS));
+
+      CompletableFuture<Void> shutdown = worker.shutdown(new ShutdownManager(), true);
+      releaseStore.countDown();
+
+      assertFalse(
+          "a store that fails while shutting down must not surface as an error on the task",
+          escaped.await(2, TimeUnit.SECONDS));
+      verify(blockingStub, never())
+          .respondWorkflowTaskFailed(any(RespondWorkflowTaskFailedRequest.class));
+      shutdown.get();
+
+      assertFalse(
+          "shutting down must not be logged as a failure to report progress",
+          logs.list.stream()
+              .anyMatch(
+                  event ->
+                      event.getLevel() == Level.WARN
+                          && event.getMessage().contains("Failure while reporting")));
+    } finally {
+      workerLog.detachAppender(logs);
+      logs.stop();
+    }
+  }
+
+  private static final class BlockingDriver implements StorageDriver {
+    private final CountDownLatch storeEntered;
+    private final CountDownLatch releaseStore;
+
+    BlockingDriver(CountDownLatch storeEntered, CountDownLatch releaseStore) {
+      this.storeEntered = storeEntered;
+      this.releaseStore = releaseStore;
+    }
+
+    @Override
+    public String getName() {
+      return "blocking";
+    }
+
+    @Override
+    public String getType() {
+      return "test.blocking";
+    }
+
+    @Override
+    public CompletableFuture<List<StorageDriverClaim>> store(
+        StorageDriverStoreContext context, List<Payload> payloads) {
+      storeEntered.countDown();
+      try {
+        releaseStore.await(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("store abandoned"));
+      return failed;
+    }
+
+    @Override
+    public CompletableFuture<List<Payload>> retrieve(
+        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -36,8 +36,10 @@ import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
+import io.temporal.common.CancellationToken;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.common.InternalUtils;
+import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.payload.storage.TestStorageDriver;
 import io.temporal.internal.replay.ReplayWorkflow;
@@ -57,6 +59,7 @@ import io.temporal.worker.tuning.WorkflowSlotInfo;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.*;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -495,6 +498,8 @@ public class WorkflowWorkerTest {
     CountDownLatch handlerEntered = new CountDownLatch(1);
     CountDownLatch releaseHandler = new CountDownLatch(1);
     CountDownLatch escaped = new CountDownLatch(1);
+    CancelSource<CancellationException> storageCancellation =
+        new CancelSource<>(() -> new CancellationException("Worker shutdown"));
 
     WorkflowWorker worker =
         new WorkflowWorker(
@@ -512,6 +517,7 @@ public class WorkflowWorkerTest {
                         .setUncaughtExceptionHandler((thread, error) -> escaped.countDown())
                         .build())
                 .setMetricsScope(metricsScope)
+                .setStorageCancellation(storageCancellation.token())
                 .build(),
             runLockManager,
             cache,
@@ -564,6 +570,7 @@ public class WorkflowWorkerTest {
 
     assertTrue(worker.start());
     assertTrue(handlerEntered.await(10, TimeUnit.SECONDS));
+    storageCancellation.cancel();
     CompletableFuture<Void> shutdown = worker.shutdown(new ShutdownManager(), true);
     releaseHandler.countDown();
 
@@ -577,6 +584,36 @@ public class WorkflowWorkerTest {
         0,
         worker.getTaskCounter().getTotalFailed());
     shutdown.get();
+  }
+
+  @Test
+  public void storageBreakingDuringAForcedShutdownIsStillReported() throws Exception {
+    // Cancelling storage means we abandoned the work. Storage genuinely breaking at the same
+    // moment is a different thing and must not disappear with it.
+    TestStorageDriver driver = TestStorageDriver.create().failStores(1);
+    Payload result = Payload.newBuilder().setData(ByteString.copyFrom("result", UTF_8)).build();
+    RespondWorkflowTaskCompletedRequest taskCompleted =
+        RespondWorkflowTaskCompletedRequest.newBuilder()
+            .addCommands(
+                Command.newBuilder()
+                    .setCompleteWorkflowExecutionCommandAttributes(
+                        CompleteWorkflowExecutionCommandAttributes.newBuilder()
+                            .setResult(Payloads.newBuilder().addPayloads(result))))
+            .build();
+    CancelSource<CancellationException> storageCancellation =
+        new CancelSource<>(() -> new CancellationException("Worker shutdown"));
+    storageCancellation.cancel();
+
+    runOneTask(
+        driver,
+        new WorkflowTaskHandler.Result(
+            WORKFLOW_TYPE, taskCompleted, null, null, null, false, null, null),
+        storageCancellation.token(),
+        blockingStub ->
+            verify(blockingStub)
+                .respondWorkflowTaskFailed(any(RespondWorkflowTaskFailedRequest.class)));
+
+    assertEquals("expected one injected store failure", 1, driver.injectedFailures.get());
   }
 
   @Test
@@ -638,6 +675,15 @@ public class WorkflowWorkerTest {
       WorkflowTaskHandler.Result handlerResult,
       java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
       throws Exception {
+    runOneTask(driver, handlerResult, CancellationToken.none(), verification);
+  }
+
+  private void runOneTask(
+      TestStorageDriver driver,
+      WorkflowTaskHandler.Result handlerResult,
+      CancellationToken<CancellationException> storageCancellation,
+      java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
+      throws Exception {
     WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
     when(client.getServerCapabilities())
         .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
@@ -671,6 +717,7 @@ public class WorkflowWorkerTest {
                             .setDriver(driver)
                             .setPayloadSizeThreshold(0)
                             .build()))
+                .setStorageCancellation(storageCancellation)
                 .build(),
             runLockManager,
             cache,
@@ -750,8 +797,10 @@ public class WorkflowWorkerTest {
       CountDownLatch storeEntered = new CountDownLatch(1);
       CountDownLatch releaseStore = new CountDownLatch(1);
       TestStorageDriver driver =
-          TestStorageDriver.create().blockStores(storeEntered, releaseStore).failStores(1);
+          TestStorageDriver.create().blockStores(storeEntered, releaseStore).cancelStores(1);
       CountDownLatch escaped = new CountDownLatch(1);
+      CancelSource<CancellationException> storageCancellation =
+          new CancelSource<>(() -> new CancellationException("Worker shutdown"));
 
       WorkflowWorker worker =
           new WorkflowWorker(
@@ -775,6 +824,7 @@ public class WorkflowWorkerTest {
                               .setDriver(driver)
                               .setPayloadSizeThreshold(0)
                               .build()))
+                  .setStorageCancellation(storageCancellation.token())
                   .build(),
               runLockManager,
               cache,
@@ -846,6 +896,7 @@ public class WorkflowWorkerTest {
       assertTrue(storeEntered.await(10, TimeUnit.SECONDS));
 
       CompletableFuture<Void> shutdown = worker.shutdown(new ShutdownManager(), true);
+      storageCancellation.cancel();
       releaseStore.countDown();
 
       assertFalse(

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -12,6 +12,11 @@ import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.RootScopeBuilder;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
+import io.temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes;
+import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributes;
+import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
+import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes;
+import io.temporal.api.common.v1.ActivityType;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.workflowservice.v1.*;
@@ -20,6 +25,9 @@ import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.replay.ReplayWorkflow;
 import io.temporal.internal.replay.ReplayWorkflowFactory;
 import io.temporal.internal.replay.ReplayWorkflowTaskHandler;
+import io.temporal.payload.storage.StorageDriverActivityInfo;
+import io.temporal.payload.storage.StorageDriverTargetInfo;
+import io.temporal.payload.storage.StorageDriverWorkflowInfo;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testUtils.Eventually;
 import io.temporal.testUtils.HistoryUtils;
@@ -447,5 +455,59 @@ public class WorkflowWorkerTest {
     when(mockFactory.isAnyTypeSupported()).thenReturn(true);
     when(mockWorkflow.eventLoop()).thenReturn(false);
     return mockFactory;
+  }
+
+  @Test
+  public void refineStorageTargetPointsActivityCommandsAtTheActivity() {
+    StorageDriverTargetInfo workflowDefault =
+        new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
+    ScheduleActivityTaskCommandAttributes command =
+        ScheduleActivityTaskCommandAttributes.newBuilder()
+            .setActivityId("act-1")
+            .setActivityType(ActivityType.newBuilder().setName("MyActivity"))
+            .build();
+
+    assertEquals(
+        new StorageDriverActivityInfo("ns", "act-1", null, "MyActivity"),
+        WorkflowWorker.refineStorageTarget("ns", workflowDefault, command));
+  }
+
+  @Test
+  public void refineStorageTargetPointsChildWorkflowCommandsAtTheChild() {
+    StorageDriverTargetInfo parent =
+        new StorageDriverWorkflowInfo("ns", "parent", "parent-run", "Parent");
+    StartChildWorkflowExecutionCommandAttributes command =
+        StartChildWorkflowExecutionCommandAttributes.newBuilder()
+            .setWorkflowId("child-1")
+            .setWorkflowType(WorkflowType.newBuilder().setName("Child"))
+            .build();
+
+    assertEquals(
+        new StorageDriverWorkflowInfo("ns", "child-1", null, "Child"),
+        WorkflowWorker.refineStorageTarget("ns", parent, command));
+  }
+
+  @Test
+  public void refineStorageTargetPointsSignalCommandsAtTheTargetWorkflow() {
+    StorageDriverTargetInfo self = new StorageDriverWorkflowInfo("ns", "self", "self-run", "Self");
+    SignalExternalWorkflowExecutionCommandAttributes command =
+        SignalExternalWorkflowExecutionCommandAttributes.newBuilder()
+            .setExecution(
+                WorkflowExecution.newBuilder().setWorkflowId("other").setRunId("other-run"))
+            .build();
+
+    assertEquals(
+        new StorageDriverWorkflowInfo("ns", "other", "other-run", null),
+        WorkflowWorker.refineStorageTarget("ns", self, command));
+  }
+
+  @Test
+  public void refineStorageTargetKeepsTheCurrentTargetForOtherCommands() {
+    StorageDriverTargetInfo current =
+        new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
+    CompleteWorkflowExecutionCommandAttributes command =
+        CompleteWorkflowExecutionCommandAttributes.newBuilder().build();
+
+    assertSame(current, WorkflowWorker.refineStorageTarget("ns", current, command));
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.never;
@@ -30,7 +31,10 @@ import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
+import io.temporal.api.failure.v1.ApplicationFailureInfo;
+import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
 import io.temporal.common.CancellationToken;
 import io.temporal.common.reporter.TestStatsReporter;
@@ -55,12 +59,18 @@ import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
 import io.temporal.worker.tuning.SlotSupplier;
 import io.temporal.worker.tuning.WorkflowSlotInfo;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -482,6 +492,150 @@ public class WorkflowWorkerTest {
   }
 
   @Test
+  public void payloadsInAFailedWorkflowTaskAreOffloaded() throws Exception {
+    TestDriver driver = new TestDriver();
+    Payload details = Payload.newBuilder().setData(ByteString.copyFrom("details", UTF_8)).build();
+    RespondWorkflowTaskFailedRequest taskFailed =
+        RespondWorkflowTaskFailedRequest.newBuilder()
+            .setFailure(
+                Failure.newBuilder()
+                    .setMessage("boom")
+                    .setApplicationFailureInfo(
+                        ApplicationFailureInfo.newBuilder()
+                            .setDetails(Payloads.newBuilder().addPayloads(details))))
+            .build();
+
+    ArgumentCaptor<RespondWorkflowTaskFailedRequest> sent =
+        ArgumentCaptor.forClass(RespondWorkflowTaskFailedRequest.class);
+    runOneTask(
+        driver,
+        new WorkflowTaskHandler.Result(
+            WORKFLOW_TYPE, null, taskFailed, null, null, false, null, null),
+        blockingStub -> verify(blockingStub).respondWorkflowTaskFailed(sent.capture()));
+
+    assertEquals("the failure details must be offloaded", 1, driver.storedCount());
+    assertNotEquals(
+        "the failure details must be replaced by a reference",
+        details,
+        sent.getValue().getFailure().getApplicationFailureInfo().getDetails().getPayloads(0));
+  }
+
+  @Test
+  public void payloadsInADirectQueryResponseAreOffloaded() throws Exception {
+    TestDriver driver = new TestDriver();
+    Payload answer = Payload.newBuilder().setData(ByteString.copyFrom("answer", UTF_8)).build();
+    RespondQueryTaskCompletedRequest queryCompleted =
+        RespondQueryTaskCompletedRequest.newBuilder()
+            .setQueryResult(Payloads.newBuilder().addPayloads(answer))
+            .build();
+
+    ArgumentCaptor<RespondQueryTaskCompletedRequest> sent =
+        ArgumentCaptor.forClass(RespondQueryTaskCompletedRequest.class);
+    runOneTask(
+        driver,
+        new WorkflowTaskHandler.Result(
+            WORKFLOW_TYPE, null, null, queryCompleted, null, false, null, null),
+        blockingStub -> verify(blockingStub).respondQueryTaskCompleted(sent.capture()));
+
+    assertEquals("the query answer must be offloaded", 1, driver.storedCount());
+    assertNotEquals(
+        "the query answer must be replaced by a reference",
+        answer,
+        sent.getValue().getQueryResult().getPayloads(0));
+  }
+
+  /** Runs a single workflow task through a worker wired to {@code driver}, then verifies. */
+  private void runOneTask(
+      TestDriver driver,
+      WorkflowTaskHandler.Result handlerResult,
+      java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
+      throws Exception {
+    WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+    when(client.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+    WorkflowRunLockManager runLockManager = new WorkflowRunLockManager();
+    Scope metricsScope =
+        new RootScopeBuilder()
+            .reporter(reporter)
+            .reportEvery(com.uber.m3.util.Duration.ofMillis(1));
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, runLockManager, metricsScope);
+    WorkflowTaskHandler taskHandler = mock(WorkflowTaskHandler.class);
+    when(taskHandler.isAnyTypeSupported()).thenReturn(true);
+
+    WorkflowWorker worker =
+        new WorkflowWorker(
+            client,
+            "default",
+            "task_queue",
+            "sticky_task_queue",
+            SingleWorkerOptions.newBuilder()
+                .setIdentity("test_identity")
+                .setBuildId(UUID.randomUUID().toString())
+                .setWorkerInstanceKey(UUID.randomUUID().toString())
+                .setPollerOptions(
+                    PollerOptions.newBuilder()
+                        .setPollerBehavior(new PollerBehaviorSimpleMaximum(1))
+                        .build())
+                .setMetricsScope(metricsScope)
+                .setExternalStorageRunner(
+                    ExternalStorageRunner.create(
+                        ExternalStorage.newBuilder()
+                            .setDriver(driver)
+                            .setPayloadSizeThreshold(0)
+                            .build()))
+                .build(),
+            runLockManager,
+            cache,
+            taskHandler,
+            mock(EagerActivityDispatcher.class),
+            3,
+            new FixedSizeSlotSupplier<>(10),
+            new NamespaceCapabilities(),
+            CancellationToken.none());
+
+    WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
+    when(futureStub.shutdownWorker(any(ShutdownWorkerRequest.class)))
+        .thenReturn(Futures.immediateFuture(ShutdownWorkerResponse.newBuilder().build()));
+    WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+    when(client.blockingStub()).thenReturn(blockingStub);
+    when(client.futureStub()).thenReturn(futureStub);
+    when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+
+    PollWorkflowTaskQueueResponse pollResponse =
+        PollWorkflowTaskQueueResponse.newBuilder()
+            .setTaskToken(ByteString.copyFrom("token", UTF_8))
+            .setWorkflowExecution(
+                WorkflowExecution.newBuilder().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID).build())
+            .setWorkflowType(WorkflowType.newBuilder().setName(WORKFLOW_TYPE).build())
+            .build();
+    CountDownLatch blockPolls = new CountDownLatch(1);
+    when(blockingStub.pollWorkflowTaskQueue(any(PollWorkflowTaskQueueRequest.class)))
+        .thenReturn(pollResponse)
+        .thenAnswer(
+            (Answer<PollWorkflowTaskQueueResponse>)
+                invocation -> {
+                  blockPolls.await();
+                  return null;
+                });
+
+    CountDownLatch handled = new CountDownLatch(1);
+    when(taskHandler.handleWorkflowTask(any(PollWorkflowTaskQueueResponse.class)))
+        .thenAnswer(
+            (Answer<WorkflowTaskHandler.Result>)
+                invocation -> {
+                  handled.countDown();
+                  return handlerResult;
+                });
+
+    assertTrue(worker.start());
+    assertTrue(handled.await(10, TimeUnit.SECONDS));
+    worker.shutdown(new ShutdownManager(), false).get();
+    verification.accept(blockingStub);
+  }
+
+  @Test
   public void aStoreThatFailsWhileShuttingDownIsNotTreatedAsAProblem() throws Exception {
     LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
     ListAppender<ILoggingEvent> logs = new ListAppender<>();
@@ -508,7 +662,10 @@ public class WorkflowWorkerTest {
 
       CountDownLatch storeEntered = new CountDownLatch(1);
       CountDownLatch releaseStore = new CountDownLatch(1);
-      BlockingDriver driver = new BlockingDriver(storeEntered, releaseStore);
+      TestDriver driver = new TestDriver();
+      driver.storeEntered = storeEntered;
+      driver.releaseStore = releaseStore;
+      driver.failStores = true;
       CountDownLatch escaped = new CountDownLatch(1);
 
       WorkflowWorker worker =
@@ -627,43 +784,63 @@ public class WorkflowWorkerTest {
     }
   }
 
-  private static final class BlockingDriver implements StorageDriver {
-    private final CountDownLatch storeEntered;
-    private final CountDownLatch releaseStore;
-
-    BlockingDriver(CountDownLatch storeEntered, CountDownLatch releaseStore) {
-      this.storeEntered = storeEntered;
-      this.releaseStore = releaseStore;
-    }
+  /** One driver for these tests: stores in memory, and can block or fail on demand. */
+  private static final class TestDriver implements StorageDriver {
+    private final Map<String, Payload> stored = new HashMap<>();
+    private int nextKey;
+    @Nullable CountDownLatch storeEntered;
+    @Nullable CountDownLatch releaseStore;
+    boolean failStores;
 
     @Override
     public String getName() {
-      return "blocking";
+      return "test";
     }
 
     @Override
     public String getType() {
-      return "test.blocking";
+      return "test.in-memory";
     }
 
     @Override
-    public CompletableFuture<List<StorageDriverClaim>> store(
+    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
         StorageDriverStoreContext context, List<Payload> payloads) {
-      storeEntered.countDown();
-      try {
-        releaseStore.await(10, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
+      if (storeEntered != null) {
+        storeEntered.countDown();
       }
-      CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
-      failed.completeExceptionally(new RuntimeException("store abandoned"));
-      return failed;
+      if (releaseStore != null) {
+        try {
+          releaseStore.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      if (failStores) {
+        CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("store abandoned"));
+        return failed;
+      }
+      List<StorageDriverClaim> claims = new ArrayList<>();
+      for (Payload payload : payloads) {
+        String key = Integer.toString(nextKey++);
+        stored.put(key, payload);
+        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+      }
+      return CompletableFuture.completedFuture(claims);
     }
 
     @Override
-    public CompletableFuture<List<Payload>> retrieve(
+    public synchronized CompletableFuture<List<Payload>> retrieve(
         StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      throw new UnsupportedOperationException();
+      List<Payload> payloads = new ArrayList<>();
+      for (StorageDriverClaim claim : claims) {
+        payloads.add(stored.get(claim.getClaimData().get("key")));
+      }
+      return CompletableFuture.completedFuture(payloads);
+    }
+
+    synchronized int storedCount() {
+      return stored.size();
     }
   }
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -41,7 +41,6 @@ import io.temporal.internal.replay.ReplayWorkflowFactory;
 import io.temporal.internal.replay.ReplayWorkflowTaskHandler;
 import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.payload.storage.StorageDriver;
-import io.temporal.payload.storage.StorageDriverActivityInfo;
 import io.temporal.payload.storage.StorageDriverClaim;
 import io.temporal.payload.storage.StorageDriverRetrieveContext;
 import io.temporal.payload.storage.StorageDriverStoreContext;
@@ -669,7 +668,7 @@ public class WorkflowWorkerTest {
   }
 
   @Test
-  public void deriveStorageTargetPointsActivityCommandsAtTheActivity() {
+  public void deriveStorageTargetKeepsActivityCommandsOnTheWorkflow() {
     StorageDriverTargetInfo workflowDefault =
         new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
     Command command =
@@ -681,8 +680,7 @@ public class WorkflowWorkerTest {
             .build();
 
     assertEquals(
-        new StorageDriverActivityInfo("ns", "act-1", null, "MyActivity"),
-        WorkflowWorker.deriveStorageTarget("ns", workflowDefault, command));
+        workflowDefault, WorkflowWorker.deriveStorageTarget("ns", workflowDefault, command));
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -40,14 +40,11 @@ import io.temporal.common.CancellationToken;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.internal.payload.storage.TestStorageDriver;
 import io.temporal.internal.replay.ReplayWorkflow;
 import io.temporal.internal.replay.ReplayWorkflowFactory;
 import io.temporal.internal.replay.ReplayWorkflowTaskHandler;
 import io.temporal.payload.storage.ExternalStorage;
-import io.temporal.payload.storage.StorageDriver;
-import io.temporal.payload.storage.StorageDriverClaim;
-import io.temporal.payload.storage.StorageDriverRetrieveContext;
-import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.payload.storage.StorageDriverTargetInfo;
 import io.temporal.payload.storage.StorageDriverWorkflowInfo;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -59,16 +56,10 @@ import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
 import io.temporal.worker.tuning.SlotSupplier;
 import io.temporal.worker.tuning.WorkflowSlotInfo;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
@@ -493,7 +484,7 @@ public class WorkflowWorkerTest {
 
   @Test
   public void payloadsInAFailedWorkflowTaskAreOffloaded() throws Exception {
-    TestDriver driver = new TestDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     Payload details = Payload.newBuilder().setData(ByteString.copyFrom("details", UTF_8)).build();
     RespondWorkflowTaskFailedRequest taskFailed =
         RespondWorkflowTaskFailedRequest.newBuilder()
@@ -522,7 +513,7 @@ public class WorkflowWorkerTest {
 
   @Test
   public void payloadsInADirectQueryResponseAreOffloaded() throws Exception {
-    TestDriver driver = new TestDriver();
+    TestStorageDriver driver = TestStorageDriver.create();
     Payload answer = Payload.newBuilder().setData(ByteString.copyFrom("answer", UTF_8)).build();
     RespondQueryTaskCompletedRequest queryCompleted =
         RespondQueryTaskCompletedRequest.newBuilder()
@@ -546,7 +537,7 @@ public class WorkflowWorkerTest {
 
   /** Runs a single workflow task through a worker wired to {@code driver}, then verifies. */
   private void runOneTask(
-      TestDriver driver,
+      TestStorageDriver driver,
       WorkflowTaskHandler.Result handlerResult,
       java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
       throws Exception {
@@ -662,10 +653,8 @@ public class WorkflowWorkerTest {
 
       CountDownLatch storeEntered = new CountDownLatch(1);
       CountDownLatch releaseStore = new CountDownLatch(1);
-      TestDriver driver = new TestDriver();
-      driver.storeEntered = storeEntered;
-      driver.releaseStore = releaseStore;
-      driver.failStores = true;
+      TestStorageDriver driver =
+          TestStorageDriver.create().blockStores(storeEntered, releaseStore).failStores(1);
       CountDownLatch escaped = new CountDownLatch(1);
 
       WorkflowWorker worker =
@@ -785,65 +774,6 @@ public class WorkflowWorkerTest {
   }
 
   /** One driver for these tests: stores in memory, and can block or fail on demand. */
-  private static final class TestDriver implements StorageDriver {
-    private final Map<String, Payload> stored = new HashMap<>();
-    private int nextKey;
-    @Nullable CountDownLatch storeEntered;
-    @Nullable CountDownLatch releaseStore;
-    boolean failStores;
-
-    @Override
-    public String getName() {
-      return "test";
-    }
-
-    @Override
-    public String getType() {
-      return "test.in-memory";
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
-        StorageDriverStoreContext context, List<Payload> payloads) {
-      if (storeEntered != null) {
-        storeEntered.countDown();
-      }
-      if (releaseStore != null) {
-        try {
-          releaseStore.await(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-      if (failStores) {
-        CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
-        failed.completeExceptionally(new RuntimeException("store abandoned"));
-        return failed;
-      }
-      List<StorageDriverClaim> claims = new ArrayList<>();
-      for (Payload payload : payloads) {
-        String key = Integer.toString(nextKey++);
-        stored.put(key, payload);
-        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
-      }
-      return CompletableFuture.completedFuture(claims);
-    }
-
-    @Override
-    public synchronized CompletableFuture<List<Payload>> retrieve(
-        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
-      List<Payload> payloads = new ArrayList<>();
-      for (StorageDriverClaim claim : claims) {
-        payloads.add(stored.get(claim.getClaimData().get("key")));
-      }
-      return CompletableFuture.completedFuture(payloads);
-    }
-
-    synchronized int storedCount() {
-      return stored.size();
-    }
-  }
-
   @Test
   public void deriveStorageTargetPointsACompletionAtItsParent() {
     StorageDriverTargetInfo child = new StorageDriverWorkflowInfo("ns", "child", "run-1", "Child");

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -22,6 +22,7 @@ import io.temporal.api.common.v1.ActivityType;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.common.CancellationToken;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.replay.ReplayWorkflow;
@@ -96,7 +97,8 @@ public class WorkflowWorkerTest {
             eagerActivityDispatcher,
             3,
             slotSupplier,
-            new NamespaceCapabilities());
+            new NamespaceCapabilities(),
+            CancellationToken.none());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -268,7 +270,8 @@ public class WorkflowWorkerTest {
             eagerActivityDispatcher,
             3,
             slotSupplier,
-            new NamespaceCapabilities());
+            new NamespaceCapabilities(),
+            CancellationToken.none());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -413,7 +416,8 @@ public class WorkflowWorkerTest {
             eagerActivityDispatcher,
             3,
             slotSupplier,
-            new NamespaceCapabilities());
+            new NamespaceCapabilities(),
+            CancellationToken.none());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -12,7 +12,9 @@ import com.uber.m3.tally.NoopScope;
 import com.uber.m3.tally.RootScopeBuilder;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
+import io.temporal.api.command.v1.Command;
 import io.temporal.api.command.v1.CompleteWorkflowExecutionCommandAttributes;
+import io.temporal.api.command.v1.ContinueAsNewWorkflowExecutionCommandAttributes;
 import io.temporal.api.command.v1.ScheduleActivityTaskCommandAttributes;
 import io.temporal.api.command.v1.SignalExternalWorkflowExecutionCommandAttributes;
 import io.temporal.api.command.v1.StartChildWorkflowExecutionCommandAttributes;
@@ -458,56 +460,98 @@ public class WorkflowWorkerTest {
   }
 
   @Test
-  public void refineStorageTargetPointsActivityCommandsAtTheActivity() {
+  public void deriveStorageTargetPointsActivityCommandsAtTheActivity() {
     StorageDriverTargetInfo workflowDefault =
         new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
-    ScheduleActivityTaskCommandAttributes command =
-        ScheduleActivityTaskCommandAttributes.newBuilder()
-            .setActivityId("act-1")
-            .setActivityType(ActivityType.newBuilder().setName("MyActivity"))
+    Command command =
+        Command.newBuilder()
+            .setScheduleActivityTaskCommandAttributes(
+                ScheduleActivityTaskCommandAttributes.newBuilder()
+                    .setActivityId("act-1")
+                    .setActivityType(ActivityType.newBuilder().setName("MyActivity")))
             .build();
 
     assertEquals(
         new StorageDriverActivityInfo("ns", "act-1", null, "MyActivity"),
-        WorkflowWorker.refineStorageTarget("ns", workflowDefault, command));
+        WorkflowWorker.deriveStorageTarget("ns", workflowDefault, command));
   }
 
   @Test
-  public void refineStorageTargetPointsChildWorkflowCommandsAtTheChild() {
+  public void deriveStorageTargetPointsChildWorkflowCommandsAtTheChild() {
     StorageDriverTargetInfo parent =
         new StorageDriverWorkflowInfo("ns", "parent", "parent-run", "Parent");
-    StartChildWorkflowExecutionCommandAttributes command =
-        StartChildWorkflowExecutionCommandAttributes.newBuilder()
-            .setWorkflowId("child-1")
-            .setWorkflowType(WorkflowType.newBuilder().setName("Child"))
+    Command command =
+        Command.newBuilder()
+            .setStartChildWorkflowExecutionCommandAttributes(
+                StartChildWorkflowExecutionCommandAttributes.newBuilder()
+                    .setWorkflowId("child-1")
+                    .setWorkflowType(WorkflowType.newBuilder().setName("Child")))
             .build();
 
     assertEquals(
         new StorageDriverWorkflowInfo("ns", "child-1", null, "Child"),
-        WorkflowWorker.refineStorageTarget("ns", parent, command));
+        WorkflowWorker.deriveStorageTarget("ns", parent, command));
   }
 
   @Test
-  public void refineStorageTargetPointsSignalCommandsAtTheTargetWorkflow() {
+  public void deriveStorageTargetPointsSignalCommandsAtTheTargetWorkflow() {
     StorageDriverTargetInfo self = new StorageDriverWorkflowInfo("ns", "self", "self-run", "Self");
-    SignalExternalWorkflowExecutionCommandAttributes command =
-        SignalExternalWorkflowExecutionCommandAttributes.newBuilder()
-            .setExecution(
-                WorkflowExecution.newBuilder().setWorkflowId("other").setRunId("other-run"))
+    Command command =
+        Command.newBuilder()
+            .setSignalExternalWorkflowExecutionCommandAttributes(
+                SignalExternalWorkflowExecutionCommandAttributes.newBuilder()
+                    .setExecution(
+                        WorkflowExecution.newBuilder()
+                            .setWorkflowId("other")
+                            .setRunId("other-run")))
             .build();
 
     assertEquals(
         new StorageDriverWorkflowInfo("ns", "other", "other-run", null),
-        WorkflowWorker.refineStorageTarget("ns", self, command));
+        WorkflowWorker.deriveStorageTarget("ns", self, command));
   }
 
   @Test
-  public void refineStorageTargetKeepsTheCurrentTargetForOtherCommands() {
+  public void deriveStorageTargetPointsContinueAsNewAtTheNewRun() {
+    StorageDriverTargetInfo current =
+        new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "CurrentWorkflow");
+    Command command =
+        Command.newBuilder()
+            .setContinueAsNewWorkflowExecutionCommandAttributes(
+                ContinueAsNewWorkflowExecutionCommandAttributes.newBuilder()
+                    .setWorkflowType(WorkflowType.newBuilder().setName("NextWorkflow")))
+            .build();
+
+    assertEquals(
+        new StorageDriverWorkflowInfo("ns", "wf-1", null, "NextWorkflow"),
+        WorkflowWorker.deriveStorageTarget("ns", current, command));
+  }
+
+  @Test
+  public void deriveStorageTargetKeepsWorkflowTypeForContinueAsNewWithoutOverride() {
+    StorageDriverTargetInfo current =
+        new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "CurrentWorkflow");
+    Command command =
+        Command.newBuilder()
+            .setContinueAsNewWorkflowExecutionCommandAttributes(
+                ContinueAsNewWorkflowExecutionCommandAttributes.newBuilder())
+            .build();
+
+    assertEquals(
+        new StorageDriverWorkflowInfo("ns", "wf-1", null, "CurrentWorkflow"),
+        WorkflowWorker.deriveStorageTarget("ns", current, command));
+  }
+
+  @Test
+  public void deriveStorageTargetKeepsTheCurrentTargetForOtherCommands() {
     StorageDriverTargetInfo current =
         new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
-    CompleteWorkflowExecutionCommandAttributes command =
-        CompleteWorkflowExecutionCommandAttributes.newBuilder().build();
+    Command command =
+        Command.newBuilder()
+            .setCompleteWorkflowExecutionCommandAttributes(
+                CompleteWorkflowExecutionCommandAttributes.newBuilder())
+            .build();
 
-    assertSame(current, WorkflowWorker.refineStorageTarget("ns", current, command));
+    assertSame(current, WorkflowWorker.deriveStorageTarget("ns", current, command));
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -668,6 +668,33 @@ public class WorkflowWorkerTest {
   }
 
   @Test
+  public void deriveStorageTargetPointsACompletionAtItsParent() {
+    StorageDriverTargetInfo child = new StorageDriverWorkflowInfo("ns", "child", "run-1", "Child");
+    StorageDriverTargetInfo parent =
+        new StorageDriverWorkflowInfo("ns", "parent", "parent-run", null);
+    Command command =
+        Command.newBuilder()
+            .setCompleteWorkflowExecutionCommandAttributes(
+                CompleteWorkflowExecutionCommandAttributes.newBuilder())
+            .build();
+
+    assertEquals(parent, WorkflowWorker.deriveStorageTarget("ns", child, command, parent));
+  }
+
+  @Test
+  public void deriveStorageTargetKeepsACompletionOnItselfWithoutAParent() {
+    StorageDriverTargetInfo self =
+        new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");
+    Command command =
+        Command.newBuilder()
+            .setCompleteWorkflowExecutionCommandAttributes(
+                CompleteWorkflowExecutionCommandAttributes.newBuilder())
+            .build();
+
+    assertEquals(self, WorkflowWorker.deriveStorageTarget("ns", self, command, null));
+  }
+
+  @Test
   public void deriveStorageTargetKeepsActivityCommandsOnTheWorkflow() {
     StorageDriverTargetInfo workflowDefault =
         new StorageDriverWorkflowInfo("ns", "wf-1", "run-1", "MyWorkflow");

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -36,7 +36,6 @@ import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
-import io.temporal.common.CancellationToken;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.common.InternalUtils;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
@@ -116,8 +115,7 @@ public class WorkflowWorkerTest {
             eagerActivityDispatcher,
             3,
             slotSupplier,
-            new NamespaceCapabilities(),
-            CancellationToken.none());
+            new NamespaceCapabilities());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -289,8 +287,7 @@ public class WorkflowWorkerTest {
             eagerActivityDispatcher,
             3,
             slotSupplier,
-            new NamespaceCapabilities(),
-            CancellationToken.none());
+            new NamespaceCapabilities());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -435,8 +432,7 @@ public class WorkflowWorkerTest {
             eagerActivityDispatcher,
             3,
             slotSupplier,
-            new NamespaceCapabilities(),
-            CancellationToken.none());
+            new NamespaceCapabilities());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -523,8 +519,7 @@ public class WorkflowWorkerTest {
             mock(EagerActivityDispatcher.class),
             3,
             new FixedSizeSlotSupplier<>(10),
-            new NamespaceCapabilities(),
-            CancellationToken.none());
+            new NamespaceCapabilities());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -683,8 +678,7 @@ public class WorkflowWorkerTest {
             mock(EagerActivityDispatcher.class),
             3,
             new FixedSizeSlotSupplier<>(10),
-            new NamespaceCapabilities(),
-            CancellationToken.none());
+            new NamespaceCapabilities());
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -788,8 +782,7 @@ public class WorkflowWorkerTest {
               mock(EagerActivityDispatcher.class),
               3,
               slotSupplier,
-              new NamespaceCapabilities(),
-              CancellationToken.none());
+              new NamespaceCapabilities());
 
       WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
           mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -483,6 +483,108 @@ public class WorkflowWorkerTest {
   }
 
   @Test
+  public void aTaskAbandonedWhileShuttingDownIsNotReported() throws Exception {
+    WorkflowServiceStubs client = mock(WorkflowServiceStubs.class);
+    when(client.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.newBuilder().build());
+    WorkflowRunLockManager runLockManager = new WorkflowRunLockManager();
+    Scope metricsScope =
+        new RootScopeBuilder()
+            .reporter(reporter)
+            .reportEvery(com.uber.m3.util.Duration.ofMillis(1));
+    WorkflowExecutorCache cache = new WorkflowExecutorCache(10, runLockManager, metricsScope);
+    WorkflowTaskHandler taskHandler = mock(WorkflowTaskHandler.class);
+    when(taskHandler.isAnyTypeSupported()).thenReturn(true);
+
+    CountDownLatch handlerEntered = new CountDownLatch(1);
+    CountDownLatch releaseHandler = new CountDownLatch(1);
+    CountDownLatch escaped = new CountDownLatch(1);
+
+    WorkflowWorker worker =
+        new WorkflowWorker(
+            client,
+            "default",
+            "task_queue",
+            "sticky_task_queue",
+            SingleWorkerOptions.newBuilder()
+                .setIdentity("test_identity")
+                .setBuildId(UUID.randomUUID().toString())
+                .setWorkerInstanceKey(UUID.randomUUID().toString())
+                .setPollerOptions(
+                    PollerOptions.newBuilder()
+                        .setPollerBehavior(new PollerBehaviorSimpleMaximum(1))
+                        .setUncaughtExceptionHandler((thread, error) -> escaped.countDown())
+                        .build())
+                .setMetricsScope(metricsScope)
+                .build(),
+            runLockManager,
+            cache,
+            taskHandler,
+            mock(EagerActivityDispatcher.class),
+            3,
+            new FixedSizeSlotSupplier<>(10),
+            new NamespaceCapabilities(),
+            CancellationToken.none());
+
+    WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
+    when(futureStub.shutdownWorker(any(ShutdownWorkerRequest.class)))
+        .thenReturn(Futures.immediateFuture(ShutdownWorkerResponse.newBuilder().build()));
+    WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub =
+        mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+    when(client.blockingStub()).thenReturn(blockingStub);
+    when(client.futureStub()).thenReturn(futureStub);
+    when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+
+    PollWorkflowTaskQueueResponse pollResponse =
+        PollWorkflowTaskQueueResponse.newBuilder()
+            .setTaskToken(ByteString.copyFrom("token", UTF_8))
+            .setWorkflowExecution(
+                WorkflowExecution.newBuilder().setWorkflowId(WORKFLOW_ID).setRunId(RUN_ID).build())
+            .setWorkflowType(WorkflowType.newBuilder().setName(WORKFLOW_TYPE).build())
+            .build();
+    CountDownLatch blockPolls = new CountDownLatch(1);
+    when(blockingStub.pollWorkflowTaskQueue(any(PollWorkflowTaskQueueRequest.class)))
+        .thenReturn(pollResponse)
+        .thenAnswer(
+            (Answer<PollWorkflowTaskQueueResponse>)
+                invocation -> {
+                  blockPolls.await();
+                  return null;
+                });
+
+    // The task is abandoned part way through, which is what stopping storage looks like.
+    when(taskHandler.handleWorkflowTask(any(PollWorkflowTaskQueueResponse.class)))
+        .thenAnswer(
+            (Answer<WorkflowTaskHandler.Result>)
+                invocation -> {
+                  handlerEntered.countDown();
+                  try {
+                    releaseHandler.await(10, TimeUnit.SECONDS);
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                  }
+                  throw new CancellationException("Worker shutdown");
+                });
+
+    assertTrue(worker.start());
+    assertTrue(handlerEntered.await(10, TimeUnit.SECONDS));
+    CompletableFuture<Void> shutdown = worker.shutdown(new ShutdownManager(), true);
+    releaseHandler.countDown();
+
+    assertFalse(
+        "abandoning a task while shutting down must not surface as an error",
+        escaped.await(2, TimeUnit.SECONDS));
+    verify(blockingStub, never())
+        .respondWorkflowTaskFailed(any(RespondWorkflowTaskFailedRequest.class));
+    assertEquals(
+        "a task abandoned while shutting down must not count as a failed task",
+        0,
+        worker.getTaskCounter().getTotalFailed());
+    shutdown.get();
+  }
+
+  @Test
   public void payloadsInAFailedWorkflowTaskAreOffloaded() throws Exception {
     TestStorageDriver driver = TestStorageDriver.create();
     Payload details = Payload.newBuilder().setData(ByteString.copyFrom("details", UTF_8)).build();

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowWorkerTest.java
@@ -31,8 +31,10 @@ import io.temporal.api.common.v1.Payload;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.common.v1.WorkflowType;
+import io.temporal.api.enums.v1.WorkflowTaskFailedCause;
 import io.temporal.api.failure.v1.ApplicationFailureInfo;
 import io.temporal.api.failure.v1.Failure;
+import io.temporal.api.namespace.v1.NamespaceInfo;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.api.workflowservice.v1.RespondQueryTaskCompletedRequest;
 import io.temporal.api.workflowservice.v1.RespondWorkflowTaskFailedRequest;
@@ -62,6 +64,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
@@ -669,6 +672,74 @@ public class WorkflowWorkerTest {
         sent.getValue().getQueryResult().getPayloads(0));
   }
 
+  @Test
+  public void anOversizedCompletionIsOffloadedRatherThanFailed() throws Exception {
+    TestStorageDriver driver = TestStorageDriver.create();
+
+    runOneTask(
+        driver,
+        completionSizeLimit(ONE_MEGABYTE),
+        oversizedCompletion(),
+        blockingStub -> {
+          verify(blockingStub)
+              .respondWorkflowTaskCompleted(any(RespondWorkflowTaskCompletedRequest.class));
+          verify(blockingStub, never())
+              .respondWorkflowTaskFailed(any(RespondWorkflowTaskFailedRequest.class));
+        });
+
+    assertEquals("the oversized result must be offloaded", 1, driver.storedCount());
+  }
+
+  @Test
+  public void anOversizedCompletionStillFailsWithoutExternalStorage() throws Exception {
+    ArgumentCaptor<RespondWorkflowTaskFailedRequest> sent =
+        ArgumentCaptor.forClass(RespondWorkflowTaskFailedRequest.class);
+
+    runOneTask(
+        null,
+        completionSizeLimit(ONE_MEGABYTE),
+        oversizedCompletion(),
+        blockingStub -> {
+          verify(blockingStub).respondWorkflowTaskFailed(sent.capture());
+          verify(blockingStub, never())
+              .respondWorkflowTaskCompleted(any(RespondWorkflowTaskCompletedRequest.class));
+        });
+
+    assertEquals(
+        WorkflowTaskFailedCause.WORKFLOW_TASK_FAILED_CAUSE_REQUEST_TOO_LARGE,
+        sent.getValue().getCause());
+  }
+
+  private static final int ONE_MEGABYTE = 1024 * 1024;
+
+  private static NamespaceCapabilities completionSizeLimit(long limitBytes) {
+    NamespaceCapabilities capabilities = new NamespaceCapabilities();
+    capabilities.setFromCapabilities(
+        NamespaceInfo.Capabilities.newBuilder().setWorkflowTaskCompletionPagination(true).build());
+    capabilities.setFromLimits(
+        NamespaceInfo.Limits.newBuilder()
+            .setWorkflowTaskCompletionSizeLimitError(limitBytes)
+            .build());
+    return capabilities;
+  }
+
+  private static WorkflowTaskHandler.Result oversizedCompletion() {
+    Payload result =
+        Payload.newBuilder()
+            .setData(ByteString.copyFrom(new byte[WorkflowTaskCompletionPaginator.MAX_PAGE_BYTES]))
+            .build();
+    RespondWorkflowTaskCompletedRequest taskCompleted =
+        RespondWorkflowTaskCompletedRequest.newBuilder()
+            .addCommands(
+                Command.newBuilder()
+                    .setCompleteWorkflowExecutionCommandAttributes(
+                        CompleteWorkflowExecutionCommandAttributes.newBuilder()
+                            .setResult(Payloads.newBuilder().addPayloads(result))))
+            .build();
+    return new WorkflowTaskHandler.Result(
+        WORKFLOW_TYPE, taskCompleted, null, null, null, false, null, null);
+  }
+
   /** Runs a single workflow task through a worker wired to {@code driver}, then verifies. */
   private void runOneTask(
       TestStorageDriver driver,
@@ -679,7 +750,28 @@ public class WorkflowWorkerTest {
   }
 
   private void runOneTask(
+      @Nullable TestStorageDriver driver,
+      NamespaceCapabilities namespaceCapabilities,
+      WorkflowTaskHandler.Result handlerResult,
+      java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
+      throws Exception {
+    runOneTask(
+        driver, namespaceCapabilities, handlerResult, CancellationToken.none(), verification);
+  }
+
+  private void runOneTask(
       TestStorageDriver driver,
+      WorkflowTaskHandler.Result handlerResult,
+      CancellationToken<CancellationException> storageCancellation,
+      java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
+      throws Exception {
+    runOneTask(
+        driver, new NamespaceCapabilities(), handlerResult, storageCancellation, verification);
+  }
+
+  private void runOneTask(
+      @Nullable TestStorageDriver driver,
+      NamespaceCapabilities namespaceCapabilities,
       WorkflowTaskHandler.Result handlerResult,
       CancellationToken<CancellationException> storageCancellation,
       java.util.function.Consumer<WorkflowServiceGrpc.WorkflowServiceBlockingStub> verification)
@@ -712,11 +804,13 @@ public class WorkflowWorkerTest {
                         .build())
                 .setMetricsScope(metricsScope)
                 .setExternalStorageRunner(
-                    ExternalStorageRunner.create(
-                        ExternalStorage.newBuilder()
-                            .setDriver(driver)
-                            .setPayloadSizeThreshold(0)
-                            .build()))
+                    driver == null
+                        ? null
+                        : ExternalStorageRunner.create(
+                            ExternalStorage.newBuilder()
+                                .setDriver(driver)
+                                .setPayloadSizeThreshold(0)
+                                .build()))
                 .setStorageCancellation(storageCancellation)
                 .build(),
             runLockManager,
@@ -725,7 +819,7 @@ public class WorkflowWorkerTest {
             mock(EagerActivityDispatcher.class),
             3,
             new FixedSizeSlotSupplier<>(10),
-            new NamespaceCapabilities());
+            namespaceCapabilities);
 
     WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
         mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
@@ -736,6 +830,8 @@ public class WorkflowWorkerTest {
     when(client.blockingStub()).thenReturn(blockingStub);
     when(client.futureStub()).thenReturn(futureStub);
     when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+    when(blockingStub.respondWorkflowTaskCompleted(any(RespondWorkflowTaskCompletedRequest.class)))
+        .thenReturn(RespondWorkflowTaskCompletedResponse.getDefaultInstance());
 
     PollWorkflowTaskQueueResponse pollResponse =
         PollWorkflowTaskQueueResponse.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityWorkflowTaskHeartbeatTest.java
@@ -37,7 +37,7 @@ public class LongLocalActivityWorkflowTaskHeartbeatTest {
     WorkflowOptions options =
         WorkflowOptions.newBuilder()
             .setWorkflowRunTimeout(Duration.ofMinutes(5))
-            .setWorkflowTaskTimeout(Duration.ofSeconds(2))
+            .setWorkflowTaskTimeout(Duration.ofSeconds(5))
             .setTaskQueue(testWorkflowRule.getTaskQueue())
             .build();
     TestWorkflow1 workflowStub =


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Integrated external storage into the replay handler and history iterator.
- `WorkflowWorker` handle + send response now use external storage.

## Why
- Workflow workers should utilize external storage and fetch payloads on replay.

## Checklist

- Added tests.