### PR TITLE
Rejecting the blank task queue names in WorkerFactory.newWorker()

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerFactory.java
@@ -181,7 +181,8 @@ public final class WorkerFactory {
    */
   public synchronized Worker newWorker(String taskQueue, WorkerOptions options) {
     Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(taskQueue), "taskQueue should not be an empty string");
+        !Strings.isNullOrEmpty(taskQueue) && !taskQueue.trim().isEmpty(),
+        "taskQueue should not be an empty or blank string");
     Preconditions.checkState(
         state == State.Initial,
         String.format(statusErrorMessage, "create new worker", state.name(), State.Initial.name()));

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerFactoryValidationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerFactoryValidationTest.java
@@ -1,0 +1,38 @@
+package io.temporal.worker;
+
+import static org.junit.Assert.assertThrows;
+
+import io.temporal.testing.TestWorkflowEnvironment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorkerFactoryValidationTest {
+
+  private TestWorkflowEnvironment env;
+
+  @Before
+  public void setUp() {
+    env = TestWorkflowEnvironment.newInstance();
+  }
+
+  @After
+  public void tearDown() {
+    env.close();
+  }
+
+  @Test
+  public void newWorkerRejectsNullTaskQueue() {
+    assertThrows(IllegalArgumentException.class, () -> env.getWorkerFactory().newWorker(null));
+  }
+
+  @Test
+  public void newWorkerRejectsEmptyTaskQueue() {
+    assertThrows(IllegalArgumentException.class, () -> env.getWorkerFactory().newWorker(""));
+  }
+
+  @Test
+  public void newWorkerRejectsBlankTaskQueue() {
+    assertThrows(IllegalArgumentException.class, () -> env.getWorkerFactory().newWorker("   "));
+  }
+}


### PR DESCRIPTION

## What was changed
`WorkerFactory.newWorker()` will now reject blank/whitespace-only task queue names (e.g. `"   "`) in addition to null and empty strings. The error message was updated from "should not be an empty string" to "should not be an empty or blank string" to reflect this. A new test class `WorkerFactoryValidationTest` covers null, empty, and blank task queue rejection using `TestWorkflowEnvironment`.

## Why?
`Strings.isNullOrEmpty("   ")` returns false, so whitespace-only task queue names silently passed validation and were forwarded to the Temporal server, producing a cryptic server-side error instead of a clear, early `IllegalArgumentException` at the call site.

This aligns `WorkerFactory` with the validation pattern already used elsewhere in this codebase. `StartNexusOperationOptions.setId()` uses `trim().isEmpty()` for the same reason.

## Checklist
1. Closes #3030
2. How was this tested: Added `WorkerFactoryValidationTest` with three unit    tests covering null, empty, and blank task queue names. All pass locally    using `TestWorkflowEnvironment` (no external service required).
3. Any docs updates needed? No.