### PR TITLE
Classify SDK tests for Cloud execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
 
   unit_test_cloud:
     name: Unit test with cloud
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 35
     steps:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -175,7 +175,7 @@ jobs:
 
       - name: Run cloud test
         if: ${{ steps.cloud-test-eligibility.outputs.enabled == 'true' }}
-        timeout-minutes: 15
+        timeout-minutes: 25
         env:
           USER: unittest
           TEMPORAL_TEST_ENV_CONFIG_SERVER: "true"
@@ -184,10 +184,7 @@ jobs:
           TEMPORAL_CLIENT_CLOUD_NAMESPACE: ${{ steps.create-cloud-namespace.outputs.namespace }}
           TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
           TEMPORAL_CLIENT_CLOUD_API_VERSION: v0.19.1
-        run: |
-          ./gradlew --no-daemon :temporal-sdk:test \
-            --tests '*CloudOperationsClientTest' \
-            --tests 'io.temporal.client.functional.SignalTest.signalCompletedWorkflow'
+        run: ./gradlew --no-daemon :temporal-sdk:testCloud
 
       - name: Delete Cloud namespace
         if: ${{ always() && steps.create-cloud-namespace.outputs.namespace != '' }}
@@ -201,7 +198,7 @@ jobs:
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         if: success() || failure() # always run even if the previous step fails
         with:
-          report_paths: "**/build/test-results/test/TEST-*.xml"
+          report_paths: "**/build/test-results/testCloud/TEST-*.xml"
 
   code_format:
     name: Code format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,32 @@ Values from `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, `TEMPORAL_API_KEY`, `TEMPO
 `TEMPORAL_GRPC_META_*` override the selected profile. Envconfig mode connects to an existing server
 and namespace; it does not create or register either one.
 
+The `:temporal-sdk:testCloud` task runs tests that are eligible for Temporal Cloud. It uses the same
+envconfig variables and excludes tests annotated with a `CloudTestExclusion` JUnit category. Tests
+are Cloud-eligible by default; use the narrowest applicable exclusion reason when a test requires a
+local server, requires Cloud resources that CI does not provision, or still needs Cloud-specific
+adaptation. Run `./gradlew :temporal-sdk:listCloudExcludedTests` to inventory the tests excluded
+from Cloud without executing them. The normal `test` task continues to run Cloud-excluded tests
+locally.
+
+Filter the inventory to one exclusion reason with, for example:
+
+```bash
+./gradlew :temporal-sdk:listCloudExcludedTests \
+  -PcloudTestExclusionReason=RequiresLocalServer
+```
+
+The accepted reasons are `RequiresLocalServer`, `RequiresCloudProvisioning`, and
+`NeedsCloudAdaptation`.
+
+JUnit category marker interfaces are the Java equivalent of test-runner traits. Every Cloud
+exclusion must pair its reason category with a complete explanatory note:
+
+```java
+@CloudTestExclusionNote("Starts an in-process time-skipping server.")
+@Category(RequiresLocalServer.class)
+```
+
 ## Things to Avoid
 
 Avoid changes that make review harder without improving the contribution:

--- a/temporal-sdk/build.gradle
+++ b/temporal-sdk/build.gradle
@@ -180,6 +180,62 @@ test {
     }
 }
 
