### PR TITLE
Add payload validation failure factory

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadValidationException.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadValidationException.java
@@ -10,14 +10,14 @@ public final class PayloadValidationException {
   private PayloadValidationException() {}
 
   /**
-   * Creates a non-retryable failure containing the aggregated validation violations.
+   * Creates a non-retryable failure containing payload validation details.
    *
-   * <p>The violations are stored as a single details value and serialized by the configured {@link
+   * <p>The details are stored as a single value and serialized by the configured {@link
    * DataConverter}.
    *
-   * @param violations aggregated payload validation violations
+   * @param details payload validation details
    */
-  public static ApplicationFailure create(Object violations) {
-    return ApplicationFailure.newNonRetryableFailure(MESSAGE, TYPE, violations);
+  public static ApplicationFailure create(Object details) {
+    return ApplicationFailure.newNonRetryableFailure(MESSAGE, TYPE, details);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadValidationException.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadValidationException.java
@@ -17,7 +17,7 @@ public final class PayloadValidationException {
    *
    * @param details payload validation details
    */
-  public static ApplicationFailure create(Object details) {
+  public static ApplicationFailure newPayloadValidationException(Object details) {
     return ApplicationFailure.newNonRetryableFailure(MESSAGE, TYPE, details);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadValidationException.java
+++ b/temporal-sdk/src/main/java/io/temporal/common/converter/PayloadValidationException.java
@@ -1,0 +1,23 @@
+package io.temporal.common.converter;
+
+import io.temporal.failure.ApplicationFailure;
+
+/** Factory for failures raised when converting a value that violates its payload schema. */
+public final class PayloadValidationException {
+  private static final String MESSAGE = "Payload validation failed";
+  private static final String TYPE = "PayloadValidationError";
+
+  private PayloadValidationException() {}
+
+  /**
+   * Creates a non-retryable failure containing the aggregated validation violations.
+   *
+   * <p>The violations are stored as a single details value and serialized by the configured {@link
+   * DataConverter}.
+   *
+   * @param violations aggregated payload validation violations
+   */
+  public static ApplicationFailure create(Object violations) {
+    return ApplicationFailure.newNonRetryableFailure(MESSAGE, TYPE, violations);
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/PayloadValidationExceptionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/PayloadValidationExceptionTest.java
@@ -13,11 +13,13 @@ import org.junit.Test;
 
 public class PayloadValidationExceptionTest {
   @Test
-  public void createReturnsNonRetryableApplicationFailureWithEncodedDetails() {
+  public void
+      newPayloadValidationExceptionReturnsNonRetryableApplicationFailureWithEncodedDetails() {
     List<Map<String, String>> details =
         Collections.singletonList(Collections.singletonMap("path", "$.customer.contact.email"));
 
-    ApplicationFailure applicationFailure = PayloadValidationException.create(details);
+    ApplicationFailure applicationFailure =
+        PayloadValidationException.newPayloadValidationException(details);
 
     assertEquals("PayloadValidationError", applicationFailure.getType());
     assertTrue(applicationFailure.isNonRetryable());

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/PayloadValidationExceptionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/PayloadValidationExceptionTest.java
@@ -13,11 +13,11 @@ import org.junit.Test;
 
 public class PayloadValidationExceptionTest {
   @Test
-  public void createReturnsNonRetryableApplicationFailureWithEncodedViolations() {
-    List<Map<String, String>> violations =
+  public void createReturnsNonRetryableApplicationFailureWithEncodedDetails() {
+    List<Map<String, String>> details =
         Collections.singletonList(Collections.singletonMap("path", "$.customer.contact.email"));
 
-    ApplicationFailure applicationFailure = PayloadValidationException.create(violations);
+    ApplicationFailure applicationFailure = PayloadValidationException.create(details);
 
     assertEquals("PayloadValidationError", applicationFailure.getType());
     assertTrue(applicationFailure.isNonRetryable());
@@ -30,9 +30,8 @@ public class PayloadValidationExceptionTest {
 
     ApplicationFailure decodedFailure =
         (ApplicationFailure) dataConverter.failureToException(encodedFailure);
-    TypeToken<List<Map<String, String>>> violationsType =
+    TypeToken<List<Map<String, String>>> detailsType =
         new TypeToken<List<Map<String, String>>>() {};
-    assertEquals(
-        violations, decodedFailure.getDetails().get(0, List.class, violationsType.getType()));
+    assertEquals(details, decodedFailure.getDetails().get(0, List.class, detailsType.getType()));
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/common/converter/PayloadValidationExceptionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/converter/PayloadValidationExceptionTest.java
@@ -1,0 +1,38 @@
+package io.temporal.common.converter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.reflect.TypeToken;
+import io.temporal.api.failure.v1.Failure;
+import io.temporal.failure.ApplicationFailure;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class PayloadValidationExceptionTest {
+  @Test
+  public void createReturnsNonRetryableApplicationFailureWithEncodedViolations() {
+    List<Map<String, String>> violations =
+        Collections.singletonList(Collections.singletonMap("path", "$.customer.contact.email"));
+
+    ApplicationFailure applicationFailure = PayloadValidationException.create(violations);
+
+    assertEquals("PayloadValidationError", applicationFailure.getType());
+    assertTrue(applicationFailure.isNonRetryable());
+    assertEquals("Payload validation failed", applicationFailure.getOriginalMessage());
+    assertEquals(1, applicationFailure.getDetails().getSize());
+
+    DataConverter dataConverter = DefaultDataConverter.STANDARD_INSTANCE;
+    Failure encodedFailure = dataConverter.exceptionToFailure(applicationFailure);
+    assertEquals(1, encodedFailure.getApplicationFailureInfo().getDetails().getPayloadsCount());
+
+    ApplicationFailure decodedFailure =
+        (ApplicationFailure) dataConverter.failureToException(encodedFailure);
+    TypeToken<List<Map<String, String>>> violationsType =
+        new TypeToken<List<Map<String, String>>>() {};
+    assertEquals(
+        violations, decodedFailure.getDetails().get(0, List.class, violationsType.getType()));
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
@@ -10,6 +10,7 @@ import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.DataConverterException;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.common.converter.EncodedValuesTest;
+import io.temporal.common.converter.PayloadValidationException;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.payload.codec.PayloadCodecException;
 import java.lang.reflect.GenericArrayType;
@@ -128,10 +129,9 @@ public class PayloadSerializerTest {
   @Test
   public void testDeserializeNonRetryablePayloadValidationErrorIsNonRetryableBadRequest() {
     // The converter understood the input and rejected it, which makes this the caller's fault.
-    RuntimeException cause = new RuntimeException("field 'name' must not be empty");
     ApplicationFailure original =
-        ApplicationFailure.newNonRetryableFailureWithCause(
-            "invalid input", PayloadSerializer.PAYLOAD_VALIDATION_ERROR_TYPE, cause);
+        PayloadValidationException.create(
+            Collections.singletonList(Collections.singletonMap("name", "must not be empty")));
     PayloadSerializer serializer = failingSerializer(null, original);
     PayloadSerializer.Content content = payloadSerializer.serialize("test");
 
@@ -149,8 +149,8 @@ public class PayloadSerializerTest {
     Assert.assertSame(original, causeFailure);
     Assert.assertEquals(PayloadSerializer.PAYLOAD_VALIDATION_ERROR_TYPE, causeFailure.getType());
     Assert.assertTrue(causeFailure.isNonRetryable());
-    Assert.assertEquals("invalid input", causeFailure.getOriginalMessage());
-    Assert.assertSame(cause, causeFailure.getCause());
+    Assert.assertEquals("Payload validation failed", causeFailure.getOriginalMessage());
+    Assert.assertEquals(1, causeFailure.getDetails().getSize());
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/PayloadSerializerTest.java
@@ -130,7 +130,7 @@ public class PayloadSerializerTest {
   public void testDeserializeNonRetryablePayloadValidationErrorIsNonRetryableBadRequest() {
     // The converter understood the input and rejected it, which makes this the caller's fault.
     ApplicationFailure original =
-        PayloadValidationException.create(
+        PayloadValidationException.newPayloadValidationException(
             Collections.singletonList(Collections.singletonMap("name", "must not be empty")));
     PayloadSerializer serializer = failingSerializer(null, original);
     PayloadSerializer.Content content = payloadSerializer.serialize("test");

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
@@ -13,6 +13,7 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.common.converter.DataConverter;
 import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.common.converter.PayloadValidationException;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.failure.TimeoutFailure;
@@ -22,6 +23,7 @@ import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.lang.reflect.Type;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
@@ -45,7 +47,6 @@ public class OperationInputDeserializationErrorPropagationTest {
       "non-retryable-payload-validation-error";
   private static final String RETRYABLE_PAYLOAD_VALIDATION_ERROR =
       "retryable-payload-validation-error";
-  private static final String PAYLOAD_VALIDATION_ERROR_TYPE = "PayloadValidationError";
   private static final String CODEC_FAILURE = "codec-failure";
 
   private static final AtomicInteger deserializeAttempts = new AtomicInteger();
@@ -145,7 +146,7 @@ public class OperationInputDeserializationErrorPropagationTest {
     Assert.assertEquals("PayloadValidationError", ((ApplicationFailure) cause).getType());
     Assert.assertTrue(
         "expected the converter's message on the cause, got " + cause.getMessage(),
-        cause.getMessage().contains("intentional failure"));
+        cause.getMessage().contains("Payload validation failed"));
 
     Assert.assertEquals(1, deserializeAttempts.get());
     Assert.assertEquals(0, operationInvocations.get());
@@ -288,11 +289,10 @@ public class OperationInputDeserializationErrorPropagationTest {
         case RETRYABLE_APPLICATION_FAILURE:
           return ApplicationFailure.newFailure("intentional failure", "TestFailure");
         case NON_RETRYABLE_PAYLOAD_VALIDATION_ERROR:
-          return ApplicationFailure.newNonRetryableFailure(
-              "intentional failure", PAYLOAD_VALIDATION_ERROR_TYPE);
+          return PayloadValidationException.create(
+              Collections.singletonList("intentional validation failure"));
         case RETRYABLE_PAYLOAD_VALIDATION_ERROR:
-          return ApplicationFailure.newFailure(
-              "intentional failure", PAYLOAD_VALIDATION_ERROR_TYPE);
+          return ApplicationFailure.newFailure("intentional failure", "PayloadValidationError");
         case CODEC_FAILURE:
           return new PayloadCodecException("intentional failure");
         default:

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
@@ -289,7 +289,7 @@ public class OperationInputDeserializationErrorPropagationTest {
         case RETRYABLE_APPLICATION_FAILURE:
           return ApplicationFailure.newFailure("intentional failure", "TestFailure");
         case NON_RETRYABLE_PAYLOAD_VALIDATION_ERROR:
-          return PayloadValidationException.create(
+          return PayloadValidationException.newPayloadValidationException(
               Collections.singletonList("intentional validation failure"));
         case RETRYABLE_PAYLOAD_VALIDATION_ERROR:
           return ApplicationFailure.newFailure("intentional failure", "PayloadValidationError");


### PR DESCRIPTION
## Summary

- add io.temporal.common.converter.PayloadValidationException.newPayloadValidationException
- return a non-retryable PayloadValidationError ApplicationFailure with violations as one details value
- replace positive Nexus test constructions with the public factory while retaining retryable compatibility coverage

## Testing

- temporal-sdk Spotless checks
- PayloadValidationException and PayloadSerializer focused tests
- OperationInputDeserializationErrorPropagationTest
- tests run with the repository Temurin 21 toolchain