### PR TITLE
Include inherited fields in service stub options toString

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/CloudServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/CloudServiceStubsOptions.java
@@ -58,6 +58,11 @@ public final class CloudServiceStubsOptions extends ServiceStubsOptions {
     return Objects.hash(super.hashCode(), version);
   }
 
+  @Override
+  public String toString() {
+    return "CloudServiceStubsOptions{" + toStringFields() + ", version='" + version + '\'' + '}';
+  }
+
   /** Builder is the builder for ClientOptions. */
   public static class Builder extends ServiceStubsOptions.Builder<Builder> {
     private String version;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/OperatorServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/OperatorServiceStubsOptions.java
@@ -20,6 +20,11 @@ public final class OperatorServiceStubsOptions extends ServiceStubsOptions {
     super(serviceStubsOptions);
   }
 
+  @Override
+  public String toString() {
+    return "OperatorServiceStubsOptions{" + toStringFields() + '}';
+  }
+
   /** Builder is the builder for ClientOptions. */
   public static class Builder extends ServiceStubsOptions.Builder<Builder> {
 

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java
@@ -489,7 +489,7 @@ public final class RpcRetryOptions {
     return "RetryOptions{"
         + "initialInterval="
         + initialInterval
-        + "congestionInitialInterval="
+        + ", congestionInitialInterval="
         + congestionInitialInterval
         + ", backoffCoefficient="
         + backoffCoefficient

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -413,8 +413,16 @@ public class ServiceStubsOptions {
 
   @Override
   public String toString() {
-    return "ServiceStubsOptions{"
-        + "channel="
+    return "ServiceStubsOptions{" + toStringFields() + '}';
+  }
+
+  /**
+   * Renders the fields declared on this class as a comma separated list, without the enclosing type
+   * name or braces. Subclasses use this to include inherited fields in their own {@link
+   * #toString()} instead of dropping them.
+   */
+  String toStringFields() {
+    return "channel="
         + channel
         + ", target='"
         + target
@@ -423,6 +431,8 @@ public class ServiceStubsOptions {
         + channelInitializer
         + ", enableHttps="
         + enableHttps
+        + ", apiKeyProvided="
+        + apiKeyProvided
         + ", sslContext="
         + sslContext
         + ", healthCheckAttemptTimeout="
@@ -454,8 +464,7 @@ public class ServiceStubsOptions {
         + ", metricsScope="
         + metricsScope
         + ", grpcCompression="
-        + grpcCompression
-        + '}';
+        + grpcCompression;
   }
 
   public static class Builder<T extends Builder<T>> {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/ServiceStubsOptions.java
@@ -455,8 +455,10 @@ public class ServiceStubsOptions {
         + connectionBackoffResetFrequency
         + ", grpcReconnectFrequency="
         + grpcReconnectFrequency
-        + ", headers="
-        + headers
+        // Only the header names are rendered. Values are omitted because they routinely carry
+        // credentials, for example an Authorization header set through setHeaders.
+        + ", headerNames="
+        + (headers == null ? null : headers.keys())
         + ", grpcMetadataProviders="
         + grpcMetadataProviders
         + ", grpcClientInterceptors="

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -137,7 +137,8 @@ public final class WorkflowServiceStubsOptions extends ServiceStubsOptions {
   @Override
   public String toString() {
     return "WorkflowServiceStubsOptions{"
-        + "disableHealthCheck="
+        + toStringFields()
+        + ", disableHealthCheck="
         + disableHealthCheck
         + ", rpcLongPollTimeout="
         + rpcLongPollTimeout

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/RpcRetryOptionsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/RpcRetryOptionsTest.java
@@ -1,6 +1,7 @@
 package io.temporal.serviceclient;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import org.junit.Test;
@@ -26,5 +27,21 @@ public class RpcRetryOptionsTest {
 
     assertEquals(Duration.ofMillis(200), merged.getInitialInterval());
     assertEquals(Duration.ofSeconds(7), merged.getCongestionInitialInterval());
+  }
+
+  /**
+   * toString omitted the separator before congestionInitialInterval, so the two durations ran
+   * together as a single unreadable token.
+   */
+  @Test
+  public void toStringSeparatesInitialAndCongestionInterval() {
+    String rendered =
+        RpcRetryOptions.newBuilder()
+            .setInitialInterval(Duration.ofMillis(100))
+            .setCongestionInitialInterval(Duration.ofSeconds(1))
+            .validateBuildWithDefaults()
+            .toString();
+
+    assertTrue(rendered, rendered.contains(", congestionInitialInterval="));
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ServiceStubsOptionsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ServiceStubsOptionsTest.java
@@ -2,6 +2,7 @@ package io.temporal.serviceclient;
 
 import static org.junit.Assert.*;
 
+import io.grpc.Metadata;
 import org.junit.Test;
 
 public class ServiceStubsOptionsTest {
@@ -242,5 +243,29 @@ public class ServiceStubsOptionsTest {
     assertFalse(rendered, rendered.contains("super-secret-api-key"));
     // The fact that an API key was configured is still useful when debugging.
     assertTrue(rendered, rendered.contains("apiKeyProvided=true"));
+  }
+
+  @Test
+  public void testToStringRendersHeaderNamesWithoutValues() {
+    Metadata headers = new Metadata();
+    headers.put(
+        Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER),
+        "Bearer super-secret-token");
+    headers.put(Metadata.Key.of("x-custom", Metadata.ASCII_STRING_MARSHALLER), "plain-value");
+
+    WorkflowServiceStubsOptions options =
+        WorkflowServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .setHeaders(headers)
+            .validateAndBuildWithDefaults();
+
+    String rendered = options.toString();
+
+    // Metadata.toString renders values in the clear, so it must not be embedded directly.
+    assertFalse(rendered, rendered.contains("super-secret-token"));
+    assertFalse(rendered, rendered.contains("plain-value"));
+    // Header names are still reported, which is what makes the output useful for debugging.
+    assertTrue(rendered, rendered.contains("authorization"));
+    assertTrue(rendered, rendered.contains("x-custom"));
   }
 }

--- a/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ServiceStubsOptionsTest.java
+++ b/temporal-serviceclient/src/test/java/io/temporal/serviceclient/ServiceStubsOptionsTest.java
@@ -177,4 +177,70 @@ public class ServiceStubsOptionsTest {
 
     assertEquals(GrpcCompression.NONE, copied.getGrpcCompression());
   }
+
+  @Test
+  public void testWorkflowServiceStubsOptionsToStringIncludesInheritedFields() {
+    WorkflowServiceStubsOptions options =
+        WorkflowServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .validateAndBuildWithDefaults();
+
+    String rendered = options.toString();
+
+    assertTrue(rendered.startsWith("WorkflowServiceStubsOptions{"));
+    // Inherited fields used to be dropped entirely.
+    assertTrue(rendered, rendered.contains("target='localhost:7233'"));
+    assertTrue(rendered, rendered.contains("enableHttps="));
+    assertTrue(rendered, rendered.contains("rpcTimeout="));
+    assertTrue(rendered, rendered.contains("grpcCompression="));
+    // Fields declared on the subclass are still present.
+    assertTrue(rendered, rendered.contains("disableHealthCheck="));
+    assertTrue(rendered, rendered.contains("rpcLongPollTimeout="));
+    // Inherited fields are inlined, not nested inside a second wrapper.
+    assertFalse(rendered, rendered.contains("{ServiceStubsOptions{"));
+  }
+
+  @Test
+  public void testOperatorServiceStubsOptionsToString() {
+    OperatorServiceStubsOptions options =
+        OperatorServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .validateAndBuildWithDefaults();
+
+    String rendered = options.toString();
+
+    assertTrue(rendered.startsWith("OperatorServiceStubsOptions{"));
+    assertTrue(rendered, rendered.contains("target='localhost:7233'"));
+    assertTrue(rendered, rendered.contains("rpcTimeout="));
+  }
+
+  @Test
+  public void testCloudServiceStubsOptionsToStringIncludesVersion() {
+    CloudServiceStubsOptions options =
+        CloudServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .setVersion("v1")
+            .validateAndBuildWithDefaults();
+
+    String rendered = options.toString();
+
+    assertTrue(rendered.startsWith("CloudServiceStubsOptions{"));
+    assertTrue(rendered, rendered.contains("target='localhost:7233'"));
+    assertTrue(rendered, rendered.contains("version='v1'"));
+  }
+
+  @Test
+  public void testToStringDoesNotLeakApiKey() {
+    WorkflowServiceStubsOptions options =
+        WorkflowServiceStubsOptions.newBuilder()
+            .setTarget("localhost:7233")
+            .addApiKey(() -> "super-secret-api-key")
+            .validateAndBuildWithDefaults();
+
+    String rendered = options.toString();
+
+    assertFalse(rendered, rendered.contains("super-secret-api-key"));
+    // The fact that an API key was configured is still useful when debugging.
+    assertTrue(rendered, rendered.contains("apiKeyProvided=true"));
+  }
 }


### PR DESCRIPTION
## What was changed

`ServiceStubsOptions.toString` now renders its fields through a package-private `toStringFields()`
that each subclass inlines alongside its own fields.

- `WorkflowServiceStubsOptions` rendered only the five fields declared on the subclass, dropping
  every inherited one — target, TLS, timeouts, headers.
- `OperatorServiceStubsOptions` and `CloudServiceStubsOptions` had no `toString` and logged as an
  identity hash.
- Added `apiKeyProvided`, already in `equals`/`hashCode` but missing from `toString`.
- Headers render as names only. `io.grpc.Metadata#toString` prints values in the clear, so
  inheriting the field as-is would have exposed credentials set through `setHeaders`.
- Fixed a missing `, ` before `congestionInitialInterval` in `RpcRetryOptions.toString`.

## Why?

This output is what lands in logs when diagnosing a client. Two of the three option types rendered
nothing usable; the third omitted every inherited field.

## Breaking changes?

None to public API. `ServiceStubsOptions.toString` now emits `headerNames=[...]` where it used to
emit `headers=` with values — deliberate, so the fix does not leak credentials.

## Server PR

N/A.

## Checklist

1. Closes #2148

2. How was this tested:

   Five new tests covering each subclass's `toString`, asserting no API key or header value appears
   in the output, plus a regression test for the separator.

   ```
   ./gradlew --offline :temporal-serviceclient:spotlessCheck
   ./gradlew --offline :temporal-serviceclient:test
   ```

3. Any docs updates needed?

   No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
