### PR TITLE
Report missing activity timeout as BAD_REQUEST inside a Nexus operation handler

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/nexus/NexusTaskHandlerImpl.java
@@ -200,6 +200,9 @@ public class NexusTaskHandlerImpl implements NexusTaskHandler {
       }
       throw new HandlerException(HandlerException.ErrorType.BAD_REQUEST, failure);
     }
+    if (failure instanceof IllegalArgumentException) {
+      throw new HandlerException(HandlerException.ErrorType.BAD_REQUEST, failure);
+    }
     if (failure instanceof ApplicationFailure) {
       if (((ApplicationFailure) failure).isNonRetryable()) {
         throw new HandlerException(

--- a/temporal-sdk/src/test/java/io/temporal/internal/nexus/NexusTaskHandlerImplTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/nexus/NexusTaskHandlerImplTest.java
@@ -163,6 +163,34 @@ public class NexusTaskHandlerImplTest {
   }
 
   @Test
+  public void startTaskHandlerMissingBothActivityTimeoutOptions() throws TimeoutException {
+    WorkflowClient client = mock(WorkflowClient.class);
+    NexusTaskHandlerImpl nexusTaskHandlerImpl =
+        new NexusTaskHandlerImpl(
+            client, NAMESPACE, TASK_QUEUE, dataConverter, new WorkerInterceptor[] {});
+    nexusTaskHandlerImpl.registerNexusServiceImplementations(
+        new Object[] {new ThrowingIllegalArgumentServiceImpl()});
+    nexusTaskHandlerImpl.start();
+
+    PollNexusTaskQueueResponse.Builder task =
+        PollNexusTaskQueueResponse.newBuilder()
+            .setRequest(
+                Request.newBuilder()
+                    .setStartOperation(
+                        StartOperationRequest.newBuilder()
+                            .setOperation("operation")
+                            .setService("TestNexusService1")
+                            .setPayload(dataConverter.toPayload("input").get())
+                            .build()));
+
+    NexusTaskHandler.Result result =
+        nexusTaskHandlerImpl.handle(new NexusTask(task, null, null), metricsScope);
+    HandlerException e = result.getHandlerException();
+    Assert.assertNotNull(e);
+    Assert.assertEquals(HandlerException.ErrorType.BAD_REQUEST, e.getErrorType());
+  }
+
+  @Test
   public void startAsyncSyncOperation() throws TimeoutException {
     WorkflowClient client = mock(WorkflowClient.class);
     NexusTaskHandlerImpl nexusTaskHandlerImpl =
@@ -401,6 +429,18 @@ public class NexusTaskHandlerImplTest {
                     .build();
             CurrentNexusOperationContext.get().addResponseLink(responseLink);
             throw OperationException.failed("boom after capturing a response link");
+          });
+    }
+  }
+
+  @ServiceImpl(service = TestNexusServices.TestNexusService1.class)
+  public class ThrowingIllegalArgumentServiceImpl {
+    @OperationImpl
+    public OperationHandler<String, String> operation() {
+      return OperationHandler.sync(
+          (ctx, details, input) -> {
+            throw new IllegalArgumentException(
+                "at least one of StartToCloseTimeout or ScheduleToCloseTimeout is required");
           });
     }
   }


### PR DESCRIPTION
## What was changed
`NexusTaskHandlerImpl.convertKnownFailures` now maps any `IllegalArgumentException` thrown by
Nexus operation handler code to `HandlerException(BAD_REQUEST)`.

## Why?
`StartActivityOptions.Builder.build()` throws a plain `IllegalArgumentException` when neither
`scheduleToCloseTimeout` nor `startToCloseTimeout` is set. Thrown from inside a Nexus operation
handler, that isn't a recognized Nexus error type, so it fell through to the generic
`HandlerException(INTERNAL)` catch-all in `NexusTaskHandlerImpl.handle()` — the caller then
retries until the operation's schedule-to-close timeout expires, instead of failing fast.

## Checklist

1. Closes: A gap found during Nexus SAA Test Plan execution for Temporal Java SDK

2. How was this tested:
Added `NexusTaskHandlerImplTest.startTaskHandlerMissingBothActivityTimeoutOptions`, which registers
a handler that throws `IllegalArgumentException`, and asserts the response comes back as `HandlerException(BAD_REQUEST)`.

3. Any docs updates needed?
No.
