### PR TITLE
:boom: Use ActivitySerializationContext when starting and getting result of Standalone Activity

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/client/RootActivityClientInvoker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/client/RootActivityClientInvoker.java
@@ -32,6 +32,7 @@ import io.temporal.internal.common.SearchAttributesUtil;
 import io.temporal.internal.nexus.CurrentNexusOperationContext;
 import io.temporal.internal.nexus.InternalNexusOperationContext;
 import io.temporal.internal.nexus.NexusOperationMetadata;
+import io.temporal.payload.context.ActivitySerializationContext;
 import io.temporal.serviceclient.StatusUtils;
 import java.lang.reflect.Type;
 import java.util.*;
@@ -63,7 +64,18 @@ public class RootActivityClientInvoker implements ActivityClientCallsInterceptor
     if (Strings.isNullOrEmpty(options.getTaskQueue())) {
       throw new IllegalArgumentException("taskQueue must not be null or empty");
     }
-    DataConverter dc = clientOptions.getDataConverter();
+    DataConverter dc =
+        clientOptions
+            .getDataConverter()
+            .withContext(
+                new ActivitySerializationContext(
+                    clientOptions.getNamespace(),
+                    null,
+                    null,
+                    input.getActivityType(),
+                    options.getTaskQueue(),
+                    false));
+
     InternalNexusOperationContext nexusContext =
         CurrentNexusOperationContext.isNexusContext() ? CurrentNexusOperationContext.get() : null;
     NexusOperationMetadata nexusOperationMetadata =
@@ -185,7 +197,11 @@ public class RootActivityClientInvoker implements ActivityClientCallsInterceptor
   public <R> GetActivityResultOutput<R> getActivityResult(GetActivityResultInput<R> input)
       throws TimeoutException {
     String namespace = clientOptions.getNamespace();
-    DataConverter dc = clientOptions.getDataConverter();
+    DataConverter dc =
+        clientOptions
+            .getDataConverter()
+            .withContext(
+                new ActivitySerializationContext(namespace, null, null, null, null, false));
     Deadline deadline = Deadline.after(input.getTimeout(), input.getTimeoutUnit());
 
     while (true) {

--- a/temporal-sdk/src/main/java/io/temporal/payload/context/ActivitySerializationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/payload/context/ActivitySerializationContext.java
@@ -37,8 +37,8 @@ public class ActivitySerializationContext implements HasWorkflowSerializationCon
     this.namespace = Objects.requireNonNull(namespace);
     this.workflowId = workflowId;
     this.workflowType = workflowType;
-    this.activityType = Objects.requireNonNull(activityType);
-    this.activityTaskQueue = Objects.requireNonNull(activityTaskQueue);
+    this.activityType = activityType;
+    this.activityTaskQueue = activityTaskQueue;
     this.local = local;
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/payload/context/ActivitySerializationContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/payload/context/ActivitySerializationContext.java
@@ -11,26 +11,28 @@ public class ActivitySerializationContext implements HasWorkflowSerializationCon
   private final @Nonnull String namespace;
   private final @Nullable String workflowId;
   private final @Nullable String workflowType;
-  private final @Nonnull String activityType;
-  private final @Nonnull String activityTaskQueue;
+  private final @Nullable String activityType;
+  private final @Nullable String activityTaskQueue;
   private final boolean local;
 
   /**
    * @param namespace the activity's namespace; must not be {@code null}
    * @param workflowId the workflow ID that scheduled the activity, or {@code null} for standalone
-   *     activities (stored as an empty string)
+   *     activities
    * @param workflowType the workflow type that scheduled the activity, or {@code null} for
-   *     standalone activities (stored as an empty string)
-   * @param activityType the activity type name; must not be {@code null}
-   * @param activityTaskQueue the task queue for this activity; must not be {@code null}
+   *     standalone activities
+   * @param activityType the activity type name, or {@code null} if unknown. Activity type is
+   *     unknown when getting a Standalone Activity result.
+   * @param activityTaskQueue the task queue for this activity, or {@code null} if unknown. Task
+   *     queue is unknown when getting a Standalone Activity result.
    * @param local {@code true} if this is a local activity
    */
   public ActivitySerializationContext(
       @Nonnull String namespace,
       @Nullable String workflowId,
       @Nullable String workflowType,
-      @Nonnull String activityType,
-      @Nonnull String activityTaskQueue,
+      @Nullable String activityType,
+      @Nullable String activityTaskQueue,
       boolean local) {
     this.namespace = Objects.requireNonNull(namespace);
     this.workflowId = workflowId;
@@ -67,12 +69,12 @@ public class ActivitySerializationContext implements HasWorkflowSerializationCon
     return workflowType;
   }
 
-  @Nonnull
+  @Nullable
   public String getActivityType() {
     return activityType;
   }
 
-  @Nonnull
+  @Nullable
   public String getActivityTaskQueue() {
     return activityTaskQueue;
   }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## 💥 **BREAKING CHANGE**
`ActivitySerializationContext.activityType` and `activityTaskQueue` are now `@Nullable` because they are unavailable when fetching result.

## What was changed
<!-- Describe what has changed in this PR -->
- Added `ActivitySerializationContext` to `DataConverter` used for de/serialization of payloads in `ActivityClient.start` and `ActivityHandle.getResult`.
- Changed `ActivitySerializationContext.activityType` and `activityTaskQueue` to `@Nullable`.

## Why?
<!-- Tell your future self why have you made these changes -->
Makes it possible to use context-aware data converters with Standalone Activities.