### PR TITLE
Fix NPE when a workflow implementation uses a composed @WorkflowImpl annotation

### DIFF
--- a/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
+++ b/temporal-spring-boot-autoconfigure/src/main/java/io/temporal/spring/boot/autoconfigure/template/WorkersTemplate.java
@@ -224,7 +224,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
       Workers workers,
       Collection<Class<?>> autoDiscoveredWorkflowImplementationClasses) {
     for (Class<?> clazz : autoDiscoveredWorkflowImplementationClasses) {
-      WorkflowImpl annotation = clazz.getAnnotation(WorkflowImpl.class);
+      WorkflowImpl annotation = AnnotationUtils.findAnnotation(clazz, WorkflowImpl.class);
       for (String taskQueue : annotation.taskQueues()) {
         taskQueue = environment.resolvePlaceholders(taskQueue);
         Worker worker = workerFactory.tryGetWorker(taskQueue);
@@ -303,7 +303,7 @@ public class WorkersTemplate implements BeanFactoryAware, EnvironmentAware {
   private void configureWorkflowImplementationsByWorkerName(
       Workers workers, Collection<Class<?>> autoDiscoveredWorkflowImplementationClasses) {
     for (Class<?> clazz : autoDiscoveredWorkflowImplementationClasses) {
-      WorkflowImpl annotation = clazz.getAnnotation(WorkflowImpl.class);
+      WorkflowImpl annotation = AnnotationUtils.findAnnotation(clazz, WorkflowImpl.class);
 
       for (String workerName : annotation.workers()) {
         Worker worker = workers.getByName(workerName);

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryComposedAnnotationTest.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/AutoDiscoveryComposedAnnotationTest.java
@@ -1,0 +1,57 @@
+package io.temporal.spring.boot.autoconfigure;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.spring.boot.autoconfigure.composedannotation.ComposedAnnotatedActivityImpl;
+import io.temporal.spring.boot.autoconfigure.composedannotation.ComposedAnnotatedWorkflow;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = AutoDiscoveryComposedAnnotationTest.Configuration.class)
+@ActiveProfiles(profiles = "auto-discovery-composed-annotation")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AutoDiscoveryComposedAnnotationTest {
+  @Autowired ConfigurableApplicationContext applicationContext;
+
+  @Autowired WorkflowClient workflowClient;
+
+  @BeforeEach
+  void setUp() {
+    applicationContext.start();
+  }
+
+  @Test
+  @Timeout(value = 10)
+  public void testAutoDiscoveryViaComposedAnnotation() {
+    ComposedAnnotatedWorkflow workflow =
+        workflowClient.newWorkflowStub(
+            ComposedAnnotatedWorkflow.class,
+            WorkflowOptions.newBuilder().setTaskQueue("UnitTest").build());
+    Assertions.assertEquals("composed:composed-activity:hi", workflow.execute("hi"));
+  }
+
+  @ComponentScan(
+      excludeFilters =
+          @ComponentScan.Filter(
+              pattern =
+                  "io\\.temporal\\.spring\\.boot\\.autoconfigure\\.(bytaskqueue|byworkername)\\..*",
+              type = FilterType.REGEX))
+  public static class Configuration {
+
+    // Not using @Component so that it stays scoped to this test
+    @Bean
+    public ComposedAnnotatedActivityImpl composedAnnotatedActivityImpl() {
+      return new ComposedAnnotatedActivityImpl();
+    }
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedActivityImpl.java
@@ -1,0 +1,12 @@
+package io.temporal.spring.boot.autoconfigure.composedannotation;
+
+import io.temporal.spring.boot.ActivityImpl;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ActivityImpl(taskQueues = "UnitTest")
+public @interface ComposedActivityImpl {}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedActivity.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedActivity.java
@@ -1,0 +1,8 @@
+package io.temporal.spring.boot.autoconfigure.composedannotation;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface ComposedAnnotatedActivity {
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedActivityImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedActivityImpl.java
@@ -1,0 +1,10 @@
+package io.temporal.spring.boot.autoconfigure.composedannotation;
+
+@ComposedActivityImpl
+public class ComposedAnnotatedActivityImpl implements ComposedAnnotatedActivity {
+
+  @Override
+  public String execute(String input) {
+    return "composed-activity:" + input;
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedWorkflow.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedWorkflow.java
@@ -1,0 +1,11 @@
+package io.temporal.spring.boot.autoconfigure.composedannotation;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface ComposedAnnotatedWorkflow {
+
+  @WorkflowMethod
+  String execute(String input);
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedWorkflowImpl.java
@@ -13,7 +13,7 @@ public class ComposedAnnotatedWorkflowImpl implements ComposedAnnotatedWorkflow 
         Workflow.newActivityStub(
             ComposedAnnotatedActivity.class,
             ActivityOptions.newBuilder()
-                .setStartToCloseTimeout(Duration.ofSeconds(1))
+                .setStartToCloseTimeout(Duration.ofSeconds(10))
                 .validateAndBuildWithDefaults());
     return "composed:" + activity.execute(input);
   }

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedAnnotatedWorkflowImpl.java
@@ -1,0 +1,20 @@
+package io.temporal.spring.boot.autoconfigure.composedannotation;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+
+@ComposedWorkflowImpl
+public class ComposedAnnotatedWorkflowImpl implements ComposedAnnotatedWorkflow {
+
+  @Override
+  public String execute(String input) {
+    ComposedAnnotatedActivity activity =
+        Workflow.newActivityStub(
+            ComposedAnnotatedActivity.class,
+            ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(1))
+                .validateAndBuildWithDefaults());
+    return "composed:" + activity.execute(input);
+  }
+}

--- a/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedWorkflowImpl.java
+++ b/temporal-spring-boot-autoconfigure/src/test/java/io/temporal/spring/boot/autoconfigure/composedannotation/ComposedWorkflowImpl.java
@@ -1,0 +1,12 @@
+package io.temporal.spring.boot.autoconfigure.composedannotation;
+
+import io.temporal.spring.boot.WorkflowImpl;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@WorkflowImpl(taskQueues = "UnitTest")
+public @interface ComposedWorkflowImpl {}

--- a/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
+++ b/temporal-spring-boot-autoconfigure/src/test/resources/application.yml
@@ -113,6 +113,18 @@ spring:
 spring:
   config:
     activate:
+      on-profile: auto-discovery-composed-annotation
+  temporal:
+    workers-auto-discovery:
+      enabled: true
+      workflow-packages:
+        - io.temporal.spring.boot.autoconfigure.composedannotation
+      register-activity-beans: true
+
+---
+spring:
+  config:
+    activate:
       on-profile: auto-discovery-with-profile
   temporal:
     workers:


### PR DESCRIPTION
## What was changed

`WorkersTemplate#configureWorkflowImplementationsByWorkerName` now uses `AnnotationUtils.findAnnotation` instead of `Class#getAnnotation` to look up `@WorkflowImpl`.
Added `AutoDiscoveryComposedAnnotationTest` and a dedicated `composedannotation` fixture package that reproduce the bug with a user-defined composed annotation on both a workflow and an activity implementation.

## Why?

If a workflow implementation class is annotated with a custom composed (meta) annotation, for example a user-defined annotation that is itself annotated with `@WorkflowImpl`, rather than `@WorkflowImpl` applied directly - worker auto-discovery threw an NPE.
`Class#getAnnotation` only resolves annotations present directly on the class, so it returned `null`, and the next line (`annotation.workers()`) NPE'd.

`@ActivityImpl`/`@NexusServiceImpl` lookups were already consistent throughout, which is why only workflows registered via `workers()` were affected.

## Checklist

1. Closes N/A - found while implementing `temporal-spring-boot-autoconfigure` in an application with a custom composed annotation.

2. How was this tested:
   Added `AutoDiscoveryComposedAnnotationTest`, confirmed it reproduces the NPE before the fix and passes after
   Ran the full `temporal-spring-boot-autoconfigure` test suite; all tests pass.

3. Any docs updates needed?
   No.
