### PR TITLE
Document root workflow namespace omission

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/WorkflowExecutionMetadata.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/WorkflowExecutionMetadata.java
@@ -80,6 +80,12 @@ public class WorkflowExecutionMetadata {
     return info.hasParentExecution() ? info.getParentExecution() : null;
   }
 
+  /**
+   * Returns the root Workflow execution.
+   *
+   * <p>Its namespace is not retained and may differ from this Workflow's namespace for
+   * cross-namespace child Workflows. Track it separately if needed.
+   */
   @Nullable
   public WorkflowExecution getRootExecution() {
     return info.hasRootExecution() ? info.getRootExecution() : null;

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -124,6 +124,8 @@ public interface WorkflowInfo {
    * @return Workflow ID of the root Workflow
    *     <p>Note: On server versions prior to v1.27.0, this method will be empty. Otherwise, it will
    *     be empty if the workflow is its own root.
+   *     <p>The root Workflow's namespace is not retained and may differ from this Workflow's
+   *     namespace for cross-namespace child Workflows. Track it separately if needed.
    */
   Optional<String> getRootWorkflowId();
 
@@ -131,6 +133,8 @@ public interface WorkflowInfo {
    * @return Run ID of the root Workflow
    *     <p>Note: On server versions prior to v1.27.0, this method will be empty. Otherwise, it will
    *     be empty if the workflow is its own root.
+   *     <p>The root Workflow's namespace is not retained and may differ from this Workflow's
+   *     namespace for cross-namespace child Workflows. Track it separately if needed.
    */
   Optional<String> getRootRunId();
 


### PR DESCRIPTION
## What was changed
Document that root workflow execution information omits its namespace. The root namespace may differ for cross-namespace child workflows and must be tracked separately.

## Why?
Completes the documentation requirement from temporalio/features#605.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Javadoc updates with no code or behavioral changes.
> 
> **Overview**
> Adds Javadoc clarifying that **root workflow** identity exposed by the Java SDK does **not** include the root’s namespace, which may differ from the current workflow in **cross-namespace child** scenarios.
> 
> The notes are added on `WorkflowExecutionMetadata.getRootExecution()` and on `WorkflowInfo.getRootWorkflowId()` / `getRootRunId()`. No runtime or API behavior changes—documentation only, aligned with temporalio/features#605.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60dab081b16708e7225f3068d51d52482f945fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->