### PR TITLE
Bumping test CLI version

### DIFF
--- a/temporal-sdk/src/test/java/io/temporal/client/functional/StandaloneActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/StandaloneActivityTest.java
@@ -15,8 +15,11 @@ import io.temporal.api.activity.v1.ActivityExecutionInfo;
 import io.temporal.api.enums.v1.ActivityExecutionStatus;
 import io.temporal.api.enums.v1.ActivityIdConflictPolicy;
 import io.temporal.api.enums.v1.ActivityIdReusePolicy;
+import io.temporal.api.workflowservice.v1.DescribeActivityExecutionRequest;
+import io.temporal.api.workflowservice.v1.DescribeActivityExecutionResponse;
 import io.temporal.client.*;
 import io.temporal.common.RetryOptions;
+import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptor.*;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptorBase;
@@ -854,7 +857,26 @@ public class StandaloneActivityTest {
       assertEventually(
           Duration.ofSeconds(60),
           () -> {
-            ActivityExecutionDescription desc = handle.describe();
+            // last_failure carries a payload, so the server returns it only when the
+            // DescribeActivityExecution request opts in via include_last_failure. handle.describe()
+            // has no way to request it yet (sdk-java PR #3013 adds DescribeActivityOptions), so the
+            // request is issued directly here and wrapped in the same description type the handle
+            // would return, keeping the failure-conversion assertions below intact.
+            DescribeActivityExecutionResponse raw =
+                testWorkflowRule
+                    .getWorkflowServiceStubs()
+                    .blockingStub()
+                    .describeActivityExecution(
+                        DescribeActivityExecutionRequest.newBuilder()
+                            .setNamespace(SDKTestWorkflowRule.NAMESPACE)
+                            .setActivityId(handle.getActivityId())
+                            .setIncludeLastFailure(true)
+                            .build());
+            ActivityExecutionDescription desc =
+                new ActivityExecutionDescription(
+                    raw.getInfo(),
+                    DefaultDataConverter.STANDARD_INSTANCE,
+                    SDKTestWorkflowRule.NAMESPACE);
             Exception lastFailure = desc.getLastFailure();
             assertNotNull("last_failure should be set after a failed attempt", lastFailure);
             assertThat(lastFailure, instanceOf(ApplicationFailure.class));

--- a/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/activityTests/cancellation/WorkflowClosedRunningActivityTest.java
@@ -105,9 +105,13 @@ public class WorkflowClosedRunningActivityTest {
       while (true) {
         try {
           Activity.getExecutionContext().heartbeat(System.currentTimeMillis() - start);
-        } catch (ActivityNotExistsException e) {
-          // in case of the whole workflow gets cancelled, we are getting
-          // ActivityNotExistsException
+        } catch (ActivityCompletionException e) {
+          // The parent type covers both ways the server reports that the workflow has closed. Older
+          // servers fail the next heartbeat with NOT_FOUND, surfacing as
+          // ActivityNotExistsException.
+          // With system.enableCancelActivityWorkerCommand and frontend.workerCommandsEnabled (both
+          // set by this repository's dev server profile) the server instead pushes a CancelActivity
+          // worker command, which surfaces as ActivityCanceledException.
           activityCancelled.signal();
         }
 

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/devserver/SdkJavaTestServerProfile.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/devserver/SdkJavaTestServerProfile.java
@@ -13,7 +13,7 @@ public final class SdkJavaTestServerProfile {
   public static final String ACTIVE_PROPERTY = "io.temporal.testing.internal.devServerProfile";
 
   // This is intentionally the sole Temporal CLI version used by sdk-java repository tests.
-  private static final String TEST_CLI_VERSION = "1.7.4-standalone-nexus-operations";
+  private static final String TEST_CLI_VERSION = "1.8.3-server-1.32.0-162.0";
   private static final String TEST_NAMESPACE = "UnitTest";
   private static final String DATABASE_FILENAME = "temporal.sqlite";
 


### PR DESCRIPTION
This bumps the test CLI server version. That caused some failures in tests, so this is to fix the tests. Full comments left in to ensure that I am fixing the tests and not covering up an unwanted change.

Some of the changes needed are in https://github.com/temporalio/sdk-java/pull/3013 - those aren't duplicated here, but maybe they should be?

The CLI server bump is from 1.7.4-standalone-nexus-operations to 1.8.3-server-1.32.0-162.0. Note that doing the same bump in the sample repo makes some of the sample code no longer run. 

--Sample code needs an extra dynamic flag, nexusoperation.enableStandalone. That is why it failed.