### PR TITLE
External Storage Integration: NexusWorker

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/NexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NexusClientImpl.java
@@ -16,6 +16,9 @@ import io.temporal.internal.client.NexusOperationHandleImpl;
 import io.temporal.internal.client.RootNexusClientInvoker;
 import io.temporal.internal.client.external.GenericWorkflowClient;
 import io.temporal.internal.client.external.GenericWorkflowClientImpl;
+import io.temporal.internal.payload.storage.ExternalStorageDataConverter;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.util.List;
@@ -46,6 +49,16 @@ public class NexusClientImpl implements NexusClient {
     workflowServiceStubs =
         new NamespaceInjectWorkflowServiceStubs(workflowServiceStubs, options.getNamespace());
     this.workflowServiceStubs = workflowServiceStubs;
+    ExternalStorage externalStorageConfig = options.getExternalStorage();
+    if (externalStorageConfig != null) {
+      options =
+          NexusClientOptions.newBuilder(options)
+              .setDataConverter(
+                  new ExternalStorageDataConverter(
+                      options.getDataConverter(),
+                      ExternalStorageRunner.create(externalStorageConfig)))
+              .build();
+    }
     this.options = options;
     this.metricsScope =
         workflowServiceStubs

--- a/temporal-sdk/src/main/java/io/temporal/client/NexusClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NexusClientImpl.java
@@ -12,13 +12,11 @@ import io.temporal.common.interceptors.NexusClientCallsInterceptor.ListNexusOper
 import io.temporal.common.interceptors.NexusClientInterceptor;
 import io.temporal.internal.WorkflowThreadMarker;
 import io.temporal.internal.client.NamespaceInjectWorkflowServiceStubs;
+import io.temporal.internal.client.NexusClientResolvedOptions;
 import io.temporal.internal.client.NexusOperationHandleImpl;
 import io.temporal.internal.client.RootNexusClientInvoker;
 import io.temporal.internal.client.external.GenericWorkflowClient;
 import io.temporal.internal.client.external.GenericWorkflowClientImpl;
-import io.temporal.internal.payload.storage.ExternalStorageDataConverter;
-import io.temporal.internal.payload.storage.ExternalStorageRunner;
-import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.util.List;
@@ -33,7 +31,7 @@ public class NexusClientImpl implements NexusClient {
   private static final Logger log = LoggerFactory.getLogger(NexusClientImpl.class);
 
   private final WorkflowServiceStubs workflowServiceStubs;
-  private final NexusClientOptions options;
+  private final NexusClientResolvedOptions options;
   private final GenericWorkflowClient genericClient;
   private final Scope metricsScope;
   private final NexusClientCallsInterceptor nexusClientCallsInvoker;
@@ -42,23 +40,13 @@ public class NexusClientImpl implements NexusClient {
   public static NexusClient newInstance(WorkflowServiceStubs service, NexusClientOptions options) {
     enforceNonWorkflowThread();
     return WorkflowThreadMarker.protectFromWorkflowThread(
-        new NexusClientImpl(service, options), NexusClient.class);
+        new NexusClientImpl(service, options.toResolvedOptions()), NexusClient.class);
   }
 
-  NexusClientImpl(WorkflowServiceStubs workflowServiceStubs, NexusClientOptions options) {
+  NexusClientImpl(WorkflowServiceStubs workflowServiceStubs, NexusClientResolvedOptions options) {
     workflowServiceStubs =
         new NamespaceInjectWorkflowServiceStubs(workflowServiceStubs, options.getNamespace());
     this.workflowServiceStubs = workflowServiceStubs;
-    ExternalStorage externalStorageConfig = options.getExternalStorage();
-    if (externalStorageConfig != null) {
-      options =
-          NexusClientOptions.newBuilder(options)
-              .setDataConverter(
-                  new ExternalStorageDataConverter(
-                      options.getDataConverter(),
-                      ExternalStorageRunner.create(externalStorageConfig)))
-              .build();
-    }
     this.options = options;
     this.metricsScope =
         workflowServiceStubs

--- a/temporal-sdk/src/main/java/io/temporal/client/NexusClientOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NexusClientOptions.java
@@ -68,6 +68,10 @@ public class NexusClientOptions {
     return dataConverter;
   }
 
+  /**
+   * Get the external storage used to offload large operation payloads, or null if payloads are sent
+   * inline.
+   */
   @Nullable
   public ExternalStorage getExternalStorage() {
     return externalStorage;
@@ -160,6 +164,12 @@ public class NexusClientOptions {
       return this;
     }
 
+    /**
+     * Offload operation payloads that exceed the storage threshold to {@code externalStorage},
+     * sending a reference to the server in their place. The client wraps its {@link DataConverter}
+     * to store outbound payloads and resolve inbound references. Defaults to null, meaning all
+     * payloads are sent inline.
+     */
     public NexusClientOptions.Builder setExternalStorage(
         @Nullable ExternalStorage externalStorage) {
       this.externalStorage = externalStorage;

--- a/temporal-sdk/src/main/java/io/temporal/client/NexusClientOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NexusClientOptions.java
@@ -4,9 +4,11 @@ import io.temporal.common.Experimental;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.GlobalDataConverter;
 import io.temporal.common.interceptors.NexusClientInterceptor;
+import io.temporal.payload.storage.ExternalStorage;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Options that configure a {@link NexusClient} (and the service-bound clients it produces).
@@ -36,16 +38,19 @@ public class NexusClientOptions {
   private final List<NexusClientInterceptor> interceptors;
   private final DataConverter dataConverter;
   private final String identity;
+  private final @Nullable ExternalStorage externalStorage;
 
   private NexusClientOptions(
       String namespace,
       List<NexusClientInterceptor> interceptors,
       DataConverter dataConverter,
-      String identity) {
+      String identity,
+      @Nullable ExternalStorage externalStorage) {
     this.namespace = namespace;
     this.interceptors = interceptors;
     this.dataConverter = dataConverter;
     this.identity = identity;
+    this.externalStorage = externalStorage;
   }
 
   /** Get the namespace this client will operate on. */
@@ -61,6 +66,11 @@ public class NexusClientOptions {
   /** Get the data converter used to serialize Nexus operation inputs and deserialize results. */
   public DataConverter getDataConverter() {
     return dataConverter;
+  }
+
+  @Nullable
+  public ExternalStorage getExternalStorage() {
+    return externalStorage;
   }
 
   /**
@@ -101,6 +111,7 @@ public class NexusClientOptions {
     private List<NexusClientInterceptor> interceptors = Collections.emptyList();
     private DataConverter dataConverter = GlobalDataConverter.get();
     private String identity;
+    private ExternalStorage externalStorage;
 
     private Builder() {}
 
@@ -112,6 +123,7 @@ public class NexusClientOptions {
       interceptors = options.interceptors;
       dataConverter = options.dataConverter;
       identity = options.identity;
+      externalStorage = options.externalStorage;
     }
 
     /** Set the namespace this client will operate on. */
@@ -148,6 +160,12 @@ public class NexusClientOptions {
       return this;
     }
 
+    public NexusClientOptions.Builder setExternalStorage(
+        @Nullable ExternalStorage externalStorage) {
+      this.externalStorage = externalStorage;
+      return this;
+    }
+
     public NexusClientOptions build() {
       String resolvedIdentity =
           identity == null ? ManagementFactory.getRuntimeMXBean().getName() : identity;
@@ -155,7 +173,8 @@ public class NexusClientOptions {
           namespace == null ? DEFAULT_NAMESPACE : namespace,
           interceptors,
           dataConverter,
-          resolvedIdentity);
+          resolvedIdentity,
+          externalStorage);
     }
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/client/NexusClientOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NexusClientOptions.java
@@ -4,6 +4,9 @@ import io.temporal.common.Experimental;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.GlobalDataConverter;
 import io.temporal.common.interceptors.NexusClientInterceptor;
+import io.temporal.internal.client.NexusClientResolvedOptions;
+import io.temporal.internal.payload.storage.ExternalStorageDataConverter;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.payload.storage.ExternalStorage;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
@@ -83,6 +86,22 @@ public class NexusClientOptions {
    */
   public String getIdentity() {
     return identity;
+  }
+
+  /**
+   * Converts this {@link NexusClientOptions} instance into a {@link NexusClientResolvedOptions}
+   * instance, which contains the fully resolved runtime settings used by the internal Nexus client.
+   *
+   * @return a {@link NexusClientResolvedOptions} instance with the resolved options
+   */
+  NexusClientResolvedOptions toResolvedOptions() {
+    DataConverter resolvedDataConverter = dataConverter;
+    if (externalStorage != null) {
+      resolvedDataConverter =
+          new ExternalStorageDataConverter(
+              resolvedDataConverter, ExternalStorageRunner.create(externalStorage));
+    }
+    return new NexusClientResolvedOptions(namespace, interceptors, resolvedDataConverter, identity);
   }
 
   /** Returns a fresh builder. */

--- a/temporal-sdk/src/main/java/io/temporal/client/NexusServiceClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/NexusServiceClientImpl.java
@@ -4,6 +4,7 @@ import io.nexusrpc.OperationDefinition;
 import io.nexusrpc.ServiceDefinition;
 import io.temporal.common.Experimental;
 import io.temporal.common.interceptors.NexusClientCallsInterceptor;
+import io.temporal.internal.client.NexusClientResolvedOptions;
 import io.temporal.internal.util.MethodExtractor;
 import io.temporal.workflow.Functions;
 import java.lang.reflect.Method;
@@ -26,7 +27,7 @@ class NexusServiceClientImpl<T> extends UntypedNexusServiceClientImpl
       NexusClientCallsInterceptor invoker,
       Class<T> serviceInterface,
       String endpoint,
-      NexusClientOptions options) {
+      NexusClientResolvedOptions options) {
     this(
         invoker,
         serviceInterface,
@@ -40,7 +41,7 @@ class NexusServiceClientImpl<T> extends UntypedNexusServiceClientImpl
       Class<T> serviceInterface,
       ServiceDefinition serviceDef,
       String endpoint,
-      NexusClientOptions options) {
+      NexusClientResolvedOptions options) {
     super(invoker, endpoint, serviceDef.getName(), options);
     this.serviceInterface = serviceInterface;
     this.serviceDef = serviceDef;

--- a/temporal-sdk/src/main/java/io/temporal/client/UntypedNexusServiceClientImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/UntypedNexusServiceClientImpl.java
@@ -6,6 +6,7 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.NexusClientCallsInterceptor;
 import io.temporal.common.interceptors.NexusClientCallsInterceptor.StartNexusOperationExecutionInput;
 import io.temporal.common.interceptors.NexusClientCallsInterceptor.StartNexusOperationExecutionOutput;
+import io.temporal.internal.client.NexusClientResolvedOptions;
 import io.temporal.internal.client.NexusOperationHandleImpl;
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -28,7 +29,7 @@ class UntypedNexusServiceClientImpl implements UntypedNexusServiceClient {
       NexusClientCallsInterceptor invoker,
       String endpoint,
       String serviceName,
-      NexusClientOptions clientOptions) {
+      NexusClientResolvedOptions clientOptions) {
     if (invoker == null || endpoint == null || serviceName == null || clientOptions == null) {
       throw new IllegalArgumentException(
           "invoker, endpoint, serviceName, and clientOptions are all required");

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/NexusClientResolvedOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/NexusClientResolvedOptions.java
@@ -1,0 +1,41 @@
+package io.temporal.internal.client;
+
+import io.temporal.common.converter.DataConverter;
+import io.temporal.common.interceptors.NexusClientInterceptor;
+import java.util.List;
+
+/** Resolved runtime settings used by the internal Nexus client implementation. */
+public final class NexusClientResolvedOptions {
+
+  private final String namespace;
+  private final List<NexusClientInterceptor> interceptors;
+  private final DataConverter dataConverter;
+  private final String identity;
+
+  public NexusClientResolvedOptions(
+      String namespace,
+      List<NexusClientInterceptor> interceptors,
+      DataConverter dataConverter,
+      String identity) {
+    this.namespace = namespace;
+    this.interceptors = interceptors;
+    this.dataConverter = dataConverter;
+    this.identity = identity;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public List<NexusClientInterceptor> getInterceptors() {
+    return interceptors;
+  }
+
+  public DataConverter getDataConverter() {
+    return dataConverter;
+  }
+
+  public String getIdentity() {
+    return identity;
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootNexusClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootNexusClientInvoker.java
@@ -20,7 +20,6 @@ import io.temporal.api.workflowservice.v1.RequestCancelNexusOperationExecutionRe
 import io.temporal.api.workflowservice.v1.StartNexusOperationExecutionRequest;
 import io.temporal.api.workflowservice.v1.StartNexusOperationExecutionResponse;
 import io.temporal.api.workflowservice.v1.TerminateNexusOperationExecutionRequest;
-import io.temporal.client.NexusClientOptions;
 import io.temporal.client.NexusOperationAlreadyStartedException;
 import io.temporal.client.NexusOperationExecutionCount;
 import io.temporal.client.NexusOperationExecutionDescription;
@@ -53,10 +52,10 @@ import javax.annotation.Nullable;
 public class RootNexusClientInvoker implements NexusClientCallsInterceptor {
 
   private final GenericWorkflowClient genericClient;
-  private final NexusClientOptions clientOptions;
+  private final NexusClientResolvedOptions clientOptions;
 
   public RootNexusClientInvoker(
-      GenericWorkflowClient genericClient, NexusClientOptions clientOptions) {
+      GenericWorkflowClient genericClient, NexusClientResolvedOptions clientOptions) {
     this.genericClient = genericClient;
     this.clientOptions = clientOptions;
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -284,16 +284,6 @@ final class NexusWorker implements SuspendableWorker {
         options.getIdentity(), namespace, taskQueue);
   }
 
-  /**
-   * Marks a failure raised by the external storage. Reported to the server as a retryable handler
-   * error.
-   */
-  private static final class ExternalStorageTaskFailure extends RuntimeException {
-    ExternalStorageTaskFailure(String message, Throwable cause) {
-      super(message, cause);
-    }
-  }
-
   private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<NexusTask> {
 
     final NexusTaskHandler handler;
@@ -326,7 +316,6 @@ final class NexusWorker implements SuspendableWorker {
     public void handle(NexusTask task) {
       boolean taskFailed = false;
       try {
-        task = retrieveInboundPayloads(task);
         PollNexusTaskQueueResponseOrBuilder pollResponse = task.getResponse();
         // Extract service and operation from the request and set them as MDC and metrics
         // scope tags. If the request does not have a service or operation, do not set the tags.
@@ -343,6 +332,14 @@ final class NexusWorker implements SuspendableWorker {
           metricsScope =
               metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_OPERATION, operation));
         }
+        try {
+          task = retrieveInboundPayloads(task);
+        } catch (Throwable e) {
+          taskFailed = true;
+          sendInboundStorageFailure(pollResponse, metricsScope, e);
+          return;
+        }
+
         slotSupplier.markSlotUsed(
             new NexusSlotInfo(
                 service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
@@ -438,14 +435,7 @@ final class NexusWorker implements SuspendableWorker {
       }
 
       try {
-        // Check if the server supports using the Failure directly in responses
-        boolean supportTemporalFailure =
-            task.getResponse().getRequest().getCapabilities().getTemporalFailureResponses();
-        if (forceOldFailureFormat) {
-          supportTemporalFailure = false;
-        }
-
-        sendReply(taskToken, supportTemporalFailure, result, metricsScope);
+        sendReply(taskToken, supportsTemporalFailure(pollResponse), result, metricsScope);
       } catch (Exception e) {
         logExceptionDuringResultReporting(e, pollResponse, result);
         throw e;
@@ -548,6 +538,30 @@ final class NexusWorker implements SuspendableWorker {
           throw new IllegalArgumentException("[BUG] Either response or failure must be set");
         }
       }
+    }
+
+    private boolean supportsTemporalFailure(PollNexusTaskQueueResponseOrBuilder pollResponse) {
+      return !forceOldFailureFormat
+          && pollResponse.getRequest().getCapabilities().getTemporalFailureResponses();
+    }
+
+    private void sendInboundStorageFailure(
+        PollNexusTaskQueueResponseOrBuilder pollResponse, Scope metricsScope, Throwable e) {
+      log.warn("Failed to retrieve externally stored payloads for a nexus task", e);
+      metricsScope
+          .tagged(
+              Collections.singletonMap(
+                  TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL))
+          .counter(MetricsType.NEXUS_EXEC_FAILED_COUNTER)
+          .inc(1);
+      HandlerException handlerException =
+          new HandlerException(
+              HandlerException.ErrorType.INTERNAL, "External storage retrieval failed", e);
+      sendReply(
+          pollResponse.getTaskToken(),
+          supportsTemporalFailure(pollResponse),
+          new NexusTaskHandler.Result(handlerException),
+          metricsScope);
     }
 
     private NexusTask retrieveInboundPayloads(NexusTask task) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -352,6 +352,7 @@ final class NexusWorker implements SuspendableWorker {
             return;
           }
           taskFailed = true;
+          recordStorageFailure(metricsScope);
           sendStorageFailure(
               pollResponse.getTaskToken(), supportsTemporalFailure(pollResponse), metricsScope, e);
           return;
@@ -451,8 +452,11 @@ final class NexusWorker implements SuspendableWorker {
       }
 
       try {
-        sendReply(taskToken, supportsTemporalFailure(pollResponse), result, metricsScope);
+        sendReply(taskToken, supportsTemporalFailure(pollResponse), result, metricsScope, true);
       } catch (ExternalStorageTaskFailure e) {
+        if (!failed) {
+          recordStorageFailure(metricsScope);
+        }
         sendStorageFailure(
             taskToken, supportsTemporalFailure(pollResponse), metricsScope, e.getCause());
         return true;
@@ -511,7 +515,8 @@ final class NexusWorker implements SuspendableWorker {
         ByteString taskToken,
         boolean supportTemporalFailure,
         NexusTaskHandler.Result response,
-        Scope metricsScope) {
+        Scope metricsScope,
+        boolean useExternalStorage) {
       Response taskResponse = response.getResponse();
       if (taskResponse != null) {
         // For old servers that do not support TemporalFailure in Failure proto,
@@ -525,7 +530,9 @@ final class NexusWorker implements SuspendableWorker {
                 .setIdentity(options.getIdentity())
                 .setNamespace(namespace)
                 .setResponse(taskResponse);
-        storeOutbound(requestBuilder);
+        if (useExternalStorage) {
+          storeOutbound(requestBuilder);
+        }
         RespondNexusTaskCompletedRequest request = requestBuilder.build();
 
         grpcRetryer.retry(
@@ -548,7 +555,9 @@ final class NexusWorker implements SuspendableWorker {
           } else {
             request.setError(NexusUtil.handlerErrorToNexusError(handlerException, dataConverter));
           }
-          storeOutbound(request);
+          if (useExternalStorage) {
+            storeOutbound(request);
+          }
           RespondNexusTaskFailedRequest failedRequest = request.build();
           grpcRetryer.retry(
               () ->
@@ -568,6 +577,19 @@ final class NexusWorker implements SuspendableWorker {
           && pollResponse.getRequest().getCapabilities().getTemporalFailureResponses();
     }
 
+    private void recordStorageFailure(Scope metricsScope) {
+      metricsScope
+          .tagged(
+              Collections.singletonMap(
+                  TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL))
+          .counter(MetricsType.NEXUS_EXEC_FAILED_COUNTER)
+          .inc(1);
+    }
+
+    /**
+     * Reports a storage failure to the server as an internal handler error. This is the only
+     * recovery attempt and it bypasses external storage.
+     */
     private void sendStorageFailure(
         ByteString taskToken, boolean supportTemporalFailure, Scope metricsScope, Throwable e) {
       String message =
@@ -576,31 +598,13 @@ final class NexusWorker implements SuspendableWorker {
                   + " configured"
               : "External storage failed for a nexus task";
       log.warn(message, e);
-      metricsScope
-          .tagged(
-              Collections.singletonMap(
-                  TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL))
-          .counter(MetricsType.NEXUS_EXEC_FAILED_COUNTER)
-          .inc(1);
-      try {
-        sendReply(
-            taskToken,
-            supportTemporalFailure,
-            new NexusTaskHandler.Result(
-                new HandlerException(HandlerException.ErrorType.INTERNAL, message, e)),
-            metricsScope);
-      } catch (ExternalStorageTaskFailure reportFailed) {
-        // report failure without extstore (since it was unavailable)
-        sendReply(
-            taskToken,
-            supportTemporalFailure,
-            new NexusTaskHandler.Result(
-                new HandlerException(
-                    HandlerException.ErrorType.INTERNAL,
-                    message,
-                    new IllegalStateException("external storage unavailable"))),
-            metricsScope);
-      }
+      sendReply(
+          taskToken,
+          supportTemporalFailure,
+          new NexusTaskHandler.Result(
+              new HandlerException(HandlerException.ErrorType.INTERNAL, message, e)),
+          metricsScope,
+          false);
     }
 
     /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -332,6 +332,11 @@ final class NexusWorker implements SuspendableWorker {
           metricsScope =
               metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_OPERATION, operation));
         }
+        slotSupplier.markSlotUsed(
+            new NexusSlotInfo(
+                service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
+            task.getPermit());
+
         try {
           task = retrieveInboundPayloads(task);
         } catch (Throwable e) {
@@ -339,11 +344,6 @@ final class NexusWorker implements SuspendableWorker {
           sendInboundStorageFailure(pollResponse, metricsScope, e);
           return;
         }
-
-        slotSupplier.markSlotUsed(
-            new NexusSlotInfo(
-                service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
-            task.getPermit());
 
         taskFailed = handleNexusTask(task, metricsScope);
       } catch (Throwable e) {

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -346,6 +346,10 @@ final class NexusWorker implements SuspendableWorker {
         try {
           task = retrieveInboundPayloads(task);
         } catch (Throwable e) {
+          if (isShutdownCancellation(e)) {
+            log.trace("Abandoned a nexus task while the worker was shutting down", e);
+            return;
+          }
           taskFailed = true;
           sendStorageFailure(
               pollResponse.getTaskToken(), supportsTemporalFailure(pollResponse), metricsScope, e);
@@ -354,6 +358,10 @@ final class NexusWorker implements SuspendableWorker {
 
         taskFailed = handleNexusTask(task, metricsScope);
       } catch (Throwable e) {
+        if (isShutdownCancellation(e)) {
+          log.trace("Abandoned a nexus task while the worker was shutting down", e);
+          return;
+        }
         taskFailed = true;
         throw e;
       } finally {
@@ -447,6 +455,9 @@ final class NexusWorker implements SuspendableWorker {
         sendStorageFailure(
             taskToken, supportsTemporalFailure(pollResponse), metricsScope, e.getCause());
         return true;
+      } catch (CancellationException e) {
+        // Absorbed by handle() when this worker is shutting down.
+        throw e;
       } catch (Exception e) {
         logExceptionDuringResultReporting(e, pollResponse, result);
         throw e;
@@ -574,6 +585,16 @@ final class NexusWorker implements SuspendableWorker {
           metricsScope);
     }
 
+    /**
+     * True when {@code e} is external storage aborting because this worker is shutting down. A
+     * storage driver that genuinely breaks at the same moment is a different thing and must still
+     * be reported to the server.
+     */
+    private boolean isShutdownCancellation(Throwable e) {
+      return e instanceof CancellationException
+          && storageCancellation.token().isCancellationRequested();
+    }
+
     private NexusTask retrieveInboundPayloads(NexusTask task) {
       ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
       PollNexusTaskQueueResponseOrBuilder response = task.getResponse();
@@ -598,7 +619,11 @@ final class NexusWorker implements SuspendableWorker {
       }
       try {
         externalStorageRunner.store(builder, null, null, storageCancellation.token());
-      } catch (Throwable e) {
+      } catch (CancellationException e) {
+        // A shutdown cancellation is not a task failure. Let it reach handle(), which abandons the
+        // task rather than telling the server the handler failed.
+        throw e;
+      } catch (Exception e) {
         throw new ExternalStorageTaskFailure("External storage store failed", e);
       }
     }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -14,10 +14,10 @@ import io.nexusrpc.handler.HandlerException;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.nexus.v1.*;
 import io.temporal.api.workflowservice.v1.*;
-import io.temporal.common.CancellationToken;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.NexusUtil;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.logging.LoggerTag;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.retryer.GrpcRetryer;
@@ -30,6 +30,7 @@ import io.temporal.worker.tuning.*;
 import io.temporal.worker.tuning.PollerBehaviorAutoscaling;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -56,6 +57,9 @@ final class NexusWorker implements SuspendableWorker {
   private final GrpcRetryer.GrpcRetryerOptions replyGrpcRetryerOptions;
   private final TrackingSlotSupplier<NexusSlotInfo> slotSupplier;
   private final NamespaceCapabilities namespaceCapabilities;
+
+  final CancelSource<CancellationException> storageCancellation =
+      new CancelSource<>(() -> new CancellationException("Worker shutdown"));
   private final boolean forceOldFailureFormat;
   private final boolean workerCommandsTaskQueue;
   private final TaskCounter taskCounter = new TaskCounter();
@@ -185,6 +189,9 @@ final class NexusWorker implements SuspendableWorker {
 
   @Override
   public CompletableFuture<Void> shutdown(ShutdownManager shutdownManager, boolean interruptTasks) {
+    if (interruptTasks) {
+      storageCancellation.cancel();
+    }
     String supplierName = this + "#executorSlots";
     return poller
         .shutdown(shutdownManager, interruptTasks)
@@ -555,7 +562,7 @@ final class NexusWorker implements SuspendableWorker {
         return task;
       }
       return new NexusTask(
-          externalStorage.retrieve(built, CancellationToken.none()),
+          externalStorage.retrieve(built, storageCancellation.token()),
           task.getPermit(),
           task.getCompletionCallback());
     }
@@ -563,7 +570,7 @@ final class NexusWorker implements SuspendableWorker {
     private void storeOutbound(Message.Builder builder) {
       ExternalStorageRunner externalStorage = options.getExternalStorage();
       if (externalStorage != null) {
-        externalStorage.store(builder, null, null, CancellationToken.none());
+        externalStorage.store(builder, null, null, storageCancellation.token());
       }
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -4,6 +4,7 @@ import static io.temporal.serviceclient.MetricsTag.METRICS_TAGS_CALL_OPTIONS_KEY
 import static io.temporal.serviceclient.MetricsTag.TASK_FAILURE_TYPE;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Stopwatch;
 import com.uber.m3.util.Duration;
@@ -17,6 +18,7 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.NexusUtil;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.logging.LoggerTag;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
@@ -274,6 +276,16 @@ final class NexusWorker implements SuspendableWorker {
         options.getIdentity(), namespace, taskQueue);
   }
 
+  /**
+   * Marks a failure raised by the external storage. Reported to the server as a retryable handler
+   * error.
+   */
+  private static final class ExternalStorageTaskFailure extends RuntimeException {
+    ExternalStorageTaskFailure(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
   private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<NexusTask> {
 
     final NexusTaskHandler handler;
@@ -304,28 +316,30 @@ final class NexusWorker implements SuspendableWorker {
 
     @Override
     public void handle(NexusTask task) {
-      PollNexusTaskQueueResponseOrBuilder pollResponse = task.getResponse();
-      // Extract service and operation from the request and set them as MDC and metrics
-      // scope tags. If the request does not have a service or operation, do not set the tags.
-      // If we don't know how to handle the task, we will fail the task further down the line.
-      Scope metricsScope = workerMetricsScope;
-      String service = getNexusTaskService(pollResponse);
-      if (!service.isEmpty()) {
-        MDC.put(LoggerTag.NEXUS_SERVICE, service);
-        metricsScope = metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_SERVICE, service));
-      }
-      String operation = getNexusTaskOperation(pollResponse);
-      if (!operation.isEmpty()) {
-        MDC.put(LoggerTag.NEXUS_OPERATION, operation);
-        metricsScope = metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_OPERATION, operation));
-      }
-      slotSupplier.markSlotUsed(
-          new NexusSlotInfo(
-              service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
-          task.getPermit());
-
       boolean taskFailed = false;
       try {
+        task = retrieveInboundPayloads(task);
+        PollNexusTaskQueueResponseOrBuilder pollResponse = task.getResponse();
+        // Extract service and operation from the request and set them as MDC and metrics
+        // scope tags. If the request does not have a service or operation, do not set the tags.
+        // If we don't know how to handle the task, we will fail the task further down the line.
+        Scope metricsScope = workerMetricsScope;
+        String service = getNexusTaskService(pollResponse);
+        if (!service.isEmpty()) {
+          MDC.put(LoggerTag.NEXUS_SERVICE, service);
+          metricsScope = metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_SERVICE, service));
+        }
+        String operation = getNexusTaskOperation(pollResponse);
+        if (!operation.isEmpty()) {
+          MDC.put(LoggerTag.NEXUS_OPERATION, operation);
+          metricsScope =
+              metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_OPERATION, operation));
+        }
+        slotSupplier.markSlotUsed(
+            new NexusSlotInfo(
+                service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
+            task.getPermit());
+
         taskFailed = handleNexusTask(task, metricsScope);
       } catch (Throwable e) {
         taskFailed = true;
@@ -484,13 +498,14 @@ final class NexusWorker implements SuspendableWorker {
         if (!supportTemporalFailure && taskResponse.getStartOperation().hasFailure()) {
           taskResponse = getResponseForOldServer(taskResponse);
         }
-        RespondNexusTaskCompletedRequest request =
+        RespondNexusTaskCompletedRequest.Builder requestBuilder =
             RespondNexusTaskCompletedRequest.newBuilder()
                 .setTaskToken(taskToken)
                 .setIdentity(options.getIdentity())
                 .setNamespace(namespace)
-                .setResponse(taskResponse)
-                .build();
+                .setResponse(taskResponse);
+        storeOutbound(requestBuilder);
+        RespondNexusTaskCompletedRequest request = requestBuilder.build();
 
         grpcRetryer.retry(
             () ->
@@ -512,16 +527,40 @@ final class NexusWorker implements SuspendableWorker {
           } else {
             request.setError(NexusUtil.handlerErrorToNexusError(handlerException, dataConverter));
           }
+          storeOutbound(request);
+          RespondNexusTaskFailedRequest failedRequest = request.build();
           grpcRetryer.retry(
               () ->
                   service
                       .blockingStub()
                       .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                      .respondNexusTaskFailed(request.build()),
+                      .respondNexusTaskFailed(failedRequest),
               replyGrpcRetryerOptions);
         } else {
           throw new IllegalArgumentException("[BUG] Either response or failure must be set");
         }
+      }
+    }
+
+    private NexusTask retrieveInboundPayloads(NexusTask task) {
+      ExternalStorageRunner externalStorage = options.getExternalStorage();
+      PollNexusTaskQueueResponseOrBuilder response = task.getResponse();
+      PollNexusTaskQueueResponse built =
+          response instanceof PollNexusTaskQueueResponse
+              ? (PollNexusTaskQueueResponse) response
+              : ((PollNexusTaskQueueResponse.Builder) response).build();
+      if (externalStorage == null) {
+        ExternalStorageRunner.throwIfContainsReference(built);
+        return task;
+      }
+      return new NexusTask(
+          externalStorage.retrieve(built), task.getPermit(), task.getCompletionCallback());
+    }
+
+    private void storeOutbound(Message.Builder builder) {
+      ExternalStorageRunner externalStorage = options.getExternalStorage();
+      if (externalStorage != null) {
+        externalStorage.store(builder, null);
       }
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -19,6 +19,7 @@ import io.temporal.internal.common.NexusUtil;
 import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.internal.concurrent.structured.CancelSource;
 import io.temporal.internal.logging.LoggerTag;
+import io.temporal.internal.payload.storage.ExternalStorageNotConfiguredException;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.internal.retryer.GrpcRetryer;
 import io.temporal.serviceclient.MetricsTag;
@@ -320,29 +321,29 @@ final class NexusWorker implements SuspendableWorker {
 
     @Override
     public void handle(NexusTask task) {
+      PollNexusTaskQueueResponseOrBuilder pollResponse = task.getResponse();
+      // Extract service and operation from the request and set them as MDC and metrics
+      // scope tags. If the request does not have a service or operation, do not set the tags.
+      // If we don't know how to handle the task, we will fail the task further down the line.
+      Scope metricsScope = workerMetricsScope;
+      String service = getNexusTaskService(pollResponse);
+      if (!service.isEmpty()) {
+        MDC.put(LoggerTag.NEXUS_SERVICE, service);
+        metricsScope = metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_SERVICE, service));
+      }
+      String operation = getNexusTaskOperation(pollResponse);
+      if (!operation.isEmpty()) {
+        MDC.put(LoggerTag.NEXUS_OPERATION, operation);
+        metricsScope = metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_OPERATION, operation));
+      }
+      // Must happen before payload retrieval so the slot is accounted for while storage runs.
+      slotSupplier.markSlotUsed(
+          new NexusSlotInfo(
+              service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
+          task.getPermit());
+
       boolean taskFailed = false;
       try {
-        PollNexusTaskQueueResponseOrBuilder pollResponse = task.getResponse();
-        // Extract service and operation from the request and set them as MDC and metrics
-        // scope tags. If the request does not have a service or operation, do not set the tags.
-        // If we don't know how to handle the task, we will fail the task further down the line.
-        Scope metricsScope = workerMetricsScope;
-        String service = getNexusTaskService(pollResponse);
-        if (!service.isEmpty()) {
-          MDC.put(LoggerTag.NEXUS_SERVICE, service);
-          metricsScope = metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_SERVICE, service));
-        }
-        String operation = getNexusTaskOperation(pollResponse);
-        if (!operation.isEmpty()) {
-          MDC.put(LoggerTag.NEXUS_OPERATION, operation);
-          metricsScope =
-              metricsScope.tagged(ImmutableMap.of(MetricsTag.NEXUS_OPERATION, operation));
-        }
-        slotSupplier.markSlotUsed(
-            new NexusSlotInfo(
-                service, operation, taskQueue, options.getIdentity(), options.getBuildId()),
-            task.getPermit());
-
         try {
           task = retrieveInboundPayloads(task);
         } catch (Throwable e) {
@@ -569,20 +570,37 @@ final class NexusWorker implements SuspendableWorker {
 
     private void sendStorageFailure(
         ByteString taskToken, boolean supportTemporalFailure, Scope metricsScope, Throwable e) {
-      log.warn("External storage failed for a nexus task", e);
+      String message =
+          e instanceof ExternalStorageNotConfiguredException
+              ? "Nexus task has externally stored payloads but this worker has no external storage"
+                  + " configured"
+              : "External storage failed for a nexus task";
+      log.warn(message, e);
       metricsScope
           .tagged(
               Collections.singletonMap(
                   TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL))
           .counter(MetricsType.NEXUS_EXEC_FAILED_COUNTER)
           .inc(1);
-      HandlerException handlerException =
-          new HandlerException(HandlerException.ErrorType.INTERNAL, "External storage failed", e);
-      sendReply(
-          taskToken,
-          supportTemporalFailure,
-          new NexusTaskHandler.Result(handlerException),
-          metricsScope);
+      try {
+        sendReply(
+            taskToken,
+            supportTemporalFailure,
+            new NexusTaskHandler.Result(
+                new HandlerException(HandlerException.ErrorType.INTERNAL, message, e)),
+            metricsScope);
+      } catch (ExternalStorageTaskFailure reportFailed) {
+        // report failure without extstore (since it was unavailable)
+        sendReply(
+            taskToken,
+            supportTemporalFailure,
+            new NexusTaskHandler.Result(
+                new HandlerException(
+                    HandlerException.ErrorType.INTERNAL,
+                    message,
+                    new IllegalStateException("external storage unavailable"))),
+            metricsScope);
+      }
     }
 
     /**

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -14,6 +14,7 @@ import io.nexusrpc.handler.HandlerException;
 import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.nexus.v1.*;
 import io.temporal.api.workflowservice.v1.*;
+import io.temporal.common.CancellationToken;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.internal.common.NexusUtil;
 import io.temporal.internal.common.ProtobufTimeUtils;
@@ -554,13 +555,15 @@ final class NexusWorker implements SuspendableWorker {
         return task;
       }
       return new NexusTask(
-          externalStorage.retrieve(built), task.getPermit(), task.getCompletionCallback());
+          externalStorage.retrieve(built, CancellationToken.none()),
+          task.getPermit(),
+          task.getCompletionCallback());
     }
 
     private void storeOutbound(Message.Builder builder) {
       ExternalStorageRunner externalStorage = options.getExternalStorage();
       if (externalStorage != null) {
-        externalStorage.store(builder, null);
+        externalStorage.store(builder, null, null, CancellationToken.none());
       }
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -551,26 +551,26 @@ final class NexusWorker implements SuspendableWorker {
     }
 
     private NexusTask retrieveInboundPayloads(NexusTask task) {
-      ExternalStorageRunner externalStorage = options.getExternalStorage();
+      ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
       PollNexusTaskQueueResponseOrBuilder response = task.getResponse();
       PollNexusTaskQueueResponse built =
           response instanceof PollNexusTaskQueueResponse
               ? (PollNexusTaskQueueResponse) response
               : ((PollNexusTaskQueueResponse.Builder) response).build();
-      if (externalStorage == null) {
+      if (externalStorageRunner == null) {
         ExternalStorageRunner.throwIfContainsReference(built);
         return task;
       }
       return new NexusTask(
-          externalStorage.retrieve(built, storageCancellation.token()),
+          externalStorageRunner.retrieve(built, storageCancellation.token()),
           task.getPermit(),
           task.getCompletionCallback());
     }
 
     private void storeOutbound(Message.Builder builder) {
-      ExternalStorageRunner externalStorage = options.getExternalStorage();
-      if (externalStorage != null) {
-        externalStorage.store(builder, null, null, storageCancellation.token());
+      ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
+      if (externalStorageRunner != null) {
+        externalStorageRunner.store(builder, null, null, storageCancellation.token());
       }
     }
   }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/NexusWorker.java
@@ -284,6 +284,12 @@ final class NexusWorker implements SuspendableWorker {
         options.getIdentity(), namespace, taskQueue);
   }
 
+  private static final class ExternalStorageTaskFailure extends RuntimeException {
+    ExternalStorageTaskFailure(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
   private class TaskHandlerImpl implements PollTaskExecutor.TaskHandler<NexusTask> {
 
     final NexusTaskHandler handler;
@@ -341,7 +347,8 @@ final class NexusWorker implements SuspendableWorker {
           task = retrieveInboundPayloads(task);
         } catch (Throwable e) {
           taskFailed = true;
-          sendInboundStorageFailure(pollResponse, metricsScope, e);
+          sendStorageFailure(
+              pollResponse.getTaskToken(), supportsTemporalFailure(pollResponse), metricsScope, e);
           return;
         }
 
@@ -436,6 +443,10 @@ final class NexusWorker implements SuspendableWorker {
 
       try {
         sendReply(taskToken, supportsTemporalFailure(pollResponse), result, metricsScope);
+      } catch (ExternalStorageTaskFailure e) {
+        sendStorageFailure(
+            taskToken, supportsTemporalFailure(pollResponse), metricsScope, e.getCause());
+        return true;
       } catch (Exception e) {
         logExceptionDuringResultReporting(e, pollResponse, result);
         throw e;
@@ -545,9 +556,9 @@ final class NexusWorker implements SuspendableWorker {
           && pollResponse.getRequest().getCapabilities().getTemporalFailureResponses();
     }
 
-    private void sendInboundStorageFailure(
-        PollNexusTaskQueueResponseOrBuilder pollResponse, Scope metricsScope, Throwable e) {
-      log.warn("Failed to retrieve externally stored payloads for a nexus task", e);
+    private void sendStorageFailure(
+        ByteString taskToken, boolean supportTemporalFailure, Scope metricsScope, Throwable e) {
+      log.warn("External storage failed for a nexus task", e);
       metricsScope
           .tagged(
               Collections.singletonMap(
@@ -555,11 +566,10 @@ final class NexusWorker implements SuspendableWorker {
           .counter(MetricsType.NEXUS_EXEC_FAILED_COUNTER)
           .inc(1);
       HandlerException handlerException =
-          new HandlerException(
-              HandlerException.ErrorType.INTERNAL, "External storage retrieval failed", e);
+          new HandlerException(HandlerException.ErrorType.INTERNAL, "External storage failed", e);
       sendReply(
-          pollResponse.getTaskToken(),
-          supportsTemporalFailure(pollResponse),
+          taskToken,
+          supportTemporalFailure,
           new NexusTaskHandler.Result(handlerException),
           metricsScope);
     }
@@ -583,8 +593,13 @@ final class NexusWorker implements SuspendableWorker {
 
     private void storeOutbound(Message.Builder builder) {
       ExternalStorageRunner externalStorageRunner = options.getExternalStorageRunner();
-      if (externalStorageRunner != null) {
+      if (externalStorageRunner == null) {
+        return;
+      }
+      try {
         externalStorageRunner.store(builder, null, null, storageCancellation.token());
+      } catch (Throwable e) {
+        throw new ExternalStorageTaskFailure("External storage store failed", e);
       }
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/client/NexusClientOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/NexusClientOptionsTest.java
@@ -3,9 +3,17 @@ package io.temporal.client;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
+import io.temporal.api.common.v1.Payload;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.NexusClientInterceptor;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.junit.Test;
 
 public class NexusClientOptionsTest {
@@ -33,6 +41,7 @@ public class NexusClientOptionsTest {
             .setNamespace("ns")
             .setIdentity("id")
             .setDataConverter(dc)
+            .setExternalStorage(storage())
             .setInterceptors(Collections.singletonList(interceptor))
             .build();
 
@@ -42,5 +51,51 @@ public class NexusClientOptionsTest {
     assertEquals(original.getIdentity(), copy.getIdentity());
     assertSame(original.getDataConverter(), copy.getDataConverter());
     assertEquals(original.getInterceptors(), copy.getInterceptors());
+    assertSame(original.getExternalStorage(), copy.getExternalStorage());
+  }
+
+  @Test
+  public void externalStorageDefaultsToDisabled() {
+    assertNull(NexusClientOptions.newBuilder().build().getExternalStorage());
+  }
+
+  @Test
+  public void externalStorageSurvivesBuild() {
+    ExternalStorage storage = storage();
+
+    NexusClientOptions options =
+        NexusClientOptions.newBuilder().setExternalStorage(storage).build();
+
+    assertSame(storage, options.getExternalStorage());
+  }
+
+  private static ExternalStorage storage() {
+    return ExternalStorage.newBuilder().setDriver(driver()).build();
+  }
+
+  private static StorageDriver driver() {
+    return new StorageDriver() {
+      @Override
+      public String getName() {
+        return "test-driver";
+      }
+
+      @Override
+      public String getType() {
+        return "test";
+      }
+
+      @Override
+      public CompletableFuture<List<StorageDriverClaim>> store(
+          StorageDriverStoreContext context, List<Payload> payloads) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public CompletableFuture<List<Payload>> retrieve(
+          StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+        throw new UnsupportedOperationException();
+      }
+    };
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/client/NexusClientOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/NexusClientOptionsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import io.temporal.api.common.v1.Payload;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.interceptors.NexusClientInterceptor;
+import io.temporal.internal.payload.storage.ExternalStorageDataConverter;
 import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.payload.storage.StorageDriver;
 import io.temporal.payload.storage.StorageDriverClaim;
@@ -67,6 +68,20 @@ public class NexusClientOptionsTest {
         NexusClientOptions.newBuilder().setExternalStorage(storage).build();
 
     assertSame(storage, options.getExternalStorage());
+  }
+
+  @Test
+  public void resolveOptionsWrapsDataConverterWithoutChangingConfiguredOptions() {
+    DataConverter dataConverter = mock(DataConverter.class);
+    NexusClientOptions options =
+        NexusClientOptions.newBuilder()
+            .setDataConverter(dataConverter)
+            .setExternalStorage(storage())
+            .build();
+
+    assertSame(dataConverter, options.getDataConverter());
+    assertTrue(
+        options.toResolvedOptions().getDataConverter() instanceof ExternalStorageDataConverter);
   }
 
   private static ExternalStorage storage() {

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageFailureTest.java
@@ -1,0 +1,181 @@
+package io.temporal.client.nexus;
+
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.uber.m3.tally.RootScopeBuilder;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.client.NexusClient;
+import io.temporal.client.NexusClientOptions;
+import io.temporal.client.NexusServiceClient;
+import io.temporal.client.StartNexusOperationOptions;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.common.reporter.TestStatsReporter;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
+import io.temporal.serviceclient.MetricsTag;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.worker.MetricsType;
+import io.temporal.worker.WorkerMetricsTag;
+import io.temporal.workflow.shared.EchoNexusServiceImpl;
+import io.temporal.workflow.shared.TestNexusServices;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NexusExternalStorageFailureTest {
+
+  private static final FlakyDriver driver = new FlakyDriver("nexus-flaky");
+
+  private static final ExternalStorage storage =
+      ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build();
+
+  private final TestStatsReporter reporter = new TestStatsReporter();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(PlaceholderWorkflowImpl.class)
+          .setNexusServiceImplementation(new EchoNexusServiceImpl())
+          .setMetricsScope(
+              new RootScopeBuilder()
+                  .reporter(reporter)
+                  .reportEvery(com.uber.m3.util.Duration.ofMillis(10)))
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder().setExternalStorage(storage).build())
+          .build();
+
+  @Before
+  public void requireStandaloneNexusSupport() {
+    assumeTrue(
+        "server does not support standalone Nexus operations",
+        testWorkflowRule.isUseExternalService());
+    driver.reset();
+  }
+
+  @Test
+  public void aFailedRetrievalIsReportedAsARetryableHandlerError() {
+    String input = "extstore-flaky-" + UUID.randomUUID();
+    driver.failNextRetrieves.set(1);
+
+    String result =
+        buildServiceClient()
+            .execute(TestNexusServices.TestNexusService1::operation, newOptionsWithId(), input);
+
+    Assert.assertEquals("echo:" + input, result);
+    Assert.assertTrue(
+        "expected the failed retrieval to be retried, attempts=" + driver.retrieveAttempts.get(),
+        driver.retrieveAttempts.get() > 1);
+    reporter.assertCounter(MetricsType.NEXUS_EXEC_FAILED_COUNTER, execFailedTags(), 1);
+  }
+
+  private Map<String, String> execFailedTags() {
+    return ImmutableMap.<String, String>builder()
+        .putAll(
+            MetricsTag.defaultTags(
+                testWorkflowRule.getWorkflowClient().getOptions().getNamespace()))
+        .put(MetricsTag.WORKER_TYPE, WorkerMetricsTag.WorkerType.NEXUS_WORKER.getValue())
+        .put(MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue())
+        .put(MetricsTag.NEXUS_SERVICE, "TestNexusService1")
+        .put(MetricsTag.NEXUS_OPERATION, "operation")
+        .put(MetricsTag.TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL)
+        .buildKeepingLast();
+  }
+
+  private static StartNexusOperationOptions newOptionsWithId() {
+    return StartNexusOperationOptions.newBuilder()
+        .setId(UUID.randomUUID().toString())
+        .setScheduleToCloseTimeout(Duration.ofSeconds(60))
+        .build();
+  }
+
+  private NexusServiceClient<TestNexusServices.TestNexusService1> buildServiceClient() {
+    NexusClient nexusClient =
+        NexusClient.newInstance(
+            testWorkflowRule.getWorkflowServiceStubs(),
+            NexusClientOptions.newBuilder()
+                .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                .setExternalStorage(storage)
+                .build());
+    return nexusClient.newNexusServiceClient(
+        TestNexusServices.TestNexusService1.class,
+        testWorkflowRule.getNexusEndpoint().getSpec().getName());
+  }
+
+  public static class PlaceholderWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      return input;
+    }
+  }
+
+  private static final class FlakyDriver implements StorageDriver {
+    private final String name;
+    private final Map<String, Payload> objects = new HashMap<>();
+    final AtomicInteger failNextRetrieves = new AtomicInteger();
+    final AtomicInteger retrieveAttempts = new AtomicInteger();
+    private int counter = 0;
+
+    FlakyDriver(String name) {
+      this.name = name;
+    }
+
+    synchronized void reset() {
+      objects.clear();
+      failNextRetrieves.set(0);
+      retrieveAttempts.set(0);
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getType() {
+      return "test.nexus.flaky";
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
+        StorageDriverStoreContext context, List<Payload> payloads) {
+      List<StorageDriverClaim> claims = new ArrayList<>();
+      for (Payload payload : payloads) {
+        String key = name + "-" + (counter++);
+        objects.put(key, payload);
+        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+      }
+      return CompletableFuture.completedFuture(claims);
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<Payload>> retrieve(
+        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      retrieveAttempts.incrementAndGet();
+      if (failNextRetrieves.getAndDecrement() > 0) {
+        CompletableFuture<List<Payload>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new IllegalStateException("storage unavailable"));
+        return failed;
+      }
+      List<Payload> payloads = new ArrayList<>();
+      for (StorageDriverClaim claim : claims) {
+        payloads.add(objects.get(claim.getClaimData().get("key")));
+      }
+      return CompletableFuture.completedFuture(payloads);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageFailureTest.java
@@ -20,6 +20,19 @@ import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerMetricsTag;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.worker.tuning.ActivitySlotInfo;
+import io.temporal.worker.tuning.CompositeTuner;
+import io.temporal.worker.tuning.FixedSizeSlotSupplier;
+import io.temporal.worker.tuning.LocalActivitySlotInfo;
+import io.temporal.worker.tuning.NexusSlotInfo;
+import io.temporal.worker.tuning.SlotMarkUsedContext;
+import io.temporal.worker.tuning.SlotPermit;
+import io.temporal.worker.tuning.SlotReleaseContext;
+import io.temporal.worker.tuning.SlotReserveContext;
+import io.temporal.worker.tuning.SlotSupplier;
+import io.temporal.worker.tuning.SlotSupplierFuture;
+import io.temporal.worker.tuning.WorkflowSlotInfo;
 import io.temporal.workflow.shared.EchoNexusServiceImpl;
 import io.temporal.workflow.shared.TestNexusServices;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -29,8 +42,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,6 +53,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class NexusExternalStorageFailureTest {
+
+  private static final List<String> events = new CopyOnWriteArrayList<>();
 
   private static final FlakyDriver driver = new FlakyDriver("nexus-flaky");
 
@@ -57,6 +74,15 @@ public class NexusExternalStorageFailureTest {
                   .reportEvery(com.uber.m3.util.Duration.ofMillis(10)))
           .setWorkflowClientOptions(
               WorkflowClientOptions.newBuilder().setExternalStorage(storage).build())
+          .setWorkerOptions(
+              WorkerOptions.newBuilder()
+                  .setWorkerTuner(
+                      new CompositeTuner(
+                          new FixedSizeSlotSupplier<WorkflowSlotInfo>(10),
+                          new FixedSizeSlotSupplier<ActivitySlotInfo>(10),
+                          new FixedSizeSlotSupplier<LocalActivitySlotInfo>(10),
+                          new RecordingNexusSlotSupplier(10)))
+                  .build())
           .build();
 
   @Before
@@ -65,6 +91,7 @@ public class NexusExternalStorageFailureTest {
         "server does not support standalone Nexus operations",
         testWorkflowRule.isUseExternalService());
     driver.reset();
+    events.clear();
   }
 
   @Test
@@ -81,6 +108,23 @@ public class NexusExternalStorageFailureTest {
         "expected the failed retrieval to be retried, attempts=" + driver.retrieveAttempts.get(),
         driver.retrieveAttempts.get() > 1);
     reporter.assertCounter(MetricsType.NEXUS_EXEC_FAILED_COUNTER, execFailedTags(), 1);
+  }
+
+  @Test
+  public void theSlotIsMarkedUsedBeforeRetrievalStarts() {
+    buildServiceClient()
+        .execute(
+            TestNexusServices.TestNexusService1::operation,
+            newOptionsWithId(),
+            "extstore-slot-" + UUID.randomUUID());
+
+    int markedUsed = events.indexOf("markSlotUsed");
+    int retrieved = events.indexOf("retrieve");
+    Assert.assertTrue("expected the slot to be marked used, events=" + events, markedUsed >= 0);
+    Assert.assertTrue("expected a retrieval, events=" + events, retrieved >= 0);
+    Assert.assertTrue(
+        "retrieval must happen inside the used-slot lifecycle, events=" + events,
+        markedUsed < retrieved);
   }
 
   private Map<String, String> execFailedTags() {
@@ -120,6 +164,41 @@ public class NexusExternalStorageFailureTest {
     @Override
     public String execute(String input) {
       return input;
+    }
+  }
+
+  private static final class RecordingNexusSlotSupplier implements SlotSupplier<NexusSlotInfo> {
+    private final FixedSizeSlotSupplier<NexusSlotInfo> delegate;
+
+    RecordingNexusSlotSupplier(int numSlots) {
+      this.delegate = new FixedSizeSlotSupplier<>(numSlots);
+    }
+
+    @Override
+    public SlotSupplierFuture reserveSlot(SlotReserveContext<NexusSlotInfo> ctx) throws Exception {
+      return delegate.reserveSlot(ctx);
+    }
+
+    @Override
+    public Optional<SlotPermit> tryReserveSlot(SlotReserveContext<NexusSlotInfo> ctx) {
+      return delegate.tryReserveSlot(ctx);
+    }
+
+    @Override
+    public void markSlotUsed(SlotMarkUsedContext<NexusSlotInfo> ctx) {
+      events.add("markSlotUsed");
+      delegate.markSlotUsed(ctx);
+    }
+
+    @Override
+    public void releaseSlot(SlotReleaseContext<NexusSlotInfo> ctx) {
+      events.add("releaseSlot");
+      delegate.releaseSlot(ctx);
+    }
+
+    @Override
+    public Optional<Integer> getMaximumSlots() {
+      return delegate.getMaximumSlots();
     }
   }
 
@@ -165,6 +244,7 @@ public class NexusExternalStorageFailureTest {
     @Override
     public synchronized CompletableFuture<List<Payload>> retrieve(
         StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      events.add("retrieve");
       retrieveAttempts.incrementAndGet();
       if (failNextRetrieves.getAndDecrement() > 0) {
         CompletableFuture<List<Payload>> failed = new CompletableFuture<>();

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageFailureTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageFailureTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -107,6 +108,21 @@ public class NexusExternalStorageFailureTest {
     Assert.assertTrue(
         "expected the failed retrieval to be retried, attempts=" + driver.retrieveAttempts.get(),
         driver.retrieveAttempts.get() > 1);
+    reporter.assertCounter(MetricsType.NEXUS_EXEC_FAILED_COUNTER, execFailedTags(), 1);
+  }
+
+  @Test
+  public void aFailedOutboundStoreIsReportedAsARetryableHandlerError() {
+    String input = "extstore-outbound-" + UUID.randomUUID();
+    driver.failStoresContaining.set("echo:" + input);
+
+    String result =
+        buildServiceClient()
+            .execute(TestNexusServices.TestNexusService1::operation, newOptionsWithId(), input);
+
+    Assert.assertEquals("echo:" + input, result);
+    Assert.assertEquals(
+        "expected exactly one injected store failure", 1, driver.injectedStoreFailures.get());
     reporter.assertCounter(MetricsType.NEXUS_EXEC_FAILED_COUNTER, execFailedTags(), 1);
   }
 
@@ -207,6 +223,8 @@ public class NexusExternalStorageFailureTest {
     private final Map<String, Payload> objects = new HashMap<>();
     final AtomicInteger failNextRetrieves = new AtomicInteger();
     final AtomicInteger retrieveAttempts = new AtomicInteger();
+    final AtomicReference<String> failStoresContaining = new AtomicReference<>();
+    final AtomicInteger injectedStoreFailures = new AtomicInteger();
     private int counter = 0;
 
     FlakyDriver(String name) {
@@ -217,6 +235,8 @@ public class NexusExternalStorageFailureTest {
       objects.clear();
       failNextRetrieves.set(0);
       retrieveAttempts.set(0);
+      failStoresContaining.set(null);
+      injectedStoreFailures.set(0);
     }
 
     @Override
@@ -232,6 +252,18 @@ public class NexusExternalStorageFailureTest {
     @Override
     public synchronized CompletableFuture<List<StorageDriverClaim>> store(
         StorageDriverStoreContext context, List<Payload> payloads) {
+      String marker = failStoresContaining.get();
+      if (marker != null) {
+        for (Payload payload : payloads) {
+          if (payload.getData().toStringUtf8().contains(marker)) {
+            failStoresContaining.set(null);
+            injectedStoreFailures.incrementAndGet();
+            CompletableFuture<List<StorageDriverClaim>> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new IllegalStateException("storage unavailable"));
+            return failed;
+          }
+        }
+      }
       List<StorageDriverClaim> claims = new ArrayList<>();
       for (Payload payload : payloads) {
         String key = name + "-" + (counter++);

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageTest.java
@@ -1,0 +1,191 @@
+package io.temporal.client.nexus;
+
+import static org.junit.Assume.assumeTrue;
+
+import io.temporal.api.common.v1.Payload;
+import io.temporal.client.NexusClient;
+import io.temporal.client.NexusClientOptions;
+import io.temporal.client.NexusServiceClient;
+import io.temporal.client.StartNexusOperationOptions;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
+import io.temporal.payload.storage.StorageDriverTargetInfo;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import io.temporal.workflow.shared.EchoNexusServiceImpl;
+import io.temporal.workflow.shared.TestNexusServices;
+import io.temporal.workflow.shared.TestWorkflows;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * End-to-end coverage of external storage on a standalone Nexus operation
+ */
+public class NexusExternalStorageTest {
+
+  private static final RecordingDriver driver = new RecordingDriver("nexus-test");
+
+  private static final ExternalStorage storage =
+      ExternalStorage.newBuilder().setDriver(driver).setPayloadSizeThreshold(0).build();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(PlaceholderWorkflowImpl.class)
+          .setNexusServiceImplementation(new EchoNexusServiceImpl())
+          .setWorkflowClientOptions(
+              WorkflowClientOptions.newBuilder().setExternalStorage(storage).build())
+          .build();
+
+  @Before
+  public void requireStandaloneNexusSupport() {
+    assumeTrue(
+        "server does not support standalone Nexus operations",
+        testWorkflowRule.isUseExternalService());
+    driver.reset();
+  }
+
+  @Test
+  public void operationInputAndResultRoundTripThroughStorage() {
+    String input = "extstore-input-" + UUID.randomUUID();
+
+    String result =
+        buildServiceClient()
+            .execute(TestNexusServices.TestNexusService1::operation, newOptionsWithId(), input);
+
+    Assert.assertEquals("echo:" + input, result);
+    Assert.assertTrue(
+        "expected the operation input to be offloaded to the driver", driver.stored(input));
+    Assert.assertTrue(
+        "expected the operation result to be offloaded to the driver",
+        driver.stored("echo:" + input));
+    Assert.assertTrue(
+        "expected the driver to be read back on retrieval", driver.retrieves.get() > 0);
+  }
+
+  /**
+   * A handler that receives an unresolved reference cannot deserialize its input, so the handler
+   * observing the original value is what proves the inbound retrieval ran.
+   */
+  @Test
+  public void handlerReceivesTheResolvedInput() {
+    String input = "extstore-inbound-" + UUID.randomUUID();
+
+    String result =
+        buildServiceClient()
+            .execute(TestNexusServices.TestNexusService1::operation, newOptionsWithId(), input);
+
+    Assert.assertEquals("echo:" + input, result);
+  }
+
+  @Test
+  public void nexusPayloadsAreStoredWithoutATarget() {
+    buildServiceClient()
+        .execute(
+            TestNexusServices.TestNexusService1::operation,
+            newOptionsWithId(),
+            "extstore-target-" + UUID.randomUUID());
+
+    Assert.assertFalse("expected the driver to have been used", driver.targets.isEmpty());
+    Assert.assertTrue(
+        "Nexus payloads are stored without a StorageDriverTargetInfo",
+        driver.targets.stream().allMatch(target -> target == null));
+  }
+
+  private static StartNexusOperationOptions newOptionsWithId() {
+    return StartNexusOperationOptions.newBuilder().setId(UUID.randomUUID().toString()).build();
+  }
+
+  private NexusServiceClient<TestNexusServices.TestNexusService1> buildServiceClient() {
+    NexusClient nexusClient =
+        NexusClient.newInstance(
+            testWorkflowRule.getWorkflowServiceStubs(),
+            NexusClientOptions.newBuilder()
+                .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                .setExternalStorage(storage)
+                .build());
+    return nexusClient.newNexusServiceClient(
+        TestNexusServices.TestNexusService1.class,
+        testWorkflowRule.getNexusEndpoint().getSpec().getName());
+  }
+
+  public static class PlaceholderWorkflowImpl implements TestWorkflows.TestWorkflow1 {
+    @Override
+    public String execute(String input) {
+      return input;
+    }
+  }
+
+  private static final class RecordingDriver implements StorageDriver {
+    private final String name;
+    private final Map<String, Payload> objects = new HashMap<>();
+    private final List<String> storedData = new CopyOnWriteArrayList<>();
+    final List<StorageDriverTargetInfo> targets = new CopyOnWriteArrayList<>();
+    final AtomicInteger retrieves = new AtomicInteger();
+    private int counter = 0;
+
+    RecordingDriver(String name) {
+      this.name = name;
+    }
+
+    synchronized void reset() {
+      objects.clear();
+      storedData.clear();
+      targets.clear();
+      retrieves.set(0);
+    }
+
+    boolean stored(String substring) {
+      return storedData.stream().anyMatch(data -> data.contains(substring));
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getType() {
+      return "test.nexus.inmemory";
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<StorageDriverClaim>> store(
+        StorageDriverStoreContext context, List<Payload> payloads) {
+      List<StorageDriverClaim> claims = new ArrayList<>();
+      for (Payload payload : payloads) {
+        targets.add(context.getTarget());
+        storedData.add(payload.getData().toStringUtf8());
+        String key = name + "-" + (counter++);
+        objects.put(key, payload);
+        claims.add(new StorageDriverClaim(Collections.singletonMap("key", key)));
+      }
+      return CompletableFuture.completedFuture(claims);
+    }
+
+    @Override
+    public synchronized CompletableFuture<List<Payload>> retrieve(
+        StorageDriverRetrieveContext context, List<StorageDriverClaim> claims) {
+      retrieves.incrementAndGet();
+      List<Payload> payloads = new ArrayList<>();
+      for (StorageDriverClaim claim : claims) {
+        payloads.add(objects.get(claim.getClaimData().get("key")));
+      }
+      return CompletableFuture.completedFuture(payloads);
+    }
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusExternalStorageTest.java
@@ -32,9 +32,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * End-to-end coverage of external storage on a standalone Nexus operation
- */
+/** End-to-end coverage of external storage on a standalone Nexus operation */
 public class NexusExternalStorageTest {
 
   private static final RecordingDriver driver = new RecordingDriver("nexus-test");

--- a/temporal-sdk/src/test/java/io/temporal/internal/client/RootNexusClientInvokerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/client/RootNexusClientInvokerTest.java
@@ -29,7 +29,13 @@ public class RootNexusClientInvokerTest {
 
   private final GenericWorkflowClient genericClient = mock(GenericWorkflowClient.class);
   private final RootNexusClientInvoker invoker =
-      new RootNexusClientInvoker(genericClient, NexusClientOptions.getDefaultInstance());
+      new RootNexusClientInvoker(
+          genericClient,
+          new NexusClientResolvedOptions(
+              NexusClientOptions.getDefaultInstance().getNamespace(),
+              NexusClientOptions.getDefaultInstance().getInterceptors(),
+              NexusClientOptions.getDefaultInstance().getDataConverter(),
+              NexusClientOptions.getDefaultInstance().getIdentity()));
 
   private static GetNexusOperationResultInput<String> input() {
     return new GetNexusOperationResultInput<>(

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
@@ -1,6 +1,7 @@
 package io.temporal.internal.worker;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,10 +10,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.protobuf.ByteString;
 import com.uber.m3.tally.NoopScope;
+import com.uber.m3.tally.RootScopeBuilder;
+import com.uber.m3.tally.Scope;
 import io.temporal.api.common.v1.Payload;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.failure.v1.ApplicationFailureInfo;
+import io.temporal.api.failure.v1.Failure;
 import io.temporal.api.nexus.v1.Request;
 import io.temporal.api.nexus.v1.Response;
 import io.temporal.api.nexus.v1.StartOperationRequest;
@@ -26,19 +33,26 @@ import io.temporal.api.workflowservice.v1.ShutdownWorkerRequest;
 import io.temporal.api.workflowservice.v1.ShutdownWorkerResponse;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.payload.storage.ExternalStorageRunner;
 import io.temporal.payload.storage.ExternalStorage;
 import io.temporal.payload.storage.StorageDriver;
 import io.temporal.payload.storage.StorageDriverClaim;
 import io.temporal.payload.storage.StorageDriverRetrieveContext;
 import io.temporal.payload.storage.StorageDriverStoreContext;
+import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.testUtils.Eventually;
+import io.temporal.worker.MetricsType;
+import io.temporal.worker.WorkerMetricsTag;
 import io.temporal.worker.tuning.FixedSizeSlotSupplier;
 import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
 import io.temporal.worker.tuning.SlotSupplier;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -49,6 +63,10 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
 public class NexusWorkerTest {
+
+  private final TestStatsReporter reporter = new TestStatsReporter();
+  private final Scope metricsScope =
+      new RootScopeBuilder().reporter(reporter).reportEvery(com.uber.m3.util.Duration.ofMillis(10));
 
   @Test
   public void interruptingShutdownCancelsInFlightStorage() throws Exception {
@@ -99,31 +117,110 @@ public class NexusWorkerTest {
    */
   @Test
   public void storageBreakingDuringAForcedShutdownIsStillReported() throws Exception {
-    CountDownLatch storeEntered = new CountDownLatch(1);
-    CompletableFuture<List<StorageDriverClaim>> broken = new CompletableFuture<>();
-    broken.completeExceptionally(new IllegalStateException("storage unavailable"));
-    BlockingDriver driver = new BlockingDriver(storeEntered, broken);
-
-    Fixture fixture = new Fixture(driver);
+    Fixture fixture = new Fixture(brokenDriver());
     // Already shutting down when the task runs, so a real failure has to survive the cancellation.
     fixture.worker.storageCancellation.cancel();
-    CountDownLatch reported = new CountDownLatch(1);
-    when(fixture.blockingStub.respondNexusTaskFailed(any()))
-        .thenAnswer(
-            (Answer<Object>)
-                invocation -> {
-                  reported.countDown();
-                  return null;
-                });
+    CountDownLatch reported = reportedLatch(fixture);
 
-    assertTrue(fixture.worker.start());
-    assertTrue(
-        "a real storage failure must still be reported", reported.await(10, TimeUnit.SECONDS));
-
-    try (ShutdownManager shutdownManager = new ShutdownManager()) {
-      fixture.worker.shutdown(shutdownManager, true).get();
+    try {
+      assertTrue(fixture.worker.start());
+      assertTrue(
+          "a real storage failure must still be reported", reported.await(10, TimeUnit.SECONDS));
+    } finally {
+      shutdown(fixture);
     }
+
     verify(fixture.blockingStub).respondNexusTaskFailed(any(RespondNexusTaskFailedRequest.class));
+  }
+
+  /**
+   * Storage breaking on the way out still has to reach the server, and that report must not go back
+   * through storage: storage is the thing that just failed.
+   */
+  @Test
+  public void anOutboundStorageFailureIsReportedWithoutRetryingStorage() throws Exception {
+    BlockingDriver driver = brokenDriver();
+    Fixture fixture = new Fixture(driver);
+    CountDownLatch reported = reportedLatch(fixture);
+
+    try {
+      assertTrue(fixture.worker.start());
+      assertTrue("the storage failure must be reported", reported.await(10, TimeUnit.SECONDS));
+    } finally {
+      shutdown(fixture);
+    }
+
+    verify(fixture.blockingStub, never()).respondNexusTaskCompleted(any());
+    assertEquals("the report must not go through storage again", 1, driver.stores.get());
+  }
+
+  /**
+   * A task whose payloads live in external storage cannot be handled by a worker with no storage
+   * configured. That has to be reported rather than silently dropped.
+   */
+  @Test
+  public void anExternallyStoredTaskWithNoStorageConfiguredIsReported() throws Exception {
+    Fixture fixture = new Fixture(null, storageReference());
+    CountDownLatch reported = reportedLatch(fixture);
+
+    try {
+      assertTrue(fixture.worker.start());
+      assertTrue("the missing storage must be reported", reported.await(10, TimeUnit.SECONDS));
+    } finally {
+      shutdown(fixture);
+    }
+
+    verify(fixture.blockingStub, never()).respondNexusTaskCompleted(any());
+  }
+
+  /** One task counts one exec failure, however many reply attempts a storage failure costs. */
+  @Test
+  public void anOutboundStorageFailureCountsOneExecFailure() throws Exception {
+    Fixture fixture = new Fixture(brokenDriver(), metricsScope, syncSuccess());
+    CountDownLatch reported = reportedLatch(fixture);
+
+    try {
+      assertTrue(fixture.worker.start());
+      assertTrue("the storage failure must be reported", reported.await(10, TimeUnit.SECONDS));
+    } finally {
+      shutdown(fixture);
+    }
+
+    Eventually.assertEventually(
+        Duration.ofSeconds(10),
+        () ->
+            reporter.assertCounter(
+                MetricsType.NEXUS_EXEC_FAILED_COUNTER,
+                execFailedTags(MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL),
+                1));
+  }
+
+  /**
+   * A handler failure is already counted under its own reason. Storage breaking while reporting it
+   * must not count the same task a second time.
+   */
+  @Test
+  public void aHandlerFailureFollowedByAStorageFailureCountsOneExecFailure() throws Exception {
+    Fixture fixture = new Fixture(brokenDriver(), metricsScope, operationFailure());
+    CountDownLatch reported = reportedLatch(fixture);
+
+    try {
+      assertTrue(fixture.worker.start());
+      assertTrue("the storage failure must be reported", reported.await(10, TimeUnit.SECONDS));
+    } finally {
+      shutdown(fixture);
+    }
+
+    Eventually.assertEventually(
+        Duration.ofSeconds(10),
+        () ->
+            reporter.assertCounter(
+                MetricsType.NEXUS_EXEC_FAILED_COUNTER,
+                execFailedTags(MetricsTag.TASK_FAILURE_VALUE_OPERATION_FAILED),
+                1));
+    reporter.assertNoMetric(
+        MetricsType.NEXUS_EXEC_FAILED_COUNTER,
+        execFailedTags(MetricsTag.TASK_FAILURE_VALUE_HANDLER_ERROR_INTERNAL));
   }
 
   /** A worker wired to {@code driver}, polling exactly one nexus task that returns a payload. */
@@ -132,10 +229,24 @@ public class NexusWorkerTest {
     final WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub;
 
     Fixture(StorageDriver driver) throws Exception {
-      this(driver, null);
+      this(driver, null, new NoopScope(), syncSuccess());
     }
 
     Fixture(StorageDriver driver, Payload inboundPayload) throws Exception {
+      this(driver, inboundPayload, new NoopScope(), syncSuccess());
+    }
+
+    Fixture(StorageDriver driver, Scope metricsScope, NexusTaskHandler.Result handlerResult)
+        throws Exception {
+      this(driver, null, metricsScope, handlerResult);
+    }
+
+    private Fixture(
+        StorageDriver driver,
+        Payload inboundPayload,
+        Scope metricsScope,
+        NexusTaskHandler.Result handlerResult)
+        throws Exception {
       WorkflowServiceStubs service = mock(WorkflowServiceStubs.class);
       when(service.getServerCapabilities())
           .thenReturn(() -> GetSystemInfoResponse.Capabilities.getDefaultInstance());
@@ -152,7 +263,11 @@ public class NexusWorkerTest {
       PollNexusTaskQueueResponse pollResponse =
           PollNexusTaskQueueResponse.newBuilder()
               .setTaskToken(ByteString.copyFrom("token", UTF_8))
-              .setRequest(Request.newBuilder().setStartOperation(startOperation(inboundPayload)))
+              .setRequest(
+                  Request.newBuilder()
+                      .setCapabilities(
+                          Request.Capabilities.newBuilder().setTemporalFailureResponses(true))
+                      .setStartOperation(startOperation(inboundPayload)))
               .build();
       CountDownLatch blockPolls = new CountDownLatch(1);
       when(blockingStub.pollNexusTaskQueue(any(PollNexusTaskQueueRequest.class)))
@@ -166,16 +281,7 @@ public class NexusWorkerTest {
 
       NexusTaskHandler handler = mock(NexusTaskHandler.class);
       when(handler.start()).thenReturn(true);
-      Payload result = Payload.newBuilder().setData(ByteString.copyFrom("a result", UTF_8)).build();
-      when(handler.handle(any(), any()))
-          .thenReturn(
-              new NexusTaskHandler.Result(
-                  Response.newBuilder()
-                      .setStartOperation(
-                          StartOperationResponse.newBuilder()
-                              .setSyncSuccess(
-                                  StartOperationResponse.Sync.newBuilder().setPayload(result)))
-                      .build()));
+      when(handler.handle(any(), any())).thenReturn(handlerResult);
 
       worker =
           new NexusWorker(
@@ -190,7 +296,7 @@ public class NexusWorkerTest {
                       PollerOptions.newBuilder()
                           .setPollerBehavior(new PollerBehaviorSimpleMaximum(1))
                           .build())
-                  .setMetricsScope(new NoopScope())
+                  .setMetricsScope(metricsScope)
                   .setExternalStorageRunner(
                       driver == null
                           ? null
@@ -205,6 +311,71 @@ public class NexusWorkerTest {
               new FixedSizeSlotSupplier<>(10),
               new NamespaceCapabilities());
     }
+  }
+
+  /** Counts down once the worker reports a task failure to the server. */
+  private static CountDownLatch reportedLatch(Fixture fixture) {
+    CountDownLatch reported = new CountDownLatch(1);
+    when(fixture.blockingStub.respondNexusTaskFailed(any(RespondNexusTaskFailedRequest.class)))
+        .thenAnswer(
+            (Answer<Object>)
+                invocation -> {
+                  reported.countDown();
+                  return null;
+                });
+    return reported;
+  }
+
+  private static void shutdown(Fixture fixture) throws Exception {
+    try (ShutdownManager shutdownManager = new ShutdownManager()) {
+      fixture.worker.shutdown(shutdownManager, true).get();
+    }
+  }
+
+  /** A driver whose every store fails outright. */
+  private static BlockingDriver brokenDriver() {
+    CompletableFuture<List<StorageDriverClaim>> broken = new CompletableFuture<>();
+    broken.completeExceptionally(new IllegalStateException("storage unavailable"));
+    return new BlockingDriver(new CountDownLatch(1), broken);
+  }
+
+  /** The tags the worker puts on {@code NEXUS_EXEC_FAILED_COUNTER}. */
+  private static Map<String, String> execFailedTags(String failureReason) {
+    return ImmutableMap.of(
+        MetricsTag.WORKER_TYPE,
+        WorkerMetricsTag.WorkerType.NEXUS_WORKER.getValue(),
+        MetricsTag.NEXUS_SERVICE,
+        "service",
+        MetricsTag.NEXUS_OPERATION,
+        "operation",
+        MetricsTag.TASK_FAILURE_TYPE,
+        failureReason);
+  }
+
+  private static NexusTaskHandler.Result syncSuccess() {
+    Payload result = Payload.newBuilder().setData(ByteString.copyFrom("a result", UTF_8)).build();
+    return new NexusTaskHandler.Result(
+        Response.newBuilder()
+            .setStartOperation(
+                StartOperationResponse.newBuilder()
+                    .setSyncSuccess(StartOperationResponse.Sync.newBuilder().setPayload(result)))
+            .build());
+  }
+
+  /** An operation failure carrying a payload, so that reporting it has something to store. */
+  private static NexusTaskHandler.Result operationFailure() {
+    Payload detail = Payload.newBuilder().setData(ByteString.copyFrom("a detail", UTF_8)).build();
+    return new NexusTaskHandler.Result(
+        Response.newBuilder()
+            .setStartOperation(
+                StartOperationResponse.newBuilder()
+                    .setFailure(
+                        Failure.newBuilder()
+                            .setMessage("operation failed")
+                            .setApplicationFailureInfo(
+                                ApplicationFailureInfo.newBuilder()
+                                    .setDetails(Payloads.newBuilder().addPayloads(detail)))))
+            .build());
   }
 
   private static StartOperationRequest.Builder startOperation(Payload inboundPayload) {

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
@@ -1,15 +1,51 @@
 package io.temporal.internal.worker;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.protobuf.ByteString;
+import com.uber.m3.tally.NoopScope;
+import io.temporal.api.common.v1.Payload;
+import io.temporal.api.nexus.v1.Request;
+import io.temporal.api.nexus.v1.Response;
+import io.temporal.api.nexus.v1.StartOperationRequest;
+import io.temporal.api.nexus.v1.StartOperationResponse;
 import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.api.workflowservice.v1.PollNexusTaskQueueRequest;
+import io.temporal.api.workflowservice.v1.PollNexusTaskQueueResponse;
+import io.temporal.api.workflowservice.v1.RespondNexusTaskFailedRequest;
+import io.temporal.api.workflowservice.v1.ShutdownWorkerRequest;
+import io.temporal.api.workflowservice.v1.ShutdownWorkerResponse;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.internal.payload.storage.ExternalStorageRunner;
+import io.temporal.payload.storage.ExternalStorage;
+import io.temporal.payload.storage.StorageDriver;
+import io.temporal.payload.storage.StorageDriverClaim;
+import io.temporal.payload.storage.StorageDriverRetrieveContext;
+import io.temporal.payload.storage.StorageDriverStoreContext;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.tuning.FixedSizeSlotSupplier;
+import io.temporal.worker.tuning.PollerBehaviorSimpleMaximum;
 import io.temporal.worker.tuning.SlotSupplier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
 public class NexusWorkerTest {
 
@@ -17,7 +53,9 @@ public class NexusWorkerTest {
   public void interruptingShutdownCancelsInFlightStorage() throws Exception {
     NexusWorker worker = worker();
 
-    worker.shutdown(new ShutdownManager(), true).get();
+    try (ShutdownManager shutdownManager = new ShutdownManager()) {
+      worker.shutdown(shutdownManager, true).get();
+    }
 
     assertTrue(worker.storageCancellation.token().isCancellationRequested());
   }
@@ -26,9 +64,188 @@ public class NexusWorkerTest {
   public void gracefulShutdownLeavesStorageRunning() throws Exception {
     NexusWorker worker = worker();
 
-    worker.shutdown(new ShutdownManager(), false).get();
+    try (ShutdownManager shutdownManager = new ShutdownManager()) {
+      worker.shutdown(shutdownManager, false).get();
+    }
 
     assertFalse(worker.storageCancellation.token().isCancellationRequested());
+  }
+
+  /**
+   * A forced shutdown cancels in-flight external storage. That cancellation means we abandoned the
+   * task, not that the handler failed, so nothing may be reported to the server.
+   */
+  @Test
+  public void storageCancelledByAForcedShutdownIsNotReportedAsATaskFailure() throws Exception {
+    CountDownLatch storeEntered = new CountDownLatch(1);
+    // Never completes: the store is still in flight when the shutdown cancels it.
+    BlockingDriver driver = new BlockingDriver(storeEntered, new CompletableFuture<>());
+
+    Fixture fixture = new Fixture(driver);
+    assertTrue(fixture.worker.start());
+    assertTrue("the store must be reached", storeEntered.await(10, TimeUnit.SECONDS));
+
+    try (ShutdownManager shutdownManager = new ShutdownManager()) {
+      fixture.worker.shutdown(shutdownManager, true).get();
+    }
+
+    verify(fixture.blockingStub, never()).respondNexusTaskFailed(any());
+  }
+
+  /**
+   * Cancelling storage means we abandoned the work. Storage genuinely breaking at the same moment
+   * is a different thing and must still reach the server.
+   */
+  @Test
+  public void storageBreakingDuringAForcedShutdownIsStillReported() throws Exception {
+    CountDownLatch storeEntered = new CountDownLatch(1);
+    CompletableFuture<List<StorageDriverClaim>> broken = new CompletableFuture<>();
+    broken.completeExceptionally(new IllegalStateException("storage unavailable"));
+    BlockingDriver driver = new BlockingDriver(storeEntered, broken);
+
+    Fixture fixture = new Fixture(driver);
+    // Already shutting down when the task runs, so a real failure has to survive the cancellation.
+    fixture.worker.storageCancellation.cancel();
+    CountDownLatch reported = new CountDownLatch(1);
+    when(fixture.blockingStub.respondNexusTaskFailed(any()))
+        .thenAnswer(
+            (Answer<Object>)
+                invocation -> {
+                  reported.countDown();
+                  return null;
+                });
+
+    assertTrue(fixture.worker.start());
+    assertTrue(
+        "a real storage failure must still be reported", reported.await(10, TimeUnit.SECONDS));
+
+    try (ShutdownManager shutdownManager = new ShutdownManager()) {
+      fixture.worker.shutdown(shutdownManager, true).get();
+    }
+    verify(fixture.blockingStub).respondNexusTaskFailed(any(RespondNexusTaskFailedRequest.class));
+  }
+
+  /** A worker wired to {@code driver}, polling exactly one nexus task that returns a payload. */
+  private static final class Fixture {
+    final NexusWorker worker;
+    final WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub;
+
+    Fixture(StorageDriver driver) throws Exception {
+      WorkflowServiceStubs service = mock(WorkflowServiceStubs.class);
+      when(service.getServerCapabilities())
+          .thenReturn(() -> GetSystemInfoResponse.Capabilities.getDefaultInstance());
+
+      blockingStub = mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
+      WorkflowServiceGrpc.WorkflowServiceFutureStub futureStub =
+          mock(WorkflowServiceGrpc.WorkflowServiceFutureStub.class);
+      when(futureStub.shutdownWorker(any(ShutdownWorkerRequest.class)))
+          .thenReturn(Futures.immediateFuture(ShutdownWorkerResponse.newBuilder().build()));
+      when(service.blockingStub()).thenReturn(blockingStub);
+      when(service.futureStub()).thenReturn(futureStub);
+      when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
+
+      PollNexusTaskQueueResponse pollResponse =
+          PollNexusTaskQueueResponse.newBuilder()
+              .setTaskToken(ByteString.copyFrom("token", UTF_8))
+              .setRequest(
+                  Request.newBuilder()
+                      .setStartOperation(
+                          StartOperationRequest.newBuilder()
+                              .setService("service")
+                              .setOperation("operation")))
+              .build();
+      CountDownLatch blockPolls = new CountDownLatch(1);
+      when(blockingStub.pollNexusTaskQueue(any(PollNexusTaskQueueRequest.class)))
+          .thenReturn(pollResponse)
+          .thenAnswer(
+              (Answer<PollNexusTaskQueueResponse>)
+                  invocation -> {
+                    blockPolls.await();
+                    return null;
+                  });
+
+      NexusTaskHandler handler = mock(NexusTaskHandler.class);
+      when(handler.start()).thenReturn(true);
+      Payload result = Payload.newBuilder().setData(ByteString.copyFrom("a result", UTF_8)).build();
+      when(handler.handle(any(), any()))
+          .thenReturn(
+              new NexusTaskHandler.Result(
+                  Response.newBuilder()
+                      .setStartOperation(
+                          StartOperationResponse.newBuilder()
+                              .setSyncSuccess(
+                                  StartOperationResponse.Sync.newBuilder().setPayload(result)))
+                      .build()));
+
+      worker =
+          new NexusWorker(
+              service,
+              "namespace",
+              "task_queue",
+              SingleWorkerOptions.newBuilder()
+                  .setIdentity("test_identity")
+                  .setBuildId(UUID.randomUUID().toString())
+                  .setWorkerInstanceKey(UUID.randomUUID().toString())
+                  .setPollerOptions(
+                      PollerOptions.newBuilder()
+                          .setPollerBehavior(new PollerBehaviorSimpleMaximum(1))
+                          .build())
+                  .setMetricsScope(new NoopScope())
+                  .setExternalStorageRunner(
+                      ExternalStorageRunner.create(
+                          ExternalStorage.newBuilder()
+                              .setDriver(driver)
+                              .setPayloadSizeThreshold(0)
+                              .build()))
+                  .build(),
+              handler,
+              DefaultDataConverter.newDefaultInstance(),
+              new FixedSizeSlotSupplier<>(10),
+              new NamespaceCapabilities());
+    }
+  }
+
+  /** Signals when a store is reached and answers every store with {@code answer}. */
+  private static final class BlockingDriver implements StorageDriver {
+    private final CountDownLatch storeEntered;
+    private final CompletableFuture<List<StorageDriverClaim>> answer;
+    final AtomicInteger stores = new AtomicInteger();
+
+    BlockingDriver(
+        CountDownLatch storeEntered, CompletableFuture<List<StorageDriverClaim>> answer) {
+      this.storeEntered = storeEntered;
+      this.answer = answer;
+    }
+
+    @Override
+    @Nonnull
+    public String getName() {
+      return "blocking";
+    }
+
+    @Override
+    @Nonnull
+    public String getType() {
+      return "test.nexus.blocking";
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<List<StorageDriverClaim>> store(
+        @Nonnull StorageDriverStoreContext context, @Nonnull List<Payload> payloads) {
+      stores.incrementAndGet();
+      storeEntered.countDown();
+      return answer;
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<List<Payload>> retrieve(
+        @Nonnull StorageDriverRetrieveContext context, @Nonnull List<StorageDriverClaim> claims) {
+      List<Payload> payloads =
+          new ArrayList<>(Collections.nCopies(claims.size(), Payload.getDefaultInstance()));
+      return CompletableFuture.completedFuture(payloads);
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
@@ -17,6 +17,7 @@ import io.temporal.api.nexus.v1.Request;
 import io.temporal.api.nexus.v1.Response;
 import io.temporal.api.nexus.v1.StartOperationRequest;
 import io.temporal.api.nexus.v1.StartOperationResponse;
+import io.temporal.api.sdk.v1.ExternalStorageReference;
 import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
 import io.temporal.api.workflowservice.v1.PollNexusTaskQueueRequest;
 import io.temporal.api.workflowservice.v1.PollNexusTaskQueueResponse;
@@ -131,6 +132,10 @@ public class NexusWorkerTest {
     final WorkflowServiceGrpc.WorkflowServiceBlockingStub blockingStub;
 
     Fixture(StorageDriver driver) throws Exception {
+      this(driver, null);
+    }
+
+    Fixture(StorageDriver driver, Payload inboundPayload) throws Exception {
       WorkflowServiceStubs service = mock(WorkflowServiceStubs.class);
       when(service.getServerCapabilities())
           .thenReturn(() -> GetSystemInfoResponse.Capabilities.getDefaultInstance());
@@ -147,12 +152,7 @@ public class NexusWorkerTest {
       PollNexusTaskQueueResponse pollResponse =
           PollNexusTaskQueueResponse.newBuilder()
               .setTaskToken(ByteString.copyFrom("token", UTF_8))
-              .setRequest(
-                  Request.newBuilder()
-                      .setStartOperation(
-                          StartOperationRequest.newBuilder()
-                              .setService("service")
-                              .setOperation("operation")))
+              .setRequest(Request.newBuilder().setStartOperation(startOperation(inboundPayload)))
               .build();
       CountDownLatch blockPolls = new CountDownLatch(1);
       when(blockingStub.pollNexusTaskQueue(any(PollNexusTaskQueueRequest.class)))
@@ -192,17 +192,41 @@ public class NexusWorkerTest {
                           .build())
                   .setMetricsScope(new NoopScope())
                   .setExternalStorageRunner(
-                      ExternalStorageRunner.create(
-                          ExternalStorage.newBuilder()
-                              .setDriver(driver)
-                              .setPayloadSizeThreshold(0)
-                              .build()))
+                      driver == null
+                          ? null
+                          : ExternalStorageRunner.create(
+                              ExternalStorage.newBuilder()
+                                  .setDriver(driver)
+                                  .setPayloadSizeThreshold(0)
+                                  .build()))
                   .build(),
               handler,
               DefaultDataConverter.newDefaultInstance(),
               new FixedSizeSlotSupplier<>(10),
               new NamespaceCapabilities());
     }
+  }
+
+  private static StartOperationRequest.Builder startOperation(Payload inboundPayload) {
+    StartOperationRequest.Builder request =
+        StartOperationRequest.newBuilder().setService("service").setOperation("operation");
+    if (inboundPayload != null) {
+      request.setPayload(inboundPayload);
+    }
+    return request;
+  }
+
+  /**
+   * A payload that looks like an external storage reference to {@code throwIfContainsReference}.
+   */
+  private static Payload storageReference() {
+    return Payload.newBuilder()
+        .putMetadata("encoding", ByteString.copyFrom("json/protobuf", UTF_8))
+        .putMetadata(
+            "messageType",
+            ByteString.copyFrom(ExternalStorageReference.getDescriptor().getFullName(), UTF_8))
+        .setData(ByteString.copyFrom("{}", UTF_8))
+        .build();
   }
 
   /** Signals when a store is reached and answers every store with {@code answer}. */

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/NexusWorkerTest.java
@@ -1,0 +1,49 @@
+package io.temporal.internal.worker;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.temporal.api.workflowservice.v1.GetSystemInfoResponse;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.tuning.SlotSupplier;
+import org.junit.Test;
+
+public class NexusWorkerTest {
+
+  @Test
+  public void interruptingShutdownCancelsInFlightStorage() throws Exception {
+    NexusWorker worker = worker();
+
+    worker.shutdown(new ShutdownManager(), true).get();
+
+    assertTrue(worker.storageCancellation.token().isCancellationRequested());
+  }
+
+  @Test
+  public void gracefulShutdownLeavesStorageRunning() throws Exception {
+    NexusWorker worker = worker();
+
+    worker.shutdown(new ShutdownManager(), false).get();
+
+    assertFalse(worker.storageCancellation.token().isCancellationRequested());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static NexusWorker worker() {
+    WorkflowServiceStubs service = mock(WorkflowServiceStubs.class);
+    when(service.getServerCapabilities())
+        .thenReturn(() -> GetSystemInfoResponse.Capabilities.getDefaultInstance());
+    return new NexusWorker(
+        service,
+        "ns",
+        "tq",
+        SingleWorkerOptions.newBuilder().build(),
+        mock(NexusTaskHandler.class),
+        DefaultDataConverter.newDefaultInstance(),
+        mock(SlotSupplier.class),
+        mock(NamespaceCapabilities.class));
+  }
+}


### PR DESCRIPTION
## What was changed
- `NexusWorker` now stores and retrieves payloads.

## Why?
- Nexus workers should use external storage.

## Checklist
