### PR TITLE
Add failure_reason tag to activity execution failed metrics

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/activity/ActivityTaskHandlerImpl.java
@@ -195,11 +195,17 @@ public final class ActivityTaskHandlerImpl implements ActivityTaskHandler {
         metricsScope.tagged(
             ImmutableMap.of(MetricsTag.EXCEPTION, exception.getClass().getSimpleName()));
     if (!FailureUtils.isBenignApplicationFailure(exception)) {
+      // The deprecated counter keeps its original tags so that dashboards still reading it are
+      // not split into a new series.
+      Scope failureScope =
+          ms.tagged(
+              ImmutableMap.of(
+                  MetricsTag.TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_ACTIVITY_ERROR));
       if (isLocalActivity) {
-        ms.counter(MetricsType.LOCAL_ACTIVITY_EXEC_FAILED_COUNTER).inc(1);
+        failureScope.counter(MetricsType.LOCAL_ACTIVITY_EXEC_FAILED_COUNTER).inc(1);
         ms.counter(MetricsType.LOCAL_ACTIVITY_FAILED_COUNTER).inc(1);
       } else {
-        ms.counter(MetricsType.ACTIVITY_EXEC_FAILED_COUNTER).inc(1);
+        failureScope.counter(MetricsType.ACTIVITY_EXEC_FAILED_COUNTER).inc(1);
       }
     }
     Failure failure = dataConverter.exceptionToFailure(exception);

--- a/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/worker/ActivityFailedMetricsTests.java
@@ -137,6 +137,7 @@ public class ActivityFailedMetricsTests {
     tags.put("namespace", "UnitTest");
     tags.put("activity_type", "Execute");
     tags.put("exception", "ApplicationFailure");
+    tags.put("failure_reason", "ActivityError");
     tags.put("worker_type", workerType);
     tags.put("workflow_type", workflowType);
     return tags;

--- a/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/MetricsTest.java
@@ -439,6 +439,7 @@ public class MetricsTest {
             .putAll(TAGS_ACTIVITY_WORKER)
             .put(MetricsTag.ACTIVITY_TYPE, "ThrowIO")
             .put(MetricsTag.EXCEPTION, "IOException")
+            .put(MetricsTag.TASK_FAILURE_TYPE, MetricsTag.TASK_FAILURE_VALUE_ACTIVITY_ERROR)
             .put(MetricsTag.WORKFLOW_TYPE, "NoArgsWorkflow")
             .build();
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -27,6 +27,7 @@ public class MetricsTag {
   public static final String TASK_FAILURE_VALUE_NON_DETERMINISM_ERROR = "NonDeterminismError";
   public static final String TASK_FAILURE_VALUE_GRPC_MESSAGE_TOO_LARGE = "GrpcMessageTooLarge";
   public static final String TASK_FAILURE_VALUE_WORKFLOW_ERROR = "WorkflowError";
+  public static final String TASK_FAILURE_VALUE_ACTIVITY_ERROR = "ActivityError";
   public static final String TASK_FAILURE_VALUE_OPERATION_FAILED = "operation_failed";
   public static final String TASK_FAILURE_VALUE_OPERATION_CANCELED = "operation_canceled";
   public static final String TASK_FAILURE_VALUE_HANDLER_ERROR_BAD_REQUEST =


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

The activity and local activity execution failure counters now carry failure_reason, matching workflow and Nexus task failures. `ActivityError` is the only value Java can currently produce; more specific failure reasons will be added when the SDK enables those features and can detect those conditions.

## Why?

Better metrics observability into known activity failure reasons.

## Checklist
<!--- add/delete as needed --->

1. Closes #3035

2. How was this tested: Updated tests

3. Any docs updates needed? Yes
