### PR TITLE
💥 Rename Standalone Activity StaticSummary to Summary

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/client/ActivityExecutionDescription.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/ActivityExecutionDescription.java
@@ -355,7 +355,7 @@ public final class ActivityExecutionDescription extends ActivityExecutionMetadat
    * the result if called multiple times.
    */
   @Nullable
-  public String getStaticSummary() {
+  public String getSummary() {
     if (!response.getInfo().getUserMetadata().hasSummary()) {
       return null;
     }

--- a/temporal-sdk/src/main/java/io/temporal/client/StartActivityOptions.java
+++ b/temporal-sdk/src/main/java/io/temporal/client/StartActivityOptions.java
@@ -42,7 +42,7 @@ public final class StartActivityOptions {
         ActivityIdConflictPolicy.ACTIVITY_ID_CONFLICT_POLICY_UNSPECIFIED;
     private @Nullable RetryOptions retryOptions;
     private @Nullable SearchAttributes typedSearchAttributes;
-    private @Nullable String staticSummary;
+    private @Nullable String summary;
     private @Nullable String staticDetails;
     private @Nullable Priority priority;
     private @Nullable Duration startDelay;
@@ -63,7 +63,7 @@ public final class StartActivityOptions {
       this.idConflictPolicy = options.idConflictPolicy;
       this.retryOptions = options.retryOptions;
       this.typedSearchAttributes = options.typedSearchAttributes;
-      this.staticSummary = options.staticSummary;
+      this.summary = options.summary;
       this.staticDetails = options.staticDetails;
       this.priority = options.priority;
       this.startDelay = options.startDelay;
@@ -148,8 +148,8 @@ public final class StartActivityOptions {
     }
 
     /** Short static summary for UI display; encoded as a payload in UserMetadata. */
-    public Builder setStaticSummary(String staticSummary) {
-      this.staticSummary = staticSummary;
+    public Builder setSummary(String summary) {
+      this.summary = summary;
       return this;
     }
 
@@ -200,7 +200,7 @@ public final class StartActivityOptions {
   private final ActivityIdConflictPolicy idConflictPolicy;
   private final @Nullable RetryOptions retryOptions;
   private final @Nullable SearchAttributes typedSearchAttributes;
-  private final @Nullable String staticSummary;
+  private final @Nullable String summary;
   private final @Nullable String staticDetails;
   private final @Nullable Priority priority;
   private final @Nullable Duration startDelay;
@@ -216,7 +216,7 @@ public final class StartActivityOptions {
     this.idConflictPolicy = builder.idConflictPolicy;
     this.retryOptions = builder.retryOptions;
     this.typedSearchAttributes = builder.typedSearchAttributes;
-    this.staticSummary = builder.staticSummary;
+    this.summary = builder.summary;
     this.staticDetails = builder.staticDetails;
     this.priority = builder.priority;
     this.startDelay = builder.startDelay;
@@ -273,8 +273,8 @@ public final class StartActivityOptions {
   }
 
   @Nullable
-  public String getStaticSummary() {
-    return staticSummary;
+  public String getSummary() {
+    return summary;
   }
 
   @Nullable
@@ -307,7 +307,7 @@ public final class StartActivityOptions {
         && idConflictPolicy == that.idConflictPolicy
         && Objects.equals(retryOptions, that.retryOptions)
         && Objects.equals(typedSearchAttributes, that.typedSearchAttributes)
-        && Objects.equals(staticSummary, that.staticSummary)
+        && Objects.equals(summary, that.summary)
         && Objects.equals(staticDetails, that.staticDetails)
         && Objects.equals(priority, that.priority)
         && Objects.equals(startDelay, that.startDelay);
@@ -326,7 +326,7 @@ public final class StartActivityOptions {
         idConflictPolicy,
         retryOptions,
         typedSearchAttributes,
-        staticSummary,
+        summary,
         staticDetails,
         priority,
         startDelay);
@@ -356,7 +356,7 @@ public final class StartActivityOptions {
         + ", typedSearchAttributes="
         + typedSearchAttributes
         + ", staticSummary='"
-        + staticSummary
+        + summary
         + "', staticDetails='"
         + staticDetails
         + "', priority="

--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootActivityClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootActivityClientInvoker.java
@@ -109,9 +109,9 @@ public class RootActivityClientInvoker implements ActivityClientCallsInterceptor
       request.setSearchAttributes(
           SearchAttributesUtil.encodeTyped(options.getTypedSearchAttributes()));
     }
-    if (options.getStaticSummary() != null || options.getStaticDetails() != null) {
+    if (options.getSummary() != null || options.getStaticDetails() != null) {
       UserMetadata userMetadata =
-          makeUserMetaData(options.getStaticSummary(), options.getStaticDetails(), dc);
+          makeUserMetaData(options.getSummary(), options.getStaticDetails(), dc);
       if (userMetadata != null) {
         request.setUserMetadata(userMetadata);
       }

--- a/temporal-sdk/src/test/java/io/temporal/client/StartActivityOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/StartActivityOptionsTest.java
@@ -90,7 +90,7 @@ public class StartActivityOptionsTest {
             .setIdReusePolicy(ActivityIdReusePolicy.ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE)
             .setIdConflictPolicy(ActivityIdConflictPolicy.ACTIVITY_ID_CONFLICT_POLICY_FAIL)
             .setRetryOptions(retry)
-            .setStaticSummary("summary")
+            .setSummary("summary")
             .setStaticDetails("details")
             .setPriority(priority)
             .setStartDelay(Duration.ofSeconds(7))
@@ -107,7 +107,7 @@ public class StartActivityOptionsTest {
         ActivityIdReusePolicy.ACTIVITY_ID_REUSE_POLICY_REJECT_DUPLICATE, copy.getIdReusePolicy());
     assertEquals(
         ActivityIdConflictPolicy.ACTIVITY_ID_CONFLICT_POLICY_FAIL, copy.getIdConflictPolicy());
-    assertEquals("summary", copy.getStaticSummary());
+    assertEquals("summary", copy.getSummary());
     assertEquals("details", copy.getStaticDetails());
     assertEquals(priority, copy.getPriority());
     assertEquals(Duration.ofSeconds(7), copy.getStartDelay());

--- a/temporal-sdk/src/test/java/io/temporal/client/functional/StandaloneActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/client/functional/StandaloneActivityTest.java
@@ -18,7 +18,6 @@ import io.temporal.api.enums.v1.ActivityIdReusePolicy;
 import io.temporal.client.*;
 import io.temporal.common.RetryOptions;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptor;
-import io.temporal.common.interceptors.ActivityClientCallsInterceptor.*;
 import io.temporal.common.interceptors.ActivityClientCallsInterceptorBase;
 import io.temporal.common.interceptors.ActivityClientInterceptorBase;
 import io.temporal.failure.ApplicationFailure;
@@ -417,7 +416,7 @@ public class StandaloneActivityTest {
             .setId(uniqueId())
             .setTaskQueue(testWorkflowRule.getTaskQueue())
             .setScheduleToCloseTimeout(Duration.ofMinutes(5))
-            .setStaticSummary("Test summary")
+            .setSummary("Test summary")
             .setStaticDetails("Test details\nLine 2")
             .build();
 
@@ -426,7 +425,7 @@ public class StandaloneActivityTest {
     handle.getResult();
 
     ActivityExecutionDescription desc = handle.describe();
-    assertEquals("Test summary", desc.getStaticSummary());
+    assertEquals("Test summary", desc.getSummary());
     assertEquals("Test details\nLine 2", desc.getStaticDetails());
   }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## **💥 BREAKING CHANGE**

## What was changed
<!-- Describe what has changed in this PR -->
`StartActivityOptions.staticSummary` and its getters and setters, and `ActivityExecutionDescription.getStaticSummary` were renamed to `summary` and `getSummary`.

## Why?
<!-- Tell your future self why have you made these changes -->
Brings Standalone Activity option names in line with Workflow Activity option names.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Tests were updated to use the new method names.