+def cloudTestExclusionCategories = [
+        RequiresLocalServer: 'io.temporal.testing.CloudTestExclusion$RequiresLocalServer',
+        RequiresCloudProvisioning: 'io.temporal.testing.CloudTestExclusion$RequiresCloudProvisioning',
+        NeedsCloudAdaptation: 'io.temporal.testing.CloudTestExclusion$NeedsCloudAdaptation',
+]
+
+task listCloudExcludedTests(type: Test) {
+    group = 'verification'
+    description = 'Lists temporal-sdk tests that are excluded from Temporal Cloud.'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    dryRun = true
+    String exclusionReason = providers.gradleProperty('cloudTestExclusionReason').getOrNull()
+    String exclusionCategory = exclusionReason == null
+            ? 'io.temporal.testing.CloudTestExclusion'
+            : cloudTestExclusionCategories.get(exclusionReason)
+    if (exclusionCategory == null) {
+        throw new GradleException(
+                "Unknown Cloud test exclusion reason '${exclusionReason}'. Expected one of: " +
+                        cloudTestExclusionCategories.keySet().join(', ') + '.')
+    }
+    useJUnit {
+        includeCategories exclusionCategory
+    }
+    testLogging {
+        events 'skipped'
+    }
+}
+
+task testCloud(type: Test) {
+    group = 'verification'
+    description = 'Runs temporal-sdk tests that are eligible for Temporal Cloud.'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    if (project.hasProperty('testJavaVersion')) {
+        javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(project.property('testJavaVersion') as int)
+        }
+    }
+    useJUnit {
+        excludeCategories 'io.temporal.testing.CloudTestExclusion'
+    }
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat 'full'
+        showStandardStreams true
+    }
+    forkEvery = 1
+    maxParallelForks = Math.max(Runtime.runtime.availableProcessors().intdiv(2), 1) ?: 1
+    afterTest { TestDescriptor descriptor, TestResult result ->
+        if (result.resultType == org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE) {
+            failedTests << ["${descriptor.className}::${descriptor.name}"]
+        }
+    }
+}
+
 // On Java 17+, prepend java17 classes to all test classpaths so that Class.forName finds
 // the real Jackson3JsonPayloadConverter instead of the Java 8 stub. This lets us test
 // the present-java17-but-absent-jackson3 behavior (NoClassDefFoundError) in the same

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityInfoTest.java
@@ -73,7 +73,8 @@ public class ActivityInfoTest {
     Assert.assertEquals(ACTIVITY_OPTIONS.getStartToCloseTimeout(), info.startToCloseTimeout);
     Assert.assertEquals(ACTIVITY_OPTIONS.getHeartbeatTimeout(), info.heartbeatTimeout);
     Assert.assertEquals(ActivityInfoWorkflow.class.getSimpleName(), info.workflowType);
-    Assert.assertEquals(SDKTestWorkflowRule.NAMESPACE, info.namespace);
+    Assert.assertEquals(
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace(), info.namespace);
     Assert.assertEquals(testWorkflowRule.getTaskQueue(), info.activityTaskQueue);
     Assert.assertFalse(info.isLocal);
     Assert.assertEquals(0, info.priorityKey);
@@ -98,7 +99,8 @@ public class ActivityInfoTest {
     Assert.assertTrue(info.startToCloseTimeout.isZero());
     Assert.assertTrue(info.heartbeatTimeout.isZero());
     Assert.assertEquals(ActivityInfoWorkflow.class.getSimpleName(), info.workflowType);
-    Assert.assertEquals(SDKTestWorkflowRule.NAMESPACE, info.namespace);
+    Assert.assertEquals(
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace(), info.namespace);
     Assert.assertEquals(testWorkflowRule.getTaskQueue(), info.activityTaskQueue);
     Assert.assertTrue(info.isLocal);
     Assert.assertEquals(0, info.priorityKey);

--- a/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/authorization/AuthorizationTokenTest.java
@@ -6,6 +6,8 @@ import io.grpc.*;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
@@ -20,9 +22,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class AuthorizationTokenTest {
   private static Metadata.Key<String> TEMPORAL_NAMESPACE_HEADER_KEY =
       Metadata.Key.of("temporal-namespace", Metadata.ASCII_STRING_MARSHALLER);

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/BuildIdVersionSetsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/BuildIdVersionSetsTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assume.assumeTrue;
 import io.temporal.api.enums.v1.TaskReachability;
 import io.temporal.client.*;
 import io.temporal.internal.testing.WorkflowTestingTest;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
@@ -16,8 +18,12 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "deprecation"})
+@CloudTestExclusionNote(
+    "Cloud CI namespaces disable the deprecated version-set and rules-based versioning APIs.")
+@Category(RequiresCloudProvisioning.class)
 public class BuildIdVersionSetsTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/GetActivityResultAsyncOverServerLongPollWaitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/GetActivityResultAsyncOverServerLongPollWaitTest.java
@@ -54,7 +54,9 @@ public class GetActivityResultAsyncOverServerLongPollWaitTest {
   private ActivityClient newActivityClient() {
     return ActivityClient.newInstance(
         testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs(),
-        ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+        ActivityClientOptions.newBuilder()
+            .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+            .build());
   }
 
   private StartActivityOptions slowOpts() {

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/GetActivityResultOverLongPollWaitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/GetActivityResultOverLongPollWaitTest.java
@@ -66,7 +66,9 @@ public class GetActivityResultOverLongPollWaitTest {
     activityClient =
         ActivityClient.newInstance(
             clientStubs,
-            ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+            ActivityClientOptions.newBuilder()
+                .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                .build());
   }
 
   @After

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/GetActivityResultSyncOverServerLongPollWaitTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/GetActivityResultSyncOverServerLongPollWaitTest.java
@@ -53,7 +53,9 @@ public class GetActivityResultSyncOverServerLongPollWaitTest {
   private ActivityClient newActivityClient() {
     return ActivityClient.newInstance(
         testWorkflowRule.getWorkflowClient().getWorkflowServiceStubs(),
-        ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+        ActivityClientOptions.newBuilder()
+            .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+            .build());
   }
 
   private StartActivityOptions slowOpts() {

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/MetricsTest.java
@@ -1,7 +1,6 @@
 package io.temporal.client.functional;
 
 import static io.temporal.testUtils.Eventually.assertEventually;
-import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static junit.framework.TestCase.*;
 import static org.junit.Assume.assumeTrue;
 
@@ -54,22 +53,26 @@ public class MetricsTest {
   private final ActivityClient activityClient =
       ActivityClient.newInstance(
           testWorkflowRule.getWorkflowServiceStubs(),
-          ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+          ActivityClientOptions.newBuilder()
+              .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+              .build());
 
-  private static final List<Tag> TAGS_NAMESPACE =
-      MetricsTag.defaultTags(NAMESPACE).entrySet().stream()
-          .map(
-              nameValueEntry ->
-                  new ImmutableTag(nameValueEntry.getKey(), nameValueEntry.getValue()))
-          .collect(Collectors.toList());
-
+  private List<Tag> tagsNamespace;
   private List<Tag> tagsNamespaceQueue;
 
   @Before
   public void setUp() {
     registry.clear();
+    tagsNamespace =
+        MetricsTag.defaultTags(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+            .entrySet()
+            .stream()
+            .map(
+                nameValueEntry ->
+                    new ImmutableTag(nameValueEntry.getKey(), nameValueEntry.getValue()))
+            .collect(Collectors.toList());
     tagsNamespaceQueue =
-        replaceTags(TAGS_NAMESPACE, MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue());
+        replaceTags(tagsNamespace, MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue());
   }
 
   @After
@@ -97,7 +100,7 @@ public class MetricsTest {
             MetricsTag.WORKFLOW_TYPE,
             "QuicklyCompletingWorkflow");
     List<Tag> longPollRequestTags =
-        replaceTag(TAGS_NAMESPACE, MetricsTag.OPERATION_NAME, "GetWorkflowExecutionHistory");
+        replaceTag(tagsNamespace, MetricsTag.OPERATION_NAME, "GetWorkflowExecutionHistory");
 
     assertEventually(
         Duration.ofSeconds(2),
@@ -130,7 +133,7 @@ public class MetricsTest {
             MetricsTag.WORKFLOW_TYPE,
             "QuicklyCompletingWorkflow");
     List<Tag> longPollRequestTags =
-        replaceTag(TAGS_NAMESPACE, MetricsTag.OPERATION_NAME, "GetWorkflowExecutionHistory");
+        replaceTag(tagsNamespace, MetricsTag.OPERATION_NAME, "GetWorkflowExecutionHistory");
 
     assertEventually(
         Duration.ofSeconds(2),

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/StandaloneActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/StandaloneActivityTest.java
@@ -23,6 +23,8 @@ import io.temporal.common.interceptors.ActivityClientCallsInterceptorBase;
 import io.temporal.common.interceptors.ActivityClientInterceptorBase;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import java.time.Duration;
 import java.util.*;
@@ -32,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Integration tests for standalone activities started via {@link ActivityClient}.
@@ -257,7 +260,9 @@ public class StandaloneActivityTest {
   private ActivityClient newActivityClient() {
     return ActivityClient.newInstance(
         testWorkflowRule.getWorkflowServiceStubs(),
-        ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+        ActivityClientOptions.newBuilder()
+            .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+            .build());
   }
 
   @Test
@@ -516,7 +521,7 @@ public class StandaloneActivityTest {
           ActivityClient.newInstance(
               testWorkflowRule.getWorkflowServiceStubs(),
               ActivityClientOptions.newBuilder()
-                  .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+                  .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
                   .setInterceptors(Collections.singletonList(interceptor))
                   .build());
 
@@ -570,7 +575,7 @@ public class StandaloneActivityTest {
 
     assertEquals(activityId, info.activityId);
     assertEquals("InspectInfo", info.activityType);
-    assertEquals(SDKTestWorkflowRule.NAMESPACE, info.namespace);
+    assertEquals(testWorkflowRule.getWorkflowClient().getOptions().getNamespace(), info.namespace);
     assertEquals(testWorkflowRule.getTaskQueue(), info.taskQueue);
     assertFalse(info.isLocal);
     assertFalse(info.isInWorkflow);
@@ -831,6 +836,9 @@ public class StandaloneActivityTest {
     assertEquals(desc.getAttempt(), rawInfo.getAttempt());
   }
 
+  @CloudTestExclusionNote(
+      "Cloud describe does not expose the last failure during retry backoff within the test window.")
+  @Category(NeedsCloudAdaptation.class)
   @Test
   public void testDescribeLastFailureIsPopulatedDuringRetryBackoff() {
     assumeTrue(SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/StartDelayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/StartDelayTest.java
@@ -1,6 +1,7 @@
 package io.temporal.client.functional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.history.v1.HistoryEvent;
@@ -37,11 +38,12 @@ public class StartDelayTest {
         testWorkflowRule
             .getWorkflowClient()
             .newWorkflowStub(TestNoArgsWorkflowFunc.class, workflowOptions);
-    long start = System.currentTimeMillis();
+    long startNanos = System.nanoTime();
     stubF.func();
-    long end = System.currentTimeMillis();
-    // Assert that the workflow took at least 5 seconds to start
-    assertEquals(1000, end - start, 500);
+    Duration elapsed = Duration.ofNanos(System.nanoTime() - startNanos);
+    assertTrue(
+        "Workflow completed before its one-second start delay: " + elapsed,
+        elapsed.compareTo(Duration.ofSeconds(1)) >= 0);
     WorkflowExecution workflowExecution = WorkflowStub.fromTyped(stubF).getExecution();
     WorkflowExecutionHistory workflowExecutionHistory =
         testWorkflowRule.getWorkflowClient().fetchHistory(workflowExecution.getWorkflowId());

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/StartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/StartTest.java
@@ -12,6 +12,8 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.client.WorkflowTargetOptions;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.common.ProtobufTimeUtils;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions.*;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class StartTest {
 
@@ -70,6 +73,9 @@ public class StartTest {
         "func", stubF.func()); // Check that duplicated start just returns the result.
   }
 
+  @CloudTestExclusionNote(
+      "This test exercises behavior that is only supported by the local test server.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void startOneArgsFuncWithDefault() {
     // TODO why it doesn't work with external service?

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusAsyncApiTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusAsyncApiTest.java
@@ -12,6 +12,8 @@ import io.temporal.client.StartNexusOperationOptions;
 import io.temporal.client.UntypedNexusOperationHandle;
 import io.temporal.client.UntypedNexusServiceClient;
 import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.EchoNexusServiceImpl;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -25,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Coverage tests for the {@link CompletableFuture}-returning surface on the standalone Nexus
@@ -33,6 +36,9 @@ import org.junit.Test;
  * UntypedNexusOperationHandle}. Each overload is asserted against the existing sync echo handler so
  * the Java async API is exercised without depending on server-side async completion.
  */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class NexusAsyncApiTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusClientTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusClientTest.java
@@ -26,6 +26,8 @@ import io.temporal.client.StartNexusOperationOptions;
 import io.temporal.client.UntypedNexusOperationHandle;
 import io.temporal.client.UntypedNexusServiceClient;
 import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.EchoNexusServiceImpl;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -41,7 +43,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class NexusClientTest {
 
   private final AtomicInteger activityInvocationCount = new AtomicInteger();

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusOperationHandleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusOperationHandleTest.java
@@ -14,6 +14,8 @@ import io.temporal.client.StartNexusOperationOptions;
 import io.temporal.client.UntypedNexusOperationHandle;
 import io.temporal.client.UntypedNexusServiceClient;
 import io.temporal.failure.ApplicationFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.EchoNexusServiceImpl;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -24,12 +26,16 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests for {@link UntypedNexusOperationHandle} per-execution lifecycle methods returned by {@link
  * NexusClient#getHandle(String, String)}: {@code describe()}, {@code cancel()}/{@code
  * cancel(reason)}, and {@code terminate()}/{@code terminate(reason)}.
  */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class NexusOperationHandleTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusServiceClientTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusServiceClientTest.java
@@ -13,6 +13,8 @@ import io.temporal.client.NexusOperationHandle;
 import io.temporal.client.NexusServiceClient;
 import io.temporal.client.StartNexusOperationOptions;
 import io.temporal.client.UntypedNexusOperationHandle;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.EchoNexusServiceImpl;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -23,11 +25,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * End-to-end tests for {@link NexusServiceClient}: typed start/execute via {@link
  * io.temporal.workflow.Functions.Func2} method references.
  */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class NexusServiceClientTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/StandaloneNexusBackingWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/StandaloneNexusBackingWorkflowTest.java
@@ -24,6 +24,8 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -36,6 +38,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Behavior tests for standalone Nexus operations whose handler is {@link WorkflowRunOperation},
@@ -43,6 +46,9 @@ import org.junit.Test;
  * individual tests can exercise cancel propagation, bidirectional link plumbing, and any other
  * behavior that depends on the SANO ↔ backing-workflow relationship.
  */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class StandaloneNexusBackingWorkflowTest {
 
   static final AtomicReference<String> capturedWorkflowId = new AtomicReference<>();

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/StandaloneNexusSignalLinkingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/StandaloneNexusSignalLinkingTest.java
@@ -21,6 +21,8 @@ import io.temporal.client.UntypedNexusServiceClient;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.nexus.Nexus;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.SignalMethod;
 import io.temporal.workflow.Workflow;
@@ -33,6 +35,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies bidirectional link propagation when a Nexus operation handler signal-with-starts a
@@ -52,6 +55,9 @@ import org.junit.Test;
  * <p>Requires a real server: standalone Nexus operations and {@code EnableCHASMSignalBacklinks} are
  * not implemented by the in-memory test server. Test skips locally and runs in CI.
  */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class StandaloneNexusSignalLinkingTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleTest.java
@@ -10,6 +10,8 @@ import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.EncodedValues;
 import io.temporal.common.interceptors.ScheduleClientInterceptor;
 import io.temporal.testUtils.Eventually;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
@@ -24,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class ScheduleTest {
   static final SearchAttributeKey<String> CUSTOM_KEYWORD_SA =
@@ -394,6 +397,9 @@ public class ScheduleTest {
   }
 
   @Test
+  @CloudTestExclusionNote(
+      "Cloud CI does not provision the custom search attribute used by this test.")
+  @Category(RequiresCloudProvisioning.class)
   public void updateSchedules() {
     ScheduleClient client = createScheduleClient();
     // Create the schedule
@@ -497,6 +503,9 @@ public class ScheduleTest {
   }
 
   @Test
+  @CloudTestExclusionNote(
+      "Cloud CI does not provision the custom search attribute used by this test.")
+  @Category(RequiresCloudProvisioning.class)
   public void listSchedules() {
     ScheduleClient client = createScheduleClient();
     // Create the schedule

--- a/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/schedules/ScheduleWithTypedSearchAttributesTest.java
@@ -12,6 +12,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.SearchAttributeKey;
 import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import java.time.Duration;
@@ -22,7 +24,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the custom search attributes used by this schedule suite.")
+@Category(RequiresCloudProvisioning.class)
 public class ScheduleWithTypedSearchAttributesTest {
   static final SearchAttributeKey<String> CUSTOM_KEYWORD_SA =
       SearchAttributeKey.forKeyword("CustomKeywordField");

--- a/temporal-sdk/src/test/java/io/temporal/common/PluginPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/PluginPropagationTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.WorkerFactoryOptions;
@@ -34,11 +36,14 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests that plugins propagate through the full chain: WorkflowServiceStubsOptions →
  * WorkflowClientOptions → WorkerFactory
  */
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class PluginPropagationTest {
 
   /** A plugin that tracks all configuration calls via subclassing. */

--- a/temporal-sdk/src/test/java/io/temporal/common/interceptors/ActivityClientCallsInterceptorChainTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/common/interceptors/ActivityClientCallsInterceptorChainTest.java
@@ -72,7 +72,7 @@ public class ActivityClientCallsInterceptorChainTest {
     return ActivityClient.newInstance(
         testRule.getWorkflowServiceStubs(),
         ActivityClientOptions.newBuilder()
-            .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+            .setNamespace(testRule.getWorkflowClient().getOptions().getNamespace())
             .setInterceptors(Arrays.asList(interceptors))
             .build());
   }

--- a/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/functional/serialization/WorkflowIdSignedPayloadsTest.java
@@ -18,6 +18,8 @@ import io.temporal.payload.codec.PayloadCodecException;
 import io.temporal.payload.context.ActivitySerializationContext;
 import io.temporal.payload.context.HasWorkflowSerializationContext;
 import io.temporal.payload.context.SerializationContext;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
@@ -32,6 +34,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 /**
@@ -78,7 +81,7 @@ public class WorkflowIdSignedPayloadsTest {
     assertEquals("result", workflowStub.execute("input"));
   }
 
-  @Test
+  @Test(timeout = 30_000)
   public void testSimpleWorkflowWithMemo() throws InterruptedException {
     assumeTrue(
         "skipping as test server does not support list", SDKTestWorkflowRule.useExternalService);
@@ -108,6 +111,8 @@ public class WorkflowIdSignedPayloadsTest {
     assertEquals(MEMO_VALUE, executions.get(0).getMemo(MEMO_KEY, String.class));
   }
 
+  @CloudTestExclusionNote("This cron test depends on local test-server time skipping.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testSimpleCronWorkflow() {
     assumeFalse("skipping as test will timeout", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/GetVersionInterleavedUpdateReplayTaskHandlerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/GetVersionInterleavedUpdateReplayTaskHandlerTest.java
@@ -11,6 +11,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.worker.QueryReplayHelper;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.versionTests.GetVersionInterleavedUpdateReplayTest;
@@ -19,7 +21,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class GetVersionInterleavedUpdateReplayTaskHandlerTest {
   private static final String EXPECTED_FIRST_CHANGE_ID = "ChangeId1";
   private static final String EXPECTED_SECOND_CHANGE_ID = "ChangeId2";

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerCacheTests.java
@@ -26,6 +26,8 @@ import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.internal.worker.WorkflowRunLockManager;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.HistoryUtils;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.MetricsType;
 import java.util.Map;
@@ -34,6 +36,7 @@ import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class ReplayWorkflowRunTaskHandlerCacheTests {
 
@@ -71,6 +74,8 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
         cache.getOrCreate(workflowTask, metricsScope, () -> createFakeExecutor(workflowTask)));
   }
 
+  @CloudTestExclusionNote("This cache test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void whenHistoryIsFullNewWorkflowExecutorIsReturned_InitiallyCached() throws Exception {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
@@ -110,6 +115,8 @@ public class ReplayWorkflowRunTaskHandlerCacheTests {
     assertSame(workflowRunTaskHandler2, workflowRunTaskHandler);
   }
 
+  @CloudTestExclusionNote("This cache test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test(timeout = 2000)
   public void whenHistoryIsPartialCachedEntryIsReturned() throws Exception {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/ReplayWorkflowRunTaskHandlerTaskHandlerTests.java
@@ -26,6 +26,8 @@ import io.temporal.internal.worker.WorkflowTaskHandler;
 import io.temporal.serviceclient.Version;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testUtils.HistoryUtils;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import java.time.Duration;
 import java.util.HashMap;
@@ -33,11 +35,14 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
 
   @Rule public SDKTestWorkflowRule testWorkflowRule = SDKTestWorkflowRule.newBuilder().build();
 
+  @CloudTestExclusionNote("This cache test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void ifStickyExecutionAttributesAreNotSetThenWorkflowsAreNotCached() throws Throwable {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
@@ -65,6 +70,8 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     assertFalse(result.getTaskCompleted().hasStickyAttributes());
   }
 
+  @CloudTestExclusionNote("This replay test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void workflowTaskFailOnIncompleteHistory() throws Throwable {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
@@ -158,6 +165,8 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     assertEquals(5, laMeteringHelper.getNonfirstAttempts());
   }
 
+  @CloudTestExclusionNote("This cache test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void ifStickyExecutionAttributesAreSetThenWorkflowsAreCached() throws Throwable {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
@@ -189,6 +198,8 @@ public class ReplayWorkflowRunTaskHandlerTaskHandlerTests {
     assertEquals(Durations.fromSeconds(5), attributes.getScheduleToStartTimeout());
   }
 
+  @CloudTestExclusionNote("This replay test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void setsSdkNameAndVersionIfNotSetInHistory() throws Throwable {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/UnknownHistoryEventReplayerTest.java
@@ -6,13 +6,18 @@ import io.temporal.activity.*;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.*;
 import java.time.Duration;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class UnknownHistoryEventReplayerTest {
 
   public static final String TASK_QUEUE = "unknown-history-event";

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/PromiseTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.fail;
 
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.CompletablePromise;
@@ -21,7 +23,10 @@ import java.util.IllegalFormatCodePointException;
 import java.util.List;
 import java.util.concurrent.*;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class PromiseTest {
 
   @Rule public final Tracer trace = new Tracer();

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalDeprecatedQueueTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.*;
@@ -16,8 +18,11 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("deprecation")
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkflowInternalDeprecatedQueueTest {
 
   @Rule public final Tracer trace = new Tracer();

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalLockTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.*;
@@ -19,7 +21,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkflowInternalLockTest {
   @Rule public final Tracer trace = new Tracer();
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalQueueTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.QueueConsumer;
@@ -20,7 +22,10 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkflowInternalQueueTest {
 
   @Rule public final Tracer trace = new Tracer();

--- a/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalSemaphoreTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/sync/WorkflowInternalSemaphoreTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.*;
@@ -16,7 +18,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkflowInternalSemaphoreTest {
   @Rule public final Tracer trace = new Tracer();
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowReplayerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowReplayerTest.java
@@ -11,6 +11,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.WorkflowExecutionHistory;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.ReplayResults;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
@@ -28,8 +30,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkflowReplayerTest {
   @Rule public Timeout testTimeout = Timeout.seconds(10);
 

--- a/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -22,6 +22,8 @@ import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.ChildWorkflowFailure;
 import io.temporal.failure.TimeoutFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
@@ -41,12 +43,15 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkflowTestingTest {
   private static final Logger log = LoggerFactory.getLogger(WorkflowTestingTest.class);
   private static final String TASK_QUEUE = "test-workflow";

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
@@ -134,7 +134,7 @@ public class ActivityFailedMetricsTests {
       String workerType, String workflowType) {
     Map<String, String> tags = new HashMap<>();
     tags.put("task_queue", testWorkflowRule.getTaskQueue());
-    tags.put("namespace", "UnitTest");
+    tags.put("namespace", testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
     tags.put("activity_type", "Execute");
     tags.put("exception", "ApplicationFailure");
     tags.put("failure_reason", "ActivityError");

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/AsyncPollerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/AsyncPollerTest.java
@@ -371,7 +371,7 @@ public class AsyncPollerTest {
     assertFalse(poller.isSuspended());
     pollLatch.await();
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(0, executor.processed.get());
           assertEquals(1, slotSupplierInner.reservedCount.get());
@@ -381,7 +381,7 @@ public class AsyncPollerTest {
     poller.suspendPolling();
     completePoll.get().apply();
     assertEventually(
-        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
         () -> {
           assertEquals(1, executor.processed.get());
           assertEquals(2, slotSupplierInner.reservedCount.get());

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotInfoTest.java
@@ -18,6 +18,8 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.WorkerDeploymentVersion;
 import io.temporal.testUtils.RecordingSlotSupplier;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerDeploymentOptions;
 import io.temporal.worker.WorkerOptions;
@@ -41,8 +43,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("deprecation")
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SlotInfoTest {
   private static final String WORKFLOW_TYPE = "slot-info-workflow";
   private static final String ACTIVITY_TYPE = "slot-info-activity";

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/SlotInfoTest.java
@@ -206,7 +206,9 @@ public class SlotInfoTest {
     assertEquals(runId, activityInfo.getWorkflowRunId());
     assertEquals(WORKFLOW_TYPE, activityInfo.getWorkflowType());
     assertEquals(testWorkflowRule.getTaskQueue(), activityInfo.getActivityTaskQueue());
-    assertEquals(SDKTestWorkflowRule.NAMESPACE, activityInfo.getNamespace());
+    assertEquals(
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
+        activityInfo.getNamespace());
     assertEquals(1, activityInfo.getAttempt());
     assertEquals(expectedLocal, activityInfo.isLocal());
     assertEquals(WORKER_IDENTITY, workerIdentity);

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowFailedMetricsTests.java
@@ -125,7 +125,7 @@ public class WorkflowFailedMetricsTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest",
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
         "workflow_type",
         workflowType);
   }

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotGrpcInterceptedTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotGrpcInterceptedTests.java
@@ -186,7 +186,7 @@ public class WorkflowSlotGrpcInterceptedTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest");
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
   }
 
   private static class MaybeFailWFTResponseInterceptor implements ClientInterceptor {

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/WorkflowSlotTests.java
@@ -14,6 +14,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.testUtils.CountingSlotSupplier;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerOptions;
@@ -27,7 +29,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowSlotTests {
   private final int MAX_CONCURRENT_WORKFLOW_TASK_EXECUTION_SIZE = 100;
   private final int MAX_CONCURRENT_ACTIVITY_EXECUTION_SIZE = 1000;

--- a/temporal-sdk/src/test/java/io/temporal/testing/CloudTestExclusion.java
+++ b/temporal-sdk/src/test/java/io/temporal/testing/CloudTestExclusion.java
@@ -1,0 +1,17 @@
+package io.temporal.testing;
+
+/** Category hierarchy for tests excluded from Temporal Cloud execution. */
+public interface CloudTestExclusion {
+
+  /** The test requires one or more local Temporal Server instances. */
+  interface RequiresLocalServer extends CloudTestExclusion {}
+
+  /**
+   * The test requires a Temporal Cloud capability that CI cannot provision or a feature that is
+   * unavailable in Temporal Cloud.
+   */
+  interface RequiresCloudProvisioning extends CloudTestExclusion {}
+
+  /** The test can run in Cloud after its setup or assertions are adapted. */
+  interface NeedsCloudAdaptation extends CloudTestExclusion {}
+}

--- a/temporal-sdk/src/test/java/io/temporal/testing/CloudTestExclusionNote.java
+++ b/temporal-sdk/src/test/java/io/temporal/testing/CloudTestExclusionNote.java
@@ -1,0 +1,17 @@
+package io.temporal.testing;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Explains why a test is excluded from Temporal Cloud execution. */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface CloudTestExclusionNote {
+  String value();
+}

--- a/temporal-sdk/src/test/java/io/temporal/testing/CloudTestExclusionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/testing/CloudTestExclusionTest.java
@@ -1,0 +1,140 @@
+package io.temporal.testing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import java.io.File;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.experimental.categories.Categories.CategoryFilter;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.Description;
+
+public class CloudTestExclusionTest {
+  private static final Set<Class<?>> REASONS =
+      new HashSet<>(
+          Arrays.asList(
+              RequiresLocalServer.class,
+              RequiresCloudProvisioning.class,
+              NeedsCloudAdaptation.class));
+
+  @Test
+  public void cloudTestExclusionContract() throws Exception {
+    assertUmbrellaCategoryExcludesEveryReason();
+    assertEveryCloudExclusionHasOneReasonAndNote();
+  }
+
+  private static void assertUmbrellaCategoryExcludesEveryReason() throws Exception {
+    CategoryFilter filter = CategoryFilter.exclude(CloudTestExclusion.class);
+
+    assertFalse(
+        filter.shouldRun(
+            Description.createSuiteDescription(
+                ClassExcludedFixture.class.getName(),
+                ClassExcludedFixture.class.getAnnotations())));
+    assertFalse(filter.shouldRun(methodDescription("requiresCloudProvisioning")));
+    assertFalse(filter.shouldRun(methodDescription("needsCloudAdaptation")));
+    assertTrue(filter.shouldRun(methodDescription("cloudEligible")));
+  }
+
+  private static void assertEveryCloudExclusionHasOneReasonAndNote() throws Exception {
+    for (Class<?> testClass : testClasses()) {
+      validateElement(testClass.getName(), testClass);
+      for (Method method : testClass.getDeclaredMethods()) {
+        validateElement(testClass.getName() + "#" + method.getName(), method);
+      }
+    }
+  }
+
+  private static List<Class<?>> testClasses() throws Exception {
+    Path classesRoot =
+        Paths.get(
+            CloudTestExclusionTest.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI());
+    Path packageRoot = classesRoot.resolve("io/temporal");
+    try (Stream<Path> paths = Files.walk(packageRoot)) {
+      return paths
+          .filter(path -> path.toString().endsWith(".class"))
+          .map(classesRoot::relativize)
+          .map(Path::toString)
+          .filter(classFile -> !classFile.contains("CloudTestExclusionTest$"))
+          .sorted()
+          .map(CloudTestExclusionTest::loadClass)
+          .collect(Collectors.toList());
+    }
+  }
+
+  private static Class<?> loadClass(String classFile) {
+    String className =
+        classFile
+            .substring(0, classFile.length() - ".class".length())
+            .replace(File.separatorChar, '.');
+    try {
+      return Class.forName(className, false, CloudTestExclusionTest.class.getClassLoader());
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Unable to inspect test class " + className + ".", e);
+    }
+  }
+
+  private static void validateElement(String name, AnnotatedElement element) {
+    Category category = element.getAnnotation(Category.class);
+    CloudTestExclusionNote note = element.getAnnotation(CloudTestExclusionNote.class);
+    List<Class<?>> reasons =
+        category == null
+            ? java.util.Collections.emptyList()
+            : Arrays.stream(category.value())
+                .filter(CloudTestExclusion.class::isAssignableFrom)
+                .collect(Collectors.toList());
+    if (reasons.isEmpty()) {
+      assertNull(name + " has a Cloud exclusion note without a reason category.", note);
+      return;
+    }
+
+    assertEquals(name + " must have exactly one Cloud exclusion reason.", 1, reasons.size());
+    assertTrue(name + " uses an unknown Cloud exclusion reason.", REASONS.contains(reasons.get(0)));
+    assertNotNull(name + " must explain its Cloud exclusion.", note);
+    assertFalse(
+        name + " must have a nonblank Cloud exclusion note.", note.value().trim().isEmpty());
+  }
+
+  private static Description methodDescription(String name) throws Exception {
+    Method method = MethodExcludedFixture.class.getDeclaredMethod(name);
+    return Description.createTestDescription(
+        MethodExcludedFixture.class, name, method.getAnnotations());
+  }
+
+  @CloudTestExclusionNote("Requires a local server for this filtering fixture.")
+  @Category(RequiresLocalServer.class)
+  private static class ClassExcludedFixture {}
+
+  private static class MethodExcludedFixture {
+    public void cloudEligible() {}
+
+    @CloudTestExclusionNote("Requires Cloud provisioning for this filtering fixture.")
+    @Category(RequiresCloudProvisioning.class)
+    public void requiresCloudProvisioning() {}
+
+    @CloudTestExclusionNote("Needs Cloud adaptation for this filtering fixture.")
+    @Category(NeedsCloudAdaptation.class)
+    public void needsCloudAdaptation() {}
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/worker/ActiveTaskQueueTypesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/ActiveTaskQueueTypesTest.java
@@ -8,6 +8,8 @@ import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import io.temporal.api.enums.v1.TaskQueueType;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.workflow.WorkflowInterface;
@@ -15,7 +17,10 @@ import io.temporal.workflow.WorkflowMethod;
 import io.temporal.workflow.shared.TestNexusServices;
 import java.util.List;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class ActiveTaskQueueTypesTest {
 
   @WorkflowInterface

--- a/temporal-sdk/src/test/java/io/temporal/worker/BuildIdVersioningTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/BuildIdVersioningTest.java
@@ -8,6 +8,8 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.internal.Signal;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
@@ -18,8 +20,11 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("deprecation")
+@CloudTestExclusionNote("Cloud CI namespaces disable deprecated build-ID versioning.")
+@Category(RequiresCloudProvisioning.class)
 public class BuildIdVersioningTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/worker/PollerAutoScaleTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/PollerAutoScaleTests.java
@@ -3,6 +3,8 @@ package io.temporal.worker;
 import static org.junit.Assume.assumeTrue;
 
 import io.temporal.client.WorkflowClient;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.tuning.PollerBehaviorAutoscaling;
 import java.util.ArrayList;
@@ -33,7 +35,9 @@ public class PollerAutoScaleTests {
         "Test Server doesn't support poller autoscaling", SDKTestWorkflowRule.useExternalService);
   }
 
-  @Category(IndependentResourceBasedTests.class)
+  @CloudTestExclusionNote(
+      "This resource-heavy test still needs a dedicated Cloud execution strategy.")
+  @Category({IndependentResourceBasedTests.class, NeedsCloudAdaptation.class})
   @Test(timeout = 300 * 1000)
   public void canRunHeavyLoadWithPollerAutoScaling() {
     List<CompletableFuture<String>> workflowResults = new ArrayList<>();

--- a/temporal-sdk/src/test/java/io/temporal/worker/ResourceBasedTunerTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/ResourceBasedTunerTests.java
@@ -1,7 +1,5 @@
 package io.temporal.worker;
 
-import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
-
 import com.uber.m3.tally.RootScopeBuilder;
 import com.uber.m3.util.ImmutableMap;
 import io.temporal.activity.ActivityInterface;
@@ -12,6 +10,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.Eventually;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.tuning.*;
 import io.temporal.workflow.*;
@@ -27,8 +27,6 @@ import org.junit.experimental.categories.Category;
 public class ResourceBasedTunerTests {
 
   private final TestStatsReporter reporter = new TestStatsReporter();
-  private static final Map<String, String> TAGS_NAMESPACE =
-      new ImmutableMap.Builder<String, String>().putAll(MetricsTag.defaultTags(NAMESPACE)).build();
 
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
@@ -55,7 +53,9 @@ public class ResourceBasedTunerTests {
     workflow.execute(5, 5, 1000);
     Map<String, String> nsAndTaskQueue =
         new ImmutableMap.Builder<String, String>()
-            .putAll(TAGS_NAMESPACE)
+            .putAll(
+                MetricsTag.defaultTags(
+                    testWorkflowRule.getWorkflowClient().getOptions().getNamespace()))
             .put(MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue())
             .build();
     reporter.assertGauge(MetricsType.RESOURCE_MEM_USAGE, nsAndTaskQueue, (val) -> val > 0);
@@ -76,7 +76,9 @@ public class ResourceBasedTunerTests {
         MetricsType.WORKER_TASK_SLOTS_USED, getWorkerTags("LocalActivityWorker"), 0);
   }
 
-  @Category(IndependentResourceBasedTests.class)
+  @CloudTestExclusionNote(
+      "This resource-heavy test still needs a dedicated Cloud execution strategy.")
+  @Category({IndependentResourceBasedTests.class, NeedsCloudAdaptation.class})
   @Test(timeout = 300 * 1000)
   public void canRunHeavyMemoryWithResourceBasedTuner() {
     ResourceTunerWorkflow workflow = testWorkflowRule.newWorkflowStub(ResourceTunerWorkflow.class);
@@ -190,6 +192,6 @@ public class ResourceBasedTunerTests {
         "task_queue",
         testWorkflowRule.getTaskQueue(),
         "namespace",
-        "UnitTest");
+        testWorkflowRule.getWorkflowClient().getOptions().getNamespace());
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/StickyWorkerTest.java
@@ -19,6 +19,8 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.internal.worker.WorkflowExecutorCache;
 import io.temporal.serviceclient.MetricsTag;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
@@ -46,10 +48,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class StickyWorkerTest {
 
   private static final boolean useExternalService =

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerHeartbeatIntegrationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerHeartbeatIntegrationTest.java
@@ -14,6 +14,8 @@ import io.temporal.api.workflowservice.v1.*;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.tuning.ResourceBasedControllerOptions;
 import io.temporal.worker.tuning.ResourceBasedTuner;
@@ -29,7 +31,11 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Requires a one-second worker heartbeat interval in addition to envconfig client options.")
+@Category(NeedsCloudAdaptation.class)
 public class WorkerHeartbeatIntegrationTest {
 
   private static final Duration EVENTUALLY_TIMEOUT = Duration.ofSeconds(10);

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerIsNotGettingStartedTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerIsNotGettingStartedTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import java.util.Map;
@@ -12,7 +14,10 @@ import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkerIsNotGettingStartedTest {
   private static final int WORKFLOW_POLL_COUNT = 11;
   private static final int ACTIVITY_POLL_COUNT = 18;

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerThreadCountTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerPollerThreadCountTest.java
@@ -7,6 +7,8 @@ import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.activity.ActivityInterface;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.workflow.WorkflowInterface;
@@ -17,7 +19,10 @@ import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkerPollerThreadCountTest {
 
   private static final String ACTIVITY_POLLER_THREAD_NAME_PREFIX = "Activity Poller task";

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerStressTests.java
@@ -11,6 +11,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
@@ -27,6 +29,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -34,6 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @RunWith(Parameterized.class)
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class WorkerStressTests {
 
   @Parameterized.Parameter public boolean useExternalService;

--- a/temporal-sdk/src/test/java/io/temporal/worker/WorkerVersioningTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/WorkerVersioningTest.java
@@ -203,7 +203,7 @@ public class WorkerVersioningTest {
     Assert.assertEquals("version-v3", res3);
   }
 
-  @Test
+  @Test(timeout = 30_000)
   public void testRampWorkerVersioning() {
     assumeTrue("Test Server doesn't support versioning", SDKTestWorkflowRule.useExternalService);
 

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanNexusWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/CleanNexusWorkerShutdownTest.java
@@ -12,6 +12,8 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.worker.tuning.PollerBehavior;
@@ -30,10 +32,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the standalone Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class CleanNexusWorkerShutdownTest {
 
   private static final String COMPLETED = "Completed";

--- a/temporal-sdk/src/test/java/io/temporal/worker/shutdown/HeartbeatDuringWorkerShutdownTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/shutdown/HeartbeatDuringWorkerShutdownTest.java
@@ -99,7 +99,9 @@ public class HeartbeatDuringWorkerShutdownTest {
     ActivityClient client =
         ActivityClient.newInstance(
             testWorkflowRule.getWorkflowServiceStubs(),
-            ActivityClientOptions.newBuilder().setNamespace(SDKTestWorkflowRule.NAMESPACE).build());
+            ActivityClientOptions.newBuilder()
+                .setNamespace(testWorkflowRule.getWorkflowClient().getOptions().getNamespace())
+                .build());
     StartActivityOptions options =
         StartActivityOptions.newBuilder()
             .setId("heartbeat-during-shutdown-" + UUID.randomUUID())

--- a/temporal-sdk/src/test/java/io/temporal/worker/tuning/ResourceBasedSlotSupplierNonRecursiveTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/worker/tuning/ResourceBasedSlotSupplierNonRecursiveTest.java
@@ -13,6 +13,7 @@ import io.temporal.internal.worker.SlotReservationData;
 import io.temporal.internal.worker.TrackingSlotSupplier;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.Worker;
@@ -190,14 +191,23 @@ public class ResourceBasedSlotSupplierNonRecursiveTest {
         "=== End-to-End Worker Test with Resource Starvation Recovery (External Service) ===");
 
     // Create connections to real Temporal server
-    WorkflowServiceStubs service =
-        WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder()
-                .setTarget(ExternalServiceTestConfigurator.getTemporalServiceAddress())
-                .build());
+    TestEnvironmentOptions environmentOptions =
+        ExternalServiceTestConfigurator.configuredTestEnvironmentOptions().build();
+    WorkflowServiceStubsOptions configuredOptions =
+        environmentOptions.getWorkflowServiceStubsOptions();
+    WorkflowServiceStubsOptions.Builder serviceOptions =
+        configuredOptions == null
+            ? WorkflowServiceStubsOptions.newBuilder()
+            : WorkflowServiceStubsOptions.newBuilder(configuredOptions);
+    if (environmentOptions.getTarget() != null) {
+      serviceOptions.setTarget(environmentOptions.getTarget());
+    }
+    WorkflowServiceStubs service = WorkflowServiceStubs.newServiceStubs(serviceOptions.build());
+    WorkflowClientOptions configuredClientOptions = environmentOptions.getWorkflowClientOptions();
     WorkflowClient client =
-        WorkflowClient.newInstance(
-            service, WorkflowClientOptions.newBuilder().setNamespace("default").build());
+        configuredClientOptions == null
+            ? WorkflowClient.newInstance(service)
+            : WorkflowClient.newInstance(service, configuredClientOptions);
     WorkerFactory workerFactory = WorkerFactory.newInstance(client);
 
     // Create our own resource controller that we can control

--- a/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/workerFactory/WorkerFactoryTests.java
@@ -11,6 +11,9 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
+import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
 import io.temporal.worker.WorkerFactory;
 import java.util.concurrent.TimeUnit;
@@ -19,13 +22,12 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class WorkerFactoryTests {
 
   private static final boolean useExternalService =
       ExternalServiceTestConfigurator.isUseExternalService();
-  private static final String serviceAddress =
-      ExternalServiceTestConfigurator.getTemporalServiceAddress();
 
   @BeforeClass
   public static void beforeClass() {
@@ -37,10 +39,10 @@ public class WorkerFactoryTests {
 
   @Before
   public void setUp() {
-    service =
-        WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder().setTarget(serviceAddress).build());
-    WorkflowClient client = WorkflowClient.newInstance(service);
+    TestEnvironmentOptions environmentOptions =
+        ExternalServiceTestConfigurator.configuredTestEnvironmentOptions().build();
+    service = newServiceStubs(environmentOptions);
+    WorkflowClient client = newWorkflowClient(service, environmentOptions);
     factory = WorkerFactory.newInstance(client);
   }
 
@@ -137,13 +139,16 @@ public class WorkerFactoryTests {
   }
 
   @Test
+  @CloudTestExclusionNote("Cloud hides nonexistent namespaces from namespace-scoped credentials.")
+  @Category(NeedsCloudAdaptation.class)
   public void startFailsOnNonexistentNamespace() {
-    WorkflowServiceStubs serviceLocal =
-        WorkflowServiceStubs.newServiceStubs(
-            WorkflowServiceStubsOptions.newBuilder().setTarget(serviceAddress).build());
+    TestEnvironmentOptions environmentOptions =
+        ExternalServiceTestConfigurator.configuredTestEnvironmentOptions().build();
+    WorkflowServiceStubs serviceLocal = newServiceStubs(environmentOptions);
     WorkflowClient clientLocal =
         WorkflowClient.newInstance(
-            serviceLocal, WorkflowClientOptions.newBuilder().setNamespace("i_dont_exist").build());
+            serviceLocal,
+            newWorkflowClientOptions(environmentOptions).setNamespace("i_dont_exist").build());
     WorkerFactory factoryLocal = WorkerFactory.newInstance(clientLocal);
     factoryLocal.newWorker("task-queue");
 
@@ -154,5 +159,34 @@ public class WorkerFactoryTests {
     factoryLocal.awaitTermination(5, TimeUnit.SECONDS);
     serviceLocal.shutdownNow();
     serviceLocal.awaitTermination(5, TimeUnit.SECONDS);
+  }
+
+  private static WorkflowServiceStubs newServiceStubs(TestEnvironmentOptions environmentOptions) {
+    WorkflowServiceStubsOptions configuredOptions =
+        environmentOptions.getWorkflowServiceStubsOptions();
+    WorkflowServiceStubsOptions.Builder serviceOptions =
+        configuredOptions == null
+            ? WorkflowServiceStubsOptions.newBuilder()
+            : WorkflowServiceStubsOptions.newBuilder(configuredOptions);
+    if (environmentOptions.getTarget() != null) {
+      serviceOptions.setTarget(environmentOptions.getTarget());
+    }
+    return WorkflowServiceStubs.newServiceStubs(serviceOptions.build());
+  }
+
+  private static WorkflowClient newWorkflowClient(
+      WorkflowServiceStubs service, TestEnvironmentOptions environmentOptions) {
+    WorkflowClientOptions configuredOptions = environmentOptions.getWorkflowClientOptions();
+    return configuredOptions == null
+        ? WorkflowClient.newInstance(service)
+        : WorkflowClient.newInstance(service, configuredOptions);
+  }
+
+  private static WorkflowClientOptions.Builder newWorkflowClientOptions(
+      TestEnvironmentOptions environmentOptions) {
+    WorkflowClientOptions configuredOptions = environmentOptions.getWorkflowClientOptions();
+    return configuredOptions == null
+        ? WorkflowClientOptions.newBuilder()
+        : WorkflowClientOptions.newBuilder(configuredOptions);
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ContextPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ContextPropagationTest.java
@@ -11,6 +11,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.context.ContextPropagator;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.internal.testing.WorkflowTestingTest;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
@@ -23,10 +25,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.MDC;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class ContextPropagationTest {
   private static final String TASK_QUEUE = "test-workflow";
   private TestWorkflowEnvironment testEnvironment;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/ContinueAsNewTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/ContinueAsNewTest.java
@@ -6,6 +6,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.SearchAttributeKey;
 import io.temporal.common.SearchAttributes;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.testing.internal.TracingWorkerInterceptor;
@@ -14,7 +16,11 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the custom search attribute used by this suite.")
+@Category(RequiresCloudProvisioning.class)
 public class ContinueAsNewTest {
   static final SearchAttributeKey<String> CUSTOM_KEYWORD_SA =
       SearchAttributeKey.forKeyword("CustomKeywordField");

--- a/temporal-sdk/src/test/java/io/temporal/workflow/EagerWorkflowTaskDispatchTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/EagerWorkflowTaskDispatchTest.java
@@ -16,6 +16,8 @@ import io.temporal.common.VersioningBehavior;
 import io.temporal.common.WorkerDeploymentVersion;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testUtils.CountingSlotSupplier;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.*;
 import io.temporal.worker.tuning.*;
@@ -26,7 +28,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Requires a test-specific gRPC interceptor in addition to envconfig connection options.")
+@Category(NeedsCloudAdaptation.class)
 public class EagerWorkflowTaskDispatchTest {
   private static final StartCallInterceptor START_CALL_INTERCEPTOR = new StartCallInterceptor();
   private final CountingSlotSupplier<WorkflowSlotInfo> workflowTaskSlotSupplier =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.fail;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import java.time.Duration;
 import java.util.HashMap;
@@ -17,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 public class GetCronScheduleFromWorkflowInfoTest {
@@ -29,6 +32,8 @@ public class GetCronScheduleFromWorkflowInfoTest {
           .setWorkflowTypes(TestGetCronScheduleWorkflowsFuncImpl.class)
           .build();
 
+  @CloudTestExclusionNote("This cron test depends on local test-server time skipping.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetCronScheduleFromWorkflowInfo() throws InterruptedException {
     Assume.assumeFalse("skipping for docker tests", testWorkflowRule.isUseExternalService());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/LoggerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/LoggerTest.java
@@ -10,6 +10,8 @@ import ch.qos.logback.core.read.ListAppender;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.internal.logging.LoggerTag;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import java.time.Duration;
@@ -21,9 +23,12 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class LoggerTest {
 
   private static final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MemoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MemoTest.java
@@ -66,7 +66,7 @@ public class MemoTest {
     GetWorkflowExecutionHistoryResponse historyResp =
         WorkflowClientHelper.getHistoryPage(
             testWorkflowRule.getWorkflowServiceStubs(),
-            SDKTestWorkflowRule.NAMESPACE,
+            testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
             executionF,
             ByteString.EMPTY,
             new NoopScope());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -28,6 +28,8 @@ import io.temporal.common.interceptors.*;
 import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
@@ -50,9 +52,12 @@ import java.util.function.Function;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class MetricsTest {
 
   private static final long REPORTING_FLUSH_TIME = 600;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/NoQueryThreadLeakTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/NoQueryThreadLeakTest.java
@@ -16,7 +16,7 @@ public class NoQueryThreadLeakTest {
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder().setWorkflowTypes(TestNoQueryWorkflowImpl.class).build();
 
-  @Test
+  @Test(timeout = 30_000)
   public void testNoQueryThreadLeak() throws InterruptedException {
     QueryableWorkflow client =
         testWorkflowRule.newWorkflowStubTimeoutOptions(QueryableWorkflow.class);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/SideEffectRaceConditionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/SideEffectRaceConditionTest.java
@@ -2,6 +2,8 @@ package io.temporal.workflow;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
@@ -14,7 +16,10 @@ import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class SideEffectRaceConditionTest {
 
   private static final String TASK_QUEUE = "test-workflow";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/TestEnvironmentCloseTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/TestEnvironmentCloseTest.java
@@ -2,11 +2,16 @@ package io.temporal.workflow;
 
 import static junit.framework.TestCase.assertTrue;
 
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import io.temporal.workflow.shared.TestActivities.NoArgsActivity;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class TestEnvironmentCloseTest {
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowTaskFailureBackoffTest.java
@@ -1,7 +1,5 @@
 package io.temporal.workflow;
 
-import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
-
 import com.google.common.collect.ImmutableMap;
 import com.uber.m3.tally.RootScopeBuilder;
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -62,7 +60,9 @@ public class WorkflowTaskFailureBackoffTest {
             .size());
     Map<String, String> tags =
         ImmutableMap.<String, String>builder()
-            .putAll(MetricsTag.defaultTags(NAMESPACE))
+            .putAll(
+                MetricsTag.defaultTags(
+                    testWorkflowRule.getWorkflowClient().getOptions().getNamespace()))
             .put(MetricsTag.WORKER_TYPE, WorkerMetricsTag.WorkerType.WORKFLOW_WORKER.getValue())
             .put(MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue())
             .put(MetricsTag.WORKFLOW_TYPE, "TestWorkflow1")

--- a/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/WorkflowWithCronScheduleTest.java
@@ -7,12 +7,15 @@ import static org.junit.Assume.assumeFalse;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflowWithCronScheduleImpl;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 public class WorkflowWithCronScheduleTest {
@@ -25,6 +28,8 @@ public class WorkflowWithCronScheduleTest {
           .setWorkflowTypes(TestWorkflowWithCronScheduleImpl.class)
           .build();
 
+  @CloudTestExclusionNote("This cron test depends on local test-server time skipping.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testCronWorkflowWithIncrementSchedule() {
     // Min interval in cron is 1min. So we will not test it against real service in Jenkins.

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/EagerActivityDispatchingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/EagerActivityDispatchingTest.java
@@ -20,6 +20,7 @@ import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.Config;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.testUtils.CountingSlotSupplier;
+import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.ExternalServiceTestConfigurator;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
@@ -56,11 +57,19 @@ public class EagerActivityDispatchingTest {
   @Before
   public void setUp() throws Exception {
     eagerActivityRequestInterceptor.reset();
+    TestEnvironmentOptions.Builder environmentOptions =
+        ExternalServiceTestConfigurator.configuredTestEnvironmentOptions();
+    WorkflowServiceStubsOptions configuredServiceOptions =
+        environmentOptions.build().getWorkflowServiceStubsOptions();
+    WorkflowServiceStubsOptions.Builder serviceOptions =
+        configuredServiceOptions == null
+            ? WorkflowServiceStubsOptions.newBuilder()
+            : WorkflowServiceStubsOptions.newBuilder(configuredServiceOptions);
     this.env =
         TestWorkflowEnvironment.newInstance(
-            ExternalServiceTestConfigurator.configuredTestEnvironmentOptions()
+            environmentOptions
                 .setWorkflowServiceStubsOptions(
-                    WorkflowServiceStubsOptions.newBuilder()
+                    serviceOptions
                         .setGrpcClientInterceptors(
                             Collections.singletonList(eagerActivityRequestInterceptor))
                         .build())

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityManyWorkflowsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LocalActivityManyWorkflowsTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.LocalActivityOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
@@ -11,6 +13,7 @@ import java.time.Duration;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class LocalActivityManyWorkflowsTest {
 
@@ -21,6 +24,8 @@ public class LocalActivityManyWorkflowsTest {
           .setWorkflowTypes(ActivityWorkflow.class)
           .build();
 
+  @CloudTestExclusionNote("This stress test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void manyWorkflowsTest() {
     Assume.assumeFalse("skipping for docker tests", testWorkflowRule.isUseExternalService());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityFailsWhileHeartbeatingMeteringTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/LongLocalActivityFailsWhileHeartbeatingMeteringTest.java
@@ -9,6 +9,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.RetryOptions;
 import io.temporal.failure.ActivityFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestActivities.TestActivitiesImpl;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class LongLocalActivityFailsWhileHeartbeatingMeteringTest {
 
@@ -39,6 +42,8 @@ public class LongLocalActivityFailsWhileHeartbeatingMeteringTest {
    * Test that local activity that failed to heartbeat and executed longer than Workflow Task
    * Timeout will be repeated during replay
    */
+  @CloudTestExclusionNote("This test depends on local test-server metering metadata behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testLongLocalActivityFailsWhileHeartbeatingMetering() {
     // Needs server release which propagates metering metadata to event

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/ActivityCancellationTokenIntegrationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/ActivityCancellationTokenIntegrationTest.java
@@ -26,6 +26,8 @@ import io.temporal.common.WorkerDeploymentVersion;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerDeploymentOptions;
 import io.temporal.worker.WorkerOptions;
@@ -47,7 +49,11 @@ import java.util.concurrent.TimeoutException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "Requires test-specific gRPC interception and worker heartbeat configuration in addition to envconfig options.")
+@Category(NeedsCloudAdaptation.class)
 public class ActivityCancellationTokenIntegrationTest {
 
   private final List<PollNexusTaskQueueRequest> workerCommandPollRequests =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
@@ -10,6 +10,8 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.client.*;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.Signal;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
@@ -17,6 +19,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -54,6 +57,9 @@ public class WorkflowClosedRunningActivityTest {
   }
 
   @Test
+  @CloudTestExclusionNote(
+      "Cloud cancellation timing can surface a shutdown exception before activity-not-found.")
+  @Category(NeedsCloudAdaptation.class)
   public void activitySeesActivityNotExistException() throws InterruptedException {
     TestWorkflow1 workflow =
         eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowRetryTest.java
@@ -1,6 +1,5 @@
 package io.temporal.workflow.childWorkflowTests;
 
-import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
 import static org.junit.Assert.*;
 
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -14,6 +13,8 @@ import io.temporal.common.interceptors.WorkflowClientCallsInterceptorBase;
 import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.ChildWorkflowFailure;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.WorkflowReplayer;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkflowImplementationOptions;
@@ -27,6 +28,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class ChildWorkflowRetryTest {
 
@@ -67,11 +69,13 @@ public class ChildWorkflowRetryTest {
                           };
                         }
                       })
-                  .setNamespace(NAMESPACE)
                   .build())
           .build();
 
   @Test
+  @CloudTestExclusionNote(
+      "Requires a workflow client interceptor in addition to envconfig client options.")
+  @Category(NeedsCloudAdaptation.class)
   public void testChildWorkflowRetry() {
     WorkflowOptions options =
         WorkflowOptions.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/childWorkflowTests/ChildWorkflowWithCronScheduleTest.java
@@ -7,6 +7,8 @@ import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestWorkflowWithCronScheduleImpl;
@@ -16,6 +18,7 @@ import java.time.Duration;
 import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 public class ChildWorkflowWithCronScheduleTest {
@@ -28,6 +31,8 @@ public class ChildWorkflowWithCronScheduleTest {
           .setWorkflowTypes(TestCronParentWorkflow.class, TestWorkflowWithCronScheduleImpl.class)
           .build();
 
+  @CloudTestExclusionNote("This test advances time through the local test service.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testChildWorkflowWithCronSchedule() {
     // Min interval in cron is 1min. So we will not test it against real service in Jenkins.

--- a/temporal-sdk/src/test/java/io/temporal/workflow/deadlockdetector/PayloadConverterEscapingDeadlockDetectionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/deadlockdetector/PayloadConverterEscapingDeadlockDetectionTest.java
@@ -7,6 +7,8 @@ import io.temporal.client.WorkflowClientOptions;
 import io.temporal.common.converter.CodecDataConverter;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.payload.codec.PayloadCodec;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows;
 import io.temporal.workflow.unsafe.WorkflowUnsafe;
@@ -16,8 +18,12 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 
+@CloudTestExclusionNote(
+    "Requires a test-specific data converter in addition to envconfig client options.")
+@Category(NeedsCloudAdaptation.class)
 public class PayloadConverterEscapingDeadlockDetectionTest {
   public @Rule Timeout timeout = Timeout.seconds(20);
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyBlockWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/determinism/NonDeterministicWorkflowPolicyBlockWorkflowTest.java
@@ -87,7 +87,7 @@ public class NonDeterministicWorkflowPolicyBlockWorkflowTest {
             "task_queue",
             testWorkflowRule.getTaskQueue(),
             "namespace",
-            "UnitTest",
+            testWorkflowRule.getWorkflowClient().getOptions().getNamespace(),
             "workflow_type",
             "TestWorkflowStringArg",
             "worker_type",

--- a/temporal-sdk/src/test/java/io/temporal/workflow/failure/FailureEncodingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/failure/FailureEncodingTest.java
@@ -22,6 +22,8 @@ import io.temporal.internal.testing.WorkflowTestingTest;
 import io.temporal.internal.testing.WorkflowTestingTest.FailingWorkflowImpl;
 import io.temporal.payload.codec.PayloadCodec;
 import io.temporal.payload.codec.PayloadCodecException;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
@@ -37,6 +39,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 
 /**
@@ -54,6 +57,8 @@ import org.junit.rules.Timeout;
  *       that Failure carries no sensible data and no stack trace.
  * </ul>
  */
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class FailureEncodingTest {
   private static final String TASK_QUEUE = "test-workflow";
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/interceptorsTests/InterceptorExceptionTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/interceptorsTests/InterceptorExceptionTests.java
@@ -8,12 +8,18 @@ import io.temporal.client.WorkflowServiceException;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptor;
 import io.temporal.common.interceptors.WorkflowClientCallsInterceptorBase;
 import io.temporal.common.interceptors.WorkflowClientInterceptorBase;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.shared.TestWorkflows.NoArgsWorkflow;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote(
+    "This suite directly controls the local test service lifecycle during cleanup.")
+@Category(RequiresLocalServer.class)
 public class InterceptorExceptionTests {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleFailOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleFailOnConflictTest.java
@@ -17,6 +17,8 @@ import io.temporal.client.WorkflowFailedException;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -29,7 +31,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class ActivityHandleFailOnConflictTest {
   private final CountDownLatch activityStarted = new CountDownLatch(1);
   private final CountDownLatch releaseActivity = new CountDownLatch(1);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleUseExistingOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleUseExistingOnConflictTest.java
@@ -13,6 +13,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowStub;
 import io.temporal.nexus.TemporalOperationHandler;
 import io.temporal.testUtils.Eventually;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusOperationExecution;
 import io.temporal.workflow.NexusOperationHandle;
@@ -31,7 +33,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class ActivityHandleUseExistingOnConflictTest {
   private static final int OPERATION_COUNT = 5;
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncActivityOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncActivityOperationTest.java
@@ -12,6 +12,8 @@ import io.temporal.internal.nexus.OperationToken;
 import io.temporal.internal.nexus.OperationTokenType;
 import io.temporal.internal.nexus.OperationTokenUtil;
 import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -20,7 +22,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class AsyncActivityOperationTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncWorkflowOperationTest.java
@@ -10,6 +10,8 @@ import io.temporal.internal.nexus.OperationToken;
 import io.temporal.internal.nexus.OperationTokenUtil;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.WorkflowReplayer;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
@@ -18,7 +20,10 @@ import io.temporal.workflow.shared.TestWorkflows;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class AsyncWorkflowOperationTest extends BaseNexusTest {
   private static final String WORKFLOW_ID_PREFIX = "test-prefix";
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelActivityAsyncOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelActivityAsyncOperationTest.java
@@ -18,6 +18,8 @@ import io.temporal.failure.NexusOperationFailure;
 import io.temporal.nexus.CancelActivityExecutionInput;
 import io.temporal.nexus.TemporalOperationCancelContext;
 import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.time.Duration;
@@ -26,7 +28,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class CancelActivityAsyncOperationTest extends BaseNexusTest {
 
   static final AtomicBoolean cancelled = new AtomicBoolean(false);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelWorkflowAsyncOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelWorkflowAsyncOperationTest.java
@@ -15,6 +15,8 @@ import io.temporal.failure.NexusOperationFailure;
 import io.temporal.internal.Signal;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.WorkflowReplayer;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
@@ -23,7 +25,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class CancelWorkflowAsyncOperationTest extends BaseNexusTest {
 
   private static final Signal opStarted = new Signal();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerCancelTest.java
@@ -13,13 +13,18 @@ import io.temporal.nexus.TemporalNexusClient;
 import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericHandlerCancelTest extends BaseNexusTest {
 
   private static final Signal opStarted = new Signal();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerDoubleStartTest.java
@@ -12,6 +12,8 @@ import io.temporal.nexus.TemporalNexusClient;
 import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -19,7 +21,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericHandlerDoubleStartTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerSyncResultTest.java
@@ -7,6 +7,8 @@ import io.temporal.nexus.TemporalNexusClient;
 import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -14,7 +16,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericHandlerSyncResultTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedProcTest.java
@@ -8,6 +8,8 @@ import io.temporal.nexus.TemporalNexusClient;
 import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -16,7 +18,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericHandlerTypedProcTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerTypedStartWorkflowTest.java
@@ -8,6 +8,8 @@ import io.temporal.nexus.TemporalNexusClient;
 import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -16,7 +18,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericHandlerTypedStartWorkflowTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericHandlerUntypedStartWorkflowTest.java
@@ -8,6 +8,8 @@ import io.temporal.nexus.TemporalNexusClient;
 import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -16,7 +18,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericHandlerUntypedStartWorkflowTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericListOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/GenericListOperationTest.java
@@ -6,6 +6,8 @@ import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.common.converter.EncodedValuesTest;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusServiceOptions;
 import io.temporal.workflow.Workflow;
@@ -15,8 +17,11 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 // Test an operation that takes and returns a List type with a non-primitive element type
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class GenericListOperationTest {
   @ClassRule
   public static SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/HeaderTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/HeaderTest.java
@@ -5,14 +5,19 @@ import io.nexusrpc.Service;
 import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 // Test the start operation handler receives the correct headers
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class HeaderTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationInfoTest.java
@@ -5,6 +5,8 @@ import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.NexusOperationInfo;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -12,7 +14,10 @@ import io.temporal.workflow.shared.TestWorkflows;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class NexusOperationInfoTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationMetadataTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/NexusOperationMetadataTest.java
@@ -8,6 +8,8 @@ import io.temporal.api.history.v1.HistoryEvent;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.testUtils.HistoryUtils;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusOperationOptions;
 import io.temporal.workflow.NexusServiceOptions;
@@ -19,7 +21,10 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class NexusOperationMetadataTest {
   static final String NEXUS_OPERATION_SUMMARY = "nexus-operation-summary";
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationFailMetricTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationFailMetricTest.java
@@ -19,6 +19,8 @@ import io.temporal.failure.NexusOperationFailure;
 import io.temporal.failure.TemporalFailure;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.Eventually;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerMetricsTag;
@@ -29,7 +31,10 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class OperationFailMetricTest {
   private static final Map<String, Integer> invocationCount = new ConcurrentHashMap<>();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationFailureConversionTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationFailureConversionTest.java
@@ -9,6 +9,8 @@ import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowNotFoundException;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -19,7 +21,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class OperationFailureConversionTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationErrorPropagationTest.java
@@ -18,6 +18,8 @@ import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.failure.TimeoutFailure;
 import io.temporal.payload.codec.PayloadCodecException;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
@@ -28,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies how a caller workflow sees failures a data converter raises while deserializing Nexus
@@ -38,6 +41,9 @@ import org.junit.*;
  * with one exception: a non-retryable {@code PayloadValidationError} is the converter's way of
  * saying the input itself was invalid, so it is reported as a non-retryable BAD_REQUEST.
  */
+@CloudTestExclusionNote(
+    "Requires Nexus endpoint provisioning and a test-specific data converter in addition to envconfig options.")
+@Category(NeedsCloudAdaptation.class)
 public class OperationInputDeserializationErrorPropagationTest {
   private static final String HANDLER_EXCEPTION = "handler-exception";
   private static final String NON_RETRYABLE_APPLICATION_FAILURE =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationFailTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationFailTest.java
@@ -13,6 +13,8 @@ import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.Eventually;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerMetricsTag;
@@ -23,12 +25,15 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies that a caller workflow sees input a handler cannot deserialize as a non-retryable {@link
  * HandlerException.ErrorType#BAD_REQUEST} rather than as a retryable internal error that is retried
  * until the operation's schedule-to-close timeout.
  */
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class OperationInputDeserializationFailTest {
   private static final AtomicInteger operationInvocations = new AtomicInteger();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationFailTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/OperationInputDeserializationFailTest.java
@@ -1,7 +1,5 @@
 package io.temporal.workflow.nexus;
 
-import static io.temporal.testing.internal.SDKTestWorkflowRule.NAMESPACE;
-
 import com.google.common.collect.ImmutableMap;
 import com.uber.m3.tally.RootScopeBuilder;
 import io.nexusrpc.handler.HandlerException;
@@ -93,7 +91,9 @@ public class OperationInputDeserializationFailTest {
     // on the first successful evaluation and would not see a later attempt.
     Map<String, String> execFailedTags =
         ImmutableMap.<String, String>builder()
-            .putAll(MetricsTag.defaultTags(NAMESPACE))
+            .putAll(
+                MetricsTag.defaultTags(
+                    testWorkflowRule.getWorkflowClient().getOptions().getNamespace()))
             .put(MetricsTag.WORKER_TYPE, WorkerMetricsTag.WorkerType.NEXUS_WORKER.getValue())
             .put(MetricsTag.TASK_QUEUE, testWorkflowRule.getTaskQueue())
             .put(MetricsTag.NEXUS_SERVICE, "TestNexusService2")

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ParallelWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ParallelWorkflowOperationTest.java
@@ -6,6 +6,8 @@ import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.WorkflowReplayer;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
@@ -17,7 +19,10 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class ParallelWorkflowOperationTest extends BaseNexusTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ProtoOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ProtoOperationTest.java
@@ -9,14 +9,19 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
 import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
 import io.temporal.nexus.Nexus;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 // Test an operation that takes and returns a protobuf message
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class ProtoOperationTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SignalOperationLinkingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SignalOperationLinkingTest.java
@@ -17,6 +17,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.nexus.Nexus;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusOperationHandle;
 import io.temporal.workflow.NexusOperationOptions;
@@ -37,6 +39,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies link propagation in both directions when a Nexus operation handler interacts with a
@@ -57,6 +60,8 @@ import org.junit.Test;
  * in-memory test server does not implement this path so the class is skipped unless a real server
  * is in use.
  */
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SignalOperationLinkingTest {
 
   private static final String MODE_SIGNAL_WITH_START = "signalWithStart";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncClientOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncClientOperationTest.java
@@ -12,6 +12,8 @@ import io.temporal.common.reporter.TestStatsReporter;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.nexus.Nexus;
 import io.temporal.serviceclient.MetricsTag;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.testing.internal.TracingWorkerInterceptor;
 import io.temporal.worker.MetricsType;
@@ -23,7 +25,10 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SyncClientOperationTest {
   private final TestStatsReporter reporter = new TestStatsReporter();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationCancelledTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationCancelledTest.java
@@ -7,6 +7,8 @@ import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.NexusOperationFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -15,7 +17,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SyncOperationCancelledTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationFailTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationFailTest.java
@@ -14,6 +14,8 @@ import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.serviceclient.MetricsTag;
 import io.temporal.testUtils.Eventually;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.MetricsType;
 import io.temporal.worker.WorkerMetricsTag;
@@ -23,7 +25,10 @@ import io.temporal.workflow.shared.TestWorkflows.TestWorkflow1;
 import java.time.Duration;
 import java.util.Map;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SyncOperationFailTest {
   private final TestStatsReporter reporter = new TestStatsReporter();
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationStubTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationStubTest.java
@@ -3,6 +3,8 @@ package io.temporal.workflow.nexus;
 import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -11,7 +13,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SyncOperationStubTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationTimeoutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/SyncOperationTimeoutTest.java
@@ -6,6 +6,8 @@ import io.nexusrpc.handler.ServiceImpl;
 import io.temporal.client.WorkflowFailedException;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.failure.TimeoutFailure;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -14,7 +16,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SyncOperationTimeoutTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/TemporalOperationAnnotationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/TemporalOperationAnnotationTest.java
@@ -11,6 +11,8 @@ import io.temporal.nexus.TemporalOperation;
 import io.temporal.nexus.TemporalOperationHandler;
 import io.temporal.nexus.TemporalOperationResult;
 import io.temporal.nexus.TemporalOperationStartContext;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -18,8 +20,11 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /** End-to-end coverage of the {@link TemporalOperation} sugar. */
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class TemporalOperationAnnotationTest {
 
   @Rule

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/TerminateWorkflowAsyncOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/TerminateWorkflowAsyncOperationTest.java
@@ -12,6 +12,8 @@ import io.temporal.failure.TerminatedFailure;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowHandle;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -19,7 +21,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class TerminateWorkflowAsyncOperationTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UntypedSyncOperationStubTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UntypedSyncOperationStubTest.java
@@ -3,6 +3,8 @@ package io.temporal.workflow.nexus;
 import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -11,7 +13,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class UntypedSyncOperationStubTest {
   @ClassRule
   public static SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/UpdateWorkflowOperationTest.java
@@ -18,6 +18,8 @@ import io.temporal.internal.nexus.OperationToken;
 import io.temporal.internal.nexus.OperationTokenType;
 import io.temporal.internal.nexus.OperationTokenUtil;
 import io.temporal.nexus.TemporalOperationHandler;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestWorkflows;
@@ -28,7 +30,10 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class UpdateWorkflowOperationTest extends BaseNexusTest {
 
   private static final String asyncVal = "async";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/VoidOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/VoidOperationTest.java
@@ -5,6 +5,8 @@ import io.nexusrpc.Service;
 import io.nexusrpc.handler.OperationHandler;
 import io.nexusrpc.handler.OperationImpl;
 import io.nexusrpc.handler.ServiceImpl;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusServiceOptions;
 import io.temporal.workflow.NexusServiceStub;
@@ -13,8 +15,11 @@ import io.temporal.workflow.shared.TestWorkflows;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 // Test an operation that takes and returns a void type
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class VoidOperationTest {
   @ClassRule
   public static SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleFailOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleFailOnConflictTest.java
@@ -10,6 +10,8 @@ import io.temporal.failure.ApplicationFailure;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -20,7 +22,10 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowHandleFailOnConflictTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleFuncTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleFuncTest.java
@@ -10,6 +10,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowHandle;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestMultiArgWorkflowFunctions;
@@ -18,7 +20,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowHandleFuncTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleProcTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleProcTest.java
@@ -10,6 +10,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowHandle;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusOperationOptions;
 import io.temporal.workflow.NexusServiceOptions;
@@ -20,7 +22,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowHandleProcTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleStubTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleStubTest.java
@@ -10,6 +10,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowHandle;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.NexusOperationOptions;
 import io.temporal.workflow.NexusServiceOptions;
@@ -20,7 +22,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowHandleStubTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictCancelTest.java
@@ -9,6 +9,8 @@ import io.temporal.failure.CanceledFailure;
 import io.temporal.failure.NexusOperationFailure;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -17,7 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowHandleUseExistingOnConflictCancelTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowHandleUseExistingOnConflictTest.java
@@ -10,6 +10,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -19,7 +21,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowHandleUseExistingOnConflictTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowOperationLinkingTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/WorkflowOperationLinkingTest.java
@@ -14,6 +14,8 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.internal.nexus.OperationTokenUtil;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.*;
 import io.temporal.workflow.shared.TestNexusServices;
@@ -22,7 +24,10 @@ import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("Cloud CI does not provision the Nexus endpoint required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class WorkflowOperationLinkingTest extends BaseNexusTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/DirectQueryReplaysDontSpamLogWithWorkflowExecutionExceptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/DirectQueryReplaysDontSpamLogWithWorkflowExecutionExceptionsTest.java
@@ -14,6 +14,8 @@ import io.temporal.common.RetryOptions;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.internal.Issue;
+import io.temporal.testing.CloudTestExclusion.NeedsCloudAdaptation;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.shared.TestActivities;
@@ -23,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -72,6 +75,9 @@ public class DirectQueryReplaysDontSpamLogWithWorkflowExecutionExceptionsTest {
   }
 
   @Test
+  @CloudTestExclusionNote(
+      "Uses an exact replay count that is not stable when queries run against Cloud.")
+  @Category(NeedsCloudAdaptation.class)
   public void queriedWorkflowFailureDoesntProduceAdditionalLogsWhenWorkflowIsNotCompleted() {
     assumeTrue("This test is flaky on the Test Server", SDKTestWorkflowRule.useExternalService);
 

--- a/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/LocalActivityAndQueryTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/queryTests/LocalActivityAndQueryTest.java
@@ -33,6 +33,7 @@ public class LocalActivityAndQueryTest {
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
+          .setTestTimeoutSeconds(30)
           .setWorkflowTypes(TestLocalActivityAndQueryWorkflow.class)
           .setActivityImplementations(activitiesImpl)
           .build();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/SearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/SearchAttributesTest.java
@@ -23,6 +23,8 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowServiceException;
 import io.temporal.internal.client.WorkflowClientHelper;
 import io.temporal.internal.common.SearchAttributesUtil;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.ChildWorkflowOptions;
@@ -36,8 +38,12 @@ import java.util.*;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("deprecation")
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the custom search attributes required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class SearchAttributesTest {
   private static final String TEST_KEY_STRING = "CustomStringField";
   private static final String TEST_VALUE_STRING = NAMESPACE;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/TypedSearchAttributesTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/TypedSearchAttributesTest.java
@@ -18,6 +18,8 @@ import io.temporal.client.WorkflowServiceException;
 import io.temporal.common.SearchAttributeKey;
 import io.temporal.internal.client.WorkflowClientHelper;
 import io.temporal.internal.common.SearchAttributesUtil;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.ChildWorkflowOptions;
@@ -31,8 +33,12 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /** Typed attribute translation of {@link SearchAttributesTest} */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the custom search attributes required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class TypedSearchAttributesTest {
   private static final SearchAttributeKey<List<String>> TEST_NEW_KEY =
       SearchAttributeKey.forKeywordList("NewKeyList");

--- a/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/UpsertSearchAttributeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/UpsertSearchAttributeTest.java
@@ -8,6 +8,8 @@ import io.temporal.api.enums.v1.EventType;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.*;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.testing.internal.TracingWorkerInterceptor;
@@ -18,8 +20,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @SuppressWarnings("deprecation")
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the custom search attributes used by this suite.")
+@Category(RequiresCloudProvisioning.class)
 public class UpsertSearchAttributeTest {
 
   private static final String TEST_VALUE = "test";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/UpsertTypedSearchAttributeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/searchattributes/UpsertTypedSearchAttributeTest.java
@@ -8,6 +8,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.common.SearchAttributeKey;
 import io.temporal.common.SearchAttributes;
+import io.temporal.testing.CloudTestExclusion.RequiresCloudProvisioning;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.testing.internal.TracingWorkerInterceptor;
@@ -18,8 +20,12 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /** Typed attribute translation of {@link UpsertSearchAttributeTest} */
+@CloudTestExclusionNote(
+    "Cloud CI does not provision the custom search attributes required by this test.")
+@Category(RequiresCloudProvisioning.class)
 public class UpsertTypedSearchAttributeTest {
 
   private static final String TEST_VALUE = "test";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/shared/TestActivities.java
@@ -17,7 +17,6 @@ import io.temporal.client.ActivityNotExistsException;
 import io.temporal.common.MethodRetry;
 import io.temporal.common.converter.RawValue;
 import io.temporal.failure.ApplicationFailure;
-import io.temporal.testing.internal.SDKTestWorkflowRule;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
@@ -352,7 +351,7 @@ public class TestActivities {
     @Override
     public void throwIO() {
       ActivityInfo info = Activity.getExecutionContext().getInfo();
-      assertEquals(SDKTestWorkflowRule.NAMESPACE, info.getNamespace());
+      assertFalse(info.getNamespace().isEmpty());
       assertNotNull(info.getWorkflowId());
       assertNotNull(info.getWorkflowRunId());
       assertFalse(info.getWorkflowId().isEmpty());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalDuringLastWorkflowTaskTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalDuringLastWorkflowTaskTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assume.assumeFalse;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowTargetOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.shared.TestWorkflows.TestSignaledWorkflow;
@@ -18,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class SignalDuringLastWorkflowTaskTest {
 
@@ -33,6 +36,8 @@ public class SignalDuringLastWorkflowTaskTest {
               WorkerOptions.newBuilder().setDefaultDeadlockDetectionTimeout(5000).build())
           .build();
 
+  @CloudTestExclusionNote("This signal timing test depends on local test-server time skipping.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testSignalDuringLastWorkflowTask() throws ExecutionException, InterruptedException {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/signalTests/SignalTest.java
@@ -177,8 +177,7 @@ public class SignalTest {
     WorkflowClient client =
         WorkflowClient.newInstance(
             testWorkflowRule.getWorkflowServiceStubs(),
-            WorkflowClientOptions.newBuilder()
-                .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+            WorkflowClientOptions.newBuilder(testWorkflowRule.getWorkflowClient().getOptions())
                 .setQueryRejectCondition(QueryRejectCondition.QUERY_REJECT_CONDITION_NOT_OPEN)
                 .build());
     WorkflowStub workflowStubNotOptionRejectCondition =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateTest.java
@@ -276,7 +276,7 @@ public class UpdateTest {
             .blockingStub()
             .resetWorkflowExecution(
                 ResetWorkflowExecutionRequest.newBuilder()
-                    .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+                    .setNamespace(workflowClient.getOptions().getNamespace())
                     .setReason("Integration test")
                     .setWorkflowExecution(execution)
                     .setWorkflowTaskFinishEventId(4)

--- a/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateWithStartTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/updateTest/UpdateWithStartTest.java
@@ -107,7 +107,7 @@ public class UpdateWithStartTest {
     return new Results(theWorkflowResult, theUpdateResult);
   }
 
-  @Test
+  @Test(timeout = 30_000)
   public void startWorkflowAndUpdate() throws ExecutionException, InterruptedException {
     // no arg
     Results results =

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAddNewBeforeTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAddNewBeforeTest.java
@@ -3,6 +3,8 @@ package io.temporal.workflow.versionTests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
 
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Workflow;
@@ -11,6 +13,7 @@ import io.temporal.workflow.unsafe.WorkflowUnsafe;
 import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +38,8 @@ public class GetVersionAddNewBeforeTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This versioning test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetVersionAddNewBefore() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAndTimerTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
@@ -12,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class GetVersionAndTimerTest extends BaseVersionTest {
 
@@ -30,12 +33,16 @@ public class GetVersionAndTimerTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This timer test depends on local test-server time skipping.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testTimedWorkflowWithoutVersionImpl() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);
     testTimedWorkflow(testWorkflowRuleWithoutVersion);
   }
 
+  @CloudTestExclusionNote("This timer test depends on local test-server time skipping.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testTimedWorkflowWithVersionImpl() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAsyncLocalActivityReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionAsyncLocalActivityReplayTest.java
@@ -16,6 +16,8 @@ import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.history.VersionMarkerUtils;
 import io.temporal.internal.statemachines.WorkflowStateMachines;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.WorkflowReplayer;
 import io.temporal.worker.Worker;
@@ -34,7 +36,10 @@ import java.util.Locale;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class GetVersionAsyncLocalActivityReplayTest {
   private static final String TASK_QUEUE = "get-version-async-local-activity-replay";
   private static final String CHANGE_ID = "async-local-activity-change";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInterleavedUpdateReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionInterleavedUpdateReplayTest.java
@@ -30,6 +30,8 @@ import io.temporal.common.WorkflowExecutionHistory;
 import io.temporal.internal.common.SdkFlag;
 import io.temporal.internal.history.VersionMarkerUtils;
 import io.temporal.internal.statemachines.WorkflowStateMachines;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestEnvironmentOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.WorkflowHistoryLoader;
@@ -51,6 +53,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 
 /**
@@ -58,6 +61,8 @@ import org.slf4j.Logger;
  * gauravthadani/samples-kotlin and captures histories that exercise interleaved updates around
  * getVersion.
  */
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class GetVersionInterleavedUpdateReplayTest {
   private static final String HISTORY_RESOURCE =
       "testGetVersionInterleavedUpdateReplayHistory.json";

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdOnReplayTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assume.assumeFalse;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.EventType;
 import io.temporal.client.WorkflowStub;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Workflow;
@@ -15,6 +17,7 @@ import io.temporal.workflow.unsafe.WorkflowUnsafe;
 import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class GetVersionSameIdOnReplayTest extends BaseVersionTest {
 
@@ -36,6 +39,8 @@ public class GetVersionSameIdOnReplayTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This replay test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetVersionSameIdOnReplay() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionSameIdTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Workflow;
@@ -12,6 +14,7 @@ import io.temporal.workflow.unsafe.WorkflowUnsafe;
 import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class GetVersionSameIdTest extends BaseVersionTest {
 
@@ -32,6 +35,8 @@ public class GetVersionSameIdTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This versioning test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetVersionSameId() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionWorkflowRemoveTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionWorkflowRemoveTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
 import io.temporal.client.WorkflowStub;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestOptions;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
@@ -17,6 +19,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class GetVersionWorkflowRemoveTest extends BaseVersionTest {
 
@@ -39,6 +42,8 @@ public class GetVersionWorkflowRemoveTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This versioning test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetVersionWorkflowRemove() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionWorkflowReplaceCompletelyTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionWorkflowReplaceCompletelyTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
 import io.temporal.client.WorkflowStub;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Workflow;
@@ -14,6 +16,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +44,8 @@ public class GetVersionWorkflowReplaceCompletelyTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This versioning test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetVersionWorkflowReplaceCompletely() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionWorkflowReplaceGetVersionIdTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/GetVersionWorkflowReplaceGetVersionIdTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
 import io.temporal.client.WorkflowStub;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.WorkerOptions;
 import io.temporal.workflow.Workflow;
@@ -14,6 +16,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +44,8 @@ public class GetVersionWorkflowReplaceGetVersionIdTest extends BaseVersionTest {
     super(setVersioningFlag, upsertVersioningSA);
   }
 
+  @CloudTestExclusionNote("This versioning test depends on local test-server execution behavior.")
+  @Category(RequiresLocalServer.class)
   @Test
   public void testGetVersionWorkflowReplaceGetVersionId() {
     assumeFalse("skipping for docker tests", SDKTestWorkflowRule.useExternalService);

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/PreferredVersionProviderRolloutTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/PreferredVersionProviderRolloutTest.java
@@ -7,6 +7,8 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.PreferredVersionProvider;
 import io.temporal.worker.VersionPreference;
@@ -24,7 +26,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class PreferredVersionProviderRolloutTest {
   private static final String CHANGE_ID = "preferred-change";
   private static final AtomicInteger unactivatedProviderCalls = new AtomicInteger();

--- a/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/PreferredVersionProviderTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/versionTests/PreferredVersionProviderTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.internal.sync.ReadOnlyException;
+import io.temporal.testing.CloudTestExclusion.RequiresLocalServer;
+import io.temporal.testing.CloudTestExclusionNote;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.testing.internal.SDKTestWorkflowRule;
 import io.temporal.worker.PreferredVersionProviderInput;
@@ -21,7 +23,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@CloudTestExclusionNote("This test directly creates and controls a local test service.")
+@Category(RequiresLocalServer.class)
 public class PreferredVersionProviderTest {
   private static final String CHANGE_ID = "preferred-change";
   private static final AtomicInteger providerCalls = new AtomicInteger();


### PR DESCRIPTION
## What was changed?

Temporal SDK tests are now eligible for Cloud execution by default. Tests that cannot run in the isolated Cloud namespace use JUnit 4 categories with one of three explicit reasons:
- require a local server
- require Cloud resources that CI does not provision
- require Cloud-specific adaptation

Every exclusion also carries a required `CloudTestExclusionNote` explaining its concrete limitation.

The new `:temporal-sdk:testCloud` task excludes that category hierarchy while leaving the normal `test` task unchanged.

Cloud CI runs this task on the same 16-core runner used by the local SDK test jobs, after provisioning an isolated namespace for the run.

The complementary `:temporal-sdk:listCloudExcludedTests` task lists concrete excluded test names without executing them and accepts `-PcloudTestExclusionReason=<reason>` to inspect one reason category.

Ex:
```
./gradlew :temporal-sdk:listCloudExcludedTests \
      -PcloudTestExclusionReason=NeedsCloudAdaptation
```
to see all tests that need cloud adaptation.

Straightforward compatibility issues were fixed rather than excluded: secondary clients use the configured namespace and connection, direct external clients preserve envconfig TLS and authentication, and assertions use the active namespace.

## **Review guide**

Commits are split logically, will be much easier to review that way.

## Why?

A hand-picked Cloud smoke test does not show which parts of the SDK suite are compatible with Temporal Cloud. Runner-native categories keep eligibility beside each test, make exclusions reviewable, and allow new compatible tests to enter the Cloud lane automatically without maintaining a separate allowlist. Machine-enforced notes preserve reviewer context while keeping reason filtering idiomatic to JUnit.

## Breaking changes?

None. The category types and Gradle task are internal test infrastructure, and normal local test execution is unchanged.

## Server PR

None.

## How was this tested?

The Cloud CI job passed the Cloud-eligible suite against its isolated namespace. On the 16-core runner, the test phase completed in 8m09s and the full namespace lifecycle completed in 11m45s.

## Documentation

`CONTRIBUTING.md` documents the Cloud task, excluded-test inventory, default eligibility policy, exclusion reasons, and required note metadata.
