### PR TITLE
Default Nexus client activity task queue to the worker task queue

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/StartActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/StartActivityOptions.java
@@ -31,7 +31,7 @@ public final class StartActivityOptions {
 
   public static final class Builder {
     private String id;
-    private String taskQueue;
+    private @Nullable String taskQueue;
     private @Nullable Duration scheduleToCloseTimeout;
     private @Nullable Duration scheduleToStartTimeout;
     private @Nullable Duration startToCloseTimeout;
@@ -75,8 +75,12 @@ public final class StartActivityOptions {
       return this;
     }
 
-    /** Required. The task queue that workers will poll for this activity. */
-    public Builder setTaskQueue(String taskQueue) {
+    /**
+     * The task queue that workers will poll for this activity. Required when starting through an
+     * {@link ActivityClient}. When starting through a Temporal Nexus client, this defaults to the
+     * current worker's task queue.
+     */
+    public Builder setTaskQueue(@Nullable String taskQueue) {
       this.taskQueue = taskQueue;
       return this;
     }
@@ -178,7 +182,7 @@ public final class StartActivityOptions {
     public StartActivityOptions build() {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be null or empty");
       Preconditions.checkArgument(
-          !Strings.isNullOrEmpty(taskQueue), "taskQueue must not be null or empty");
+          taskQueue == null || !taskQueue.isEmpty(), "taskQueue must not be empty");
       Preconditions.checkArgument(
           scheduleToCloseTimeout != null || startToCloseTimeout != null,
           "At least one of scheduleToCloseTimeout or startToCloseTimeout must be set");
@@ -187,7 +191,7 @@ public final class StartActivityOptions {
   }
 
   private final String id;
-  private final String taskQueue;
+  private final @Nullable String taskQueue;
   private final @Nullable Duration scheduleToCloseTimeout;
   private final @Nullable Duration scheduleToStartTimeout;
   private final @Nullable Duration startToCloseTimeout;
@@ -226,7 +230,7 @@ public final class StartActivityOptions {
     return id;
   }
 
-  public String getTaskQueue() {
+  public @Nullable String getTaskQueue() {
     return taskQueue;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootActivityClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootActivityClientInvoker.java
@@ -55,6 +55,9 @@ public class RootActivityClientInvoker implements ActivityClientCallsInterceptor
   @Override
   public StartActivityOutput startActivity(StartActivityInput input) {
     StartActivityOptions options = input.getOptions();
+    if (Strings.isNullOrEmpty(options.getTaskQueue())) {
+      throw new IllegalArgumentException("taskQueue must not be null or empty");
+    }
     DataConverter dc = clientOptions.getDataConverter();
     InternalNexusOperationContext nexusContext =
         CurrentNexusOperationContext.isNexusContext() ? CurrentNexusOperationContext.get() : null;

--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusStartActivityHelper.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusStartActivityHelper.java
@@ -23,7 +23,8 @@ public class NexusStartActivityHelper {
    * @param details the operation start details containing requestId, callback, links
    * @param activityType the activity type name
    * @param args the activity arguments
-   * @param options the activity scheduling options (must include task queue, ID)
+   * @param options the activity scheduling options; the task queue defaults to the current worker's
+   *     task queue
    * @param header the propagated header
    * @param invoker function that starts the activity given a {@link NexusStartActivityRequest}
    * @return the {@link NexusStartActivityResponse} containing the activity ID and operation token
@@ -37,6 +38,9 @@ public class NexusStartActivityHelper {
       Header header,
       Function<NexusStartActivityRequest, NexusStartActivityResponse> invoker) {
     InternalNexusOperationContext nexusCtx = CurrentNexusOperationContext.get();
+    if (options.getTaskQueue() == null) {
+      options = options.toBuilder().setTaskQueue(nexusCtx.getTaskQueue()).build();
+    }
 
     NexusStartActivityRequest nexusRequest =
         new NexusStartActivityRequest(

--- a/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
+++ b/temporal-sdk/src/main/java/io/temporal/nexus/TemporalNexusClient.java
@@ -1379,7 +1379,7 @@ public interface TemporalNexusClient {
    *
    * @param activityInterface the activity interface class
    * @param activityMethod unbound method reference to the activity method
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <R> the activity return type
    * @return an async {@link TemporalOperationResult} with the activity-execution operation token
@@ -1395,7 +1395,7 @@ public interface TemporalNexusClient {
    * @param activityInterface the activity interface class
    * @param activityMethod unbound method reference to the activity method
    * @param arg1 first activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <R> the activity return type
@@ -1414,7 +1414,7 @@ public interface TemporalNexusClient {
    * @param activityMethod unbound method reference to the activity method
    * @param arg1 first activity argument
    * @param arg2 second activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1436,7 +1436,7 @@ public interface TemporalNexusClient {
    * @param arg1 first activity argument
    * @param arg2 second activity argument
    * @param arg3 third activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1461,7 +1461,7 @@ public interface TemporalNexusClient {
    * @param arg2 second activity argument
    * @param arg3 third activity argument
    * @param arg4 fourth activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1489,7 +1489,7 @@ public interface TemporalNexusClient {
    * @param arg3 third activity argument
    * @param arg4 fourth activity argument
    * @param arg5 fifth activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1520,7 +1520,7 @@ public interface TemporalNexusClient {
    * @param arg4 fourth activity argument
    * @param arg5 fifth activity argument
    * @param arg6 sixth activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1547,7 +1547,7 @@ public interface TemporalNexusClient {
    *
    * @param activityInterface the activity interface class
    * @param activityMethod unbound method reference to the activity method
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @return an async {@link TemporalOperationResult} with the activity-execution operation token
    */
@@ -1560,7 +1560,7 @@ public interface TemporalNexusClient {
    * @param activityInterface the activity interface class
    * @param activityMethod unbound method reference to the activity method
    * @param arg1 first activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @return an async {@link TemporalOperationResult} with the activity-execution operation token
@@ -1578,7 +1578,7 @@ public interface TemporalNexusClient {
    * @param activityMethod unbound method reference to the activity method
    * @param arg1 first activity argument
    * @param arg2 second activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1599,7 +1599,7 @@ public interface TemporalNexusClient {
    * @param arg1 first activity argument
    * @param arg2 second activity argument
    * @param arg3 third activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1623,7 +1623,7 @@ public interface TemporalNexusClient {
    * @param arg2 second activity argument
    * @param arg3 third activity argument
    * @param arg4 fourth activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1650,7 +1650,7 @@ public interface TemporalNexusClient {
    * @param arg3 third activity argument
    * @param arg4 fourth activity argument
    * @param arg5 fifth activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1680,7 +1680,7 @@ public interface TemporalNexusClient {
    * @param arg4 fourth activity argument
    * @param arg5 fifth activity argument
    * @param arg6 sixth activity argument
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param <I> the activity interface type
    * @param <A1> the type of the first activity argument
    * @param <A2> the type of the second activity argument
@@ -1712,7 +1712,7 @@ public interface TemporalNexusClient {
    *
    * @param activityType the activity type name string
    * @param resultClass the expected result class
-   * @param options activity start options (must include taskQueue)
+   * @param options activity start options; taskQueue defaults to the current worker task queue
    * @param args activity arguments
    * @param <R> the activity return type
    * @return an async {@link TemporalOperationResult} with the activity-execution operation token

--- a/temporal-sdk/src/test/java/io/temporal/client/StartActivityOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/StartActivityOptionsTest.java
@@ -19,10 +19,22 @@ public class StartActivityOptionsTest {
         .build();
   }
 
+  @Test
+  public void testMissingTaskQueueAllowed() {
+    StartActivityOptions options =
+        StartActivityOptions.newBuilder()
+            .setId("id")
+            .setStartToCloseTimeout(Duration.ofSeconds(10))
+            .build();
+
+    assertNull(options.getTaskQueue());
+  }
+
   @Test(expected = IllegalArgumentException.class)
-  public void testMissingTaskQueueFails() {
+  public void testEmptyTaskQueueFails() {
     StartActivityOptions.newBuilder()
         .setId("id")
+        .setTaskQueue("")
         .setStartToCloseTimeout(Duration.ofSeconds(10))
         .build();
   }

--- a/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusClientTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/nexus/NexusClientTest.java
@@ -391,7 +391,6 @@ public class NexusClientTest {
                   activityId,
                   StartActivityOptions.newBuilder()
                       .setId(activityId)
-                      .setTaskQueue(testWorkflowRule.getTaskQueue())
                       .setScheduleToCloseTimeout(Duration.ofSeconds(30))
                       .build()));
     }

--- a/temporal-sdk/src/test/java/io/temporal/internal/client/RootActivityClientInvokerTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/client/RootActivityClientInvokerTest.java
@@ -148,6 +148,25 @@ public class RootActivityClientInvokerTest {
     Assert.assertTrue(nexusContext.getResponseLinks().isEmpty());
   }
 
+  @Test
+  public void missingTaskQueueFailsAtInvocation() {
+    StartActivityOptions options =
+        StartActivityOptions.newBuilder()
+            .setId("activity-id")
+            .setStartToCloseTimeout(Duration.ofSeconds(10))
+            .build();
+
+    IllegalArgumentException exception =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                invoker.startActivity(
+                    new StartActivityInput(
+                        "TestActivity", Collections.emptyList(), options, Header.empty())));
+
+    Assert.assertEquals("taskQueue must not be null or empty", exception.getMessage());
+  }
+
   private static StartActivityInput newStartActivityInput() {
     StartActivityOptions options =
         StartActivityOptions.newBuilder()

--- a/temporal-sdk/src/test/java/io/temporal/nexus/TemporalNexusClientImplTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/nexus/TemporalNexusClientImplTest.java
@@ -178,7 +178,6 @@ public class TemporalNexusClientImplTest {
     StartActivityOptions options =
         StartActivityOptions.newBuilder()
             .setId("act-1")
-            .setTaskQueue(TASK_QUEUE)
             .setStartToCloseTimeout(Duration.ofSeconds(10))
             .build();
 
@@ -195,7 +194,6 @@ public class TemporalNexusClientImplTest {
                     TestActivity::doSomething,
                     StartActivityOptions.newBuilder()
                         .setId("act-2")
-                        .setTaskQueue(TASK_QUEUE)
                         .setStartToCloseTimeout(Duration.ofSeconds(10))
                         .build()));
 
@@ -258,7 +256,6 @@ public class TemporalNexusClientImplTest {
                     TestActivity::doSomething,
                     StartActivityOptions.newBuilder()
                         .setId("act-mixed-1")
-                        .setTaskQueue(TASK_QUEUE)
                         .setStartToCloseTimeout(Duration.ofSeconds(10))
                         .build()));
 
@@ -272,7 +269,6 @@ public class TemporalNexusClientImplTest {
     StartActivityOptions actOptions =
         StartActivityOptions.newBuilder()
             .setId("act-mixed-2")
-            .setTaskQueue(TASK_QUEUE)
             .setStartToCloseTimeout(Duration.ofSeconds(10))
             .build();
 

--- a/temporal-sdk/src/test/java/io/temporal/nexus/TemporalNexusClientImplTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/nexus/TemporalNexusClientImplTest.java
@@ -145,18 +145,32 @@ public class TemporalNexusClientImplTest {
   // ---------- Activity double-start ----------
 
   @Test
-  public void startActivity_propagatesWorkflowClientContext() {
+  public void startActivity_defaultsTaskQueueAndPropagatesWorkflowClientContext() {
     StartActivityOptions options =
         StartActivityOptions.newBuilder()
             .setId("act-context")
-            .setTaskQueue(TASK_QUEUE)
             .setStartToCloseTimeout(Duration.ofSeconds(10))
             .build();
 
     client.startActivity(TestActivity.class, TestActivity::doSomething, options);
 
     Assert.assertNotNull(activityInput.get());
+    Assert.assertEquals(TASK_QUEUE, activityInput.get().getOptions().getTaskQueue());
     Assert.assertTrue(activityInput.get().getHeader().getValues().containsKey("propagated-key"));
+  }
+
+  @Test
+  public void startActivity_preservesExplicitTaskQueue() {
+    StartActivityOptions options =
+        StartActivityOptions.newBuilder()
+            .setId("act-explicit-task-queue")
+            .setTaskQueue("explicit-task-queue")
+            .setStartToCloseTimeout(Duration.ofSeconds(10))
+            .build();
+
+    client.startActivity(TestActivity.class, TestActivity::doSomething, options);
+
+    Assert.assertEquals("explicit-task-queue", activityInput.get().getOptions().getTaskQueue());
   }
 
   @Test

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleFailOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleFailOnConflictTest.java
@@ -133,7 +133,6 @@ public class ActivityHandleFailOnConflictTest {
                 activityId,
                 StartActivityOptions.newBuilder()
                     .setId(activityId)
-                    .setTaskQueue(testWorkflowRule.getTaskQueue())
                     .setScheduleToCloseTimeout(Duration.ofMinutes(1))
                     .setIdConflictPolicy(ActivityIdConflictPolicy.ACTIVITY_ID_CONFLICT_POLICY_FAIL)
                     .build());

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleUseExistingOnConflictTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/ActivityHandleUseExistingOnConflictTest.java
@@ -159,7 +159,6 @@ public class ActivityHandleUseExistingOnConflictTest {
                   activityId,
                   StartActivityOptions.newBuilder()
                       .setId(activityId)
-                      .setTaskQueue(testWorkflowRule.getTaskQueue())
                       .setScheduleToCloseTimeout(Duration.ofMinutes(1))
                       .setIdConflictPolicy(
                           ActivityIdConflictPolicy.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING)

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncActivityOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/AsyncActivityOperationTest.java
@@ -95,7 +95,6 @@ public class AsyncActivityOperationTest {
                   input,
                   StartActivityOptions.newBuilder()
                       .setId("act-" + context.getRequestId())
-                      .setTaskQueue(testWorkflowRule.getTaskQueue())
                       .setStartToCloseTimeout(Duration.ofSeconds(10))
                       .build()));
     }

--- a/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelActivityAsyncOperationTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/nexus/CancelActivityAsyncOperationTest.java
@@ -191,7 +191,6 @@ public class CancelActivityAsyncOperationTest extends BaseNexusTest {
                   input,
                   StartActivityOptions.newBuilder()
                       .setId("act-" + context.getRequestId())
-                      .setTaskQueue(input)
                       .setStartToCloseTimeout(Duration.ofSeconds(60))
                       .setHeartbeatTimeout(Duration.ofSeconds(2))
                       .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
@@ -246,7 +245,6 @@ public class CancelActivityAsyncOperationTest extends BaseNexusTest {
                   input,
                   StartActivityOptions.newBuilder()
                       .setId("act-override-" + context.getRequestId())
-                      .setTaskQueue(input)
                       .setStartToCloseTimeout(Duration.ofSeconds(5))
                       .setHeartbeatTimeout(Duration.ofSeconds(2))
                       .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Previously, the taskQueue field was required to be defined in StartActivityOptions for TemporalNexusClient.startActivity.

This PR allows that field to be null, and uses the Workers taskQueue when it is not defined.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Removed the taskQueue field from the end to end test, and ran it locally.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
