### PR TITLE
Remove Experimental annotation for user metadata from a few APIs

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/workflow/MutableSideEffectOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/MutableSideEffectOptions.java
@@ -1,6 +1,5 @@
 package io.temporal.workflow;
 
-import io.temporal.common.Experimental;
 import java.util.Objects;
 
 /** MutableSideEffectOptions is used to specify options for a side effect. */
@@ -42,7 +41,6 @@ public class MutableSideEffectOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public MutableSideEffectOptions.Builder setSummary(String summary) {
       this.summary = summary;
       return this;

--- a/temporal-sdk/src/main/java/io/temporal/workflow/NexusOperationOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/NexusOperationOptions.java
@@ -106,7 +106,6 @@ public final class NexusOperationOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public NexusOperationOptions.Builder setSummary(String summary) {
       this.summary = summary;
       return this;
@@ -199,7 +198,6 @@ public final class NexusOperationOptions {
     return cancellationType;
   }
 
-  @Experimental
   public String getSummary() {
     return summary;
   }

--- a/temporal-sdk/src/main/java/io/temporal/workflow/SideEffectOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/SideEffectOptions.java
@@ -1,6 +1,5 @@
 package io.temporal.workflow;
 
-import io.temporal.common.Experimental;
 import java.util.Objects;
 
 /** SideEffectOptions is used to specify options for a side effect. */
@@ -42,7 +41,6 @@ public class SideEffectOptions {
      *
      * <p>Default is none/empty.
      */
-    @Experimental
     public SideEffectOptions.Builder setSummary(String summary) {
       this.summary = summary;
       return this;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove Experimental annotation for user metadata from a few APIs

## Why?
Feature is GA

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only GA promotion with no logic or signature changes.
> 
> **Overview**
> Promotes the **UI/CLI summary** user-metadata APIs from experimental to stable by removing `@Experimental` on `setSummary` in `SideEffectOptions`, `MutableSideEffectOptions`, and `NexusOperationOptions`, and on `NexusOperationOptions.getSummary()`.
> 
> Unused `Experimental` imports are dropped where they are no longer needed. **No runtime or API signature changes**—only the stability annotation on these summary accessors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cbdda785161ab18292c6d4d03d3c3ae654d054e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->